### PR TITLE
Only replace the deeplift multiplier if the absolute value of delta_in is small

### DIFF
--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -534,14 +534,18 @@ def nonlinear(module, delta_in, delta_out, grad_input, grad_output, eps=1e-10):
     # supported non-linear modules take only single tensor as input hence accessing
     # only the first element in `grad_input` and `grad_output`
     grad_input[0] = torch.where(
-        abs(delta_in[0]) < eps, grad_input[0], grad_output[0] * delta_out[0] / delta_in[0]
+        abs(delta_in[0]) < eps,
+        grad_input[0],
+        grad_output[0] * delta_out[0] / delta_in[0],
     )
     return grad_input
 
 
 def softmax(module, delta_in, delta_out, grad_input, grad_output, eps=1e-10):
     grad_input_unnorm = torch.where(
-        abs(delta_in[0]) < eps, grad_input[0], grad_output[0] * delta_out[0] / delta_in[0]
+        abs(delta_in[0]) < eps,
+        grad_input[0],
+        grad_output[0] * delta_out[0] / delta_in[0],
     )
     # normalizing
     n = np.prod(grad_input[0].shape)

--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -534,14 +534,14 @@ def nonlinear(module, delta_in, delta_out, grad_input, grad_output, eps=1e-10):
     # supported non-linear modules take only single tensor as input hence accessing
     # only the first element in `grad_input` and `grad_output`
     grad_input[0] = torch.where(
-        delta_in[0] < eps, grad_input[0], grad_output[0] * delta_out[0] / delta_in[0]
+        abs(delta_in[0]) < eps, grad_input[0], grad_output[0] * delta_out[0] / delta_in[0]
     )
     return grad_input
 
 
 def softmax(module, delta_in, delta_out, grad_input, grad_output, eps=1e-10):
     grad_input_unnorm = torch.where(
-        delta_in[0] < eps, grad_input[0], grad_output[0] * delta_out[0] / delta_in[0]
+        abs(delta_in[0]) < eps, grad_input[0], grad_output[0] * delta_out[0] / delta_in[0]
     )
     # normalizing
     n = np.prod(grad_input[0].shape)
@@ -634,7 +634,7 @@ def maxpool(
         )
 
     new_grad_input = torch.where(
-        delta_in[0] < eps, grad_input[0], unpool_grad_out_delta / delta_in[0]
+        abs(delta_in[0]) < eps, grad_input[0], unpool_grad_out_delta / delta_in[0]
     )
 
     # If the module is invalid, save the newly computed gradients

--- a/tests/attr/helpers/basic_models.py
+++ b/tests/attr/helpers/basic_models.py
@@ -104,6 +104,21 @@ class ReLUDeepLiftModel(nn.Module):
         return 2 * self.relu1(x1) + 2 * self.relu2(x2 - 1.5)
 
 
+class TanhDeepLiftModel(nn.Module):
+    r"""
+        Same as the ReLUDeepLiftModel, but with activations
+        that can have negative outputs
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.tanh1 = nn.Tanh()
+        self.tanh2 = nn.Tanh()
+
+    def forward(self, x1, x2):
+        return 2 * self.tanh1(x1) + 2 * self.tanh2(x2 - 1.5)
+
+
 class ReLULinearDeepLiftModel(nn.Module):
     r"""
         Architecture is based on:

--- a/tests/attr/test_deeplift_basic.py
+++ b/tests/attr/test_deeplift_basic.py
@@ -10,7 +10,7 @@ from .helpers.utils import (
     assertArraysAlmostEqual,
     BaseTest,
 )
-from .helpers.basic_models import ReLUDeepLiftModel
+from .helpers.basic_models import ReLUDeepLiftModel, TanhDeepLiftModel
 from .helpers.basic_models import ReLULinearDeepLiftModel
 
 
@@ -27,6 +27,20 @@ class Test(BaseTest):
 
         model = ReLUDeepLiftModel()
         self._deeplift_helper(model, DeepLift(model), inputs, baselines)
+
+    def test_tanh_deeplift(self):
+        x1 = torch.tensor([-1.0], requires_grad=True)
+        x2 = torch.tensor([-2.0], requires_grad=True)
+
+        b1 = torch.tensor([0.0], requires_grad=True)
+        b2 = torch.tensor([0.0], requires_grad=True)
+
+        inputs = (x1, x2)
+        baselines = (b1, b2)
+
+        model = TanhDeepLiftModel()
+        self._deeplift_helper(model, DeepLift(model), inputs, baselines)
+
 
     def test_relu_deeplift_batch(self):
         x1 = torch.tensor([[1.0], [1.0], [1.0], [1.0]], requires_grad=True)

--- a/tests/attr/test_deeplift_basic.py
+++ b/tests/attr/test_deeplift_basic.py
@@ -41,7 +41,6 @@ class Test(BaseTest):
         model = TanhDeepLiftModel()
         self._deeplift_helper(model, DeepLift(model), inputs, baselines)
 
-
     def test_relu_deeplift_batch(self):
         x1 = torch.tensor([[1.0], [1.0], [1.0], [1.0]], requires_grad=True)
         x2 = torch.tensor([[2.0], [2.0], [2.0], [2.0]], requires_grad=True)


### PR DESCRIPTION
Currently, the deeplift multiplier gets replaced with the normal gradient if `delta_in` is smaller than epsilon - this means any negative values get replaced.

This PR only replaces the gradient if the absolute value of `delta_in` is smaller than `epsilon`, and adds a test which failed before the change.

Thanks!