### PR TITLE
Rename Test Models to Basic Models

### DIFF
--- a/tests/attr/helpers/basic_models.py
+++ b/tests/attr/helpers/basic_models.py
@@ -170,7 +170,7 @@ class BasicEmbeddingModel(nn.Module):
         return self.linear2(self.relu(self.linear1(embeddings))).squeeze(1)
 
 
-class TestModel_MultiLayer(nn.Module):
+class BasicModel_MultiLayer(nn.Module):
     def __init__(self):
         super().__init__()
         # Linear 0 is simply identity transform
@@ -198,16 +198,16 @@ class TestModel_MultiLayer(nn.Module):
             return lin2_out
 
 
-class TestModel_MultiLayer_MultiInput(nn.Module):
+class BasicModel_MultiLayer_MultiInput(nn.Module):
     def __init__(self):
         super().__init__()
-        self.model = TestModel_MultiLayer()
+        self.model = BasicModel_MultiLayer()
 
     def forward(self, x1, x2, x3, scale):
         return self.model(scale * (x1 + x2 + x3))
 
 
-class TestModel_ConvNet(nn.Module):
+class BasicModel_ConvNet(nn.Module):
     def __init__(self):
         super().__init__()
         self.conv1 = nn.Conv2d(1, 2, 3, 1)
@@ -235,7 +235,7 @@ class TestModel_ConvNet(nn.Module):
         return self.softmax(x)
 
 
-class TestModel_ConvNet_MaxPool1d(nn.Module):
+class BasicModel_ConvNet_MaxPool1d(nn.Module):
     """Same as above, but with the MaxPool2d replaced
     with a MaxPool1d. This is useful because the MaxPool modules
     behave differently to other modules from the perspective
@@ -269,7 +269,7 @@ class TestModel_ConvNet_MaxPool1d(nn.Module):
         return self.softmax(x)
 
 
-class TestModel_ConvNet_MaxPool3d(nn.Module):
+class BasicModel_ConvNet_MaxPool3d(nn.Module):
     """Same as above, but with the MaxPool1d replaced
     with a MaxPool3d. This is useful because the MaxPool modules
     behave differently to other modules from the perspective

--- a/tests/attr/test_data_parallel.py
+++ b/tests/attr/test_data_parallel.py
@@ -13,16 +13,16 @@ from captum.attr._core.neuron_gradient import NeuronGradient
 from captum.attr._core.neuron_integrated_gradients import NeuronIntegratedGradients
 
 from .helpers.basic_models import (
-    TestModel_MultiLayer,
-    TestModel_MultiLayer_MultiInput,
-    TestModel_ConvNet,
+    BasicModel_MultiLayer,
+    BasicModel_MultiLayer_MultiInput,
+    BasicModel_ConvNet,
 )
 from .helpers.utils import BaseGPUTest
 
 
 class Test(BaseGPUTest):
     def test_simple_input_internal_inf(self):
-        net = TestModel_MultiLayer().cuda()
+        net = BasicModel_MultiLayer().cuda()
         inp = torch.tensor(
             [
                 [0.0, 100.0, 0.0],
@@ -36,7 +36,7 @@ class Test(BaseGPUTest):
         )
 
     def test_multi_input_internal_inf(self):
-        net = TestModel_MultiLayer_MultiInput().cuda()
+        net = BasicModel_MultiLayer_MultiInput().cuda()
         inp1, inp2, inp3 = (
             10 * torch.randn(12, 3).cuda(),
             5 * torch.randn(12, 3).cuda(),
@@ -54,7 +54,7 @@ class Test(BaseGPUTest):
         )
 
     def test_simple_layer_activation(self):
-        net = TestModel_MultiLayer().cuda()
+        net = BasicModel_MultiLayer().cuda()
         inp = torch.tensor(
             [
                 [0.0, 100.0, 0.0],
@@ -66,7 +66,7 @@ class Test(BaseGPUTest):
         self._data_parallel_test_assert(LayerActivation, net, net.relu, inputs=inp)
 
     def test_multi_input_layer_activation(self):
-        net = TestModel_MultiLayer_MultiInput().cuda()
+        net = BasicModel_MultiLayer_MultiInput().cuda()
         inp1, inp2, inp3 = (
             10 * torch.randn(12, 3).cuda(),
             5 * torch.randn(12, 3).cuda(),
@@ -82,7 +82,7 @@ class Test(BaseGPUTest):
         )
 
     def test_simple_layer_conductance(self):
-        net = TestModel_MultiLayer().cuda()
+        net = BasicModel_MultiLayer().cuda()
         inp = torch.tensor(
             [
                 [0.0, 100.0, 0.0],
@@ -96,7 +96,7 @@ class Test(BaseGPUTest):
         )
 
     def test_multi_input_layer_conductance(self):
-        net = TestModel_MultiLayer_MultiInput().cuda()
+        net = BasicModel_MultiLayer_MultiInput().cuda()
         inp1, inp2, inp3 = (
             10 * torch.randn(12, 3).cuda(),
             5 * torch.randn(12, 3).cuda(),
@@ -114,14 +114,14 @@ class Test(BaseGPUTest):
         )
 
     def test_multi_dim_layer_conductance(self):
-        net = TestModel_ConvNet().cuda()
+        net = BasicModel_ConvNet().cuda()
         inp = 100 * torch.randn(4, 1, 10, 10).cuda()
         self._data_parallel_test_assert(
             LayerConductance, net, net.conv2, alt_device_ids=True, inputs=inp, target=1
         )
 
     def test_simple_layer_gradient_x_activation(self):
-        net = TestModel_MultiLayer().cuda()
+        net = BasicModel_MultiLayer().cuda()
         inp = torch.tensor(
             [
                 [0.0, 100.0, 0.0],
@@ -135,7 +135,7 @@ class Test(BaseGPUTest):
         )
 
     def test_multi_input_layer_gradient_x_activation(self):
-        net = TestModel_MultiLayer_MultiInput().cuda()
+        net = BasicModel_MultiLayer_MultiInput().cuda()
         inp1, inp2, inp3 = (
             10 * torch.randn(12, 3).cuda(),
             5 * torch.randn(12, 3).cuda(),
@@ -152,7 +152,7 @@ class Test(BaseGPUTest):
         )
 
     def test_simple_neuron_conductance(self):
-        net = TestModel_MultiLayer().cuda()
+        net = BasicModel_MultiLayer().cuda()
         inp = torch.tensor(
             [
                 [0.0, 100.0, 0.0],
@@ -166,7 +166,7 @@ class Test(BaseGPUTest):
         )
 
     def test_multi_input_neuron_conductance(self):
-        net = TestModel_MultiLayer_MultiInput().cuda()
+        net = BasicModel_MultiLayer_MultiInput().cuda()
         inp1, inp2, inp3 = (
             10 * torch.randn(12, 3).cuda(),
             5 * torch.randn(12, 3).cuda(),
@@ -185,7 +185,7 @@ class Test(BaseGPUTest):
         )
 
     def test_multi_dim_neuron_conductance(self):
-        net = TestModel_ConvNet().cuda()
+        net = BasicModel_ConvNet().cuda()
         inp = 100 * torch.randn(4, 1, 10, 10).cuda()
         self._data_parallel_test_assert(
             NeuronConductance,
@@ -198,7 +198,7 @@ class Test(BaseGPUTest):
         )
 
     def test_simple_neuron_gradient(self):
-        net = TestModel_MultiLayer().cuda()
+        net = BasicModel_MultiLayer().cuda()
         inp = torch.tensor(
             [
                 [0.0, 100.0, 0.0],
@@ -217,7 +217,7 @@ class Test(BaseGPUTest):
         )
 
     def test_multi_input_neuron_gradient(self):
-        net = TestModel_MultiLayer_MultiInput().cuda()
+        net = BasicModel_MultiLayer_MultiInput().cuda()
         inp1, inp2, inp3 = (
             10 * torch.randn(12, 3).cuda(),
             5 * torch.randn(12, 3).cuda(),
@@ -233,7 +233,7 @@ class Test(BaseGPUTest):
         )
 
     def test_simple_neuron_integrated_gradient(self):
-        net = TestModel_MultiLayer().cuda()
+        net = BasicModel_MultiLayer().cuda()
         inp = torch.tensor(
             [
                 [0.0, 100.0, 0.0],
@@ -252,7 +252,7 @@ class Test(BaseGPUTest):
         )
 
     def test_multi_input_integrated_gradient(self):
-        net = TestModel_MultiLayer_MultiInput().cuda()
+        net = BasicModel_MultiLayer_MultiInput().cuda()
         inp1, inp2, inp3 = (
             10 * torch.randn(12, 3).cuda(),
             5 * torch.randn(12, 3).cuda(),

--- a/tests/attr/test_deeplift_classification.py
+++ b/tests/attr/test_deeplift_classification.py
@@ -8,9 +8,9 @@ from captum.attr._core.integrated_gradients import IntegratedGradients
 from .helpers.utils import assertAttributionComparision, BaseTest
 from .helpers.classification_models import SigmoidDeepLiftModel
 from .helpers.classification_models import SoftmaxDeepLiftModel
-from .helpers.basic_models import TestModel_ConvNet
-from .helpers.basic_models import TestModel_ConvNet_MaxPool1d
-from .helpers.basic_models import TestModel_ConvNet_MaxPool3d
+from .helpers.basic_models import BasicModel_ConvNet
+from .helpers.basic_models import BasicModel_ConvNet_MaxPool1d
+from .helpers.basic_models import BasicModel_ConvNet_MaxPool3d
 
 
 class Test(BaseTest):
@@ -75,7 +75,7 @@ class Test(BaseTest):
         input = 100 * torch.randn(2, 1, 10, 10, 10, requires_grad=True)
         baseline = 20 * torch.randn(2, 1, 10, 10, 10)
 
-        model = TestModel_ConvNet_MaxPool3d()
+        model = BasicModel_ConvNet_MaxPool3d()
         dl = DeepLift(model)
 
         self.softmax_classification(model, dl, input, baseline)
@@ -84,7 +84,7 @@ class Test(BaseTest):
         input = 100 * torch.randn(2, 1, 10, 10, requires_grad=True)
         baseline = 20 * torch.randn(2, 1, 10, 10)
 
-        model = TestModel_ConvNet()
+        model = BasicModel_ConvNet()
         dl = DeepLift(model)
 
         self.softmax_classification(model, dl, input, baseline)
@@ -93,7 +93,7 @@ class Test(BaseTest):
         input = 100 * torch.randn(2, 1, 10, requires_grad=True)
         baseline = 20 * torch.randn(2, 1, 10)
 
-        model = TestModel_ConvNet_MaxPool1d()
+        model = BasicModel_ConvNet_MaxPool1d()
         dl = DeepLift(model)
 
         self.softmax_classification(model, dl, input, baseline)

--- a/tests/attr/test_gradient.py
+++ b/tests/attr/test_gradient.py
@@ -13,7 +13,7 @@ from .helpers.utils import assertArraysAlmostEqual, BaseTest
 from .helpers.basic_models import (
     BasicModel,
     BasicModel6_MultiTensor,
-    TestModel_MultiLayer,
+    BasicModel_MultiLayer,
 )
 
 
@@ -66,7 +66,7 @@ class Test(BaseTest):
         assertArraysAlmostEqual(grads[1].squeeze(0).tolist(), [0.0, 1.0], delta=0.01)
 
     def test_layer_gradient_linear0(self):
-        model = TestModel_MultiLayer()
+        model = BasicModel_MultiLayer()
         input = torch.tensor([[5.0, -11.0, 23.0]], requires_grad=True)
         grads, eval = compute_layer_gradients_and_eval(
             model, model.linear0, input, target_ind=0
@@ -77,7 +77,7 @@ class Test(BaseTest):
         )
 
     def test_layer_gradient_linear1(self):
-        model = TestModel_MultiLayer()
+        model = BasicModel_MultiLayer()
         input = torch.tensor([[5.0, 2.0, 1.0]], requires_grad=True)
         grads, eval = compute_layer_gradients_and_eval(
             model, model.linear1, input, target_ind=1
@@ -90,7 +90,7 @@ class Test(BaseTest):
         )
 
     def test_layer_gradient_output(self):
-        model = TestModel_MultiLayer()
+        model = BasicModel_MultiLayer()
         input = torch.tensor([[5.0, 2.0, 1.0]], requires_grad=True)
         grads, eval = compute_layer_gradients_and_eval(
             model, model.linear2, input, target_ind=1

--- a/tests/attr/test_integrated_gradients_basic.py
+++ b/tests/attr/test_integrated_gradients_basic.py
@@ -11,7 +11,7 @@ from .helpers.basic_models import (
     BasicModel4_MultiArgs,
     BasicModel5_MultiArgs,
     BasicModel6_MultiTensor,
-    TestModel_MultiLayer,
+    BasicModel_MultiLayer,
 )
 from .helpers.utils import assertArraysAlmostEqual, BaseTest
 
@@ -188,7 +188,7 @@ class Test(BaseTest):
         )
 
     def _assert_batched_tensor_input(self, type):
-        model = TestModel_MultiLayer()
+        model = BasicModel_MultiLayer()
         input = (
             torch.tensor(
                 [[1.5, 2.0, 1.3], [0.5, 0.1, 2.3], [1.5, 2.0, 1.3]], requires_grad=True
@@ -198,7 +198,7 @@ class Test(BaseTest):
         self._compute_attribution_batch_helper_evaluate(model, input, target=0)
 
     def _assert_batched_tensor_multi_input(self, type):
-        model = TestModel_MultiLayer()
+        model = BasicModel_MultiLayer()
         input = (
             torch.tensor(
                 [[1.5, 2.1, 1.9], [0.5, 0.0, 0.7], [1.5, 2.1, 1.1]], requires_grad=True

--- a/tests/attr/test_internal_influence.py
+++ b/tests/attr/test_internal_influence.py
@@ -5,35 +5,38 @@ import unittest
 import torch
 from captum.attr._core.internal_influence import InternalInfluence
 
-from .helpers.basic_models import TestModel_MultiLayer, TestModel_MultiLayer_MultiInput
+from .helpers.basic_models import (
+    BasicModel_MultiLayer,
+    BasicModel_MultiLayer_MultiInput,
+)
 from .helpers.utils import assertArraysAlmostEqual, BaseTest
 
 
 class Test(BaseTest):
     def test_simple_input_internal_inf(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
         self._internal_influence_test_assert(net, net.linear0, inp, [[3.9, 3.9, 3.9]])
 
     def test_simple_linear_internal_inf(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         self._internal_influence_test_assert(
             net, net.linear1, inp, [[0.9, 1.0, 1.0, 1.0]]
         )
 
     def test_simple_relu_internal_inf(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[3.0, 4.0, 0.0]], requires_grad=True)
         self._internal_influence_test_assert(net, net.relu, inp, [[1.0, 1.0, 1.0, 1.0]])
 
     def test_simple_output_internal_inf(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         self._internal_influence_test_assert(net, net.linear2, inp, [[1.0, 0.0]])
 
     def test_simple_with_baseline_internal_inf(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 80.0, 0.0]])
         base = torch.tensor([[0.0, -20.0, 0.0]])
         self._internal_influence_test_assert(
@@ -41,7 +44,7 @@ class Test(BaseTest):
         )
 
     def test_simple_multi_input_linear2_internal_inf(self):
-        net = TestModel_MultiLayer_MultiInput()
+        net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 10.0, 0.0]])
         inp2 = torch.tensor([[0.0, 10.0, 0.0]])
         inp3 = torch.tensor([[0.0, 5.0, 0.0]])
@@ -54,7 +57,7 @@ class Test(BaseTest):
         )
 
     def test_simple_multi_input_relu_internal_inf(self):
-        net = TestModel_MultiLayer_MultiInput()
+        net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 10.0, 1.0]])
         inp2 = torch.tensor([[0.0, 4.0, 5.0]])
         inp3 = torch.tensor([[0.0, 0.0, 0.0]])
@@ -67,7 +70,7 @@ class Test(BaseTest):
         )
 
     def test_simple_multi_input_batch_relu_internal_inf(self):
-        net = TestModel_MultiLayer_MultiInput()
+        net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 6.0, 14.0], [0.0, 80.0, 0.0]])
         inp2 = torch.tensor([[0.0, 6.0, 14.0], [0.0, 20.0, 0.0]])
         inp3 = torch.tensor([[0.0, 0.0, 0.0], [0.0, 20.0, 0.0]])
@@ -80,7 +83,7 @@ class Test(BaseTest):
         )
 
     def test_multiple_linear_internal_inf(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor(
             [
                 [0.0, 100.0, 0.0],
@@ -103,7 +106,7 @@ class Test(BaseTest):
         )
 
     def test_multiple_with_baseline_internal_inf(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 80.0, 0.0], [30.0, 30.0, 0.0]], requires_grad=True)
         base = torch.tensor(
             [[0.0, -20.0, 0.0], [-20.0, -20.0, 0.0]], requires_grad=True

--- a/tests/attr/test_layer_activation.py
+++ b/tests/attr/test_layer_activation.py
@@ -5,35 +5,38 @@ import unittest
 import torch
 from captum.attr._core.layer_activation import LayerActivation
 
-from .helpers.basic_models import TestModel_MultiLayer, TestModel_MultiLayer_MultiInput
+from .helpers.basic_models import (
+    BasicModel_MultiLayer,
+    BasicModel_MultiLayer_MultiInput,
+)
 from .helpers.utils import assertArraysAlmostEqual, BaseTest
 
 
 class Test(BaseTest):
     def test_simple_input_activation(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
         self._layer_activation_test_assert(net, net.linear0, inp, [0.0, 100.0, 0.0])
 
     def test_simple_linear_activation(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         self._layer_activation_test_assert(
             net, net.linear1, inp, [90.0, 101.0, 101.0, 101.0]
         )
 
     def test_simple_relu_activation(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[3.0, 4.0, 0.0]], requires_grad=True)
         self._layer_activation_test_assert(net, net.relu, inp, [0.0, 8.0, 8.0, 8.0])
 
     def test_simple_output_activation(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         self._layer_activation_test_assert(net, net.linear2, inp, [392.0, 394.0])
 
     def test_simple_multi_input_linear2_activation(self):
-        net = TestModel_MultiLayer_MultiInput()
+        net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 10.0, 0.0]])
         inp2 = torch.tensor([[0.0, 10.0, 0.0]])
         inp3 = torch.tensor([[0.0, 5.0, 0.0]])
@@ -42,7 +45,7 @@ class Test(BaseTest):
         )
 
     def test_simple_multi_input_relu_activation(self):
-        net = TestModel_MultiLayer_MultiInput()
+        net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 10.0, 1.0]])
         inp2 = torch.tensor([[0.0, 4.0, 5.0]])
         inp3 = torch.tensor([[0.0, 0.0, 0.0]])

--- a/tests/attr/test_layer_conductance.py
+++ b/tests/attr/test_layer_conductance.py
@@ -6,9 +6,9 @@ import torch
 from captum.attr._core.layer_conductance import LayerConductance
 
 from .helpers.basic_models import (
-    TestModel_ConvNet,
-    TestModel_MultiLayer,
-    TestModel_MultiLayer_MultiInput,
+    BasicModel_ConvNet,
+    BasicModel_MultiLayer,
+    BasicModel_MultiLayer_MultiInput,
 )
 from .helpers.conductance_reference import ConductanceReference
 from .helpers.utils import assertArraysAlmostEqual, BaseTest
@@ -16,29 +16,29 @@ from .helpers.utils import assertArraysAlmostEqual, BaseTest
 
 class Test(BaseTest):
     def test_simple_input_conductance(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         self._conductance_test_assert(net, net.linear0, inp, [[0.0, 390.0, 0.0]])
 
     def test_simple_linear_conductance(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
         self._conductance_test_assert(
             net, net.linear1, inp, [[90.0, 100.0, 100.0, 100.0]]
         )
 
     def test_simple_relu_conductance(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         self._conductance_test_assert(net, net.relu, inp, [[90.0, 100.0, 100.0, 100.0]])
 
     def test_simple_output_conductance(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
         self._conductance_test_assert(net, net.linear2, inp, [[390.0, 0.0]])
 
     def test_simple_multi_input_linear2_conductance(self):
-        net = TestModel_MultiLayer_MultiInput()
+        net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 10.0, 0.0]])
         inp2 = torch.tensor([[0.0, 10.0, 0.0]])
         inp3 = torch.tensor([[0.0, 5.0, 0.0]])
@@ -47,7 +47,7 @@ class Test(BaseTest):
         )
 
     def test_simple_multi_input_relu_conductance(self):
-        net = TestModel_MultiLayer_MultiInput()
+        net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 10.0, 1.0]])
         inp2 = torch.tensor([[0.0, 4.0, 5.0]])
         inp3 = torch.tensor([[0.0, 0.0, 0.0]])
@@ -56,7 +56,7 @@ class Test(BaseTest):
         )
 
     def test_simple_multi_input_relu_conductance_batch(self):
-        net = TestModel_MultiLayer_MultiInput()
+        net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 10.0, 1.0], [0.0, 0.0, 10.0]])
         inp2 = torch.tensor([[0.0, 4.0, 5.0], [0.0, 0.0, 10.0]])
         inp3 = torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 5.0]])
@@ -69,32 +69,32 @@ class Test(BaseTest):
         )
 
     def test_matching_conv1_conductance(self):
-        net = TestModel_ConvNet()
+        net = BasicModel_ConvNet()
         inp = 100 * torch.randn(1, 1, 10, 10, requires_grad=True)
         self._conductance_reference_test_assert(net, net.conv1, inp)
 
     def test_matching_pool1_conductance(self):
-        net = TestModel_ConvNet()
+        net = BasicModel_ConvNet()
         inp = 100 * torch.randn(1, 1, 10, 10)
         self._conductance_reference_test_assert(net, net.pool1, inp)
 
     def test_matching_conv2_conductance(self):
-        net = TestModel_ConvNet()
+        net = BasicModel_ConvNet()
         inp = 100 * torch.randn(1, 1, 10, 10, requires_grad=True)
         self._conductance_reference_test_assert(net, net.conv2, inp)
 
     def test_matching_pool2_conductance(self):
-        net = TestModel_ConvNet()
+        net = BasicModel_ConvNet()
         inp = 100 * torch.randn(1, 1, 10, 10)
         self._conductance_reference_test_assert(net, net.pool2, inp)
 
     def test_matching_conv_multi_input_conductance(self):
-        net = TestModel_ConvNet()
+        net = BasicModel_ConvNet()
         inp = 100 * torch.randn(4, 1, 10, 10, requires_grad=True)
         self._conductance_reference_test_assert(net, net.relu3, inp)
 
     def test_matching_conv_with_baseline_conductance(self):
-        net = TestModel_ConvNet()
+        net = BasicModel_ConvNet()
         inp = 100 * torch.randn(3, 1, 10, 10)
         baseline = 100 * torch.randn(3, 1, 10, 10, requires_grad=True)
         self._conductance_reference_test_assert(net, net.fc1, inp, baseline)

--- a/tests/attr/test_layer_gradient_x_activation.py
+++ b/tests/attr/test_layer_gradient_x_activation.py
@@ -5,35 +5,38 @@ import unittest
 import torch
 from captum.attr._core.layer_gradient_x_activation import LayerGradientXActivation
 
-from .helpers.basic_models import TestModel_MultiLayer, TestModel_MultiLayer_MultiInput
+from .helpers.basic_models import (
+    BasicModel_MultiLayer,
+    BasicModel_MultiLayer_MultiInput,
+)
 from .helpers.utils import assertArraysAlmostEqual, BaseTest
 
 
 class Test(BaseTest):
     def test_simple_input_gradient_activation(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
         self._layer_activation_test_assert(net, net.linear0, inp, [0.0, 400.0, 0.0])
 
     def test_simple_linear_gradient_activation(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         self._layer_activation_test_assert(
             net, net.linear1, inp, [90.0, 101.0, 101.0, 101.0]
         )
 
     def test_simple_relu_gradient_activation(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[3.0, 4.0, 0.0]], requires_grad=True)
         self._layer_activation_test_assert(net, net.relu, inp, [0.0, 8.0, 8.0, 8.0])
 
     def test_simple_output_gradient_activation(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         self._layer_activation_test_assert(net, net.linear2, inp, [392.0, 0.0])
 
     def test_simple_gradient_activation_multi_input_linear2(self):
-        net = TestModel_MultiLayer_MultiInput()
+        net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 10.0, 0.0]])
         inp2 = torch.tensor([[0.0, 10.0, 0.0]])
         inp3 = torch.tensor([[0.0, 5.0, 0.0]])
@@ -42,7 +45,7 @@ class Test(BaseTest):
         )
 
     def test_simple_gradient_activation_multi_input_relu(self):
-        net = TestModel_MultiLayer_MultiInput()
+        net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 10.0, 1.0]])
         inp2 = torch.tensor([[0.0, 4.0, 5.0]])
         inp3 = torch.tensor([[0.0, 0.0, 0.0]])

--- a/tests/attr/test_neuron_conductance.py
+++ b/tests/attr/test_neuron_conductance.py
@@ -7,33 +7,33 @@ from captum.attr._core.layer_conductance import LayerConductance
 from captum.attr._core.neuron_conductance import NeuronConductance
 
 from .helpers.basic_models import (
-    TestModel_ConvNet,
-    TestModel_MultiLayer,
-    TestModel_MultiLayer_MultiInput,
+    BasicModel_ConvNet,
+    BasicModel_MultiLayer,
+    BasicModel_MultiLayer_MultiInput,
 )
 from .helpers.utils import assertArraysAlmostEqual, BaseTest
 
 
 class Test(BaseTest):
     def test_simple_conductance_input_linear2(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
         self._conductance_input_test_assert(
             net, net.linear2, inp, (0,), [0.0, 390.0, 0.0]
         )
 
     def test_simple_conductance_input_linear1(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         self._conductance_input_test_assert(net, net.linear1, inp, 0, [0.0, 90.0, 0.0])
 
     def test_simple_conductance_input_relu(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 70.0, 30.0]], requires_grad=True)
         self._conductance_input_test_assert(net, net.relu, inp, (3,), [0.0, 70.0, 30.0])
 
     def test_simple_conductance_multi_input_linear2(self):
-        net = TestModel_MultiLayer_MultiInput()
+        net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 10.0, 0.0]])
         inp2 = torch.tensor([[0.0, 10.0, 0.0]])
         inp3 = torch.tensor([[0.0, 5.0, 0.0]])
@@ -47,7 +47,7 @@ class Test(BaseTest):
         )
 
     def test_simple_conductance_multi_input_relu(self):
-        net = TestModel_MultiLayer_MultiInput()
+        net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 10.0, 1.0]])
         inp2 = torch.tensor([[0.0, 4.0, 5.0]])
         inp3 = torch.tensor([[0.0, 0.0, 0.0]])
@@ -61,7 +61,7 @@ class Test(BaseTest):
         )
 
     def test_simple_conductance_multi_input_batch_relu(self):
-        net = TestModel_MultiLayer_MultiInput()
+        net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 10.0, 1.0], [0.0, 0.0, 10.0]])
         inp2 = torch.tensor([[0.0, 4.0, 5.0], [0.0, 0.0, 10.0]])
         inp3 = torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 5.0]])
@@ -78,18 +78,18 @@ class Test(BaseTest):
         )
 
     def test_matching_conv2_multi_input_conductance(self):
-        net = TestModel_ConvNet()
+        net = BasicModel_ConvNet()
         inp = 100 * torch.randn(2, 1, 10, 10)
         self._conductance_input_sum_test_assert(net, net.conv2, inp)
 
     def test_matching_relu2_multi_input_conductance(self):
-        net = TestModel_ConvNet()
+        net = BasicModel_ConvNet()
         inp = 100 * torch.randn(3, 1, 10, 10, requires_grad=True)
         baseline = 20 * torch.randn(3, 1, 10, 10, requires_grad=True)
         self._conductance_input_sum_test_assert(net, net.relu2, inp, baseline)
 
     def test_matching_pool2_multi_input_conductance(self):
-        net = TestModel_ConvNet()
+        net = BasicModel_ConvNet()
         inp = 100 * torch.randn(1, 1, 10, 10)
         baseline = 20 * torch.randn(1, 1, 10, 10, requires_grad=True)
         self._conductance_input_sum_test_assert(net, net.pool2, inp, baseline)

--- a/tests/attr/test_neuron_gradient.py
+++ b/tests/attr/test_neuron_gradient.py
@@ -9,36 +9,36 @@ from captum.attr._utils.common import _extend_index_list
 from captum.attr._utils.gradient import _forward_layer_eval
 
 from .helpers.basic_models import (
-    TestModel_ConvNet,
-    TestModel_MultiLayer,
-    TestModel_MultiLayer_MultiInput,
+    BasicModel_ConvNet,
+    BasicModel_MultiLayer,
+    BasicModel_MultiLayer_MultiInput,
 )
 from .helpers.utils import assertArraysAlmostEqual, BaseTest
 
 
 class Test(BaseTest):
     def test_simple_gradient_input_linear2(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
         self._gradient_input_test_assert(net, net.linear2, inp, (0,), [4.0, 4.0, 4.0])
 
     def test_simple_gradient_input_linear1(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         self._gradient_input_test_assert(net, net.linear1, inp, (0,), [1.0, 1.0, 1.0])
 
     def test_simple_gradient_input_relu(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 5.0, 4.0]], requires_grad=True)
         self._gradient_input_test_assert(net, net.relu, inp, 0, [0.0, 0.0, 0.0])
 
     def test_simple_gradient_input_relu2(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 5.0, 4.0]])
         self._gradient_input_test_assert(net, net.relu, inp, 1, [1.0, 1.0, 1.0])
 
     def test_simple_gradient_multi_input_linear2(self):
-        net = TestModel_MultiLayer_MultiInput()
+        net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 100.0, 0.0]])
         inp2 = torch.tensor([[0.0, 100.0, 0.0]])
         inp3 = torch.tensor([[0.0, 100.0, 0.0]])
@@ -52,7 +52,7 @@ class Test(BaseTest):
         )
 
     def test_simple_gradient_multi_input_linear1(self):
-        net = TestModel_MultiLayer_MultiInput()
+        net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 100.0, 0.0]])
         inp2 = torch.tensor([[0.0, 100.0, 0.0]])
         inp3 = torch.tensor([[0.0, 100.0, 0.0]])
@@ -66,12 +66,12 @@ class Test(BaseTest):
         )
 
     def test_matching_output_gradient(self):
-        net = TestModel_ConvNet()
+        net = BasicModel_ConvNet()
         inp = torch.randn(2, 1, 10, 10, requires_grad=True)
         self._gradient_matching_test_assert(net, net.softmax, inp)
 
     def test_matching_intermediate_gradient(self):
-        net = TestModel_ConvNet()
+        net = BasicModel_ConvNet()
         inp = torch.randn(3, 1, 10, 10)
         self._gradient_matching_test_assert(net, net.relu2, inp)
 

--- a/tests/attr/test_neuron_integrated_gradients.py
+++ b/tests/attr/test_neuron_integrated_gradients.py
@@ -7,36 +7,36 @@ from captum.attr._core.integrated_gradients import IntegratedGradients
 from captum.attr._core.neuron_integrated_gradients import NeuronIntegratedGradients
 
 from .helpers.basic_models import (
-    TestModel_ConvNet,
-    TestModel_MultiLayer,
-    TestModel_MultiLayer_MultiInput,
+    BasicModel_ConvNet,
+    BasicModel_MultiLayer,
+    BasicModel_MultiLayer_MultiInput,
 )
 from .helpers.utils import assertArraysAlmostEqual, BaseTest
 
 
 class Test(BaseTest):
     def test_simple_ig_input_linear2(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         self._ig_input_test_assert(net, net.linear2, inp, 0, [0.0, 390.0, 0.0])
 
     def test_simple_ig_input_linear1(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
         self._ig_input_test_assert(net, net.linear1, inp, (0,), [0.0, 100.0, 0.0])
 
     def test_simple_ig_input_relu(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 6.0, 14.0]], requires_grad=True)
         self._ig_input_test_assert(net, net.relu, inp, (0,), [0.0, 3.0, 7.0])
 
     def test_simple_ig_input_relu2(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 5.0, 4.0]])
         self._ig_input_test_assert(net, net.relu, inp, 1, [0.0, 5.0, 4.0])
 
     def test_simple_ig_multi_input_linear2(self):
-        net = TestModel_MultiLayer_MultiInput()
+        net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 10.0, 0.0]])
         inp2 = torch.tensor([[0.0, 10.0, 0.0]])
         inp3 = torch.tensor([[0.0, 5.0, 0.0]])
@@ -50,7 +50,7 @@ class Test(BaseTest):
         )
 
     def test_simple_ig_multi_input_relu(self):
-        net = TestModel_MultiLayer_MultiInput()
+        net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 6.0, 14.0]])
         inp2 = torch.tensor([[0.0, 6.0, 14.0]])
         inp3 = torch.tensor([[0.0, 0.0, 0.0]])
@@ -64,7 +64,7 @@ class Test(BaseTest):
         )
 
     def test_simple_ig_multi_input_relu_batch(self):
-        net = TestModel_MultiLayer_MultiInput()
+        net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 6.0, 14.0], [0.0, 80.0, 0.0]])
         inp2 = torch.tensor([[0.0, 6.0, 14.0], [0.0, 20.0, 0.0]])
         inp3 = torch.tensor([[0.0, 0.0, 0.0], [0.0, 20.0, 0.0]])
@@ -78,7 +78,7 @@ class Test(BaseTest):
         )
 
     def test_matching_output_gradient(self):
-        net = TestModel_ConvNet()
+        net = BasicModel_ConvNet()
         inp = 100 * torch.randn(2, 1, 10, 10, requires_grad=True)
         baseline = 20 * torch.randn(2, 1, 10, 10, requires_grad=True)
         self._ig_matching_test_assert(net, net.softmax, inp, baseline)

--- a/tests/attr/test_targets.py
+++ b/tests/attr/test_targets.py
@@ -16,27 +16,27 @@ from captum.attr._core.layer_gradient_x_activation import LayerGradientXActivati
 
 from captum.attr._core.neuron_conductance import NeuronConductance
 
-from .helpers.basic_models import TestModel_MultiLayer
+from .helpers.basic_models import BasicModel_MultiLayer
 from .helpers.utils import BaseTest, assertTensorAlmostEqual
 
 
 class Test(BaseTest):
     def test_simple_target_missing_error(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.zeros((1, 3))
         with self.assertRaises(AssertionError):
             attr = IntegratedGradients(net)
             attr.attribute(inp)
 
     def test_multi_target_error(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.zeros((1, 3))
         with self.assertRaises(AssertionError):
             attr = IntegratedGradients(net)
             attr.attribute(inp, additional_forward_args=(None, True), target=(1, 0))
 
     def test_simple_target_ig(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             IntegratedGradients,
@@ -47,7 +47,7 @@ class Test(BaseTest):
         )
 
     def test_simple_target_ig_tensor(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             IntegratedGradients,
@@ -58,7 +58,7 @@ class Test(BaseTest):
         )
 
     def test_simple_target_ig_single_tensor(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             IntegratedGradients,
@@ -70,7 +70,7 @@ class Test(BaseTest):
         )
 
     def test_multi_target_ig(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             IntegratedGradients,
@@ -82,19 +82,19 @@ class Test(BaseTest):
         )
 
     def test_simple_target_saliency(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(Saliency, net, inputs=inp, targets=[0, 1, 1, 0])
 
     def test_simple_target_saliency_tensor(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             Saliency, net, inputs=inp, targets=torch.tensor([0, 1, 1, 0])
         )
 
     def test_multi_target_saliency(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             Saliency,
@@ -105,12 +105,12 @@ class Test(BaseTest):
         )
 
     def test_simple_target_deep_lift(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(DeepLift, net, inputs=inp, targets=[0, 1, 1, 0])
 
     def test_multi_target_deep_lift(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             DeepLift,
@@ -121,14 +121,14 @@ class Test(BaseTest):
         )
 
     def test_simple_target_deep_lift_shap(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             DeepLiftShap, net, inputs=inp, baselines=0.5 * inp, targets=[0, 1, 1, 0]
         )
 
     def test_simple_target_deep_lift_shap_tensor(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             DeepLiftShap,
@@ -139,7 +139,7 @@ class Test(BaseTest):
         )
 
     def test_simple_target_deep_lift_shap_single_tensor(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             DeepLiftShap,
@@ -151,7 +151,7 @@ class Test(BaseTest):
         )
 
     def test_multi_target_deep_lift_shap(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             DeepLiftShap,
@@ -163,7 +163,7 @@ class Test(BaseTest):
         )
 
     def test_simple_target_gradient_shap(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             GradientShap,
@@ -177,7 +177,7 @@ class Test(BaseTest):
         )
 
     def test_simple_target_gradient_shap_tensor(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             GradientShap,
@@ -191,7 +191,7 @@ class Test(BaseTest):
         )
 
     def test_simple_target_gradient_shap_single_tensor(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             GradientShap,
@@ -206,7 +206,7 @@ class Test(BaseTest):
         )
 
     def test_multi_target_gradient_shap(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             GradientShap,
@@ -221,7 +221,7 @@ class Test(BaseTest):
         )
 
     def test_simple_target_nt(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             NoiseTunnel,
@@ -233,7 +233,7 @@ class Test(BaseTest):
         )
 
     def test_simple_target_nt_tensor(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             NoiseTunnel,
@@ -245,7 +245,7 @@ class Test(BaseTest):
         )
 
     def test_simple_target_nt_single_tensor(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             NoiseTunnel,
@@ -258,7 +258,7 @@ class Test(BaseTest):
         )
 
     def test_multi_target_nt(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             NoiseTunnel,
@@ -271,14 +271,14 @@ class Test(BaseTest):
         )
 
     def test_simple_target_input_x_gradient(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             InputXGradient, net, inputs=inp, targets=[0, 1, 1, 0]
         )
 
     def test_multi_target_input_x_gradient(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             InputXGradient,
@@ -289,7 +289,7 @@ class Test(BaseTest):
         )
 
     def test_simple_target_int_inf(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             InternalInfluence,
@@ -301,7 +301,7 @@ class Test(BaseTest):
         )
 
     def test_multi_target_int_inf(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             InternalInfluence,
@@ -314,7 +314,7 @@ class Test(BaseTest):
         )
 
     def test_simple_target_layer_cond(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             LayerConductance,
@@ -326,7 +326,7 @@ class Test(BaseTest):
         )
 
     def test_simple_target_layer_cond_tensor(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             LayerConductance,
@@ -338,7 +338,7 @@ class Test(BaseTest):
         )
 
     def test_multi_target_layer_cond(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             LayerConductance,
@@ -351,7 +351,7 @@ class Test(BaseTest):
         )
 
     def test_simple_target_layer_gradient_x_act(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             LayerGradientXActivation,
@@ -362,7 +362,7 @@ class Test(BaseTest):
         )
 
     def test_multi_target_layer_gradient_x_act(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             LayerGradientXActivation,
@@ -374,7 +374,7 @@ class Test(BaseTest):
         )
 
     def test_simple_target_neuron_conductance(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             NeuronConductance,
@@ -387,7 +387,7 @@ class Test(BaseTest):
         )
 
     def test_simple_target_neuron_conductance_tensor(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             NeuronConductance,
@@ -400,7 +400,7 @@ class Test(BaseTest):
         )
 
     def test_multi_target_neuron_conductance(self):
-        net = TestModel_MultiLayer()
+        net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         self._target_batch_test_assert(
             NeuronConductance,


### PR DESCRIPTION
Renaming models from Test* to Basic* to avoid test warnings. 