### PR TITLE
fix division by zero in captum/insights/features.py

### DIFF
--- a/captum/attr/_utils/common.py
+++ b/captum/attr/_utils/common.py
@@ -16,7 +16,7 @@ class ExpansionTypes(Enum):
 def safe_div(denom, quotient, default_value=None):
     r"""
         A simple utility function to perform `denom / quotient`
-        if `quotient` == 0 => result will be `default_value`
+        if the statement is undefined => result will be `default_value`
     """
     return denom / quotient if quotient != 0.0 else default_value
 

--- a/captum/attr/_utils/common.py
+++ b/captum/attr/_utils/common.py
@@ -13,6 +13,14 @@ class ExpansionTypes(Enum):
     repeat_interleave = 2
 
 
+def safe_div(denom, quotient, default_value=None):
+    r"""
+        A simple utility function to perform `denom / quotient`
+        if `quotient` == 0 => result will be `default_value`
+    """
+    return denom / quotient if quotient != 0.0 else default_value
+
+
 def validate_target(num_samples, target):
     if isinstance(target, list) or (
         isinstance(target, torch.Tensor) and torch.numel(target) > 1

--- a/captum/insights/api.py
+++ b/captum/insights/api.py
@@ -150,9 +150,10 @@ class AttributionVisualizer(object):
         )
 
         # normalise the contribution, s.t. sum(abs(x_i)) = 1
+        from captum.attr._utils.common import safe_div
+
         norm = torch.norm(net_contrib, p=1)
-        if norm > 0:
-            net_contrib /= norm
+        net_contrib = safe_div(net_contrib, norm, default_value=net_contrib)
 
         return net_contrib.tolist()
 

--- a/captum/insights/api.py
+++ b/captum/insights/api.py
@@ -3,7 +3,7 @@ from typing import Callable, Iterable, List, NamedTuple, Optional, Tuple, Union
 
 from captum.attr import IntegratedGradients
 from captum.attr._utils.batching import _batched_generator
-from captum.attr._utils.common import _run_forward
+from captum.attr._utils.common import _run_forward, safe_div
 from captum.insights.features import BaseFeature
 
 import torch
@@ -150,8 +150,6 @@ class AttributionVisualizer(object):
         )
 
         # normalise the contribution, s.t. sum(abs(x_i)) = 1
-        from captum.attr._utils.common import safe_div
-
         norm = torch.norm(net_contrib, p=1)
         net_contrib = safe_div(net_contrib, norm, default_value=net_contrib)
 

--- a/captum/insights/features.py
+++ b/captum/insights/features.py
@@ -118,7 +118,7 @@ class TextFeature(BaseFeature):
         # L-Infinity norm
         normalized_attribution = attribution
         attr_max = abs(attribution).max()
-        if attr_max > 0:
+        if attr_max != 0.0:
             normalized_attribution /= attr_max
 
         modified = [x * 100 for x in normalized_attribution.tolist()]
@@ -152,7 +152,7 @@ class GeneralFeature(BaseFeature):
         # L-2 norm
         normalized_attribution = attribution
         l2_norm = attribution.norm()
-        if l2_norm > 0:
+        if l2_norm != 0.0:
             normalized_attribution /= l2_norm
 
         modified = [x * 100 for x in normalized_attribution.tolist()]

--- a/captum/insights/features.py
+++ b/captum/insights/features.py
@@ -5,6 +5,7 @@ from io import BytesIO
 from typing import Callable, List, Optional, Union
 
 from captum.attr._utils import visualization as viz
+from captum.attr._utils.common import safe_div
 
 import numpy as np
 
@@ -116,10 +117,10 @@ class TextFeature(BaseFeature):
         attribution = attribution.sum(dim=1)
 
         # L-Infinity norm
-        normalized_attribution = attribution
         attr_max = abs(attribution).max()
-        if attr_max != 0.0:
-            normalized_attribution /= attr_max
+        normalized_attribution = safe_div(
+            attribution, attr_max, default_value=attribution
+        )
 
         modified = [x * 100 for x in normalized_attribution.tolist()]
 
@@ -150,10 +151,10 @@ class GeneralFeature(BaseFeature):
         data = data.squeeze(0)
 
         # L-2 norm
-        normalized_attribution = attribution
         l2_norm = attribution.norm()
-        if l2_norm != 0.0:
-            normalized_attribution /= l2_norm
+        normalized_attribution = safe_div(
+            attribution, l2_norm, default_value=attribution
+        )
 
         modified = [x * 100 for x in normalized_attribution.tolist()]
 

--- a/captum/insights/features.py
+++ b/captum/insights/features.py
@@ -96,7 +96,7 @@ class TextFeature(BaseFeature):
         name: str,
         baseline_transforms: Union[Callable, List[Callable]],
         input_transforms: Union[Callable, List[Callable]],
-        visualization_transform: Optional[Callable],
+        visualization_transform: Callable,
     ):
         super().__init__(
             name,
@@ -116,7 +116,11 @@ class TextFeature(BaseFeature):
         attribution = attribution.sum(dim=1)
 
         # L-Infinity norm
-        normalized_attribution = attribution / abs(attribution).max()
+        normalized_attribution = attribution
+        attr_max = abs(attribution).max()
+        if attr_max > 0:
+            normalized_attribution /= attr_max
+
         modified = [x * 100 for x in normalized_attribution.tolist()]
 
         return FeatureOutput(
@@ -146,7 +150,11 @@ class GeneralFeature(BaseFeature):
         data = data.squeeze(0)
 
         # L-2 norm
-        normalized_attribution = attribution / attribution.norm()
+        normalized_attribution = attribution
+        l2_norm = attribution.norm()
+        if l2_norm > 0:
+            normalized_attribution /= l2_norm
+
         modified = [x * 100 for x in normalized_attribution.tolist()]
 
         base = [f"{c}: {d:.2f}" for c, d in zip(self.categories, data.tolist())]


### PR DESCRIPTION
- if attribution vector == 0, L2 and L-infinity norm will be zero
- removed Optional annotation from `TextFeature`'s `visualization_transform` since it is required