### PR TITLE
Remove auto_deploy_site from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,20 +119,6 @@ jobs:
       - sphinx
 #      - upload_coverage
 
-  auto_deploy_site:
-    docker:
-      - image: circleci/python:3.6.8-node
-    steps:
-      - checkout
-      - pip_install:
-          args: "-n -f -d"
-#      - lint_flake8
-#      - lint_black
-      - unit_tests
-      - sphinx
-      - configure_github_bot
-      - deploy_site
-
 
 aliases:
 
@@ -152,11 +138,3 @@ workflows:
 # TODO: support conda install
       # - lint_test_py37_conda:
       #     filters: *exclude_ghpages_fbconfig
-
-  auto_deploy_site:
-    jobs:
-      - auto_deploy_site:
-          filters:
-            branches:
-              only:
-                - master


### PR DESCRIPTION
This removes the `auto_deploy_site` job from CircleCI, since we don't need it right now.

cc @jlin27 