### PR TITLE
Support baselines as a function for DeepLift SHAP and Gradient SHAP

### DIFF
--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -179,7 +179,7 @@ class DeepLift(GradientAttribution):
         is_inputs_tuple = isinstance(inputs, tuple)
 
         inputs = format_input(inputs)
-        baselines = _format_callable_baseline(baselines, inputs)
+        baselines = format_baseline(baselines, inputs)
 
         gradient_mask = apply_gradient_requirements(inputs)
 
@@ -488,7 +488,7 @@ class DeepLiftShap(DeepLift):
         is_inputs_tuple = isinstance(inputs, tuple)
 
         inputs = format_input(inputs)
-        baselines = format_baseline(baselines, inputs)
+        baselines = _format_callable_baseline(baselines, inputs)
 
         # batch sizes
         inp_bsz = inputs[0].shape[0]

--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -387,8 +387,9 @@ class DeepLiftShap(DeepLift):
                         the differences between the inputs and references and
                         corresponding outputs.
                         `baselines` can be either a single tensor, a tuple of
-                        tensors or a callable function that either returns a single
-                        tensor or a tuple of those.
+                        tensors or a callable function that, optionally takes
+                        `inputs` as an argument and either returns a single tensor
+                        or a tuple of those.
                         If inputs is a single tensor, baselines must also be either
                         a single tensor or a function that returns a single tensor.
                         If inputs is a tuple of tensors, baselines must also be

--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -9,6 +9,7 @@ import numpy as np
 from .._utils.common import (
     format_input,
     format_baseline,
+    _format_callable_baseline,
     _format_attributions,
     _format_tensor_into_tuples,
     _run_forward,
@@ -178,7 +179,8 @@ class DeepLift(GradientAttribution):
         is_inputs_tuple = isinstance(inputs, tuple)
 
         inputs = format_input(inputs)
-        baselines = format_baseline(baselines, inputs)
+        baselines = _format_callable_baseline(baselines, inputs)
+
         gradient_mask = apply_gradient_requirements(inputs)
 
         validate_input(inputs, baselines)
@@ -379,15 +381,21 @@ class DeepLiftShap(DeepLift):
                         to the number of examples (aka batch size), and if
                         multiple input tensors are provided, the examples must
                         be aligned appropriately.
-            baselines (tensor or tuple of tensors, optional): Baselines define
-                        reference samples which are compared with the inputs.
+            baselines (tensor, tuple of tensors or callable, optional): Baselines
+                        define reference samples which are compared with the inputs.
                         In order to assign attribution scores DeepLift computes
                         the differences between the inputs and references and
                         corresponding outputs.
-                        If inputs is a single tensor, baselines must also be a
-                        single tensor. If inputs is a tuple of tensors, baselines
-                        must also be a tuple of tensors. The first dimension in
-                        baseline tensors defines the distribution of baselines.
+                        `baselines` can be either a single tensor, a tuple of
+                        tensors or a callable function that either returns a single
+                        tensor or a tuple of those.
+                        If inputs is a single tensor, baselines must also be either
+                        a single tensor or a function that returns a single tensor.
+                        If inputs is a tuple of tensors, baselines must also be
+                        either a tuple of tensors or a function that returns a
+                        tuple of tensors.
+                        The first dimension in baseline tensors defines the
+                        distribution of baselines.
                         All other dimensions starting after the first dimension
                         should match with the inputs' dimensions after the
                         first dimension. It is recommended that the number of

--- a/captum/attr/_core/gradient_shap.py
+++ b/captum/attr/_core/gradient_shap.py
@@ -74,8 +74,9 @@ class GradientShap(GradientAttribution):
             baselines (tensor or tuple of tensors, optional):  Baselines define
                         the starting point from which expectation is computed.
                         `baselines` can be either a single tensor, a tuple of
-                        tensors or a callable function that either returns a single
-                        tensor or a tuple of those.
+                        tensors or a callable function that, optionally, takes inputs
+                        as an argument and either returns a single tensor or
+                        a tuple of those.
                         If inputs is a single tensor, baselines must also be either
                         a single tensor or a function that returns a single tensor.
                         If inputs is a tuple of tensors, baselines must also be

--- a/captum/attr/_utils/common.py
+++ b/captum/attr/_utils/common.py
@@ -98,10 +98,11 @@ def format_baseline(baselines, inputs):
     if not isinstance(baselines, tuple):
         baselines = (baselines,)
 
+    # TODO create a separate PR to support scalar baselines
     assert isinstance(
         baselines[0], torch.Tensor
-    ), "baselines input argument must be either a torch.Tensor or a tuple of \
-          those however {} detected".format(
+    ), "baselines input argument must be either a torch.Tensor or a tuple \
+         of those however {} detected".format(
         type(baselines[0])
     )
 

--- a/captum/attr/_utils/common.py
+++ b/captum/attr/_utils/common.py
@@ -98,9 +98,12 @@ def format_baseline(baselines, inputs):
     if not isinstance(baselines, tuple):
         baselines = (baselines,)
 
-    assert isinstance(baselines[0], torch.Tensor), \
-        ("baselines input argument must be either a torch.Tensor or a tuple of \
-          those however {} detected".format(type(baselines[0])))
+    assert isinstance(
+        baselines[0], torch.Tensor
+    ), "baselines input argument must be either a torch.Tensor or a tuple of \
+          those however {} detected".format(
+        type(baselines[0])
+    )
 
     return baselines
 
@@ -126,9 +129,10 @@ def _format_callable_baseline(baselines, inputs):
             baselines = baselines(inputs)
         # check the type of the baselines and make sure that it is either a
         # tensor or a list of tensors
-        assert isinstance(baselines, tuple) or isinstance(baselines, torch.Tensor), \
-            ("`baselines` function should either return a torch.Tensor \
-             or a tuple of those")
+        assert isinstance(baselines, tuple) or isinstance(
+            baselines, torch.Tensor
+        ), "`baselines` function should either return a torch.Tensor \
+             or a tuple of those"
     return format_baseline(baselines, inputs)
 
 

--- a/tests/attr/test_deeplift_basic.py
+++ b/tests/attr/test_deeplift_basic.py
@@ -2,6 +2,8 @@ from __future__ import print_function
 
 import torch
 
+from inspect import signature
+
 from captum.attr._core.deep_lift import DeepLift, DeepLiftShap
 from captum.attr._core.integrated_gradients import IntegratedGradients
 
@@ -26,7 +28,7 @@ class Test(BaseTest):
         baselines = (b1, b2)
 
         model = ReLUDeepLiftModel()
-        self._deeplift_helper(model, DeepLift(model), inputs, baselines)
+        self._deeplift_assert(model, DeepLift(model), inputs, baselines)
 
     def test_tanh_deeplift(self):
         x1 = torch.tensor([-1.0], requires_grad=True)
@@ -39,7 +41,7 @@ class Test(BaseTest):
         baselines = (b1, b2)
 
         model = TanhDeepLiftModel()
-        self._deeplift_helper(model, DeepLift(model), inputs, baselines)
+        self._deeplift_assert(model, DeepLift(model), inputs, baselines)
 
     def test_relu_deeplift_batch(self):
         x1 = torch.tensor([[1.0], [1.0], [1.0], [1.0]], requires_grad=True)
@@ -52,33 +54,7 @@ class Test(BaseTest):
         baselines = (b1, b2)
 
         model = ReLUDeepLiftModel()
-        self._deeplift_helper(model, DeepLift(model), inputs, baselines)
-
-    def test_relu_deeplift_batch_4D_input(self):
-        x1 = torch.ones(4, 1, 1, 1)
-        x2 = torch.tensor([[[[2.0]]]] * 4)
-
-        b1 = torch.zeros(4, 1, 1, 1)
-        b2 = torch.zeros(4, 1, 1, 1)
-
-        inputs = (x1, x2)
-        baselines = (b1, b2)
-
-        model = ReLUDeepLiftModel()
-        self._deeplift_helper(model, DeepLiftShap(model), inputs, baselines)
-
-    def test_relu_deeplift_multi_ref(self):
-        x1 = torch.tensor([[1.0]], requires_grad=True)
-        x2 = torch.tensor([[2.0]], requires_grad=True)
-
-        b1 = torch.tensor([[0.0], [0.0], [0.0], [0.0]], requires_grad=True)
-        b2 = torch.tensor([[0.0], [0.0], [0.0], [0.0]], requires_grad=True)
-
-        inputs = (x1, x2)
-        baselines = (b1, b2)
-
-        model = ReLUDeepLiftModel()
-        self._deeplift_helper(model, DeepLiftShap(model), inputs, baselines)
+        self._deeplift_assert(model, DeepLift(model), inputs, baselines)
 
     def test_relu_linear_deeplift(self):
         model = ReLULinearDeepLiftModel()
@@ -92,11 +68,75 @@ class Test(BaseTest):
         baselines = (b1, b2)
 
         # expected = [[[0.0, 0.0]], [[6.0, 2.0]]]
-        self._deeplift_helper(model, DeepLift(model), inputs, baselines)
+        self._deeplift_assert(model, DeepLift(model), inputs, baselines)
 
-    def _deeplift_helper(self, model, attr_method, inputs, baselines):
-        input_bsz = inputs[0].shape[0]
-        baseline_bsz = baselines[0].shape[0]
+    def test_relu_deepliftshap_batch_4D_input(self):
+        x1 = torch.ones(4, 1, 1, 1)
+        x2 = torch.tensor([[[[2.0]]]] * 4)
+
+        b1 = torch.zeros(4, 1, 1, 1)
+        b2 = torch.zeros(4, 1, 1, 1)
+
+        inputs = (x1, x2)
+        baselines = (b1, b2)
+
+        model = ReLUDeepLiftModel()
+        self._deeplift_assert(model, DeepLiftShap(model), inputs, baselines)
+
+    def test_relu_deepliftshap_multi_ref(self):
+        x1 = torch.tensor([[1.0]], requires_grad=True)
+        x2 = torch.tensor([[2.0]], requires_grad=True)
+
+        b1 = torch.tensor([[0.0], [0.0], [0.0], [0.0]], requires_grad=True)
+        b2 = torch.tensor([[0.0], [0.0], [0.0], [0.0]], requires_grad=True)
+
+        inputs = (x1, x2)
+        baselines = (b1, b2)
+
+        model = ReLUDeepLiftModel()
+        self._deeplift_assert(model, DeepLiftShap(model), inputs, baselines)
+
+    def test_relu_deepliftshap_baselines_as_function(self):
+        model = ReLULinearDeepLiftModel()
+        x1 = torch.tensor([[-10.0, 1.0, -5.0]])
+        x2 = torch.tensor([[3.0, 3.0, 1.0]])
+
+        def gen_baselines():
+            b1 = torch.tensor([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
+            b2 = torch.tensor([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
+            return (b1, b2)
+
+        def gen_baselines_with_inputs(inputs):
+            b1 = inputs[0].mean(0, keepdim=True)
+            b2 = inputs[1].mean(0, keepdim=True)
+            return (b1, b2)
+
+        def gen_baselines_returns_array():
+            b1 = [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]
+            b2 = [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]
+            return (b1, b2)
+
+        inputs = (x1, x2)
+
+        self._deeplift_assert(model, DeepLiftShap(model), inputs, gen_baselines)
+        self._deeplift_assert(
+            model, DeepLiftShap(model), inputs, gen_baselines_with_inputs
+        )
+        with self.assertRaises(AssertionError):
+            self._deeplift_assert(
+                model, DeepLiftShap(model), inputs, gen_baselines_returns_array
+            )
+
+    def _deeplift_assert(self, model, attr_method, inputs, baselines):
+        input_bsz = len(inputs[0])
+        if callable(baselines):
+            baseline_parameters = signature(baselines).parameters
+            if len(baseline_parameters) > 0:
+                baselines = baselines(inputs)
+            else:
+                baselines = baselines()
+
+        baseline_bsz = len(baselines[0])
         # Run attribution multiple times to make sure that it is working as
         # expected
         for _ in range(5):


### PR DESCRIPTION
Expanding supported data types for `baselines` and adding callable function in addition to torch.Tensor and a tuple of torch.Tensor-s.

1. Adding support of baselines as a functions for DeepLiftShap and GradientShap, however we can 
    potentially expand it and  add support for all methods that take baselines.
2. We can potentially combine `_format_callable_baseline` and `format_baseline`  but since other 
     algorithms do not support callable baseline I created a separate function and will potentially 
     combine it with `format_baseline`