### PR TITLE
Fixing Neuron Indexing

### DIFF
--- a/captum/attr/_core/neuron_conductance.py
+++ b/captum/attr/_core/neuron_conductance.py
@@ -5,13 +5,13 @@ from .._utils.attribution import NeuronAttribution
 from .._utils.batching import _batched_operator
 from .._utils.common import (
     _reshape_and_sum,
-    _extend_index_list,
     _format_input_baseline,
     _format_additional_forward_args,
     validate_input,
     _format_attributions,
     _expand_additional_forward_args,
     _expand_target,
+    _verify_select_column,
 )
 from .._utils.gradient import compute_layer_gradients_and_eval
 
@@ -216,13 +216,10 @@ class NeuronConductance(NeuronAttribution):
             device_ids=self.device_ids,
         )
 
-        # Creates list of target neuron across batched examples (dimension 0)
-        indices = _extend_index_list(total_batch, neuron_index)
-
         # Multiplies by appropriate gradient of output with respect to hidden neurons
         # mid_grads is a 1D Tensor of length num_steps*internal_batch_size,
         # containing mid layer gradient for each input step.
-        mid_grads = torch.stack([layer_gradients[index] for index in indices])
+        mid_grads = _verify_select_column(layer_gradients, neuron_index)
 
         scaled_input_gradients = tuple(
             input_grad

--- a/captum/attr/_utils/common.py
+++ b/captum/attr/_utils/common.py
@@ -131,20 +131,6 @@ def _zeros(inputs):
     return tuple(0 * input for input in inputs)
 
 
-def _extend_index_list(dim_max, base_index):
-    r"""
-    Returns list of index tuples in the form [(0, base_index_tuple),
-    (1, base_index_tuple), ... (dim_max, base_index_tuple)]
-    where base_index_tuple is either an int or tuple of arbitrary length.
-    """
-    assert isinstance(base_index, tuple) or isinstance(
-        base_index, int
-    ), "Base index must be either an integer or tuple"
-    if isinstance(base_index, int):
-        base_index = (base_index,)
-    return [(ind,) + base_index for ind in range(dim_max)]
-
-
 def _reshape_and_sum(tensor_input, num_steps, num_examples, layer_size):
     # Used for attribution methods which perform integration
     # Sums across integration steps by reshaping tensor to

--- a/captum/attr/_utils/gradient.py
+++ b/captum/attr/_utils/gradient.py
@@ -3,7 +3,7 @@ import threading
 import torch
 import warnings
 
-from .common import _run_forward, _extend_index_list
+from .common import _run_forward, _verify_select_column
 from .batching import _reduce_list, _sort_key_list
 
 
@@ -100,12 +100,9 @@ def _neuron_gradients(inputs, saved_layer_outputs, key_list, gradient_neuron_ind
             current_out_tensor = saved_layer_outputs[key]
             gradient_tensors.append(
                 torch.autograd.grad(
-                    [
-                        current_out_tensor[index]
-                        for index in _extend_index_list(
-                            current_out_tensor.shape[0], gradient_neuron_index
-                        )
-                    ],
+                    torch.unbind(
+                        _verify_select_column(current_out_tensor, gradient_neuron_index)
+                    ),
                     inputs,
                 )
             )

--- a/sphinx/source/common.rst
+++ b/sphinx/source/common.rst
@@ -8,7 +8,6 @@ Captum.Utils
 .. autofunction:: format_input
 .. autofunction:: _format_attributions
 .. autofunction:: zeros
-.. autofunction:: _extend_index_list
 .. autofunction:: _reshape_and_sum
 .. autofunction:: _run_forward
 .. autoclass:: MaxList

--- a/tests/attr/test_neuron_gradient.py
+++ b/tests/attr/test_neuron_gradient.py
@@ -5,7 +5,6 @@ import unittest
 import torch
 from captum.attr._core.saliency import Saliency
 from captum.attr._core.neuron_gradient import NeuronGradient
-from captum.attr._utils.common import _extend_index_list
 from captum.attr._utils.gradient import _forward_layer_eval
 
 from .helpers.basic_models import (
@@ -108,12 +107,9 @@ class Test(BaseTest):
             while len(neuron) < len(out.shape) - 1:
                 neuron = neuron + (0,)
             input_attrib = Saliency(
-                lambda x: torch.stack(
-                    [
-                        _forward_layer_eval(model, x, output_layer)[index]
-                        for index in _extend_index_list(test_input.shape[0], neuron)
-                    ]
-                )
+                lambda x: _forward_layer_eval(model, x, output_layer)[
+                    (slice(None), *neuron)
+                ]
             )
             sal_vals = input_attrib.attribute(test_input, abs=False)
             grad_vals = gradient_attrib.attribute(test_input, neuron)


### PR DESCRIPTION
Switching to suggested new approach for indexing neurons with arbitrary length tuples as opposed to an iterated select.