### PR TITLE
Bump master version to v0.2.0

### DIFF
--- a/captum/__init__.py
+++ b/captum/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/captum/insights/frontend/package.json
+++ b/captum/insights/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "dependencies": {
     "react": "^16.9.0",


### PR DESCRIPTION
Now that we have a `v0.1.0` branch and tag, bumping master to `v0.2.0`. @edward-io is there any way to have the frontend package.json consume the universal version number in `__init__.py`? Not something to change right now, though.