### PR TITLE
[WIP] Add seq2seq_interpret.ipynb to Tutorials

### DIFF
--- a/tutorials/seq2seq_interpret.ipynb
+++ b/tutorials/seq2seq_interpret.ipynb
@@ -1,0 +1,857 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Translate and Interpret Samples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook trains a vanilla seq2seq model for German to English Translation on Multi30K dataset. It makes translate a sample sentence and interprets the translation using integrated gradients method.\n",
+    "\n",
+    "The model was trained using an open source sentiment analysis tutorials described in [here](https://github.com/bentrevett/pytorch-seq2seq/blob/master/1%20-%20Sequence%20to%20Sequence%20Learning%20with%20Neural%20Networks.ipynb)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Part 1 - Training Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import fairseq\n",
+    "import math\n",
+    "import numpy as np\n",
+    "import random\n",
+    "import spacy\n",
+    "\n",
+    "import torch\n",
+    "import torchtext\n",
+    "import torchtext.data\n",
+    "import torch.nn as nn\n",
+    "import torch.nn.functional as F\n",
+    "import torch.optim as optim\n",
+    "from torch.autograd import Variable\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ['HTTP_PROXY'] = \"http://fwdproxy:8080\"\n",
+    "os.environ['HTTPS_PROXY'] = \"https://fwdproxy:8080\"\n",
+    "os.environ['http_proxy'] = \"fwdproxy:8080\"\n",
+    "os.environ['https_proxy'] = \"fwdproxy:8080\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device = torch.device(\"cuda:5\" if torch.cuda.is_available() else \"cpu\")\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SEED = 5\n",
+    "random.seed(SEED)\n",
+    "torch.manual_seed(SEED)\n",
+    "torch.backends.cudnn.deterministic = True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "spaCy has model for a handful of languages (\"de\" for German and \"en\" for English)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# for tokenizing the english sentences\n",
+    "spacy_en = spacy.load('en')\n",
+    "# for tokenizing the german sentences\n",
+    "spacy_de = spacy.load('de')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def tokenize_de(text):\n",
+    "    # tokenizes the german text into a list of strings(tokens)\n",
+    "    return [tok.text for tok in spacy_de.tokenizer(text)]\n",
+    "\n",
+    "\n",
+    "def tokenize_en(text):\n",
+    "    # tokenizes the english text into a list of strings(tokens)\n",
+    "    return [tok.text for tok in spacy_en.tokenizer(text)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "TorchText's Fields handle how data should be processed. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SRC = torchtext.data.Field(tokenize=tokenize_de, init_token='<sos>', eos_token='<eos>', lower=True)\n",
+    "TRG = torchtext.data.Field(tokenize=tokenize_en, init_token='<sos>', eos_token='<eos>', lower=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For this task, we are using the Multi30K dataset, which is built in dataset in torchtext."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_data, valid_data, test_data = torchtext.datasets.Multi30k.splits(exts=('.de', '.en'), fields=(SRC, TRG))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SRC.build_vocab(train_data, min_freq=2)\n",
+    "TRG.build_vocab(train_data, min_freq=2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create data iterator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define batch size\n",
+    "BATCH_SIZE = 32\n",
+    "\n",
+    "train_iterator, valid_iterator, test_iterator = torchtext.data.BucketIterator.splits(\n",
+    "    (train_data, valid_data, test_data), batch_size=BATCH_SIZE, device=device\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Encoder(nn.Module):\n",
+    "    def __init__(self, input_dim, emb_dim, hidden_dim, n_layers, dropout):\n",
+    "        super().__init__()\n",
+    "        self.input_dim = input_dim\n",
+    "        self.emb_dim = emb_dim\n",
+    "        self.hidden_dim = hidden_dim\n",
+    "        self.n_layers = n_layers\n",
+    "        self.dropout = dropout\n",
+    "        \n",
+    "        self.embedding = nn.Embedding(input_dim, emb_dim)\n",
+    "        self.rnn = nn.LSTM(emb_dim, hidden_dim, n_layers, dropout=dropout)\n",
+    "        self.dropout = nn.Dropout(dropout)\n",
+    "     \n",
+    "    def forward(self, src):\n",
+    "        \n",
+    "        #src = [src sent len, batch size]\n",
+    "        embedded = self.embedding(src)\n",
+    "        embedded = self.dropout(embedded)\n",
+    "        #embedded = [src sent len, batch size, emb dim]\n",
+    "        \n",
+    "        outputs, (hidden, cell) = self.rnn(embedded)\n",
+    "        #outputs = [src sent len, batch size, hid dim]\n",
+    "        #hidden = [n layers, batch size, hid dim]\n",
+    "        #cell = [n layers, batch size, hid dim]\n",
+    "        \n",
+    "        return hidden, cell"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Decoder(nn.Module):\n",
+    "    def __init__(self, embedding_dim, output_dim, hidden_dim, n_layers, dropout):\n",
+    "        super().__init__()\n",
+    "        \n",
+    "        self.embedding_dim = embedding_dim\n",
+    "        self.output_dim = output_dim\n",
+    "        self.hidden_dim = hidden_dim\n",
+    "        self.n_layers = n_layers\n",
+    "        self.dropout = dropout\n",
+    "        \n",
+    "        self.embedding = nn.Embedding(output_dim, embedding_dim)\n",
+    "        self.rnn = nn.LSTM(embedding_dim, hidden_dim, n_layers, dropout=dropout)\n",
+    "        self.linear = nn.Linear(hidden_dim, output_dim)\n",
+    "        self.dropout = nn.Dropout(dropout)\n",
+    "        \n",
+    "    def forward(self, input, hidden, cell):\n",
+    "        #input = [batch size]\n",
+    "        input = input.unsqueeze(0)\n",
+    "        \n",
+    "        embedded = self.embedding(input)\n",
+    "        embedded = self.dropout(embedded)\n",
+    "        #embedded = [1, batch size, emb dim]\n",
+    "        \n",
+    "        output, (hidden, cell) = self.rnn(embedded, (hidden, cell))\n",
+    "        #output = [1, batch size, hid dim]\n",
+    "        #hidden = [n layers, batch size, hid dim]\n",
+    "        #cell = [n layers, batch size, hid dim]\n",
+    "\n",
+    "        predicted = self.linear(output.squeeze(0))\n",
+    "        #predicted = [batch size, output dim]\n",
+    "        \n",
+    "        return predicted, hidden, cell\n",
+    "    \n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Seq2Seq(nn.Module):\n",
+    "    \n",
+    "    def __init__(self, encoder, decoder):\n",
+    "        super().__init__()\n",
+    "        self.encoder = encoder\n",
+    "        self.decoder = decoder\n",
+    "        \n",
+    "    def forward(self, src, trg, teacher_forcing_ratio=0):\n",
+    "        #src = [src sent len, batch size]\n",
+    "        #trg = [trg sent len, batch size]\n",
+    "        batch_size = trg.shape[1]\n",
+    "        max_len = trg.shape[0]\n",
+    "        trg_vocab_size = self.decoder.output_dim\n",
+    "        \n",
+    "        outputs = torch.zeros(max_len, batch_size, trg_vocab_size)\n",
+    "        \n",
+    "        hidden, cell = self.encoder(src)\n",
+    "        \n",
+    "        input = trg[0, :]\n",
+    "        \n",
+    "        for t in range(1, max_len):\n",
+    "            output, hidden, cell = self.decoder(input, hidden, cell)\n",
+    "            outputs[t] = output \n",
+    "            use_teacher_force = random.random() < teacher_forcing_ratio\n",
+    "            top1 = output.max(1)[1]\n",
+    "            input = (trg[t] if use_teacher_force else top1)\n",
+    "            \n",
+    "        return outputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "INPUT_DIM = len(SRC.vocab)\n",
+    "OUTPUT_DIM = len(TRG.vocab)\n",
+    "\n",
+    "ENC_EMB_DIM = 256   # encoder embedding size\n",
+    "DEC_EMB_DIM = 256   # decoder embedding size (can be different from encoder embedding size)\n",
+    "HID_DIM = 512       # hidden dimension (must be same for encoder & decoder)\n",
+    "N_LAYERS = 2        # number of rnn layers (must be same for encoder & decoder)\n",
+    "ENC_DROPOUT = 0.5   # encoder dropout\n",
+    "DEC_DROPOUT = 0.5   # decoder dropout (can be different from encoder droput)\n",
+    "\n",
+    "enc = Encoder(INPUT_DIM, ENC_EMB_DIM, HID_DIM, N_LAYERS, ENC_DROPOUT)\n",
+    "dec = Decoder(DEC_EMB_DIM, OUTPUT_DIM, HID_DIM, N_LAYERS, DEC_DROPOUT)\n",
+    "model = Seq2Seq(enc, dec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Seq2Seq(\n",
+       "  (encoder): Encoder(\n",
+       "    (embedding): Embedding(7855, 256)\n",
+       "    (rnn): LSTM(256, 512, num_layers=2, dropout=0.5)\n",
+       "    (dropout): Dropout(p=0.5, inplace=False)\n",
+       "  )\n",
+       "  (decoder): Decoder(\n",
+       "    (embedding): Embedding(5893, 256)\n",
+       "    (rnn): LSTM(256, 512, num_layers=2, dropout=0.5)\n",
+       "    (linear): Linear(in_features=512, out_features=5893, bias=True)\n",
+       "    (dropout): Dropout(p=0.5, inplace=False)\n",
+       "  )\n",
+       ")"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optimizer = optim.Adam(model.parameters())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The loss function calculates the average loss per token, however by passing the index of the <pad> token as the ignore_index argument we ignore the loss whenever the target token is a padding token."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pad_idx = TRG.vocab.stoi['<pad>']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "criterion = nn.CrossEntropyLoss(ignore_index=pad_idx)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def train(model, iterator, optimizer, criterion, clip):\n",
+    "    model.train()\n",
+    "    epoch_loss = 0\n",
+    "    \n",
+    "    for i, batch in enumerate(iterator):\n",
+    "        src = batch.src\n",
+    "        trg = batch.trg\n",
+    "        \n",
+    "        optimizer.zero_grad()\n",
+    "        output = model(src, trg)\n",
+    "        loss = criterion(output[1:].view(-1, output.shape[2]), trg[1:].view(-1))\n",
+    "        \n",
+    "        loss.backward()\n",
+    "        \n",
+    "        torch.nn.utils.clip_grad_norm_(model.parameters(), clip)\n",
+    "        \n",
+    "        optimizer.step()\n",
+    "        \n",
+    "        epoch_loss += loss.item()\n",
+    "    \n",
+    "    return epoch_loss / len(iterator)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def evaluate(model, iterator, criterion):\n",
+    "    model.eval()\n",
+    "    epoch_loss = 0\n",
+    "    \n",
+    "    with torch.no_grad():\n",
+    "        for i, batch in enumerate(iterator):\n",
+    "            src = batch.src\n",
+    "            trg = batch.trg\n",
+    "            \n",
+    "            output = model(src, trg, 0)\n",
+    "            \n",
+    "            loss = criterion(output[1:].view(-1, output.shape[2]), trg[1:].view(-1))\n",
+    "\n",
+    "            epoch_loss += loss.item()\n",
+    "    \n",
+    "    return epoch_loss/len(iterator), output\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# N_EPOCHS = 10           # number of epochs\n",
+    "# CLIP = 10               # gradient clip value\n",
+    "# SAVE_DIR = 'models'     # directory name to save the models.\n",
+    "# MODEL_SAVE_PATH = os.path.join(SAVE_DIR, 'seq2seq_model.pt')\n",
+    "\n",
+    "# best_validation_loss = float('inf')\n",
+    "\n",
+    "# if not os.path.isdir(f'{SAVE_DIR}'):\n",
+    "#     os.makedirs(f'{SAVE_DIR}')\n",
+    "\n",
+    "# for epoch in range(N_EPOCHS):\n",
+    "#     print (os.path.join('seq2seq_model_{}.pt').format(str(epoch)))\n",
+    "#     train_loss = train(model, train_iterator, optimizer, criterion, CLIP)\n",
+    "#     valid_loss = evaluate(model, valid_iterator, criterion)\n",
+    "\n",
+    "#     if valid_loss < best_validation_loss:\n",
+    "#         best_validation_loss = valid_loss\n",
+    "#         torch.save(model.state_dict(), os.path.join('seq2seq_model_{}.pt').format(str(epoch)))\n",
+    "#         print(f'| Epoch: {epoch+1:03} | Train Loss: {train_loss:.3f} | Train PPL: {math.exp(train_loss):7.3f} | Val. Loss: {valid_loss:.3f} | Val. PPL: {math.exp(valid_loss):7.3f} |')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Part 2 - Interpreting Translation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Loads the pretrained model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from captum.attr import IntegratedGradients\n",
+    "from captum.attr import InterpretableEmbeddingBase, TokenReferenceBase\n",
+    "from captum.attr import configure_interpretable_embedding_layer, remove_interpretable_embedding_layer\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pretrained_model = Seq2Seq(enc, dec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<All keys matched successfully>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pretrained_model.load_state_dict(torch.load('/home/irisz/local/notebooks/migrated_notebooks/seq2seq_model_6.pt'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Forward method that allows you to extract a output tensor at a specific index."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def ig_forward(src, trg, idx):\n",
+    "    # Make sure the dimentaionality of the output is [batch_size, vocab_size]\n",
+    "    # The batch_size is 1 as we are running on 1 sample\n",
+    "    assert (model.forward(src, trg)[idx][0].unsqueeze(0).shape == (1, len(TRG.vocab)))\n",
+    "    return model.forward(src, trg)[idx][0].unsqueeze(0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In order to explain text features, we introduce interpretable embedding layers which allows access word embeddings and generate meaningful attributions for each embedding dimension.\n",
+    "\n",
+    "configure_interpretable_embedding_layer function separates embedding layer from the model and precomputes word embeddings in advance. The embedding layer of our model is then being replaced by an Interpretable Embedding Layer which wraps original embedding layer and takes word embedding vectors as inputs of the forward function. This allows to generate baselines for word embeddings and compute attributions for each embedding dimension.\n",
+    "\n",
+    "Note: After finishing interpretation it is important to call remove_interpretable_embedding_layer which removes the Interpretable Embedding Layer that we added for interpretation purposes and sets the original embedding layer back in the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/data/users/irisz/captum/captum/attr/_models/base.py:133: UserWarning: In order to make embedding layers more interpretable they will\n",
+      "        be replaced with an interpretable embedding layer which wraps the\n",
+      "        original embedding layer and takes word embedding vectors as inputs of\n",
+      "        the forward function. This allows to generate baselines for word\n",
+      "        embeddings and compute attributions for each embedding dimension.\n",
+      "        The original embedding layer must be set\n",
+      "        back by calling `remove_interpretable_embedding_layer` function\n",
+      "        after model interpretation is finished.\n",
+      "  after model interpretation is finished.\"\"\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "interpretable_embedding = configure_interpretable_embedding_layer(pretrained_model, 'encoder.embedding')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Seq2Seq(\n",
+       "  (encoder): Encoder(\n",
+       "    (embedding): InterpretableEmbeddingBase(\n",
+       "      7855, 256\n",
+       "      (embedding): Embedding(7855, 256)\n",
+       "    )\n",
+       "    (rnn): LSTM(256, 512, num_layers=2, dropout=0.5)\n",
+       "    (dropout): Dropout(p=0.5, inplace=False)\n",
+       "  )\n",
+       "  (decoder): Decoder(\n",
+       "    (embedding): Embedding(5893, 256)\n",
+       "    (rnn): LSTM(256, 512, num_layers=2, dropout=0.5)\n",
+       "    (linear): Linear(in_features=512, out_features=5893, bias=True)\n",
+       "    (dropout): Dropout(p=0.5, inplace=False)\n",
+       "  )\n",
+       ")"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pretrained_model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ig = IntegratedGradients(ig_forward)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 92,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def interpret_sentence(model, src, trg):\n",
+    "    \n",
+    "    # get a list of src_tokens from the src sentence\n",
+    "    src_tokens = tokenize_de(src)\n",
+    "    src_tokens = [SRC.init_token] + src_tokens + [SRC.eos_token]\n",
+    "    src_indices = [[SRC.vocab.stoi[t]] for t in src_tokens]\n",
+    "    \n",
+    "    # get a list of trg_tokens from the trg sentence\n",
+    "    trg_tokens = tokenize_en(trg)\n",
+    "    trg_tokens = [TRG.init_token] + trg_tokens + [TRG.eos_token]\n",
+    "    trg_indices = [[TRG.vocab.stoi[t]] for t in trg_tokens]\n",
+    "    \n",
+    "    model.eval()\n",
+    "    model.zero_grad()\n",
+    "    \n",
+    "    # pre-computing word embeddings\n",
+    "    src_indices = torch.LongTensor(src_indices)\n",
+    "    src_embedding = interpretable_embedding.indices_to_embeddings(src_indices)\n",
+    "    \n",
+    "    # get outputs tensor [seq_length, batch_size, trg_vocab_size]\n",
+    "    trg_indices = torch.LongTensor(trg_indices)\n",
+    "    outputs = model(src_embedding, trg_indices, 0).squeeze(0)\n",
+    "    \n",
+    "    # get output_tokens from outputs\n",
+    "    # compute attributions and approximation delta using integrated gradients\n",
+    "    output_tokens = []\n",
+    "    attribution_igs = [] # size: [len(output_tokens), len(src_tokens)]\n",
+    "    for idx, output in enumerate(outputs):\n",
+    "        max_idx = torch.argmax(output.squeeze(0))\n",
+    "        output_token = TRG.vocab.itos[max_idx]\n",
+    "        output_tokens.append(output_token)\n",
+    "        \n",
+    "        attribution_ig, delta =  ig.attribute(src_embedding, additional_forward_args=(trg_indices, idx), target=max_idx, n_steps=10)\n",
+    "        attribution_igs.append(attribution_ig)\n",
+    "    \n",
+    "    return attribution_igs, output_tokens\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Visualize attribution by creating a matrix of probablity of size \\[len(output_tokens), len(src_tokens)\\]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 182,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy\n",
+    "\n",
+    "def plot_attributions(attribution_igs, src, output_tokens):\n",
+    "    # This is an example of how we can visualize attributions.\n",
+    "    # We plot an attribution-based alignments between every output token and every input token.\n",
+    "    \n",
+    "    # get a list of src_tokens from the src sentence\n",
+    "    src_tokens = tokenize_de(src)\n",
+    "    src_tokens = [SRC.init_token] + src_tokens + [SRC.eos_token]\n",
+    "    \n",
+    "    # For each output token, we aggregate and normalize attribution of each input token.\n",
+    "    normalized_attribution_igs = [] #size [len(output_tokens), len(src_tokens)]\n",
+    "    end_idx = len(output_tokens) - 1\n",
+    "    for idx, attribution_ig in enumerate(attribution_igs):\n",
+    "        # Disregard the token <eos> token at the end of the output_tokens.\n",
+    "        if output_tokens[idx] == SRC.eos_token:\n",
+    "            end_idx = idx\n",
+    "            break\n",
+    "            \n",
+    "        attribution_ig = attribution_ig.sum(dim=2).squeeze(0)\n",
+    "        attribution_ig /= torch.norm(attribution_ig)\n",
+    "        attribution_ig = attribution_ig.detach().squeeze(1).numpy()\n",
+    "        normalized_attribution_igs.append(attribution_ig)\n",
+    "    \n",
+    "    normalized_attribution_igs = numpy.array(normalized_attribution_igs)\n",
+    "    \n",
+    "    plot_heatmap(normalized_attribution_igs[:].transpose(), output_tokens, src_tokens)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The heatmap was created based on documentation of creating annotated heatmaps on matplotlib. For more info, read [here](https://matplotlib.org/3.1.1/gallery/images_contours_and_fields/image_annotated_heatmap.html."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 186,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_heatmap(data, x_labels, y_labels):\n",
+    "    \n",
+    "    ax = plt.gca()\n",
+    "    \n",
+    "    # Plot the heatmap\n",
+    "    im = ax.imshow(data, cmap='RdBu', interpolation='nearest', aspect='auto')\n",
+    "    \n",
+    "    # Create colorbar\n",
+    "    cbar = ax.figure.colorbar(im, ax=ax)\n",
+    "    cbar.ax.set_ylabel(\"attributions\", rotation=-90, va=\"bottom\")\n",
+    "    \n",
+    "    # how all ticks and label them with the respective list entries\n",
+    "    ax.set_xticks(np.arange(data.shape[1]))\n",
+    "    ax.set_yticks(np.arange(data.shape[0]))\n",
+    "    ax.set_xticklabels(x_labels)\n",
+    "    ax.set_yticklabels(y_labels)\n",
+    "    ax.set_xlabel('Output Sequence')\n",
+    "    ax.set_ylabel('Input Sequence')\n",
+    "    \n",
+    "    # Turn spines off and create white grid\n",
+    "    for edge, spine in ax.spines.items():\n",
+    "        spine.set_visible(False)\n",
+    "    \n",
+    "    ax.set_xticks(np.arange(data.shape[1]+1)-.5, minor=True)\n",
+    "    ax.set_yticks(np.arange(data.shape[0]+1)-.5, minor=True)\n",
+    "    ax.grid(which=\"minor\", color=\"w\", linestyle='-', linewidth=3)\n",
+    "    ax.tick_params(which=\"minor\", bottom=False, left=False)\n",
+    "    \n",
+    "    # Set alignment to center\n",
+    "    kw = dict(horizontalalignment=\"center\",\n",
+    "              verticalalignment=\"center\")\n",
+    "    kw.update()\n",
+    "    \n",
+    "    # Get the formatter in case a string is supplied\n",
+    "    valfmt = \"{x:.1f}\"\n",
+    "    if isinstance(valfmt, str):\n",
+    "        valfmt = matplotlib.ticker.StrMethodFormatter(valfmt)\n",
+    "    \n",
+    "    # Loop over the data and assign the probablity for each output-input token alignment pair.\n",
+    "    # Change the color of probability depending on the value.\n",
+    "    textcolors =[\"black\", \"white\"]\n",
+    "    threshold = im.norm(data.max())/2.\n",
+    "    texts = []\n",
+    "    for i in range(data.shape[0]):\n",
+    "        for j in range(data.shape[1]):\n",
+    "            if data[i, j] == \"nan\":\n",
+    "                continue\n",
+    "            kw.update(color=textcolors[int(im.norm(data[i, j]) > threshold)])\n",
+    "            text = im.axes.text(j, i, valfmt(data[i, j], None), **kw)\n",
+    "            texts.append(text)\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Translate sample sentences and interpret them"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 180,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "attribution_igs, output_tokens = interpret_sentence(\n",
+    "    pretrained_model, \n",
+    "    'Ein mann im blauen Hemd.', \n",
+    "    'a man in blue shirt.'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 181,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAaAAAAEGCAYAAAAjc0GqAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8QZhcZAAAgAElEQVR4nOydd3gUZdeH75NKAoQOKbRggdACBIg0BekiiGBBQcWCDUTF8uL7WkE/EBXFhoAUS2yA0kQ6EVGEUIUgSotCGj0JJECyOd8fu0k2lYVMEspzX9dcmXJmnt/ObPbM084RVcVgMBgMhtLGrawFGAwGg+HKxDggg8FgMJQJxgEZDAaDoUwwDshgMBgMZYJxQAaDwWAoEzzKWkAZYob/GQwGV5HiXsDNr7aScdolW007ulRVexW3zIudK9kBGQwGQ+mRcRqPhv1cMk3fOrN6Cau5KDAO6CLhRe+ryqTc18/szV5POplaJhoAKlXwzV6fWbVRmWi4/9iu7PVHpX6ZaAD4RGOy1099/XqZaCh/14vZ60+5B5eJBoD3bPuz1ztP/LlMNESOusGaC4kgbu7WXOsywTggg8FgKBUENw+vshZxUWEckMFgMJQGpgaUD+OADAaDoRQQQNyNA3LGOCCDwWAoDURwMzWgXBgHZDAYDKWEaYLLjXFABoPBUBqYPqB8GAdkMBgMpYAguHl4lrWMiwrjgC4RVJVltqPszUzFU9y42b0GAW7e+ex22k7ya+YJMlGuEV9u9KhmqY4Vy5cx+vnnsWXauPfe+3j6mWdzHT9z5gyPPjyMrVu3ULVqVWbM+px69epZqkFV+SrtENvTT+ElwoO+AdTzKJfP7vezyfyYdhQRqCweDCsfQEU3677yivIbx/mXNDwQOlONGuR/Jns4xRaSUKAuPlxHFes0qPLc54tZtvVvfLw8mfLoAFoEBxZqf8fbX7L/0HGiJjxhmYYsHT/rMWIc96KHVKem5L8Xf+spNugJFAjGh45uVS3TcGzXevbM+xDNtBEQ3oe6XQfnszm0dTX/LJsFCBUCryJkyEuWlX9OTA0oHyYW3CXCXk3jmKbzmGcdbnKvzhLbkXw2qWpjpe0od3sE8IhnHU5iY39mmmUabDYbzz4zijnf/8D6qE3MmTObXbv+zGXzxeefUblyZbZs287jw0fw6svW/4NvzzhFoi2dcX7B3Ofrz+epifm1qvJ16iGer1iHMX7B1Hb3ZuWZE5bqOMBpkkhnEIFcTzXWciyfzWlsrOc4N1OLOwgkDRsHse6ZLNu6m70JR9k28Sk+eOgWnpqxsFDb+RuiKV+uZOahxJDGCTK4T4LoKtVYpUfz2aSpjV/0GAPEn3vcgkjFxr9qzb3QTBu7v59Es2Fv0ub5zzi0ZRWnEmJy2aQePsiBlRG0GPEhbZ6fxVW3jLCk7PNB3NxdWq4USt0BiYiXiJS36FrlRaTE6rQxMTGEhIQwbNgwmjRpQo8ePUhLS2PatGm0adOG0NBQBg4cSGqqPYLA0KFDGTlyJO3bt6dBgwbMmTPHMi1/Z56iuVtFRIQgt3Kc1kxSNCOXzQlNp6p4Ul7sX+Bg8WFX5inLNGzauJEGDRpQPzgYLy8vBg68jcWLFuWyWfzjIu662/7meUv/W/k5MhKrs+5uOXuS9t5+iAhXefiQqjZOZOa+F+pYzqiiqpzWTCpbWPsBiCGVa6mAINTCmzNkcorcOpLJwA9PfLA/kyDKsR/rIk4s2vQnd3VqgYjQ9po6JKWmkXA8JZ/dydNn+HDxbzzfv7NlZTuzT1MJkfKICAFSzn4v8nw/k8igMp74Or6fdcSHPWrNvUj+dxc+1YLwqRaIm4cnNVveyNHoX3PZxP++iMAO/fH0rQiAV0XraqIuIYK4u7u0XCmUmgMSkRAReQf4C7jWsW+8iOwUkT9E5G3Hvvoissqxb6WI1HXsv11EdojINhFZ47jstcDfIvK2iISUhO7du3czfPhwoqOjqVy5MnPnzmXAgAFERUWxbds2QkJCmD59erZ9fHw8a9euZdGiRYwePdoyHSlqw09yfkD9xJ0UteWyqSKeHNV0Tmg6mar8lXmK5Dw/AsUhPj6OoKDa2duBQUHEx8fntomLI6i23cbDwwO/Sn4cO5r/bbg4HNcMqjo5k6punhzP44A8RLjXtxYvJ8cwKmkvcZlnud6rkqU6TmGjPDk/FuXxIJXcz6QSHiSRTgoZZKLEkMbJPDbFIf54MrWr5nyuwKqViDuenM9u7OyVPNGnA77eJfO+dhIbFZxa9Cvgke9zVsaDE6ST7Ph+7tVUTmLN9/Ns0mG8K9fI3vauVIMzSYdz2aQdPkDq4YNs+WAEmyc9xrFd6y0p21UEUwPKS4k6IEcN5X4RWQtMA3YCzVV1i4hUA24FmqhqcyAr6NUHwGeOfRHA+479LwM9VTUU6AegqluA5sAu4FMRWesor8Aalog8LCIbRWTj1KlTXfoMwcHBtGjRAoCwsDBiYmLYsWMHnTp1olmzZkRERBAdHZ1t379/f9zc3GjcuDGJifmbhkoSH3Gnl0d1fsg4xOcZcVQWzyu2jTVDldVnTvCqXz0mVrqK2u7e/Hg6fxNZSeONOx2pygoOM58EKuJe6s/kj5h49iceo1+bxqVccm7KiTtdpBqL9TCzNQE/PIofYvo80EwbaUcOEvr4e4QMeZm/v3ubjLT8tcUSQ9xw9/ByablSKOlBCPHAH8BDqrorz7Ek4DQwXUQWAVltOe2AAY71L4AJjvVfgVki8h3wfdZFVDUF+BS7AwoBpgOTAL+8YlR1KpDleVxqF/L2zulIdXd3Jy0tjaFDhzJv3jxCQ0OZNWsWkZGRBdoXt+lpoy2JLZn2f5BA8c5Vm0lWGxUl/5vStW7ludbN7n8325It/QcPCAgkNvZg9nZcbCwBAQG5bQIDiT14kKCgIDIyMkhOSqZqteIPhFh5+jhrziYBEOxejmNONZ5jmelUydO8dsBmD3tf093+z9zGsyKLLXBAO0hhF/ZnUgNvTjm95Z8iA1/yP5P6+FIfe7DVnaQgxXwqU5atZ9bqjQCENQji4LGk7GNxx5IIrJL7q79+9wE274uj8ch3yMjM5HDSKXqNnc6Slx4slo5tmswOtd+LWnjnqs2cJIMKBdyLBuJLA7Hfi+2agptFrbNelWpw5kROjedM0mG8K9XIZeNduQZ+dRvj5u6BT7UAfGrUIfVwLH51Syn4rZh5QHkp6Zex24BY4HsReVlEsodDqWoG0BaYA9wMLCnqQqr6KPAiUAfY5KhBAdnNdq8APwAHHOWWGCkpKQQEBJCenk5ERESJldPavRLDPGszzLM217qV54/MFFSV2MzTeIsbFSX/+8MpR7NcmtrYlJlMC/eKlulpFRbG3r17iYmJ4ezZs8ydO4feffrksul9Ux++/sp+T+bP+4Hrb7gBkeK7wa7lqvCaX31e86tPS68K/HYmGVVlb0YavuKer3+nspsncbYzJDscVXRGKgHuxX+zbEpFbiOQ2wikPj78zUkUJZEzeOFG+QLe6dIcTuoMNnaSQiMqFEvDIz3CWTduOOvGDefm1iF8/ctWVJUNuw/g51MO/yq5n/mw7m3Z8/Hz7Hz/GZa/8hBXB1QrtvMBCBU/BrsFMdgtiKvElz/1FKpKvJ7GGzfKF/D9THV8P0+rjT80mSZizffTr05D0o4cJO1oPJkZ6RzasopqTdrnsqnetCMn9m4FIP3kCdIOH8CnWkBBlysRBDFNcHko0RqQqi4DljmcxRBgvogcAR4CjgC+qrpYRH4F9jlO+w0YhL32Mxj4BUBErlLV9cB6EekN1BGRithrP9WBmUAH1QKG31jM2LFjCQ8Pp0aNGoSHh5OSUvLV+KvFh72SysfpB/AU4Wb3mtnHpqUfZJinvd9lme0IhzLPAtDRvQrVxLrqvIeHB2+9/Q4D+9+CLdPGkHvuJSSkMW+8PpaWLVtxU58+3HPvfTwy7CFahjajSpUqzJj5mWXlZ9Hcozx/uJ9idPJ+vBAeKJ/zI/JKcgyv+dWnipsH/Xyq82bKAdwFqrl58qCvtT82dfHhX9L4hrjsYdhZzCGO27APh/6VYxwlHYAwKlEZ6/phera4lqVb/6b50+/i4+3JJ48MyD7W7oWPWDduuGVlFUV9fIghjc80Fg+E7pKTziYiM5bBbkEA/KzHOKL272dbqUQVi8YQibsHVw94ku1Tn0M1E/+2vSnvH8z+JTOoWLsh1Zt2oErDthz7ayNRE+5DxI0GfR/Fs7y1/YLn1HkFORdXEKtHKJ2zQJG22JvmMoD5QDns/XNvq+pnjlrSTOxO5TBwv6r+KyLfA9c4bFcCTwG1gQBV3XABUi6qjKgmH5DJB5SFyQeUw0WUD6jY1XivavW1Zi/XpiXEfvXQJlVtXdwyL3ZKfSJqHmfRtoDj/wA3FrB/QN592JvbDlinzmAwGEoKMxE1LyYSgsFgMJQCIoKbpzVN4iLSC/tgK3fgU1Udn+f4u0AXx6YvUFNVKzuO2YDtjmP/qqprecJLAOOADAaDoTSwKBSPiLgDHwHdgYNAlIgsUNWdWTaq+rST/RNAS6dLpKlqi2ILsYArdZqIwWAwlDoWjYJrC+xR1X2qehb4BrilCPu7gK8t+giWYhyQwWAwlBJubuLSAlTPmjTvWB52ukwQufu+Dzr25cMxqCsYWOW0u5zjmr+LSH+LP+J5YZrgDAaDoRQQEcTN5cF0RywaBTcImKOaK25XPVWNFZEGwCoR2a6qews5v0QxDshgMBhKCXd3SxqdYrFPyM+itmNfQQwCck0GU9VYx999IhKJvX+oTByQaYIzGAyG0kBA3MSl5RxEAdeISLCIeGF3MgvyFSfSCKgCrHPaV0XEnqhJRKoDHbDH6CwTSn0i6kXEFfvBDQbDeVPsiag+ta7W+ndPdMl213u3FDkRVURuAt7DPgx7hqq+ISJjgI2qusBh8ypQTlVHO53XHpgCZGKvgLynqtPzXr+0ME1wBoPBUCoIbhbERQRQ1cXA4jz7Xs6z/WoB5/0GNLNEhAUYB2QwGAylgaMJzpCDcUAXCelxf5dJuZ6B12av2/ZvKhMNAO7BYdnrZ5JKPJ5sgXhXygkmmp6wp0w0AHj6X529bttbuknTsnC/Kjx7vayeB+R+JuNX7y4TDaO7XGPZtYwDyo1xQAaDwVAKiIC7h3FAzhgHZDAYDKWEFbmxLieMAzIYDIZSQCQ7yoHBgXFABoPBUEqYPqDcGAdkMBgMpYRxQLkxDshgMBhKA8GyeUCXCyYUzyWCqvL0S68T0qE7rbr1Zcv26ALtXhr/Lg1a30CVa1oWeNwKHU+99hYNu/SnZe9BbN6xK59Natpp+j7wJE26DaR5zzt44c0PLNcw6vkXaNyyDa3bX8+WrdsKtNu8dSth7TvRuGUbRj3/AlZH/VBVnn5xDCHtutLqxpvZ8kchz2TcRBqEdaLKVaGWlp+l4akx79Dwxtto2Wdw4c/joVE06XEnzXvdxQsTPioRHWX9TP7asIZ37u3JW0O6EfnVlELtdqxZygs3XsvBv7YXalMSCIKbh5tLy5XCJftJRWSxiFQuax2lxZJVa9izP4ada5cx+c2xjHjh1QLtbu7ehV9/nF1iOn6K/JXdMQfYteoHJv/f/xj+0rgC7UYNu4foFXPZuDCC3zZt46fIXy3TsHT5Cvbs20f05g18NGkiI595rkC7kaOe4+NJ7xK9eQN79u1j2YqVlmkAWLLqZ/bs+4edv61g8ltjGTH65QLtbu7RhV8Xz7W07Cx++nmd/XmsnM3k119g+CsTCrQb9eBgopd9y8YFn/Pb5j/46effLNVR1s8k02ZjwaTXuH/8NJ6euZhtqxaRGJN/LteZ1JP8Ovcz6oRY/zJwTuS80jFcEVyyDkhVb1LVEyVZRkxMDCEhIQwbNowmTZrQo0cP0tLSmDZtGm3atCE0NJSBAweSmpoKwNChQxk5ciTt27enQYMGzJkzxzItC5euZPBt/RERwsNacCIpmfjEQ/nswsNaEFCrpmXl5tOx4mfuufUmRITrWjYjKTmF+ENHctn4+pSjSzt7GCsvL09aNW1EbEJ+rResYfFPDB50h/1etGnNiaQk4hMSctnEJySQnJJCeJvWiAiDB93Bgh8XF3LFC9SxZAWDb896Ji05kZxSyDNpWWLPZOGKNU7PoylJyScLeR72ib5eXp60atKQ2HjrngeU/TM5sOsPqgXVo2pgXTw8vQi9sQ9//rYin92yGZO44a5heHh5W1Lu+SIiLi1XCpeEAxKRISKyQUS2isgUEXEXkRgRqS4i9UXkTxGZJiLRIrJMRHysKnv37t0MHz6c6OhoKleuzNy5cxkwYABRUVFs27aNkJAQpk/PieUXHx/P2rVrWbRoEaNHjy7iyudHXEIidQL9s7drB/gTl5Bo2fVdJTbhMLUDcnQE+dcq0rmcSE5h0cpfuLF9G8s0xMXHUzsoJ/9WUGAgcfHx+WyCAgOLtCm2joRE6gQGZG/XDvAnLr50n0ls4mFqB+Q4tyD/msQmHi7U/kRyCotWrbX0eUDZP5PkI4lUqpnzvfSr7k/S4dzPIvbvaJIOx9Poui6WlHm+CCBuri1XChf9RxWREOBOoIMjj7kNGJzH7BrgI1VtApwABhZyrYezMgxOnTrVpfKDg4Np0cKePj0sLIyYmBh27NhBp06daNasGREREURH57T99+/fHzc3Nxo3bkxiYuk7iIuJjIwMBj/5P0bcdycN6tYuazlXPBkZGQx+6iVG3HsHDeoWmEDzsiUzM5MfJ4+jz2PWvRSeN6YJLh+Xwii4rkAYEOWomvoAeV+596vqVsf6JqB+QRdS1alAludxqffT2zunqu7u7k5aWhpDhw5l3rx5hIaGMmvWLCIjIwu0L24H6+RZEUyP+A6A1i2acSAup0njYHwCgf61inV9V/n48++Y/u08u47mjTkYn6MjNiGRIP+Cm5ce/e8bXFO/Dk8+cHexNXwybTozPvsCgLBWLTgYm5N/KzYujsCAgFz2gQEBxMbFFWlzIUye+SXTI74FoHVocw7E5bzBH4xPIDCg5J/Jx1/MYfp38+0amoVw0Kk5LTbhEEG1ahR43qMvjrc/j/sHWaLjYnkmAH7Va5F0KOd7mXwkgUo1cp7F2dRTJO7/m6lP3wPAyWOH+fzFx7j39cnUblhawaEFN2sS0l02XAp3Q4DPVLWFY2lYQJjxM07rNkrYsaakpBAQEEB6ejoRERElVs5jQwezcfl8Ni6fT7+e3YiYMw9VZf2mrVTyq1iifT3OPH7vHWz68Ss2/fgV/bp35osfFqOq/L5lO34VKxBQs3q+c15652OSUk4y8aVnLNHw6LAH2bA2kg1rI+nX5yYivvnOfi+iNlLJz48Af/9c9gH+/vhVrMj6qI2oKhHffEffm3oXW8dj9w9h44qFbFyxkH69uxExO+uZbKFSxdJ5Jo/fcxubFn7BpoVf0K/7DU7PY0fhz2PiJ/bn8eLTlum4WJ4JQO1GzTgSG8Ox+ANkpJ9l26ofCWnXNft4uQoVeWneBv7z9Wr+8/Vq6jRuUcrOxx4LztSAcnMpOKCVwG0iUhNARKqKSL2yFDR27FjCw8Pp0KEDjRo1KpUye3e9geC6dQjp0J1Hn3+JD/7vlexjrbvfkr0++vUJBIddT2paGsFh1zPmHWuHQN/UpQMN6gTRsEt/Hn3hdT4ck9OkEdbHXtM5GJ/IuI9m8Oee/bTpO4SwPndn16CsoFeP7gTXr0fjlm14/MmnmfROzsivth07Z69PemcCj418isYt29AguD49u3ezTANA766dCa5Xh5B2XXn02Rf5YNyr2cdad+ubvT567JsEt+pofyatOjLm7fct03BT5/b253HjbTz6v3F8+FrO6LOwvva3/YPxhxj38Sz787jlPsL63sP0b+dbpgHK/pm4u3vQ74mXmfGfB3l3aG+ad76JWsHXsHzmJHb+au3ox+JgUUbUy4ZLIiOqiNwJvIDdYaZjz3H+DdAaqAAsUtWmDttngQoFJWPKw0X1wU06BpOOIQuTjiGHiygdQ7G9QqV6jfS6/7iWfHTZ8I5FZkS9XLgU+oBQ1W+Bb/Psru/4ewRo6mT7dinJMhgMhvPC/Qqq3bjCJeGADAaD4VJHEOOA8mAckMFgMJQCIuB1BYXZcQVzNwwGg6EUEAEPN3FpOfe1pJeI/CUie0Qk3+QmERkqIocdk/e3ishDTsfuE5HdjuU+iz/meWFqQAaDwVAKCNb0AYmIO/AR0B04iH2O5AJV3ZnH9FtVHZHn3KrAK9gHcCmwyXHu8WILuwBMDchgMBhKA7H3AbmynIO2wB5V3aeqZ7GPCL7lHOdk0RNYrqrHHE5nOdDrgj9TMTEOyGAwGEoBew3IzaUFqJ4VNsyxPOx0qSDggNP2Qce+vAwUkT9EZI6I1DnPc0sF0wRnMBgMpcR5NMEdKeY8oIXA16p6RkQeAT4DbizG9UoE44AuEpwnhJYVzpNByxLnyYdlhfNk0LLEeUJoWXExPA/InhB6yeImYtUouFigjtN2bce+bFTVefbwp0BWaIpYoHOecyOtEHUhmCY4g8FgKCXcRVxazkEUcI2IBIuIFzAIWOBsICLOUV77AX861pcCPUSkiohUAXo49pUJpgZkMBgMpYCINaPgVDVDREZgdxzuwAxVjRaRMcBGVV0AjBSRfkAGcAwY6jj3mIiMxe7EAMao6rFii7pAjAO6SFi1u/AkYiXJjdfkhO7/dX/ZxfzqEJzTzLP8b2uzdbpK92tzIllfLPHPzv7+Q5lo8Lru1hwNh2LKRAOAV8362es/7LA2oaCr3NrUmpQRYF0oHlVdDCzOs+9lp/UXsMfPLOjcGcAMS4QUE+OADAaDoRTImohqyME4IIPBYCgFBMsGIVw2GAdkMBgMpYBVfUCXE8YBGQwGQylgVSieywnjgAwGg6E0MDWgfBgHZDAYDKWAyQeUH9MjdomwYc0q7uvZjnu6teXrKe/nOz57xmTu792Rh/rewLP3DiQx9kABVyk+v/+8kru6hnNnlzZ8MXlSvuPffPoxQ3q0577e1/Pk4FtJKAEdUWtW8UDP9gztHs43U/Pfi0Vff8bDfW/g0Vtu5Om7+vLPnr8s1wCgqox6/gUat2xD6/bXs2XrtgLtNm/dSlj7TjRu2YZRz7+AqnXZ4FWVpyd+SshtjxM25Gm2/LW3QLubnxpD63uepsXdTzL8zU+w2WyWacjW8d9XCQnvTFjnXmz5Y0eBdi//31tc1bI9VYObWFo+wOa1qxnRtyOP39Se7z/9IN/xpd99zlO33sio27rx33tv4cDevy3XcC4sCkZ62VAmDkhEVES+dNr2cOSuWFQWei52bDYb77/2H8ZN+5oZi9eyatH3xOT5Ub26cTMmf7+MTxf+zPW9bmbqhDElomPiK//h7Znf8uXSX1mx8Hv2786t49omzfh0/go++2kNnXv35ePxr1qu4cMxo3nj06+Y9uMvRC76IZ+D6dJ3AFMX/swn81dxx0PDmTLuFUs1ZLF0+Qr27NtH9OYNfDRpIiOfea5Au5GjnuPjSe8SvXkDe/btY9mKlZZpWLJuM3sOxLNz9kd8PPpRnpgwtUC7r954lo1fvMuWiPc4ciKZuavWWaYBYMnKSPbsj2Hn76v5+O1xPPH8iwXa9enRjbVL5llaNti/F9Pe+C8vfhzBpPmR/PLT/HwOptNNt/LeD6uYOGcF/e9/nJlvvWq5jqJwcySkc2W5UiirT3oKaCoiPo7t7uSJZXQxEBMTQ0hICMOGDaNJkyb06NGDtLQ0pk2bRps2bQgNDWXgwIGkpqYCMHToUEaOHEn79u1p0KABc+bMsUTHrj82E1QvmMC69fH08qJLn1v5bcWSXDYtr+tIOR9fAEJatOZwYpwlZTvz57bN1K4XTJBDR7ebb2Xt8p9y2bRq1ylbR5OWrTmcYO3kwb/+2ExgvWAC6tg13NCnP7+tzH0vyleomL1+Oi3VPvyoBFi4+CcGD7oDESG8TWtOJCURn5CQyyY+IYHklBTC27RGRBg86A4W/Li4kCtegIY1GxjSu7NdQ9OGnDh5ivgj+Se2+5W3P5MMm42z6RmW35KFS5Yz5PYBdh2tW3IiOZn4xPwTisNbtySgVs0CrlA89mzfQkDd+vjXqYenpxcde9/ChtW5I8z4On0vzqSlIpRyTUNMDSgvZelqFwN9HOt3AV9nHRCRtiKyTkS2iMhvItLQsX+oiHwvIksc2fwmOJ1zUkTeEJFtIvK7iNSyQuTu3bsZPnw40dHRVK5cmblz5zJgwACioqLYtm0bISEhTJ8+Pds+Pj6etWvXsmjRIkaPzpeo8II4kphADf+ciOk1/AM4klj4D/tPsyNoe31XS8p25nBCPDUDAnN0BARyuAgdi76LIPwGa3XY74WThlqBHE1MyGe3IGIG93Vry7S3xjL8xTcs1ZBFXHw8tYNynktQYCBx8fH5bIICA4u0KZaGw8eoXat6zvVrVCPucMGRVfo8NYbaN91PRV8fBnRpZ5kGgLj4RGoH5UQMCAoIIC4+/3MpKY4eSqCa0/eiWq0AjhXw3fzp65k81rsdn098nQdfGFtq+sDRB2RNLLjLhrJ0QN8Ag0SkHNAcWO90bBfQSVVbAi8D/+d0rAVwJ9AMuNMpz0V54HdVDQXWAMPyFigiD2fl15g6teCmirwEBwfTokULAMLCwoiJiWHHjh106tSJZs2aERERQXR0dLZ9//79cXNzo3HjxiQmJrpUhpUsnz+bv3ds446Hhpd62c4snfcdu7Zv5e5hI85tXAL0G/wAn63YwEPPvkjE5HfLRMPFxo/vvcw/C6dzJj2d1Zu2l7WcMqH3Xfcz+ad13PP0/5gzNX8fZknjJuLScqVQZqPgVPUPEamPvfaTt02iEvCZiFyDPW2sp9OxlaqaBCAiO4F62BMsnQWy+pA2YW/Wy1vmVCDL87jUE+zt7Z297u7uTlpaGkOHDmXevHmEhoYya9YsIiMjC7S3qrO5ei1/DifktFAeToineq388ak2/fozX01+j4kR8/Dy8s53vLjU8A/gUHxO097h+DhqFKAjau3PfP7Ru3z49QK8vK3VYb8XThoS46hWy79Q+859buX9V/9jWfmfTJvOjICqvhoAACAASURBVM++ACCsVQsOxuY8l9i4OAIDct+PwIAAYuPiirQ5XybP+YkZC5YD0Drkag4mHsm5/uGjBNaoWui55by96NupDQvXRNGtbYvi6ZjxOTO+/Mauo0VzDsbm1Dhi4+MJDCj8uVhNtZr+HHX6XhxNjKdqAd/NLDr27s/U1wsMlVZiCOB+5fgWlyjr3q4FwNs4Nb85GAusVtWmQF+gnNOxM07rNnKcaLrm/OI777eclJQUAgICSE9PJyIioqSKyaZRs5bExuwj/sA/pJ89y+off6B91565bHbv3M67Lz/L2E++oEq1GoVcqZg6mrfkQMw+4hw6Viz6gQ7dcmfz/Tv6D9568RnGT/2SKtWt19Ewz734+cd5tLsx972IjdmXvb4+cjlB9RpYVv6jwx5kw9pINqyNpF+fm4j45jtUlfVRG6nk50eAf+4f3QB/f/wqVmR91EZUlYhvvqPvTb2LpeGx23oT9flEoj6fSN/r2/LlT5F2DTv+olJ5XwKq53ZAJ1PTsvuFMjJs/PTbJhrWK34SzMceuJeoVYuJWrWYvr178OXs7+06Nm6hUsWKJdLXUxhXN21B/D/7STz4L+npZ1n703zadO6Ryybun5zvxaY1KwioG1xq+gAQcHMTl5YrhbKeBzQDOKGq20Wks9P+SuQMShha2qLOxdixYwkPD6dGjRqEh4eTkpJSouW5e3jwxMvj+c+Dd5Jps9H7trupf00jZk4aT8OmLWjftRdT33yVtNRTjBn5IAA1A2vz+idfWKrDw8ODUa+OZ9R9t5OZmUmf2++mwbWN+PTdcTRq1oKO3Xrz0bhXSTt1ipdG2HXUCgzizWnWOWl3Dw9GvDyO/z40iEybjZ4D76L+NY34bNKbXNs0lHZdezH/y+lsWfcL7h4eVPSrxHNv5h+qbQW9enRnyfIVNG7ZBl9fH6Z+lFNO246d2bA2EoBJ70xg2ONPkJZ2mp7du9KzezfLNPRuH8aS3zYTcvvj+Hp7M+3FnCbPNveOIurziZw6fYaBz4/jzNkMMjWTG1o15eFbexZx1QvQ0a0LS1auJiS8M74+PkyblN09S5sbbyJqlb2R44Ux4/j2+wWkpqXRoEU77h98Jy8991Sxy3f38OCh/77BmEfvJtNmo+utg6h7dUO+/nACVzUJpW2Xnvz09Uz++N3+vajgV5kn3ijdJjgBPN3K+p3/4kLO1UwkIgIMBhqo6hgRqQv4q+qGCy5U5KSqVsizrzPwrKreLCLtsKeQPQX8CAxR1foiMhRoraojHOcsAt5W1Ujna4rIbcDNqjq0CBnWTcawAJOOwaRjyMKkY3DScfGkYyh2taRB4+b6eoRrIyAHt6qzqZgpuS8JXKkBfQxkYs8nPgZIAeYCbS600LzOx7EvEkdqWFVdBzjnqH7RsX8WMMvpnJsLuqaqzgGsGQNtMBgMViBXVvOaK7jigMJVtZWIbAFQ1eOONLAGg8FgcBGBK2qEmyu44oDSRcQdR5OViNTAXiMyGAwGw3lgRsHlxhUH9D7wA1BTRN4AbsPRJGYwGAwG1xABT3czCMGZczogVY0QkU1AV+y1yP6q+meJKzMYDIbLCCub4ESkFzAJcAc+VdXxeY6PAh4CMoDDwAOq+o/jmA3Imon8r6r2s0TUBXBOByQi1wHRqvqRY9tPRMJVdf05TjUYDAaDE1Y0wTm6RD7CPtn+IBAlIgtUdaeT2RbsI4ZTReQxYAL2CDIAaapavFnIFuFKfXAycNJp+6Rjn8FgMBhcRHAtDI8LtaS2wB5V3aeqZ7GHNbvF2UBVV6tqqmPzd6C25R/IAlxxQOIUYQBVzaTsJ7AaDAbDpYV10bCDsIcfy+KgY19hPAg4h60v54iJ+buI9L+wD2MNrjiSfSIykpxaz+PAviLsDReA84TQssJ5MmhZ4jwhtKxwngxaljhPCC0zDU6TQcsSx4TQSxZ7H5DL5tVFZKPT9lRHLMvzK1NkCNAauMFpdz1VjRWRBsAqEdmuqgVnMixhXHFAj2IfCfci9qHYK4GHS1KUwWAwXG6cZyieI0VEQogF6jht16aAfGoi0g34H3CDqmbH0FTVWMfffSISCbQEiu2AHPNDewFJqvqzK+e4MgruEDComNoMBoPhykbAolHYUcA1IhKM3fEMAu7OVZRIS2AK0MvxG561vwqQqqpnRKQ60AH7AAUrmAekA1VEZBXwHjBTVQutxrsyCq4G9tw69Z3tVfWB4qo15FBW8bacm1fS4/4u3LCE8QzMibyUnlg2LbyetXKiZs+PLpu4YwC3NMlparovYlOZaPhscFj2+tm135WJBgCvjndkrye8+USZaPD/zweWXMeqYdiqmiEiI4Cl2Idhz1DVaBEZA2xU1QXAW0AFYLY9nGf2cOsQYIqIZGIfAzA+z+i54lBPVZuIiDewXlVfFZEiBz+40gQ3H/gFWIE9zYHBYDAYzhvrsp2q6mLy5FFT1Zed1gsMua6qv2FP5lkS/CUijVR1l4jgSDZarqgTXHFAvqpqXUYvg8FguAK5AmLBVQa2iMjv2BOFRmEfP1AorjigRSJyk8PjGgwGg+ECsIfiuawd0KvkpK04DfwNPF/UCa44oCeB/4rIWexprwVQVfW7cJ0Gg8Fw5XF5V4DojX2EtKfTPl9Hf9X/qeq4vCe4MgquonX6DAaD4crFrfh57S5mbgFqqWpG1g4R2ayqrQo74ZyDAsXOEBF5ybFdR0TaWiLXYDAYrhAEew3IleUSZZOz83EQXdQJ55sRdSz2WHAfUYyMqIbzR1UZ9b/XWLIyEl+fcnz6/tu0bN40n93L//cWEbN/4PiJJI7tL/LZX7iOl99gyaqf8fEpx/R3x9OyWZN8di+Nf5eIOfM4npTM8d1brNfw4hiWrIzEx8eH6ZMmFHgvXhr3tuNeJHN83/YCrlQ8Nq9dzafjXyLTlkn3gXcx8KHcw4SXfPs5i7+ZhZubGz6+5Xn81beoc9W1hVztwojd9htRX7yNZmZydef+NOs3NNfxPWsWsunrSfhWsUeXaNT9Dq7pYn30FVVl1KRZLPl9C77e3nz638do2bBBPrubn/k/Eo4eJ8OWSYfQRrz/9IO4WzQ5RlV5aeEvrPzrH3w8PXjv9q40D8ofVWPAlO85lJJKOU/7z983D/ajegVfSzSci8s5Iaqq3iMiVQHnVjMPEakPHFfVpLznXHIZUUXkN1VtX1bllxVLVkayZ38MO39fzYZNW3ni+RdZu2RePrs+Pbrx2IP30eS6LiWjY9Uau461y9iweRsjXniVXxfNzmd3c/cuPH7/YBp37Gm9hpWR7NkXw851q9iweSsj/vMyv/70fX4NPbry+AP30rhdV8s12Gw2prz+X16b9g3V/AN47s6baNulZy4Hc32fW+l1570AbFi9lBkTXuWVKV9ZpiEz08b6z96k++iP8K1ai8Uv30udsOupHJT7h7/+dd0Jv69kB7Iu+X0rew4msPPrSWzYuZsn3pnO2qlv5LP7asxT+JX3RVUZ9NJE5q5exx3dOliiYdVf/7DvyAl+e3YImw8kMnrezywefnuBth8O6k6L2rUsKddlLu3azTkRkQigPZDitPtqoCn2iky+INauvHpcVBlRS9P5xMTEEBISwrBhw2jSpAk9evQgLS2NadOm0aZNG0JDQxk4cCCpqfags0OHDmXkyJG0b9+eBg0aMGfOHMu0LFyynCG3D0BECG/dkhPJycQnHspnF966JQG1Si6W2sKlKxl8W3+7jrAWnEgqREdYixLTsXDpCgbfcatDQxH3Iqzk7sXu7VsIqFsf/zr18PT0omPvW1i/amkuG98KOS+Cp9NSEYt/fY7ujaZirTpUrFkbdw9P6l/XgwObXIqAYjkL10YxpNf19mfS5FpOnDxF/JHj+ez8yttrGhk2G2fTMyy9J0t27uf2Vo0QEcLq+pOcdobE5FOWXb+4iGMekCvLJUozVQ1W1eZZC7BLVZupaoEZFFxxQHkzoq4F/s86zeeHiJx0/O0sIj+LyHwR2Sci40VksIhsEJHtInKVFeXt3r2b4cOHEx0dTeXKlZk7dy4DBgwgKiqKbdu2ERISwvTp07Pt4+PjWbt2LYsWLWL06NFWSAAgLj6R2kE5M+SDAgKIi0+w7Pou60hIpE6gf/Z27QB/4hISS1dDfCJ1AgNzayjle3HsUALV/XM0VKsVwLFD+aMnLP56Jo/0asdn77zOQy+MtVRD6vFDlK+a8xbvW7UmqcfzO+J/N6xiwQuDiJz0PKeOlsx9ijt8nNo1cwK4BtWoRtyRYwXa9hn1BrX7PkxFXx8GdL7OMg0JyScJrFwhezugUgXik08WaPv07JV0m/QNE1dG4RTsv8RxE9eWS5SfCti3vKgTzumAVDUC+1jucUA89oyo+dtcyoZQ7MFSQ4B7gGtVtS3wKZAvboeIPOwIQ75x6lTXAssGBwfTooU9d1NYWBgxMTHs2LGDTp060axZMyIiIoiOzulr6d+/P25ubjRu3JjExNL9YTZcfNx01/1MWbKOe0f9j9lTJpV6+bVbdmLAewvpN+4bApuG8+uUV0tdQ15+nPg//pn3CWfS01m9eUepl//RoB6sfvpu5j06gPUxccze/FeplS0uLpcoi0XkBueFPNEa8uJKLLi6QCqw0Hmfqv5bbLnFJ0pV4wFEZC+wzLF/O5CvE8QRzjzL87j02uPt7Z297u7uTlpaGkOHDmXevHmEhoYya9YsIiMjC7Qv7pvV5BmfM+PLbwBo3aI5B2Nz3rBj4+MJDPAv7FRLmTwrgukR3zl0NONAXM5b9MH4BAL9S74tffKML5ge8a2ThrjcGkrpXmRRtaY/RxJyNBxNjKdqzcLTBXTq3Z8pY1+wVINvlZqcOpbzkpN67FD2YIMsylWsnL1+dZf+bPqmyInp58Xk75cyY+FKAFo3uoqDh45mH4s9fJTA6lULPbectxd9O7Zm4dqNdGvT/II1zFz3BxEb7KHMQmvXJO5ETo0nPukkAX4V8p0TUMm+r4K3FwNCr2XrwUTuCGt0wRpc5QqIhPCM03p57InztgDXF3aCK01wPwKLHH9XYs8FVFBVqyw447Se6bRdoknzUlJSCAgIID09nYiIiJIqhsceuJeoVYuJWrWYvr178OXs71FV1m/cQqWKFUu0ryeXjqGD2bh8PhuXz6dfz25EzJln17FpK5X8SkfHYw/cw8aVi9i4chH9evUg4rsfHBpK915kcU3TFsT/u5/Eg/+Snn6WtT/Np22XHrls4v7JCaq6cc0KAuoGW6qhWoPGpCQcIOVQLLaMdGJ+X0adVrn/11OPH8leP7hpDZUCrdPw2ICeRM2cQNTMCfTt1IYvl6yxP5Pov6lUwZeA6lVy2Z9MPZ3dL5SRYeOndVtoWDewoEu7zP3tmrPiyUGseHIQvZs0YPbmXagqm/5NoGI5L2r5lc9ln2HL5OipNADSbTaW74qhYa3Sy/10OQ/DVtV+TktXoAmQvyPQCVcmouYKXCcirbAnpbtiGTt2LOHh4dSoUYPw8HBSUlLOfVIx6d2tC0tWriYkvDO+Pj5Mm5QTQb3NjTcRtcpe031hzDi+/X4BqWlpNGjRjvsH38lLzz1lnY6uN7Bk1c+EdOiOj48Pn07M6Q5s3f0WNi6fD8Do1yfw7Q+LSE1LIzjseu6/+3ZefsaaaMa9u3VmycpIQq67ER+fcnz63ps5GrrezMaVi+waxozn2x8W2jW07MD9d9/By889aYkGdw8Phv33DV575G5sNhvdbh1E3asb8tWHE7i6SShtu/Rk8Vcz2fb7L7h7eFDBrzJP/p+1TXBu7h60ve85Vkx4As20cfUN/ahc+yq2zvmEasEh1Am7gV3LvuHA5jW4ubvjVd6PDo+8aqmGLHq3a8mS37cQMuhJfMt5Me2Fx7KPtbn/eaJmTuDU6dMMfGECZ85mkKmZ3NCyCQ/f0t0yDV0b1mPlrn9o99YX+Hh68O7tOaMfu036hhVPDuKszcZdMxaQYcvElql0uro2Q9o2tkzDubBmwPmlgar+KyINRcRdVQsMZC0X0kzkyKBXUhFVz1X2SVWtICKdgWdV9WbH/kjH9sa8xwqh9HoeXcCkYzDpGLIw6RhyuIjSMRS7XhLaspUuWf2LS7aBVSpsKiIh3WWDK31Ao5w23YBWQFwh5iWOqlZw/I0EIp32d3Zaz3XMYDAYLgYu1eY1VxCRZByxQp13q2pFEVmrqh3znuNKP4nzrNYM7H1Bc4ul1GAwGK4whMu7Ca6oANUFOR9wrQ/oteKIMhgMBoMdqycjX0w4hl0XiqrmmyXtShPcQoroL3GkeTUYDAZDUVzak0xd4TXsQ6/XY6/wtcWelC7JsX3+Dgj7sGt/4EvH9l1AIpA/EJnBYDAYCkSAyzsfHSlAiKr+AyAi9YCPiqqkuOKAOuQZjbFQRDaq6tPF02owGAxXFpdzExz2wKMHnLb/dewrFFf6xMqLSPb4VBEJxj7L1WAwGAwuYo+EYE0sOBHpJSJ/icgeEckXdFJEvEXkW8fx9Y6UCFnHXnDs/0tErAxXvwp7OJ77ReR+YKljX6G4UgN6GogUkX3Y72E94JHiKjUYDIYrDSvqP47sBB8B3YGDQJSILFDVnU5mD2LPwXO1iAwC3gTuFJHGwCDsUQoCgRUicm1hE0XPB1UdLiL9gU7YP+onqpo/T4rzZ3FlIqqIeANZwZJ2qeqZouwvES6qiagGg+Gipti+o1WrMF37668u2Zb39Sl0IqqItANeVdWeju0XAFR1nJPNUofNOhHxABKAGsBoZ1tnuwv+YMXAlZTcvsBzwAhV3QbUFZGiIgwYDAaDIS8uxoFzdBNVz4rc71gedrpSELn7Wg469lGQjSNNdhJQzcVzL+zjiQwUkb9FJFlEUrL+FnWOK01wM4FNQDvHdiwwG3uAUoPBYDC4gKgimS63dB25BEPxvAn0UVWX81u44oCuUtU7ReQuAFVNlct8KEdZkDr37TIp13fgs9nrXi0fKBMNAGe3zMhev2PmhjLR8N39bbPXT58q+QCzhVGufE7wkabPLizCsuTY8Xbf7PVf9h0pwrJk6dSgevb6kUnPFGFZclR/8h3LriVqSTLpWKCO03Ztx76CbA46muAqAUddPPdCOQTsPp8TXHFAZ0XEh5yU3FeROw2CwWAwGM6JgjUOKAq4xjEiORb7oIK789gsAO4D1gG3AatUVUVkAfCViEzEPgjhGsCqN76NwHci8gNwOmunqhYaus0VB/QKsASoIyIRQAdgaPF0GgwGwxWIBem/VTVDREZgH+bsDsxQ1WgRGQNsVNUFwHTgCxHZAxzD7qRw2H0H7MQe23O4FSPgHFQAkoGuTvuEImKHuhILbrmIbAauc1zsSVUtuzq5wWAwXIqoZTUgVHUxedJdq+rLTuungdsLOfcN4A1LhOS+br42fMeIvUIp1AE5wiicUNUkVT0qIqlAf+BaEflQVc8WW7HBYDBcQVjUB3RRIiLtsde0nDMo9HM0+81T1fl5zylqGPZ3OCIeiEgL7CPf/gVCgY+tEm0wGAxXBgqZGa4tlybTgM3AQqflBPYR0wWOjCuqCc5HVbMSzw3B3s74joi4AVstk2wwGAxXAoplTXAXKadVdZbzDhF5sahBCEXVgJyHWt8IrARQvbzvoMFgMJQMCpmZri2XJrcVsG9gUScUVQNa5RgtEQ9UwRFUTkQCANP/U8qoKs/NmM/SLbvw8fJkyog7admgdj67W16fRsLxFGy2TNqHBPPuQ7fi7m5NHsaMf9eiyQfAoxyejW4tUGNm7Hoykw+CmwcedTsivtULuFLxSNi+ji1fTUQ1kwad+tGoz325jsesXcS27z7Ap0oNAK7uejsNrr/Fch2qyjPPPc/SZcvw9fFl6pTJtGzRIp/d5i1bePiRx0g7nUbPHj14560JlkVFTtm/iYTVn4LaqNy0BzXCc/8GxK/+lNQD2wHIzDhDRmoSISO+tqRsZ9b/vJL3x/6PTJuNPncOYcijT+Y6/u30ySz67kvc3T2oXLUao9+chH9QnUKudmGoKv/9fjUr/tyPr6cn79/dk9A6tQq1HzJtHv8cTeKX0fcVamM1l3MfEPBSIXNE7xeR11T1lbwHinJATwF3AgFAR1VNd+z3B/53LiWO6KuLVLVpnv2RwLOquvFc1zDksHTLLvbEH+GPD/5D1O5/eWrq9/w8fmQ+uy9G3YOfbzlUlcFvf8736/7g9o75fxQvBLeqVyPVG5Hx7y8FHteUg+iZZDxCBqKph7EdXIfHtX0LtL1QNNPG5i/f4vpnPsC3ak1WjBlKYItO+AU1yGVXp203Wg15ztKy87J02TL27t3Ljm1b2RAVxcinnuaXyNX57EY+9TQfffg+bdu0of+AgSxbvpyePXoUu3zNtBG/cgr1bxuDR8Vq7It4hopXt6VctbrZNgFdHspeP7p5EacP7S12uXmx2Wy8++poJn42mxr+gTx8aw86du1F/WsaZttc07gZ0+Ytp5yPL/MiZjJ5/Gu89sGnlupY8ed+9h0+wYb/PcCmf+J5fvZKlo7KOz3GzqJtuynv7Wlp+S5xeTugoqLj5EtGB0U0wamdb1T1XVWNddq/RVWXFkPkJUNMTAwhISEMGzaMJk2a0KNHD9LS0pg2bRpt2rQhNDSUgQMHkpqaCsDQoUMZOXIk7du3p0GDBsyZM8cyLT9GRXN35zBEhLbX1iMp9TTxx5Pz2fn5lgMgw5bJ2QwbVsascKvgD+7ehR7XpH/tTkoEt/I1UdtZND3VOgHAsX07qVCzNhVqBuHm4Umd8O7Ebl1jaRmusmjRYu6+6y5EhPC2bUlKSiI+ISGXTXxCAinJKYS3bYuIcPddd7Fw4Y+WlJ+WsBuvygF4VfbHzd2TSg07kbJnfaH2SbvWUKnR9ZaU7cyf2zYTVK8+gXXr4+nlRdeb+7N2xU+5bFq160g5H18AGrcI43BCXEGXKhZLtu/lzjaNERFa1w8kKe0MCUkn89mdPHOWyZGbGNXjOss1FIkqZNpcWy5BHJGvfwT2OJYfs6Jhq2qBaRmsaZspHA8RiRCRP0VkjiOwaTYiMtkRaC9aRF5z2h8jItUd660dtSZEpLyIzBCRDSKyRURucewfKiLfi8gSEdktIhOs+gC7d+9m+PDhREdHU7lyZebOncuAAQOIiopi27ZthISEMH369Gz7+Ph41q5dy6JFixg9Ol+ajgsm7mgytatVzt4OrFqJ+KNJBdr2GzuN+g++RgUfb269rrllGs6FpqeCZ06qKPEsb7kDSjtxCN+qOc0qvlVqknb8cD672E2rWfbyYH77aDSpxxIt1ZBFXHwctWvnNIMGBQYRF5f7hzUuLo6goJxYj0FBQcTFW/Pjm37yKJ4Vc5o4PStWJ+Pk0QJtzyYfIj05kfJ1rf8+HEmMp2ZAzmes4R/I4cT4Qu1/nB1B+A1dCz1+ocQnnSSwSs4I4MDKFQp0QOMX/8bjXcLw8XRlHr61iGa6tFyKiEgX7KPdPgDeB3aLSJEPuqQdUEPgY1UNwT5D9vE8x//nCLjXHLhBRM713/E/7CEl2gJdgLdEJOsXrwX2JsNm2PNe5GtgFpGHs6LLTp061aUPEBwcTAtHu35YWBgxMTHs2LGDTp060axZMyIiIoiOjs6279+/P25ubjRu3JjExJL54TsXC14axt5pL3E2PYPIHXvKRENZEtCiEzdNmEePMRHUatKWDZ++du6TLnOSdv2C3zXtETf3MtWxbN5s/tq+jbuGjSiT8rcfPETMkRP0aX5NGZTumIjqynJp8g5wo6reoKqdcfxGF3XCOV8BRORJVZ10rn2FcEBVsxJgfAnk7bS4wxFm3AN7X1Nj4I8irtcD+8SmrAia5YCsBu+Vqprk0LcTe+I857DjqOpUIMvzuBQTw9s7p8nJ3d2dtLQ0hg4dyrx58wgNDWXWrFlERkYWaO9KrqWimPLTr8xcaW9SCbuqDgePnsg+FncsiYBqlQo9t5yXJ33aNOHHqGi6hl5bLB2uIp6+kH4qe1vTT9n3WYhP5Zq5ajSpxw9lDzbIwrtCzn1pcP0t/DH7Q8vK/2TKVGbO+gyAsLBWHDx4MPtYbFwsgYGBuewDAwOJjc2J9RgbG0tgQG6bC8WzQjXSU3KCkqSnHMGjQrUCbZN3rSGg66OWlJuX6rUCOBSf8xkPJ8RRo1ZAPruNv/7M5x+/ywdfzcfLu/Cm3PNh+i9b+WKdfZBFy7q1iDueE0Q27sRJ/CtVyK0hJp6tBxJp9dqnZGRmcuRkKrd88B3zn7jDEj3n5NJ1Lq7grqr7sjZUda8jeV6huFIDKmiIyFAXBeX9Bc7edgTSexboqqrNsbcdlnMcznDSVs7pfAEGqmoLx1JXVf90HHMOkGrDtTh3F0RKSgoBAQGkp6cTERFRUsXwSO8O/P72KH5/exR92zblq8hNqCob/v4HP99yBFTxy2V/Mu1Mdr9Qhs3G0s27uDaoZonpy4v41SXz2B77aLhThxB3L8sdUJXgEE4mHuDU4TgyM9I5sH45gS1y92ukncj5UY7b8gt+AfUtK//RRx5m/bpfWb/uV/re3Ievvv4aVWX9hg34+fkR4O+fyz7A35+KfhVZv2EDqspXX3/NzTffZIkWH/9rOHsijrNJCWTa0kn66xcqXhWez+7M0YPYzpzCJ7BRAVcpPo2at+RgzH7iDvxD+tmzrFw0jw5de+Wy+Tv6D95+8VnGTfmCKtVrFHKl8+fBTi2IfP4eIp+/h97NrubbqJ2oKhtj4vDz8crngO7vGMqOMY+w+ZWHWDTyTq6qUaUUnc9lXwOKEpGZInKjY/kMe+DUQikqFM9d2COsBjtCKWRREXtwO1eoKyLtHNn27gbWAlnDovyAU0CSiNQCegORjmMxQBjwE7nHkS8FnhCRJxyRXVuq6hYXtVjG2LFjCQ8Pp0aNGoSHh5OSUvKh+3u2asTSzX/SbMR4fLy9mPJ4zj/Ndc9O5Pe3R3HqJ8WhiQAAIABJREFUzFnuGD+TM+kZZKpyQ9OrecjCjtaMmEj0ZAJknCY9+lvc/VuSNS3MvXojxK82knKQjD/ngps77nU7WVZ2Fm7uHrQc8ixrJo5EMzMJ7tiXSkEN2PHDFKrWDyGw5fXsWfEtcVt/Qdzc8argR5sHXz73hS+AXj17snTpMpo0D8XXx5cpn+QECAlv14H16+yV/0nvTsweht2je3dLRsABiJs7ATc+wj9zX0UzM6nStBvlqtfl0K8RlKt1NX5X251R0l9rqNSwk2VDv/Pi4eHBU6+M49mhd5CZmclNt91F8LWNmP7ueBo2a0HHbr2YPP410k6d4pUnHgSgZmBtxk/90lId3RsHs+LP/bR9fQY+Xh68f1fP7GOdJ3xB5PP3WFre+SJc9sOwHwMeIaerZQ0wuagTCk3J7YgFFwyMw5HG1UEK8Icjy17hF7YPw16CPUR3GPboq/dgD6D3rKpuFJFZQHvsTWVJwAJVnSUinbBHc03G7pRaq2pnR1qI9xznuAH7VfVmERnqsBnhKHsR8LaqRhYh8aJKyW3yAZl8QFmYfEA5XET5gIrtvVs3b6zrF3zlkq1HcMtCU3JfThRaA1LVf4B/yMmEel6oagxQUJ2/s5PN0ELO/QXI13GhqmnYPWze/bOAWU7bJmW4wWC4uLjMQ/GIyD4KcNSqGlzYOa4MQkghp7bgBXgCp1TVr/CzDAaDwZCXy7wJzrnG5g3cChTZCe1KPqDs9gBHmIVbsOcGMhgMBoPLWJcP6GJEVfOODfhYRDYBrxZ2znmNFFN7h9E8EXmF3P1CBoPBYDgXl7EDEpEwp0137H3/RfoYV5rgBjhtumGvZp0uxNxgMBgMBZEViufyxXnSaQb20cwFZmXNwpUakHM0yayLWh9a+P/bO/P4qqqr73+XWgfaBGr1KUmwEnzbmgQIZBQQpVYSZbBOrSC2po9CVSTKpFhbH1vq4wgYBKuAiENEK1QqESGgooI2CZIEEjpAkL4PyYW+HYT4EBVhvX+ck+QmuTfc5E6BrO/ncz45wzpn/+4++2bdfc7eaxmGYZzQKPrl4WObHaeo6iUdPSeQd0A/7ZwcwzAMownlhO4Bich84HFV3S0idwPDcKbD+I0W7HcekNdF+wEFOAMPFPgQmOodcuE4pUvNAzIMo0sT9Dyg9JTvaMlLgYWF+sqg3E7PAxKRM4FXgL44T6x+pKr/bmUzCGeSaCxO5JgHVPUV99gy4GKcuZkAeap6zCzYIrJdVQeISArOPM6pOLFAB/s7J5BQPC8Bv8OJ1RYPvAqEPqOVYRjGiYwSqYyos3BiY34bJ5O1rwFjh4CfqGoKcBnwuIj08jo+0yvk2TGdj0tj9240UOhGwGn3h34gDqiHqr6gql+6y4u0jM9mGIZhHJOI5QP6AfCcu/4ccGUbJap/VdWd7nod8Hcg2CB91SLyKk4ont+76XfadUCBDEJ4U0RmAS+7F7sOWON283yN/TY6wef/jk7qhtO+3pxb5/P6f7djGWYdMV9vWo9WGBzvEDifH/CdVycSnNazOaL1F//Y245l+Dj1rOY8R1/8a187lmHWcWZzcNfPDv1vO5bh4/QeXz22USBohwYhnCUi3lmjF7nR/APhm6ramJBpH+A/LzkgIlk4QQa80+U+ICL34fagVPVznye3JA8npue9qlorIicB7WZADMQBNUa9bB0CZxyOQ+qHYRiGcQwUDbx384/23gGJyAagt49D97Yo0Qna7LcXIiJxwAvAjapNk5TuwXFcp+Kkr7kb+PWxBKvqYeB1r+2jOAGn/RLIKDi/cXwMwzCMAAnhKDhVvdTfMRHZLyJxqupxHczf/djF4qTBuVdV/+h17cbe0+ci8ixO2pywEFAkBBEZijOiosleVZ8PkybDMIwTEA3FAINAeB0nj9tD7t8/tDYQkVOB14DnVXVFq2ONzktw3h9VhUtoIJEQXgDOAypoHuWggDkgwzCMQFHQIxGZB/QQ8DsRuQkno8GPAEQkA7hFVW92910EfMNNZwPNw60LReRsnKHnFUB4UukSWA8oA0jWYPNLG4ZhdGsiE4pHVf8JfN/H/i3Aze76i4DPjICdiWjQWQJxQFU4L7s8xzI0DMMw/NCxUXDdgkAc0FnADhEpBZqG4qnqFWFTZRiGccJxwgcj7TCBTES9H+dF1H8Dc7wWI4KoKtNm3Uty+gVkXPg9yiu3+bS77zcPcl7/NL5xTnhGx6sq02bOIjk1nYwhF1JeUenTbmt5BekXDCM5NZ1pM2cRyie4qsq0GTNJGZhKZvYQyit8T9TeWl5ORtYFpAxMZdqMmSHV0KTjrntIHpxJxtCL/NdFRQXpQ4eTPDiTaXfdE/K6mHrPfSRlXkj6xSMpr9zu0+6+Bx7mvNQszjz3uyEru42OWb8gKWMI6cMvab99DkjnzG+dFxYN02bMIGXAQDKzsikvb6ddZGaRMmAg02bMCHm78C+QSE1EPW44pgNS1Xd9LZ0pTEQ+bbWdJyKBBUfqWDkjRKQo1NeNJus2vMWumt1Ub/mQhfMeI3/63T7tRufmsGnDm+HTUbyBXTU1VFdsYWHBPPKnTvdplz91Bk/Of5zqii3sqqmheP2GEGoopqamhqrKChY8UUD+nVN9a7hzKgsXzKeqsoKamhqK168PmQaAdes3sGv3bqq3lrKwYC7502f61jFtJk8WzKN6aym7du+meMNbIdOwdsM77Nr9MTtK3+fJOQ8z5a6f+7QbnTuSTetWh6zctjreZtfu3ewo+4An5z7KlBm+04WNzs1h0/o1YdGwbl0xNbtqqNpWyYIFT5B/550+7fLvuJOFCxdQta2Sml01FBeHtl34Q1H06NGAlu6CXwckIvUictDHUi8iByMpMlrs2bOHpKQkJk6cSEpKCjk5OTQ0NLB48WIyMzNJTU3lmmuu4dChQwDk5eWRn5/P0KFD6devHytWrDhGCYGzes06Joz7ESJCdmY6nxw8iGdf2+gJ2ZnpxPVud+JzkDrWMGH8OEdHViafHDiIZ1/LmfKeffs4WF9PdlYmIsKE8eN4/Y3Q/dMpKlrD9ePHuxqyOHDggE8N9Qfryc7KQkS4fvx4Vq9+I2QaAFavedPrnmTwiR8dB+vryc7McOpi3I9CWher1xZzw3XXOBoy0tz74aNdZKSFt128uZYbrvthc/v0pyOM7bPojSKuv75Vu/C0uh+efdTXH2xuF9ePZ3VR+BxzC6wH1Aa/DkhVY1Q11scSo6qxoRYiImeLyEoRKXOXYe7++0XkORF5X0T+JiJXi8gjIrJdRNaKyFdcu8tE5M8ishW4ut3COsDOnTuZPHky1dXV9OrVi5UrV3L11VdTVlZGZWUlSUlJPPPMM032Ho+HTZs2UVRUxKxZoUsaW+fx0Cchvmk7IT6OOk/kx4XU1Xno0yehWUdCPHV1njY2Cd5afdgEpcFTR58+zaFiEuITqKura6WhjoQEb50J1Hla2gSvw0Mf7zLi49vckzqPh4T4+HZtgtOwjz7xrdrFvsiHzqnz7It6+3Tapne7iG9zz+s8dSTEt2oXIWyb7aKKHv4ioKW7EMg7oFByhohUNC60DO9QAMxT1UzgGmCJ17HzgEuAK3CGDr6jqgOABmC0iJwOLMZJnpeO7xAViMgkEdkiIlsWLQosrFJiYiKDBg0CID09nT179lBVVcXw4cMZMGAAhYWFVFdXN9lfeeWVnHTSSSQnJ7N/f3TiuxmG0RXRSEXDPm4IKBJCCGlQ1UGNG+4EqMZ4R5cCyc7kWwBiReRr7vqbqnpYRLbj5Bpf6+7fjhOh4Xzg48boriLyIjCpdeFuML9GzxPQm8fTTjutaf3kk0+moaGBvLw8Vq1aRWpqKsuWLWPjxo0+7YN9ufnUkqUsfb4QgPTBg9hb2/xrrrbOQ3xcXFDXD1jHoiUsfc6Zd5yeNpi9e2ubddTWER/fUkd8fBy13lp92HRYw9OLeHaZE+A3PT2NvXubg3TW1tUS79ULcDTEU1vrrbOW+LiWNp3SsfgZlj73gqMjbRB7vcuoq2tzT+Lj4qitq2vXpqP89pllLH3ByYiSMTiVvXWt2kVvn7+/Qs5vlzzL0hcKm3VEoX0+9fTTPPvsMsD5gdiyXdS1uefxcfHU1rVqF0G2zQ7RjR6vBUKke0DtcRJwgVcOigRVbRy08Dk0Bbc77DUp9iiRd6LU19cTFxfH4cOHKSwsDFs5t9z8n5S+9xal773FFaMvo/Dl36GqlJR9RM/YmLA+02+hY9LNlG5+j9LN73HF6NEULn/Z0VFaRs/YWOJa/cOL692b2JgYSkrLUFUKl7/M2FGjgtPws0mUfLiZkg83M3bMaF5avtzVUEqsHw0xsTGUlJaiqry0fDljxgSnAeCWiTdRumkjpZs2csXoUV73ZEv7dVG2xamLl3/H2FGXB6Xh1pvyKNu4jrKN6xh7eS4vvrLS0bBla0Tbxa03/5SydzdQ9u4Gxo66nBdfeTXi7fOWn/2Mkj9+SMkfP2Ts2DG89FKrdhHX6n7E9SYmJra5Xby0nDGjx4RdJ+A8gjt6JKClu9CVHFAxMKVxw83YFyh/BvqKSOPYzvGhFNaa2bNnk52dzbBhwzj//PPDWVQTl428lMS+55KcfgG33TmdgkcfajqWdVHzpOef/9evOS9lMIcONXBeymBmP/RoaHXkjiSxb1+SU9O5Lf9OCuY2Xz9rWHPk9YK5j3LrlDtITk2nX2IiuTl+Yyd2QkMuiX37kjIwlcm351Mwb27Tsewhw5o1zJvLbZOnkDIwlcTERHJzckKmAeCynJHOPRmcyW13TKVgziNNx7IuHNGsY84j3Jp/J8mDM+mX2JfckaGri8tHXkLiud8iKetCbp12F/MfeaDpWOaI3Kb1e371AP0GZnKooYF+AzOZ/chcX5cLQsf3STz3XJIyhnDr1BnMf/TBZh0XN3/ee+6fTb/+aRw61EC//mnMfvixkGm4LDeXxMS+pAwYyOTJt1Pw+LymY9kXDGlaL3h8HrfdNpmUAQNJ7JdIbm5o20V72Ci4lhwzJXdICxP5VFW/5rWdB2So6u0ichawEEjC6dW8p6q3iMj9wKeq+ljra3gfE5HLgMdxMv29D5ynqu39tOlSoYUsH5DlA2rE8gF56eg6+YCCTsmdlhiv7/6qzZsBn8Te+KtOp+Q+nojo4ytv5+NuLwOWuev/wEl21/qc+/1dw/uYqq7FeRdkGIbR5VBVjh7+MtoyuhQRf39iGIbRLVHQI93n8VogmAMyDMOIEOaAWmIOyDAMIwKoKkcjkw/ouMEckGEYRoToTiPcAsEckGEYRiRQtUdwrTAHZBiGEQFsFFxbzAF1Ebzn40RNg9dcnGjiPR8nWnjPxYkm3vNxoqbhzMiE9jkW7nyc45qj1gNqQVeKhGAYhnHi4g7DDmQJBhE5U0TWi8hO96/PX5YicsQrOPTrXvsTRaRERHaJyCsicmpQgtrBHJBhGEYkcN8BhdsBAbOAt1T128Bb7rYvGrxib17htf9hnMwE/wf4N3BTsIL8YY/gughdIvzMJ/8vKhoATut1dtP6Z58eiIqG07/Ws2m9q4Ql+uLve6Ki4dT/6NusIUrhgKDlI8iu8B0JBiVio+B+AIxw158DNgK+Uyi3Qpx0BJcA13udfz/w21AKbMQckGEYRiRQ5egXAQ9COEtEtnhtL3LTyQTCN1W1McvePsDfC+bT3TK+BB5S1VXAN4BPVLVR6F4gwc/5QWMOyDAMIxIoHA28B/SP9oKRisgGfCfevLdFkaoqIv4CL5+rqrUi0g942823FtHHD+aADMMwIoASunlAquo3p4eI7BeROFX1iEgc8Hc/16h1/+4WkY3AYGAl0EtETnF7QX2AWl/nhwIbhGAYhhEJFPTIkYCWIHkduNFdvxH4Q2sDEfm6iJzmrp8FDAN2uMk+3wGube/8UGEOyDAMIyJopBLSPQSMFJGdwKXuNiKSISJLXJskYIuIVOI4nIdUdYd77G5gmojswnkn9Eywgvxhj+AMwzAiQYTSMajqP4Hv+9i/BbjZXf8AGODn/N1AVjg1NmIOyDAMIwKoKkcCHwXXLbBHcMcJqsq0GTNJGZhKZvYQyisqfNptLS8nI+sCUgamMm3GTEKdcl1VmXb3z0lOyyJj2MWUV27zraOikvShF5OclsW0u38eUh2qyrSZd5GSOpjMC4a2UxcVZGQPJSV1MNNm3hWeupg5i+TUdDKGXEh5RaVfHekXDCM5NZ1pM2eFvC6m/vx+krJHkD7iMsq3Vfm0u++/H+W8wUM5MzElZGW30XHPfSRlXkj6xSMpr9zuW8cDD3NeahZnnvvdsGjoCt+RdhRG6hHccYM5oOOEdcXF1NTUUFVZwYInCsi/c6pPu/w7p7JwwXyqKiuoqamheP360OpY/xa7anZT/VEJCx+fQ/70u3zrmH4XTxbMofqjEnbV7KZ4w9uh01C8npqa3VRVbGXB/ALyp073rWHqNBY+UUBVxVZqanZTvH5DyDQ4Ojawq6aG6ootLCyY146OGTw5/3GqK7awq6YmpDrWvrWRXR/vYccf3+HJxx5kyl2/8Gk3OudSNq1dFbJy2+jY8A67dn/MjtL3eXLOw0y56+e+deSOZNO61WHR0FW+I36JUCie44mIOiAROVVEQhZRUER6ikjYPsOePXtISkpi4sSJpKSkkJOTQ0NDA4sXLyYzM5PU1FSuueYaDh06BEBeXh75+fkMHTqUfv36sWLFipBpKSpaw/XjxyMiZGdlceDAATz79rWw8ezbR/3BerKzshARrh8/ntWr3wiZBoDVa95kwrgfOToyM/jkwAE8+/a30rGfg/X1ZGdmICJMGPcjXn9jTcg0FL2xhuvHj3PrIpMDn7RXF5luXYxjdVGo62INE7x0fHLgoE8dB+ubdUwYPy6kdbF67Xpu+OHVjoaMwXxy8CCe/W1H3WZnDCbum/8RsnLb6ijmhuuucXWkuXWxv41ddkYacb3DE3i3q3xH/KKgRzSgpbsQEQckIkkiMgf4C/Add1+6iLwrIh+JyDp3vDoiMkhE/igi20TktcZAeiKSLyI73P0vu5e+EPiLiNwvIt8Kh/adO3cyefJkqqur6dWrFytXruTqq6+mrKyMyspKkpKSeOaZ5kEiHo+HTZs2UVRUxKxZ/kIwdZw6Tx19+jSHJUmIT6Curq6lTV0dCQnNk5YTEhKo87S0CV7HPvokxHvpiKfO42ll4yEhPq6VTct/BEFpqPPQp8XnjKeuztPGJqG1zlY2IdHRp4M6fNgEpcGznz4JXnUdFxfSug5cxz76xHvXdxx1+yKro6t8R/yhKEePHA1o6S6EzQGJyFdF5KcisglYDOwABqpquYh8BXgCuFZV04GlwAPuqc8Dd6vqQGA78F/u/lnAYHf/LQCq+gYwBGf27usislZEfugvequITBKRLSKyZdGiwKJaJCYmMmjQIADS09PZs2cPVVVVDB8+nAEDBlBYWEh1dXWT/ZVXXslJJ51EcnIy+/e3/QVoGEY3RUGPakBLdyGco+A8wDbgZlX9c6tj3wX6A+ud2HecDHhEpCfQS1Xfde2eA15117cBhSKyCmh6mK2q/wDmAfNEZAiOM/slMLC1IDeWUqPnCegun3baaU3rJ598Mg0NDeTl5bFq1SpSU1NZtmwZGzdu9Gkf7MvNp55exLPLngMgPT2NvXubg0LW1tUS7/WLEyA+Pp7a2uZJy7W1tcTHtbTplI7Fz7D0+RcdHWmD2Vvb/Iuxtq6O+Li4FvbxcXHUev3Kd2yCyynz1KLFzXWRlsbeFp+zjvj4Vhri46htrbOVTed0LGHpc8+7Ogazd28Hdfiw6Si/Xfo8S190HgJkDBrI3lqvuvZ4gq7rgHU8s4ylLyx3dAxOZW+dd317iO8dfh1d5TsSCKpw5IugJ5meUITzEdy1OCEcfi8i94nIuV7HBKj2CgU+QFVzjnG90cBCIA0oE5Em5ykiySLyKE7vaTMwMaSfpBX19fXExcVx+PBhCgsLw1bOLT+bRMmHmyn5cDNjx4zmpeXLUVVKSkuJjY0lrtUXPK53b2JiYygpLUVVeWn5csaMGRW8jok3Ufr+O5S+/w5XjLqcwpd/5+go20LP2Ng2z/Tjen+T2JgYSsq2oKoUvvw7xo66PDgNkyZS8sEmSj7Y5NbFy25dlBHbs726KHPr4mXGjA5BXUy6mdLN71G6+T2uGD2aQi8dPf3ck9iYZh2Fy19m7KjgdNz6nz+h7O01lL29hrGX5/Diq793NGwpp2dMTFjf9bTQcVMeZRvXUbZxHWMvz+XFV1a6OrbSMzYmbO96vOkq35GA0MDe/9g7oBCgqsWqeh0wHOcR2R9EZIOI9MV5F3S222NBRL4iIimqegD4t4gMdy/zY+Bdd6DBOar6Ds4s3Z7A10QkTUT+CCwB/ozziO5mVS0J1+cCmD17NtnZ2QwbNozzzz8/nEU1cVluLol9+5IyMJXJt+dTMG9u07HsIcOa1gvmzeW2yVNIGZhKYmIiuTnH8usd1JFzKYl9zyU5LYvb7phOwWMPNx3LGv69Zh2PPcyt+dNITsuiX2Jfcke2mRfXeQ25OU5dpA5m8pQ7KJg7p+lY9tALmzXMncNtt+eTkjrYrYuRIdPg6BhJYt++JKemc1v+nRTMfbTpWNawi7x0PMqtU+4gOTWdfomJ5Ob4DePVYS6/9HsknnsOSdkjuHX6Pcx/eHbTscxLmv+x3vPrB+k3aAiHGhroN2gIsx99PGQaAC4feQmJ536LpKwLuXXaXcx/5IGmY5kjcpt1/OoB+g3MdHQMzGT2I3N9Xa5TdJXvSHscPaIBLd0FidwYeBCRLMCjqv8jIoOA+TjO5BTgcVVd7O5/CugB7AZ+CnyKEy6iJ07v6UVVfUhEkgBU9U+dkNOl7nJXyHVi+YAsH1Ajlg+oGfc7IsFeJ7lnrD4/LDMg28w33/6ovWjYJwoRjYSgqqVe6xXART5sKoALfJx+oQ/bzjgewzCMiKPA0W40wCAQLBSPYRhGJFC1QQitMAdkGIYRAdSdiGo0Yw7IMAwjEpgDaoM5IMMwjIig3SrKQSCYAzIMw4gEbiQEoxlzQIZhGBFAoVvN8QkEc0CGYRiRQJWjNgquBeaAugjeE0Kjhfdk0GjiPSE0WnhPBo0m3hNCo6bBazJoNOkK35FgULUeUGvMARmGYUSI7pTtNBAsI6phGEYk0MDiwAXbSxKRM0VkvYjsdP+26c6LyPdEpMJr+UxErnSPLRORj72ODQpKUDtYD6iL0BXin33W0BAVDQCnn3FG03q04rB5P3brKnXxv4eio+OrPaJ/P6BVXLx/RT7RHsCpZ4YorUTk5gHNAt5y42XOcrfvbiHFCew8CByHBewCir1MZqpq6FI6+8F6QIZhGBFAAT1yNKAlSH6Ak0sN9++Vx7C/FnhTVQ8FW3BHMQdkGIYRCVQ58sXRgBbgrMbsze4yqQMlfVNVG7MU7gOOlZhpHLC81b4HRGSbiMwTkdN8nRQK7BGcYRhGBFCFo4Gnv/lHe+kYRGQD4OvZ4L0ty1QVEb+FikgcMABY57X7HhzHdSpOBum7gV8HKrwjmAMyDMOIEEdClH9NVf1mNRSR/SISp6oe18H8vZ1L/Qh4TVUPe127sff0uYg8C8wIiWgf2CM4wzCMCKDAEQ1sCZLXgRvd9RuBP7RjO55Wj99cp4WICM77o6qgFfnBHJBhGEaEOKIa0BIkDwEjRWQncKm7jYhkiMiSRiMR6QucA7zb6vxCEdkObAfOAn4TrCB/mAM6TlBVps28i5TUwWReMJTyigqfdlvLK8jIHkpK6mCmzbyLUKdcV1WmTZ9OSv/+ZGZlUV5e7lvH1q1kZGaS0r8/06ZPD6kOpy5mkZyaTsaQCymvqPStobyC9AuGkZyazrSZs07IulhfXMzgQakMHNCfOY891ub4559/zk9+8mMGDujPiIsv4m9/+1vIyvamK9wTVWXqrF+QlDGE9OGXUF65zafdfb95kPMGpHPmt84LWdmBcFThi6Ma0BIMqvpPVf2+qn5bVS9V1X+5+7eo6s1edntUNUFVj7Y6/xJVHaCq/VX1BlX9NChB7WAO6DhhXfF6amp2U1WxlQXzC8ifOt2nXf7UaSx8ooCqiq3U1OymeP2G0OpYt46aXbuo2r6dBQsWkH/HHb513HEHCxcupGr7dmp27aK4uNinXac0FG9gV00N1RVbWFgwr526mMGT8x+numILu2pqTri6OHLkCNOmTeX3r61iy0dbefXVV/nTn1pmqX/uuWX06tWLbdurmHz7FH75y1+EpOzWdIV7snbD2+zavZsdZR/w5NxHmTJjlk+70bk5bFq/JmTldoQIPYI7bjAH1A579uwhKSmJiRMnkpKSQk5ODg0NDSxevJjMzExSU1O55pprOHTIGT6fl5dHfn4+Q4cOpV+/fqxYEbp5XEVvrOH68eMQEbKzMjnwyQE8+1pOzPPs20f9wXqyszIREa4fP47VRW+ETANAUVER10+Y4OrI4sCBA3g8nhY2Ho+H+vp6srOyHB0TJrB69eqQaVi9Zg0TvOrikwMHfdbFwfrmupgwfhyvvxHafzrRrostW7bQr995JCYmcuqpp3LttdfyRlFRC5s3it5gwoQbALjqqqvYuHFjyHuC0DXuyeo313LDdT90NGSmuxr2t7HLzkwnrvexRiaHHiWwx2+hGqhwPGAO6Bjs3LmTyZMnU11dTa9evVi5ciVXX301ZWVlVFZWkpSUxDPPPNNk7/F42LRpE0VFRcya5fsXWGeoq/PQJyGhaTshIZ66Ok8bm4SE+Gab+LY2weuoo0+f5uCUCQkJ1NXVtbFJaKG1rU1wGjz06dPBuvBhE7yO6NaFU36ra3valt9oc8opp9AzNpZ//vOfISm/ZTnRvyd1nn30adH+46jzhPaeB0MEByEcN3QrByQikxondi1atCigcxITExk0yAmFlJ6ezp49e6iz6DNoAAAL9UlEQVSqqmL48OEMGDCAwsJCqqurm+yvvPJKTjrpJJKTk9m/v+2vL8Mwui/mgFrSreYBqeoinIlV4PwgOSanndY8Cfjkk0+moaGBvLw8Vq1aRWpqKsuWLWPjxo0+7YN91PHUosU8u8yJqJGelsbe2tqmY7W1dcTHx7Wwj4+Po7a2+RdwbV1bm07peOopnn32WUdHejp79+710lFLfHx8C/v4+HhqW2hta9NhDYuWsPS55x0NaYPZu7eDdeHDplM6ukBdeF+7ZT3UEh/Xtvy9e2tJSOjDl19+yYGDB/nGN74RkvK7wj357ZJnWfpCIQAZg1PZ26L9e4iPC/6ehwrV0M0DOlHoVj2gUFFfX09cXByHDx+msLAwbOXcMmkiJR9souSDTYwdM5qXlr+MqlJSWkZsz1jierecCB3XuzcxsTGUlJahqry0/GXGjB4VvI5bbqGkpISSkhLGjh3LS4WFro5SYmNjiWv1JY+LiyMmJoaS0lJHR2EhY8aMCU7DpJsp3fwepZvf44rRoyn0qouesb7rIjamuS4Kl7/M2FEnRl00kp6eTk3NLvbs2cMXX3zBihUrGDV6dAubUaNHUVj4IgCvvfYaF198Mc70juDpCvfk1pt/Stm7Gyh7dwNjR13Oi6+86mgo+4iesTFRedfjDyUyo+COJ7pVDyhUzJ49m+zsbM4++2yys7Opr68Pe5mX5eawrng9KamD6XFGD57+7cKmY9lDL6Tkg00AFMydw6RbbqPhswZyRo4kN2dkaHVcdhnr1q0jpX9/evTowdNPPdWsIzubkpISR8fjjzPpZz+joaGBnJwccnNzQ6chdyRri9eTnJpOjx5nsOjJBU3HsoZdROnm9xwNcx9l4q2TaWj4jNyRl5Kb43fyeOd0RLkuTjnlFObMmcuVP7iCI0eO8OOf/ITk5GRmz/41aWlpjB49hhtvzOPmm29i4ID+fP3rX2eZ22MJNV3hnlw+8vusXf8WSRlD6HHGGSx+Yl7TscyLL6XsXWfE3T33z+aVFa9x6FAD/fqn8dMfX88v7w7bZP8mGt8BGc1IOEbEHCd0qQ9u6RiiH/7f0jE0Y+kYmnHTMQTdbexz8ul6++nnBGR7z6FdH7UXC+5EwXpAhmEYEUC72QCDQDAHZBiGESFsEEJLzAEZhmFEAAWCTjV3gmEOyDAMIwIo3WuEWyCYAzIMw4gAzig4c0DemAMyDMOIBDYIoQ3mgAzDMCKA9YDaYg7IMAwjQlgPqCXmgLoI3hNCo6bBawJkNPGefBgtukpdeE8IjRZd4X5A04TQ45ajYIMQWtGdIyEEjYhMcgOcdnsdXUFDV9FhGrqWjq6gwdWxFifFdSD8Q1UvC6eeroA5oCAQkS1dIVxGV9DRFTR0FR2moWvp6AoaDN9YNGzDMAwjKpgDMgzDMKKCOaDgiPpzZZeuoKMraICuocM0NNMVdHQFDYYP7B2QYRiGERWsB2QYhmFEBXNAhmEYRlQwB2Qc14jIB9HWEGlEpK+IVPnYv1FEojLcWET2iEibOS4icoWIzPJzzggRGRomPd2uXRyPWCQE47hGVcPyD8wIDar6OvB66/0icgowAvgUCLmzsHZxfGA9IC9E5BYRqXCXj0XkHRH51Ov4tSKyzF1fJiLzReQDEdktItd62c0UkTIR2SYivwqj3lUi8pGIVIvIpDCV0VdE/ux+3r+KSKGIXCoim0Vkp4hkucuHIlLu1sd33XPzROT3IrLWtX0kDPo+df+OcHsAK1y9hSIioS4vAD1hvycup7if8U/uZ+7RSoe/dnu2iKx022eZiAzraMEi8lUReUNEKkWkSkSucw9NEZGtIrJdRM53bfNEZIG7vkxEnhKREuB3wC3AVPf7NrxTteBfY2O7iBOR99wyqkJdjhEkqmpLqwX4CvA+MBb41Gv/tcAyd30Z8CqOE08Gdrn7c3CGfYp7rAi4KEw6z3T/ngFUAd8IQxl9gS+BAe7n+QhY6n6+HwCrgFjgFNf+UmClu54H7AZ6AqcDfwPOCbG+T92/I4ADQB9X54fAhVFoO5G6JwoMc7eXAjOAjUCGd734aLcvNdYL8C3gT50o/xpgsdd2T2APMMXdvg1Y4tUGFrjry9zvw8nu9v3AjDDdh8Z2MR24110/GYiJdJuwxf9ij+B8UwC8raqrj/EjepWqHgV2iMg33X057lLubn8N+DbwXhh05ovIVe76OW45/wxDOR+r6nYAEakG3lJVFZHtOP8MewLPici3cf4xfsXr3LdU9YB77g7gXOB/wqARoFRV97plVbjaNoWpLH9E6p78j6pudtdfBPIDPO9SINmrXceKyNdU9dN2zmnNdmCOiDwMFKnq++71fu8e/wi42s+5r6rqkQ6UFSxlwFIR+QrO97UigmUbx8AcUCtEJA/nn+Tt7i7viVKntzL/3PtUr78PqurTYRHYWIjICJx/JkNU9ZCIbPShL1R4f86jXttHcdrQbOAdVb1KRPri/BL3de4RwtvmIllWGyJ8T1pP4Gtv21vDScAFqvpZpwtW/auIpAGjgN+IyFvuocb6b6/u/7ez5XYGVX1PRC4CRgPLRGSuqj4fSQ2Gf+wdkBciko7zKOMGt2cDsF9EkkTkJOAq/2c3sQ74TxH5mnvNBBH5jzDI7Qn82/1Hdz5wQRjK6IiWWnc9L4o6ok0k78m3RGSIu349bXt6/tptMTClcUNEBnW0YBGJBw6p6ovAo0BaR6/hUg/EdPLcgBCRc4H9qroYWELntRphwBxQS24HzgTecV9aLgFm4Ty3/gDwHOsCqlqM85z9Q/cR1QrC8yVbi/Mi+k/AQ8Afw1BGoDwCPCgi5XTvXnUk78lfgMluWV8HftvquL92mw9kuANkduAMBOgoA4BS9zHnfwG/6cQ1AFYDV4VjEIIXI4BKt21eh/N43egiWCgewzAMIypYD8gwDMOICuaADMMwjKhgDsgwDMOICuaADMMwjKhgDsgwDMOICuaAjIggIn1E5A9uTLgaESkQkVMDOO/nQZbrN+KyiHxTRIrcmGY7RGRNMGUZhtExzAEZYccNCvp7nFAo3wa+gxOi6IEATg/KAeHMA/EXGfnXwHpVTVXVZJy5M4ZhRAhzQEYkuAT4TFWfBXBjgU3FiRjRwztiMoDbKxkhIg8BZ7gTFQulOTJ3myjQ4pWPRkQy3MjYfWk/4nIcsLdxQ1W3eWnwGdFcRO4VJyr4JhFZLiIz3P1NuXhE5CwR2eOunywij3pd62fufr/Ru0UkU5yo4pUiUioiMf6uYxjHM+aAjEiQghOgsglVPQj8X+D/+DtJVWcBDao6SFUnuLu/CzypqknAQZzIy/7O3wM8Bcxzr/F+K5OFwDPipN241w0xg4jk4AQRzQIGAekicpEbqmmcu28UkBnAZ78JOKCqma79RBFJdI8NBu7EiabeDxjmPpZ8BbhDVVNxYss1HOM6hnFc0p3DphjHJ76iQD/WmQup6joR6QdcBlwOlItIf/xHNI8BXlPVQwAi0ibRmg9ygIHSnC+qp3utL/AdvfsA4FHVMlfjQfe4v+t83JnPbhhdAXNARiTYgZOTpgkRicXJR7MLGEjL3nh7EaT9RX3+0usaAUegVtV/4cTue0lEioCL8BPRXETubOdS/soXnDw561pdawQdi97t8zqGcTxjj+CMSPAW0ENEfgLOexFgDk6StEM4ycwGichJInIOzqOvRg6Lk8ulEX9RoPcA6e76NV72fiMui8glXu+QYoDzcB4L+oto/h5wpYic4dqP9bqcd/neznYdcGvjZxCR74jIV33pcfkLECcimY26xElf3dHrGEaXxxyQEXbUiXh7FfBDEdkJ/BX4jOYRbptxHiXtAOYDW71OXwRsE5FCd9tfFOhfAQUisgWnN9FIexGX04EtIrINJ4PqElUt8xfRXFW34ryfqQTexEl21shjOA6iHDjLa/8S93NtFZEq4Gna6emo6hc4UZufEJFKYD1Oj6pD1zGM4wGLhm0cN7ij2opUtX+UpQAgIvfjpH7u1Dsow+juWA/IMAzDiArWAzIMwzCigvWADMMwjKhgDsgwDMOICuaADMMwjKhgDsgwDMOICuaADMMwjKjw/wEq/K17Knk5mQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot_attributions(attribution_igs, 'ein Mann im blauen Hemd', output_tokens)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 187,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "remove_interpretable_embedding_layer(pretrained_model, interpretable_embedding)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Current stage: still looking for a translation pre-trained model that is easy to work with to demonstrate Captum's functionality. 

The notebook contains two parts: Part 1 is a vanilla seq2seq model, which does not perform that well for demonstrative purpose. This part will be discarded once we found a reasonably good pre-trained model.

Part 2 is the tutorial we want to show, including how we are going to interpret results from the models and show visualization. At the end of part 2, there is an example of attribution matrix. Ideally, we want the diagonal to be blue (having higher attribution score). 

