### PR TITLE
Add .gitattributes to fix misclassification of repo as notebook

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+notebooks/* linguist-documentation
+


### PR DESCRIPTION
See https://github.com/github/linguist#overrides for documentation on syntax