### PR TITLE
Add sphinx.ext.intersphinx extension

### DIFF
--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -82,7 +82,7 @@ autoclass_content = "both"
 # Configuration for intersphinx: refer to the Python standard library and PyTorch
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "pytorch": ("https://pytorch.org/docs/stable/index.html", None),
+    "pytorch": ("https://pytorch.org/docs", None),
 }
 
 


### PR DESCRIPTION
Adding this extension which generates automatic links to the documentation of objects in other projects (e.g. linking to a Python class).