### PR TITLE
Add usage / documentation extensions for Integrated Gradients

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,6 +1,7 @@
 {
   "docs": {
     "About": ["introduction"],
-    "General": ["getting_started", "captum_insights", "algorithms"]
+    "General": ["getting_started", "captum_insights", "algorithms"],
+    "Usage": ["integrated_gradients"]
   }
 }


### PR DESCRIPTION
Add howtos / documentation extensions for Integrated Gradients

I called it extensions because `howto` folder name looked weird. We can still give label `howto` on the web page. Also, I need to know if the `id` and `title` definitions will be necessary for this one.
 