### PR TITLE
Add support for attributing to layer and neuron inputs and DeepLift layer and neuron

### DIFF
--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -191,6 +191,11 @@ class DeepLift(GradientAttribution):
         validate_input(inputs, baselines)
 
         # set hooks for baselines
+        warnings.warn(
+            """Setting forward, backward hooks and attributes on non-linear
+               activations. The hooks and attributes will be removed
+            after the attribution is finished"""
+        )
         self.model.apply(self._register_hooks)
 
         # make forward pass and remove baseline hooks

--- a/captum/attr/_core/grad_cam.py
+++ b/captum/attr/_core/grad_cam.py
@@ -27,7 +27,13 @@ class LayerGradCam(LayerAttribution):
         """
         super().__init__(forward_func, layer, device_ids)
 
-    def attribute(self, inputs, target=None, additional_forward_args=None):
+    def attribute(
+        self,
+        inputs,
+        target=None,
+        additional_forward_args=None,
+        attribute_to_layer_input=False,
+    ):
         r"""
             Computes GradCAM attribution for chosen layer. GradCAM is designed for
             convolutional neural networks, and is usually applied to the last
@@ -106,6 +112,17 @@ class LayerGradCam(LayerAttribution):
                             Note that attributions are not computed with respect
                             to these arguments.
                             Default: None
+                attribute_to_layer_input (bool, optional): Indicates whether to
+                            compute the attributions with respect to the layer input
+                            or output. If `attribute_to_layer_input` is set to True
+                            then the attributions will be computed with respect to the
+                            layer input, otherwise it will be computed with respect
+                            to layer output.
+                            Note that currently it is assumed that either the input
+                            or the outputs of internal layers, depending on whether we
+                            attribute to the input or output, are single tensors.
+                            Support for multiple tensors will be added later.
+                            Default: False
 
             Returns:
                 *tensor* of **attributions**:
@@ -149,6 +166,7 @@ class LayerGradCam(LayerAttribution):
             target,
             additional_forward_args,
             device_ids=self.device_ids,
+            attribute_to_layer_input=attribute_to_layer_input,
         )
         summed_grads = torch.mean(
             layer_gradients,

--- a/captum/attr/_core/guided_grad_cam.py
+++ b/captum/attr/_core/guided_grad_cam.py
@@ -34,6 +34,7 @@ class GuidedGradCam(GradientAttribution):
         target=None,
         additional_forward_args=None,
         interpolate_mode="nearest",
+        attribute_to_layer_input=False,
     ):
         r"""
             Computes element-wise product of guided backpropagation attributions
@@ -124,6 +125,18 @@ class GuidedGradCam(GradientAttribution):
                             interpolation, but we default to "nearest" for
                             applicability to any of 3D, 4D or 5D tensors.
                             Default: "nearest"
+                attribute_to_layer_input (bool, optional): Indicates whether to
+                            compute the attribution with respect to the layer input
+                            or output in `LayerGradCam`.
+                            If `attribute_to_layer_input` is set to True
+                            then the attributions will be computed with respect to
+                            layer inputs, otherwise it will be computed with respect
+                            to layer outputs.
+                            Note that currently it is assumed that either the input
+                            or the output of internal layer, depending on whether we
+                            attribute to the input or output, is a single tensor.
+                            Support for multiple tensors will be added later.
+                            Default: False
 
             Returns:
                 *tensor* of **attributions**:
@@ -163,6 +176,7 @@ class GuidedGradCam(GradientAttribution):
                 inputs=inputs,
                 target=target,
                 additional_forward_args=additional_forward_args,
+                attribute_to_layer_input=attribute_to_layer_input,
             )
         )
         guided_backprop_attr = self.guided_backprop.attribute(

--- a/captum/attr/_core/internal_influence.py
+++ b/captum/attr/_core/internal_influence.py
@@ -137,14 +137,14 @@ class InternalInfluence(LayerAttribution):
                             are processed in one batch.
                             Default: None
                 attribute_to_layer_input (bool, optional): Indicates whether to
-                            compute the attribution with respect to layer input
+                            compute the attribution with respect to the layer input
                             or output. If `attribute_to_layer_input` is set to True
                             then the attributions will be computed with respect to
-                            layer inputs otherwise it will be computed with respect
+                            layer inputs, otherwise it will be computed with respect
                             to layer outputs.
-                            Note that currently it is assumed that either the inputs
-                            or the outputs of internal layers, depending on whether we
-                            attribute to the inputs or outputs, are single tensors.
+                            Note that currently it is assumed that either the input
+                            or the output of internal layer, depending on whether we
+                            attribute to the input or output, is a single tensor.
                             Support for multiple tensors will be added later.
                             Default: False
 

--- a/captum/attr/_core/internal_influence.py
+++ b/captum/attr/_core/internal_influence.py
@@ -22,11 +22,14 @@ class InternalInfluence(LayerAttribution):
             forward_func (callable):  The forward function of the model or any
                           modification of it
             layer (torch.nn.Module): Layer for which attributions are computed.
-                          Output size of attribute matches this layer's output
-                          dimensions, corresponding to attribution of each neuron
-                          in the output of this layer.
-                          Currently, only layers with a single tensor output are
-                          supported.
+                          Output size of attribute matches this layer's input or
+                          output dimensions, depending on whether we attribute to
+                          the inputs or outputs of the layer, corresponding to
+                          attribution of each neuron in the input or output of
+                          this layer.
+                          Currently, it is assumed that the inputs or the outputs
+                          of the layer, depending on which one is used for
+                          attribution can only be a single tensor.
             device_ids (list(int)): Device ID list, necessary only if forward_func
                           applies a DataParallel model. This allows reconstruction of
                           intermediate outputs from batched results across devices.
@@ -139,6 +142,10 @@ class InternalInfluence(LayerAttribution):
                             then the attributions will be computed with respect to
                             layer inputs otherwise it will be computed with respect
                             to layer outputs.
+                            Note that currently it is assumed that either the inputs
+                            or the outputs of internal layers, depending on whether we
+                            attribute to the inputs or outputs, are single tensors.
+                            Support for multiple tensors will be added later.
                             Default: False
 
             Returns:

--- a/captum/attr/_core/internal_influence.py
+++ b/captum/attr/_core/internal_influence.py
@@ -44,6 +44,7 @@ class InternalInfluence(LayerAttribution):
         n_steps=50,
         method="gausslegendre",
         internal_batch_size=None,
+        attribute_to_layer_input=False,
     ):
         r"""
             Computes internal influence by approximating the integral of gradients
@@ -132,13 +133,22 @@ class InternalInfluence(LayerAttribution):
                             If internal_batch_size is None, then all evaluations
                             are processed in one batch.
                             Default: None
+                attribute_to_layer_input (bool, optional): Indicates whether to
+                            compute the attribution with respect to layer input
+                            or output. If `attribute_to_layer_input` is set to True
+                            then the attributions will be computed with respect to
+                            layer inputs otherwise it will be computed with respect
+                            to layer outputs.
+                            Default: False
 
             Returns:
                 *tensor* of **attributions**:
                 - **attributions** (*tensor*):
                             Internal influence of each neuron in given
                             layer output. Attributions will always be the same size
-                            as the output of the given layer.
+                            as the output or input of the given layer depending on
+                            whether `attribute_to_layer_input` is set to `False` or
+                            `True`respectively.
 
             Examples::
 
@@ -193,6 +203,7 @@ class InternalInfluence(LayerAttribution):
             layer=self.layer,
             target_ind=expanded_target,
             device_ids=self.device_ids,
+            attribute_to_layer_input=attribute_to_layer_input,
         )
         # flattening grads so that we can multipy it with step-size
         # calling contigous to avoid `memory whole` problems

--- a/captum/attr/_core/layer_activation.py
+++ b/captum/attr/_core/layer_activation.py
@@ -11,11 +11,14 @@ class LayerActivation(LayerAttribution):
             forward_func (callable):  The forward function of the model or any
                           modification of it
             layer (torch.nn.Module): Layer for which attributions are computed.
-                          Output size of attribute matches this layer's output
-                          dimensions, corresponding to attribution of each neuron
-                          in the output of this layer.
-                          Currently, only layers with a single tensor output are
-                          supported.
+                          Output size of attribute matches this layer's input or
+                          output dimensions, depending on whether we attribute to
+                          the inputs or outputs of the layer, corresponding to
+                          attribution of each neuron in the input or output of
+                          this layer.
+                          Currently, it is assumed that the inputs or the outputs
+                          of the layer, depending on which one is used for
+                          attribution, can only be a single tensor.
             device_ids (list(int)): Device ID list, necessary only if forward_func
                           applies a DataParallel model. This allows reconstruction of
                           intermediate outputs from batched results across devices.
@@ -24,7 +27,9 @@ class LayerActivation(LayerAttribution):
         """
         super().__init__(forward_func, layer, device_ids)
 
-    def attribute(self, inputs, additional_forward_args=None):
+    def attribute(
+        self, inputs, additional_forward_args=None, attribute_to_layer_input=False
+    ):
         r"""
             Computes activation of selected layer for given input.
 
@@ -50,7 +55,17 @@ class LayerActivation(LayerAttribution):
                             Note that attributions are not computed with respect
                             to these arguments.
                             Default: None
-
+                attribute_to_layer_input (bool, optional): Indicates whether to
+                            compute the attribution with respect to layer input
+                            or output. If `attribute_to_layer_input` is set to True
+                            then the attributions will be computed with respect to
+                            layer inputs otherwise it will be computed with respect
+                            to layer outputs.
+                            Note that currently it is assumed that either the inputs
+                            or the outputs of internal layers, depending on whether we
+                            attribute to the inputs or outputs, are single tensors.
+                            Support for multiple tensors will be added later.
+                            Default: False
             Returns:
                 *tensor* of **attributions**:
                 - **attributions** (*tensor*):
@@ -77,4 +92,5 @@ class LayerActivation(LayerAttribution):
             self.layer,
             additional_forward_args,
             device_ids=self.device_ids,
+            attribute_to_layer_input=attribute_to_layer_input,
         )

--- a/captum/attr/_core/layer_activation.py
+++ b/captum/attr/_core/layer_activation.py
@@ -56,16 +56,17 @@ class LayerActivation(LayerAttribution):
                             to these arguments.
                             Default: None
                 attribute_to_layer_input (bool, optional): Indicates whether to
-                            compute the attribution with respect to layer input
+                            compute the attribution with respect to the layer input
                             or output. If `attribute_to_layer_input` is set to True
                             then the attributions will be computed with respect to
-                            layer inputs otherwise it will be computed with respect
-                            to layer outputs.
-                            Note that currently it is assumed that either the inputs
-                            or the outputs of internal layers, depending on whether we
-                            attribute to the inputs or outputs, are single tensors.
+                            layer input, otherwise it will be computed with respect
+                            to layer output.
+                            Note that currently it is assumed that either the input
+                            or the output of internal layer, depending on whether we
+                            attribute to the input or output, is a single tensor.
                             Support for multiple tensors will be added later.
                             Default: False
+
             Returns:
                 *tensor* of **attributions**:
                 - **attributions** (*tensor*):

--- a/captum/attr/_core/layer_conductance.py
+++ b/captum/attr/_core/layer_conductance.py
@@ -48,6 +48,7 @@ class LayerConductance(LayerAttribution):
         method="riemann_trapezoid",
         internal_batch_size=None,
         return_convergence_delta=False,
+        attribute_to_layer_input=False,
     ):
         r"""
             Computes conductance with respect to the given layer. The
@@ -143,13 +144,26 @@ class LayerConductance(LayerAttribution):
                             is set to True convergence delta will be returned in
                             a tuple following attributions.
                             Default: False
+                attribute_to_layer_input (bool, optional): Indicates whether to
+                            compute the attributions with respect to layer input
+                            or output. If `attribute_to_layer_input` is set to True
+                            then the attributions will be computed with respect to
+                            layer inputs, otherwise it will be computed with respect
+                            to layer outputs.
+                            Note that currently it assumes that both the inputs and
+                            outputs of internal layers are single tensors.
+                            Support for multiple tensors will be added later.
+                            Default: False
 
             Returns:
                 **attributions** or 2-element tuple of **attributions**, **delta**:
                 - **attributions** (*tensor*):
-                            Conductance of each neuron in given layer output.
-                            Attributions will always be the same size as the
-                            output of the given layer.
+                            Conductance of each neuron in given layer input or
+                            output. Attributions will always be the same size as
+                            the input or output of the given layer, depending on
+                            whether we attribute to the inputs or outputs
+                            of the layer which is decided by the input flag
+                            `attribute_to_layer_input`.
                 - **delta** (*tensor*, returned if return_convergence_delta=True):
                             The difference between the total
                             approximated and true conductance.
@@ -216,6 +230,7 @@ class LayerConductance(LayerAttribution):
             layer=self.layer,
             target_ind=expanded_target,
             device_ids=self.device_ids,
+            attribute_to_layer_input=attribute_to_layer_input,
         )
 
         # Compute differences between consecutive evaluations of layer_eval.

--- a/captum/attr/_core/layer_conductance.py
+++ b/captum/attr/_core/layer_conductance.py
@@ -22,11 +22,14 @@ class LayerConductance(LayerAttribution):
             forward_func (callable):  The forward function of the model or any
                           modification of it
             layer (torch.nn.Module): Layer for which attributions are computed.
-                          Output size of attribute matches this layer's output
-                          dimensions, corresponding to attribution of each neuron
-                          in the output of this layer.
-                          Currently, only layers with a single tensor output are
-                          supported.
+                          Output size of attribute matches this layer's input or
+                          output dimensions, depending on whether we attribute to
+                          the inputs or outputs of the layer, corresponding to
+                          attribution of each neuron in the input or output of
+                          this layer.
+                          Currently, it is assumed that the inputs or the outputs
+                          of the layer, depending on which one is used for
+                          attribution, can only be a single tensor.
             device_ids (list(int)): Device ID list, necessary only if forward_func
                           applies a DataParallel model. This allows reconstruction of
                           intermediate outputs from batched results across devices.
@@ -150,8 +153,9 @@ class LayerConductance(LayerAttribution):
                             then the attributions will be computed with respect to
                             layer inputs, otherwise it will be computed with respect
                             to layer outputs.
-                            Note that currently it assumes that both the inputs and
-                            outputs of internal layers are single tensors.
+                            Note that currently it is assumed that either the inputs
+                            or the outputs of internal layers, depending on whether we
+                            attribute to the inputs or outputs, are single tensors.
                             Support for multiple tensors will be added later.
                             Default: False
 

--- a/captum/attr/_core/layer_conductance.py
+++ b/captum/attr/_core/layer_conductance.py
@@ -148,14 +148,14 @@ class LayerConductance(LayerAttribution):
                             a tuple following attributions.
                             Default: False
                 attribute_to_layer_input (bool, optional): Indicates whether to
-                            compute the attributions with respect to layer input
+                            compute the attribution with respect to the layer input
                             or output. If `attribute_to_layer_input` is set to True
                             then the attributions will be computed with respect to
                             layer inputs, otherwise it will be computed with respect
                             to layer outputs.
-                            Note that currently it is assumed that either the inputs
-                            or the outputs of internal layers, depending on whether we
-                            attribute to the inputs or outputs, are single tensors.
+                            Note that currently it is assumed that either the input
+                            or the output of internal layer, depending on whether we
+                            attribute to the input or output, is a single tensor.
                             Support for multiple tensors will be added later.
                             Default: False
 

--- a/captum/attr/_core/layer_deep_lift.py
+++ b/captum/attr/_core/layer_deep_lift.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+
+import torch.nn as nn
+from .._utils.attribution import LayerAttribution
+from .._core.deep_lift import DeepLift, DeepLiftShap
+from .._utils.gradient import (
+    apply_gradient_requirements,
+    undo_gradient_requirements,
+    _forward_layer_eval,
+    compute_layer_gradients_and_eval,
+)
+
+from .._utils.common import (
+    format_input,
+    format_baseline,
+    _format_callable_baseline,
+    validate_input,
+)
+
+
+class LayerDeepLift(LayerAttribution, DeepLift):
+    def __init__(self, model, layer):
+        r"""
+        Args:
+
+            model (torch.nn.Module):  The reference to PyTorch model instance.
+            layer (torch.nn.Module): Layer for which attributions are computed.
+                          The size and dimensionality of the attributions
+                          corresponds to the size and dimensionality of the layer's
+                          input or output depending on whether we attribute to the
+                          inputs or outputs of the layer.
+                          Currently, it is assumed that both inputs and ouputs of
+                          the layer can only be a single tensor.
+        """
+        if isinstance(model, nn.DataParallel):
+            model = model.module
+
+        super(LayerAttribution, self).__init__(model, layer)
+        super(DeepLift, self).__init__(model)
+
+    def attribute(
+        self,
+        inputs,
+        baselines=None,
+        target=None,
+        additional_forward_args=None,
+        return_convergence_delta=False,
+        attribute_to_layer_input=False,
+    ):
+        r""""
+        Implements DeepLIFT algorithm for the layer based on the following paper:
+        Learning Important Features Through Propagating Activation Differences,
+        Avanti Shrikumar, et. al.
+        https://arxiv.org/abs/1704.02685
+
+        and the gradient formulation proposed in:
+        Towards better understanding of gradient-based attribution methods for
+        deep neural networks,  Marco Ancona, et.al.
+        https://openreview.net/pdf?id=Sy21R9JAW
+
+        This implementation supports only Rescale rule. RevealCancel rule will
+        be supported in later releases.
+        Although DeepLIFT's(Rescale Rule) attribution quality is comparable with
+        Integrated Gradients, it runs significantly faster than Integrated
+        Gradients and is preferred for large datasets.
+
+        Currently we only support a limited number of non-linear activations
+        but the plan is to expand the list in the future.
+
+        Note: As we know, currently we cannot access the building blocks,
+        of PyTorch's built-in LSTM, RNNs and GRUs such as Tanh and Sigmoid.
+        Nonetheless, it is possible to build custom LSTMs, RNNS and GRUs
+        with performance similar to built-in ones using TorchScript.
+        More details on how to build custom RNNs can be found here:
+        https://pytorch.org/blog/optimizing-cuda-rnn-with-torchscript/
+
+        Args:
+
+            inputs (tensor or tuple of tensors):  Input for which layer
+                        attributions are computed. If forward_func takes a
+                        single tensor as input, a single input tensor should be
+                        provided. If forward_func takes multiple tensors as input,
+                        a tuple of the input tensors should be provided. It is
+                        assumed that for all given input tensors, dimension 0
+                        corresponds to the number of examples (aka batch size),
+                        and if multiple input tensors are provided, the examples
+                        must be aligned appropriately.
+            baselines (tensor or tuple of tensors, optional): Baselines define
+                        reference samples which are compared with the inputs.
+                        In order to assign attribution scores DeepLift computes
+                        the differences between the inputs and references and
+                        corresponding outputs.
+                        If inputs is a single tensor, baselines must also be a
+                        single tensor with exactly the same dimensions as inputs.
+                        If inputs is a tuple of tensors, baselines must also be
+                        a tuple of tensors, with matching dimensions to inputs.
+                        Default: zero tensor for each input tensor
+            target (int, tuple, tensor or list, optional):  Output indices for
+                        which gradients are computed (for classification cases,
+                        this is usually the target class).
+                        If the network returns a scalar value per example,
+                        no target index is necessary.
+                        For general 2D outputs, targets can be either:
+
+                        - a single integer or a tensor containing a single
+                            integer, which is applied to all input examples
+
+                        - a list of integers or a 1D tensor, with length matching
+                            the number of examples in inputs (dim 0). Each integer
+                            is applied as the target for the corresponding example.
+
+                        For outputs with > 2 dimensions, targets can be either:
+
+                        - A single tuple, which contains #output_dims - 1
+                            elements. This target index is applied to all examples.
+
+                        - A list of tuples with length equal to the number of
+                            examples in inputs (dim 0), and each tuple containing
+                            #output_dims - 1 elements. Each tuple is applied as the
+                            target for the corresponding example.
+                        Default: None
+            additional_forward_args (tuple, optional): If the forward function
+                        requires additional arguments other than the inputs for
+                        which attributions should not be computed, this argument
+                        can be provided. It must be either a single additional
+                        argument of a Tensor or arbitrary (non-tuple) type or a tuple
+                        containing multiple additional arguments including tensors
+                        or any arbitrary python types. These arguments are provided to
+                        forward_func in order, following the arguments in inputs.
+                        Note that attributions are not computed with respect
+                        to these arguments.
+                        Default: None
+            return_convergence_delta (bool, optional): Indicates whether to return
+                        convergence delta or not. If `return_convergence_delta`
+                        is set to True convergence delta will be returned in
+                        a tuple following attributions.
+                        Default: False
+            attribute_to_layer_input (bool, optional): Indicates whether to
+                        compute the attributions with respect to the layer input
+                        or output. If `attribute_to_layer_input` is set to True
+                        then the attributions will be computed with respect to the
+                        layer inputs, otherwise it will be computed with respect
+                        to layer outputs.
+                        Note that currently it assumes that both the inputs and
+                        outputs of internal layers are single tensors.
+                        Support for multiple tensors will be added later.
+                        Default: False
+        Returns:
+            **attributions** or 2-element tuple of **attributions**, **delta**:
+            - **attributions** (*tensor* or tuple of *tensors*):
+                Attribution score computed based on DeepLift's rescale rule with
+                respect to layer's inputs or outputs. Attributions will always be the
+                same size as the provided layer's inputs or outputs, depending on
+                whether we attribute to the inputs or outputs of the layer.
+                Since currently it is assumed that the inputs and outputs of the
+                layer must be single tensor, returned attributions have the shape
+                of that tensor.
+            - **delta** (*tensor*, returned if return_convergence_delta=True):
+                This is computed using the property that the total sum of
+                forward_func(inputs) - forward_func(baselines) must equal the
+                total sum of the attributions computed based on Deeplift's
+                rescale rule.
+                Delta is calculated per example, meaning that the number of
+                elements in returned delta tensor is equal to the number of
+                of examples in input.
+
+        Examples::
+
+            >>> # ImageClassifier takes a single input tensor of images Nx3x32x32,
+            >>> # and returns an Nx10 tensor of class probabilities.
+            >>> net = ImageClassifier()
+            >>> # creates an instance of LayerDeepLift to interpret target
+            >>> # class 1 with respect to conv4 layer.
+            >>> dl = LayerDeepLift(net, net.conv4)
+            >>> input = torch.randn(1, 3, 32, 32, requires_grad=True)
+            >>> # Computes deeplift attribution scores for conv4 layer and class 3.
+            >>> attribution = dl.attribute(input, target=1)
+        """
+        inputs = format_input(inputs)
+        baselines = format_baseline(baselines, inputs)
+        gradient_mask = apply_gradient_requirements(inputs)
+
+        validate_input(inputs, baselines)
+
+        # set hooks for baselines
+        self.model.apply(self._register_hooks)
+
+        attr_baselines = _forward_layer_eval(
+            self.model,
+            baselines,
+            self.layer,
+            additional_forward_args=additional_forward_args,
+            attribute_to_layer_input=attribute_to_layer_input,
+        )
+        # Fixme later: we need to do this because `_forward_layer_eval`
+        # always returns a tensor
+        attr_baselines = (attr_baselines,)
+
+        # remove forward hook set for baselines
+        for forward_handles_ref in self.forward_handles_refs:
+            forward_handles_ref.remove()
+
+        gradients, attr_inputs = compute_layer_gradients_and_eval(
+            self.model,
+            self.layer,
+            inputs,
+            additional_forward_args=additional_forward_args,
+            attribute_to_layer_input=attribute_to_layer_input,
+        )
+        # Fixme later: we need to do this because
+        # `compute_layer_gradients_and_eval` always returns a tensor
+        attr_inputs = (attr_inputs,)
+        gradients = (gradients,)
+
+        attributions = tuple(
+            (input - baseline) * gradient
+            for input, baseline, gradient in zip(attr_inputs, attr_baselines, gradients)
+        )
+
+        # remove hooks from all activations
+        self._remove_hooks()
+
+        undo_gradient_requirements(inputs, gradient_mask)
+
+        return self._compute_conv_delta_and_format_attrs(
+            return_convergence_delta,
+            attributions,
+            baselines,
+            inputs,
+            additional_forward_args,
+            target,
+            False, # currently both the input and output of layer can only be a tensor
+        )
+
+
+class LayerDeepLiftShap(LayerDeepLift, DeepLiftShap):
+    def __init__(self, model, layer):
+        r"""
+        Args:
+
+            model (torch.nn.Module):  The reference to PyTorch model instance.
+            layer (torch.nn.Module): Layer for which attributions are computed.
+                          The size and dimensionality of the attributions
+                          corresponds to the size and dimensionality of the layer's
+                          input or output depending on whether we attribute to the
+                          inputs or outputs of the layer.
+                          Currently, it is assumed that both inputs and ouputs of
+                          the layer can only be a single tensor.
+        """
+        super(DeepLiftShap, self).__init__(model)
+        super(LayerDeepLift, self).__init__(model, layer)
+
+    def attribute(
+        self,
+        inputs,
+        baselines=None,
+        target=None,
+        additional_forward_args=None,
+        return_convergence_delta=False,
+        attribute_to_layer_input=False,
+    ):
+        r"""
+        Extends LayerDeepLift and DeepLiftShap alogrithms and approximates SHAP
+        values for given input `layer`.
+        For each input sample - baseline pair it computes DeepLift attributions
+        with respect to inputs or outputs of given `layer` averages
+        resulting attributions across baselines. Whether to compute the attributions
+        with respect to the inputs or outputs of the layer is defined by the
+        input flag `attribute_to_layer_input`.
+        More details about the algorithm can be found here:
+
+        http://papers.nips.cc/paper/7062-a-unified-approach-to-interpreting-model-predictions.pdf
+
+        Note that the explanation model:
+            1. Assumes that input features are independent of one another
+            2. Is linear, meaning that the explanations are modeled through
+               the additive composition of feature effects.
+        Although, it assumes a linear model for each explanation, the overall
+        model across multiple explanations can be complex and non-linear.
+
+        Args:
+
+            inputs (tensor or tuple of tensors):  Input for which layer
+                        attributions are computed. If forward_func takes a single
+                        tensor as input, a single input tensor should be provided.
+                        If forward_func takes multiple tensors as input, a tuple
+                        of the input tensors should be provided. It is assumed
+                        that for all given input tensors, dimension 0 corresponds
+                        to the number of examples (aka batch size), and if
+                        multiple input tensors are provided, the examples must
+                        be aligned appropriately.
+            baselines (tensor, tuple of tensors or callable, optional): Baselines
+                        define reference samples which are compared with the inputs.
+                        In order to assign attribution scores DeepLift computes
+                        the differences between the inputs and references and
+                        corresponding outputs.
+                        `baselines` can be either a single tensor, a tuple of
+                        tensors or a callable function that, optionally takes
+                        `inputs` as an argument and either returns a single tensor
+                        or a tuple of those.
+                        If inputs is a single tensor, baselines must also be either
+                        a single tensor or a function that returns a single tensor.
+                        If inputs is a tuple of tensors, baselines must also be
+                        either a tuple of tensors or a function that returns a
+                        tuple of tensors.
+                        The first dimension in baseline tensors defines the
+                        distribution of baselines.
+                        All other dimensions starting after the first dimension
+                        should match with the inputs' dimensions after the
+                        first dimension. It is recommended that the number of
+                        samples in the baselines' tensors is larger than one.
+                        Default: zero tensor for each input tensor
+            target (int, tuple, tensor or list, optional):  Output indices for
+                        which gradients are computed (for classification cases,
+                        this is usually the target class).
+                        If the network returns a scalar value per example,
+                        no target index is necessary.
+                        For general 2D outputs, targets can be either:
+
+                        - a single integer or a tensor containing a single
+                            integer, which is applied to all input examples
+
+                        - a list of integers or a 1D tensor, with length matching
+                            the number of examples in inputs (dim 0). Each integer
+                            is applied as the target for the corresponding example.
+
+                        For outputs with > 2 dimensions, targets can be either:
+
+                        - A single tuple, which contains #output_dims - 1
+                            elements. This target index is applied to all examples.
+
+                        - A list of tuples with length equal to the number of
+                            examples in inputs (dim 0), and each tuple containing
+                            #output_dims - 1 elements. Each tuple is applied as the
+                            target for the corresponding example.
+
+                        Default: None
+            additional_forward_args (tuple, optional): If the forward function
+                        requires additional arguments other than the inputs for
+                        which attributions should not be computed, this argument
+                        can be provided. It must be either a single additional
+                        argument of a Tensor or arbitrary (non-tuple) type or a tuple
+                        containing multiple additional arguments including tensors
+                        or any arbitrary python types. These arguments are provided to
+                        forward_func in order, following the arguments in inputs.
+                        Note that attributions are not computed with respect
+                        to these arguments.
+                        Default: None
+            return_convergence_delta (bool, optional): Indicates whether to return
+                        convergence delta or not. If `return_convergence_delta`
+                        is set to True convergence delta will be returned in
+                        a tuple following attributions.
+                        Default: False
+            attribute_to_layer_input (bool, optional): Indicates whether to
+                        compute the attributions with respect to the layer input
+                        or output. If `attribute_to_layer_input` is set to True
+                        then the attributions will be computed with respect to
+                        layer inputs, otherwise it will be computed with respect
+                        to layer outputs.
+                        Note that currently it assumes that both the inputs and
+                        outputs of internal layers are single tensors.
+                        Support for multiple tensors will be added later.
+                        Default: False
+
+        Returns:
+            **attributions** or 2-element tuple of **attributions**, **delta**:
+            - **attributions** (*tensor* or tuple of *tensors*):
+                        Attribution score computed based on DeepLift's rescale rule
+                        with respect to layer's inputs or outputs. Attributions
+                        will always be the same size as the provided layer's inputs
+                        or outputs, depending on whether we attribute to the inputs
+                        or outputs of the layer. Since currently it is assumed that
+                        the inputs and outputs of the layer must be single tensor,
+                        returned attributions have the shape of that tensor.
+            - **delta** (*tensor*, returned if return_convergence_delta=True):
+                        This is computed using the property that the
+                        total sum of forward_func(inputs) - forward_func(baselines)
+                        must be very close to the total sum of attributions
+                        computed based on approximated SHAP values using
+                        Deeplift's rescale rule.
+                        Delta is calculated for each example input and baseline pair,
+                        meaning that the number of elements in returned delta tensor
+                        is equal to the
+                        `number of examples in input` * `number of examples
+                        in baseline`. The deltas are ordered in the first place by
+                        input example, followed by the baseline.
+        Examples::
+
+            >>> # ImageClassifier takes a single input tensor of images Nx3x32x32,
+            >>> # and returns an Nx10 tensor of class probabilities.
+            >>> net = ImageClassifier()
+            >>> # creates an instance of LayerDeepLift to interpret target
+            >>> # class 1 with respect to conv4 layer.
+            >>> dl = LayerDeepLiftShap(net, net.conv4)
+            >>> input = torch.randn(2, 3, 32, 32, requires_grad=True)
+            >>> # Computes shap values using deeplift for class 3.
+            >>> attribution = dl.attribute(input, target=3)
+        """
+        inputs = format_input(inputs)
+        baselines = _format_callable_baseline(baselines, inputs)
+
+        # batch sizes
+        inp_bsz = inputs[0].shape[0]
+        base_bsz = baselines[0].shape[0]
+
+        exp_inp, exp_base, exp_target = DeepLiftShap._expand_inputs_baselines_targets(
+            self, base_bsz, inp_bsz, baselines, inputs, target
+        )
+        attributions = LayerDeepLift.attribute(
+            self,
+            exp_inp,
+            exp_base,
+            target=exp_target,
+            additional_forward_args=additional_forward_args,
+            return_convergence_delta=return_convergence_delta,
+            attribute_to_layer_input=attribute_to_layer_input,
+        )
+        if return_convergence_delta:
+            attributions, delta = attributions
+
+        attributions = DeepLiftShap._compute_mean_across_baselines(
+            self, inp_bsz, base_bsz, attributions
+        )
+        if return_convergence_delta:
+            return attributions, delta
+        else:
+            return attributions

--- a/captum/attr/_core/layer_deep_lift.py
+++ b/captum/attr/_core/layer_deep_lift.py
@@ -141,16 +141,17 @@ class LayerDeepLift(LayerAttribution, DeepLift):
                         a tuple following attributions.
                         Default: False
             attribute_to_layer_input (bool, optional): Indicates whether to
-                        compute the attributions with respect to the layer input
+                        compute the attribution with respect to the layer input
                         or output. If `attribute_to_layer_input` is set to True
-                        then the attributions will be computed with respect to the
-                        layer inputs, otherwise it will be computed with respect
-                        to layer outputs.
-                        Note that currently it is assumed that either the inputs
-                        or the outputs of internal layers, depending on whether we
-                        attribute to the inputs or outputs, are single tensors.
+                        then the attributions will be computed with respect to
+                        layer input, otherwise it will be computed with respect
+                        to layer output.
+                        Note that currently it is assumed that either the input
+                        or the output of internal layer, depending on whether we
+                        attribute to the input or output, is a single tensor.
                         Support for multiple tensors will be added later.
                         Default: False
+
         Returns:
             **attributions** or 2-element tuple of **attributions**, **delta**:
             - **attributions** (*tensor* or tuple of *tensors*):

--- a/captum/attr/_core/layer_deep_lift.py
+++ b/captum/attr/_core/layer_deep_lift.py
@@ -229,7 +229,7 @@ class LayerDeepLift(LayerAttribution, DeepLift):
             inputs,
             additional_forward_args,
             target,
-            False, # currently both the input and output of layer can only be a tensor
+            False,  # currently both the input and output of layer can only be a tensor
         )
 
 

--- a/captum/attr/_core/layer_gradient_x_activation.py
+++ b/captum/attr/_core/layer_gradient_x_activation.py
@@ -25,7 +25,13 @@ class LayerGradientXActivation(LayerAttribution):
         """
         super().__init__(forward_func, layer, device_ids)
 
-    def attribute(self, inputs, target=None, additional_forward_args=None):
+    def attribute(
+        self,
+        inputs,
+        target=None,
+        additional_forward_args=None,
+        attribute_to_layer_input=False,
+    ):
         r"""
             Computes element-wise product of gradient and activation for selected
             layer on given inputs.
@@ -77,6 +83,16 @@ class LayerGradientXActivation(LayerAttribution):
                             Note that attributions are not computed with respect
                             to these arguments.
                             Default: None
+                attribute_to_layer_input (bool, optional): Indicates whether to
+                            compute the attribution with respect to the layer input
+                            or output. If `attribute_to_layer_input` is set to True
+                            then the attributions will be computed with respect to
+                            layer inputs, otherwise it will be computed with respect
+                            to layer outputs.
+                            Note that currently it assumes that both the inputs and
+                            outputs of internal layers are single tensors.
+                            Support for multiple tensors will be added later.
+                            Default: False
 
             Returns:
                 *tensor* of **attributions**:
@@ -112,5 +128,6 @@ class LayerGradientXActivation(LayerAttribution):
             target,
             additional_forward_args,
             device_ids=self.device_ids,
+            attribute_to_layer_input=attribute_to_layer_input,
         )
         return layer_gradients * layer_eval

--- a/captum/attr/_core/layer_gradient_x_activation.py
+++ b/captum/attr/_core/layer_gradient_x_activation.py
@@ -90,11 +90,11 @@ class LayerGradientXActivation(LayerAttribution):
                             compute the attribution with respect to the layer input
                             or output. If `attribute_to_layer_input` is set to True
                             then the attributions will be computed with respect to
-                            layer inputs, otherwise it will be computed with respect
-                            to layer outputs.
-                            Note that currently it is assumed that either the inputs
-                            or the outputs of internal layers, depending on whether we
-                            attribute to the inputs or outputs, are single tensors.
+                            layer input, otherwise it will be computed with respect
+                            to layer output.
+                            Note that currently it is assumed that either the input
+                            or the output of internal layer, depending on whether we
+                            attribute to the input or output, is a single tensor.
                             Support for multiple tensors will be added later.
                             Default: False
 

--- a/captum/attr/_core/layer_gradient_x_activation.py
+++ b/captum/attr/_core/layer_gradient_x_activation.py
@@ -12,11 +12,14 @@ class LayerGradientXActivation(LayerAttribution):
             forward_func (callable):  The forward function of the model or any
                           modification of it
             layer (torch.nn.Module): Layer for which attributions are computed.
-                          Output size of attribute matches this layer's output
-                          dimensions, corresponding to attribution of each neuron
-                          in the output of this layer.
-                          Currently, only layers with a single tensor output are
-                          supported.
+                          Output size of attribute matches this layer's input or
+                          output dimensions, depending on whether we attribute to
+                          the inputs or outputs of the layer, corresponding to
+                          attribution of each neuron in the input or output of
+                          this layer.
+                          Currently, it is assumed that the inputs or the outputs
+                          of the layer, depending on which one is used for
+                          attribution, can only be a single tensor.
             device_ids (list(int)): Device ID list, necessary only if forward_func
                           applies a DataParallel model. This allows reconstruction of
                           intermediate outputs from batched results across devices.
@@ -89,8 +92,9 @@ class LayerGradientXActivation(LayerAttribution):
                             then the attributions will be computed with respect to
                             layer inputs, otherwise it will be computed with respect
                             to layer outputs.
-                            Note that currently it assumes that both the inputs and
-                            outputs of internal layers are single tensors.
+                            Note that currently it is assumed that either the inputs
+                            or the outputs of internal layers, depending on whether we
+                            attribute to the inputs or outputs, are single tensors.
                             Support for multiple tensors will be added later.
                             Default: False
 

--- a/captum/attr/_core/neuron_conductance.py
+++ b/captum/attr/_core/neuron_conductance.py
@@ -29,6 +29,15 @@ class NeuronConductance(NeuronAttribution):
                           in the attribute method.
                           Currently, only layers with a single tensor input or output
                           are supported.
+            layer (torch.nn.Module): Layer for which attributions are computed.
+                          Output size of attribute matches this layer's input or
+                          output dimensions, depending on whether we attribute to
+                          the inputs or outputs of the layer, corresponding to
+                          attribution of each neuron in the input or output of
+                          this layer.
+                          Currently, it is assumed that the inputs or the outputs
+                          of the layer, depending on which one is used for
+                          attribution, can only be a single tensor.
             device_ids (list(int)): Device ID list, necessary only if forward_func
                           applies a DataParallel model. This allows reconstruction of
                           intermediate outputs from batched results across devices.
@@ -144,9 +153,10 @@ class NeuronConductance(NeuronAttribution):
                             then the attributions will be computed with respect to
                             neuron inputs, otherwise it will be computed with respect
                             to layer outputs.
-                            Note that currently it assumes that both the inputs and
-                            outputs of internal neurons are single tensors.
-                            Support for multiple tensors will be added soon.
+                            Note that currently it is assumed that either the inputs
+                            or the outputs of internal layers, depending on whether we
+                            attribute to the inputs or outputs, are single tensors.
+                            Support for multiple tensors will be added later.
                             Default: False
 
             Returns:

--- a/captum/attr/_core/neuron_conductance.py
+++ b/captum/attr/_core/neuron_conductance.py
@@ -24,11 +24,11 @@ class NeuronConductance(NeuronAttribution):
             forward_func (callable):  The forward function of the model or any
                           modification of it
             layer (torch.nn.Module): Layer for which neuron attributions are computed.
-                          Attributions for a particular neuron in the output of
-                          this layer are computed using the argument neuron_index
+                          Attributions for a particular neuron in the input or output
+                          of this layer are computed using the argument neuron_index
                           in the attribute method.
-                          Currently, only layers with a single tensor output are
-                          supported.
+                          Currently, only layers with a single tensor input or output
+                          are supported.
             device_ids (list(int)): Device ID list, necessary only if forward_func
                           applies a DataParallel model. This allows reconstruction of
                           intermediate outputs from batched results across devices.
@@ -47,6 +47,7 @@ class NeuronConductance(NeuronAttribution):
         n_steps=50,
         method="riemann_trapezoid",
         internal_batch_size=None,
+        attribute_to_neuron_input=False,
     ):
         r"""
             Computes conductance with respect to particular hidden neuron. The
@@ -137,6 +138,16 @@ class NeuronConductance(NeuronAttribution):
                             If internal_batch_size is None, then all evaluations are
                             processed in one batch.
                             Default: None
+                attribute_to_neuron_input (bool, optional): Indicates whether to
+                            compute the attribution with respect to the neuron input
+                            or output. If `attribute_to_neuron_input` is set to True
+                            then the attributions will be computed with respect to
+                            neuron inputs, otherwise it will be computed with respect
+                            to layer outputs.
+                            Note that currently it assumes that both the inputs and
+                            outputs of internal neurons are single tensors.
+                            Support for multiple tensors will be added later.
+                            Default: False
 
             Returns:
                 *tensor* or tuple of *tensors* of **attributions**:
@@ -214,6 +225,7 @@ class NeuronConductance(NeuronAttribution):
             target_ind=expanded_target,
             gradient_neuron_index=neuron_index,
             device_ids=self.device_ids,
+            attribute_to_layer_input=attribute_to_neuron_input,
         )
 
         # Multiplies by appropriate gradient of output with respect to hidden neurons

--- a/captum/attr/_core/neuron_conductance.py
+++ b/captum/attr/_core/neuron_conductance.py
@@ -148,14 +148,14 @@ class NeuronConductance(NeuronAttribution):
                             processed in one batch.
                             Default: None
                 attribute_to_neuron_input (bool, optional): Indicates whether to
-                            compute the attribution with respect to neuron input
+                            compute the attributions with respect to the neuron input
                             or output. If `attribute_to_neuron_input` is set to True
                             then the attributions will be computed with respect to
-                            neuron inputs, otherwise it will be computed with respect
-                            to layer outputs.
-                            Note that currently it is assumed that either the inputs
-                            or the outputs of internal layers, depending on whether we
-                            attribute to the inputs or outputs, are single tensors.
+                            neuron's inputs, otherwise it will be computed with respect
+                            to neuron's outputs.
+                            Note that currently it is assumed that either the input
+                            or the output of internal neuron, depending on whether we
+                            attribute to the input or output, is a single tensor.
                             Support for multiple tensors will be added later.
                             Default: False
 

--- a/captum/attr/_core/neuron_conductance.py
+++ b/captum/attr/_core/neuron_conductance.py
@@ -139,14 +139,14 @@ class NeuronConductance(NeuronAttribution):
                             processed in one batch.
                             Default: None
                 attribute_to_neuron_input (bool, optional): Indicates whether to
-                            compute the attribution with respect to the neuron input
+                            compute the attribution with respect to neuron input
                             or output. If `attribute_to_neuron_input` is set to True
                             then the attributions will be computed with respect to
                             neuron inputs, otherwise it will be computed with respect
                             to layer outputs.
                             Note that currently it assumes that both the inputs and
                             outputs of internal neurons are single tensors.
-                            Support for multiple tensors will be added later.
+                            Support for multiple tensors will be added soon.
                             Default: False
 
             Returns:

--- a/captum/attr/_core/neuron_deep_lift.py
+++ b/captum/attr/_core/neuron_deep_lift.py
@@ -96,15 +96,16 @@ class NeuronDeepLift(NeuronAttribution):
                         Default: None
             attribute_to_neuron_input (bool, optional): Indicates whether to
                         compute the attributions with respect to the neuron input
-                        or output. If `attribute_to_layer_input` is set to True
+                        or output. If `attribute_to_neuron_input` is set to True
                         then the attributions will be computed with respect to
                         neuron's inputs, otherwise it will be computed with respect
                         to neuron's outputs.
-                        Note that currently it is assumed that either the inputs
-                        or the outputs of internal layers, depending on whether we
-                        attribute to the inputs or outputs, are single tensors.
+                        Note that currently it is assumed that either the input
+                        or the output of internal neuron, depending on whether we
+                        attribute to the input or output, is a single tensor.
                         Support for multiple tensors will be added later.
                         Default: False
+
         Returns:
             **attributions** or 2-element tuple of **attributions**, **delta**:
             - **attributions** (*tensor* or tuple of *tensors*):
@@ -224,12 +225,13 @@ class NeuronDeepLiftShap(NeuronAttribution):
                         Default: None
             attribute_to_neuron_input (bool, optional): Indicates whether to
                         compute the attributions with respect to the neuron input
-                        or output. If `attribute_to_layer_input` is set to True
+                        or output. If `attribute_to_neuron_input` is set to True
                         then the attributions will be computed with respect to
-                        neuron inputs, otherwise it will be computed with respect
-                        to neuron outputs.
-                        Note that currently it assumes that both the inputs and
-                        outputs of internal layers are single tensors.
+                        neuron's inputs, otherwise it will be computed with respect
+                        to neuron's outputs.
+                        Note that currently it is assumed that either the input
+                        or the output of internal neuron, depending on whether we
+                        attribute to the input or output, is a single tensor.
                         Support for multiple tensors will be added later.
                         Default: False
         Returns:

--- a/captum/attr/_core/neuron_deep_lift.py
+++ b/captum/attr/_core/neuron_deep_lift.py
@@ -1,0 +1,281 @@
+from .._utils.attribution import NeuronAttribution
+from .._utils.gradient import _forward_layer_eval_with_neuron_grads
+
+from .deep_lift import DeepLift, DeepLiftShap
+
+
+class NeuronDeepLift(NeuronAttribution):
+    def __init__(self, model, layer):
+        r"""
+        Args:
+
+            model (torch.nn.Module):  The reference to PyTorch model instance.
+            layer (torch.nn.Module): Layer for which neuron attributions are computed.
+                          Attributions for a particular neuron for the input or output
+                          of this layer are computed using the argument neuron_index
+                          in the attribute method.
+                          Currently, only layers with a single tensor input and output
+                          are supported.
+        """
+        super(NeuronAttribution, self).__init__(model, layer)
+
+    def attribute(
+        self,
+        inputs,
+        neuron_index,
+        baselines=None,
+        additional_forward_args=None,
+        attribute_to_neuron_input=False,
+    ):
+        r""""
+        Implements DeepLIFT algorithm for the neuron based on the following paper:
+        Learning Important Features Through Propagating Activation Differences,
+        Avanti Shrikumar, et. al.
+        https://arxiv.org/abs/1704.02685
+
+        and the gradient formulation proposed in:
+        Towards better understanding of gradient-based attribution methods for
+        deep neural networks,  Marco Ancona, et.al.
+        https://openreview.net/pdf?id=Sy21R9JAW
+
+        This implementation supports only Rescale rule. RevealCancel rule will
+        be supported in later releases.
+        Although DeepLIFT's(Rescale Rule) attribution quality is comparable with
+        Integrated Gradients, it runs significantly faster than Integrated
+        Gradients and is preferred for large datasets.
+
+        Currently we only support a limited number of non-linear activations
+        but the plan is to expand the list in the future.
+
+        Note: As we know, currently we cannot access the building blocks,
+        of PyTorch's built-in LSTM, RNNs and GRUs such as Tanh and Sigmoid.
+        Nonetheless, it is possible to build custom LSTMs, RNNS and GRUs
+        with performance similar to built-in ones using TorchScript.
+        More details on how to build custom RNNs can be found here:
+        https://pytorch.org/blog/optimizing-cuda-rnn-with-torchscript/
+
+        Args:
+
+            inputs (tensor or tuple of tensors):  Input for which layer
+                        attributions are computed. If forward_func takes a
+                        single tensor as input, a single input tensor should be
+                        provided. If forward_func takes multiple tensors as input,
+                        a tuple of the input tensors should be provided. It is
+                        assumed that for all given input tensors, dimension 0
+                        corresponds to the number of examples (aka batch size),
+                        and if multiple input tensors are provided, the examples
+                        must be aligned appropriately.
+            neuron_index (int or tuple): Index of neuron in output of given
+                        layer for which attribution is desired. Length of
+                        this tuple must be one less than the number of
+                        dimensions in the output of the given layer (since
+                        dimension 0 corresponds to number of examples).
+                        An integer may be provided instead of a tuple of
+                        length 1.
+            baselines (tensor or tuple of tensors, optional): Baselines define
+                        reference samples which are compared with the inputs.
+                        In order to assign attribution scores DeepLift computes
+                        the differences between the inputs and references and
+                        corresponding outputs.
+                        If inputs is a single tensor, baselines must also be a
+                        single tensor with exactly the same dimensions as inputs.
+                        If inputs is a tuple of tensors, baselines must also be
+                        a tuple of tensors, with matching dimensions to inputs.
+                        Default: zero tensor for each input tensor
+            additional_forward_args (tuple, optional): If the forward function
+                        requires additional arguments other than the inputs for
+                        which attributions should not be computed, this argument
+                        can be provided. It must be either a single additional
+                        argument of a Tensor or arbitrary (non-tuple) type or a tuple
+                        containing multiple additional arguments including tensors
+                        or any arbitrary python types. These arguments are provided
+                        to forward_func in order, following the arguments in inputs.
+                        Note that attributions are not computed with respect
+                        to these arguments.
+                        Default: None
+            attribute_to_neuron_input (bool, optional): Indicates whether to
+                        compute the attributions with respect to the neuron input
+                        or output. If `attribute_to_layer_input` is set to True
+                        then the attributions will be computed with respect to
+                        neuron's inputs, otherwise it will be computed with respect
+                        to neuron's outputs.
+                        Note that currently it assumes that both the inputs and
+                        outputs of internal layers are single tensors.
+                        Support for multiple tensors will be added later.
+                        Default: False
+        Returns:
+            **attributions** or 2-element tuple of **attributions**, **delta**:
+            - **attributions** (*tensor* or tuple of *tensors*):
+                Computes attributions using Deeplift's rescale rule for
+                particular neuron with respect to each input feature.
+                Attributions will always be the same size as the provided
+                inputs, with each value providing the attribution of the
+                corresponding input index.
+                If a single tensor is provided as inputs, a single tensor is
+                returned. If a tuple is provided for inputs, a tuple of
+                corresponding sized tensors is returned.
+
+        Examples::
+
+            >>> # ImageClassifier takes a single input tensor of images Nx3x32x32,
+            >>> # and returns an Nx10 tensor of class probabilities.
+            >>> net = ImageClassifier()
+            >>> # creates an instance of LayerDeepLift to interpret target
+            >>> # class 1 with respect to conv4 layer.
+            >>> dl = NeuronDeepLift(net, net.conv4)
+            >>> input = torch.randn(1, 3, 32, 32, requires_grad=True)
+            >>> # Computes deeplift attribution scores for conv4 layer and neuron
+            >>> # index (4,1,2).
+            >>> attribution = dl.attribute(input, (4,1,2))
+        """
+        def grad_fn(forward_fn, inputs, target_ind=None, additional_forward_args=None):
+            _, grads = _forward_layer_eval_with_neuron_grads(
+                forward_fn,
+                inputs,
+                self.layer,
+                additional_forward_args,
+                neuron_index,
+                attribute_to_layer_input=attribute_to_neuron_input,
+            )
+            return grads
+
+        dl = DeepLift(self.forward_func)
+        dl.gradient_func = grad_fn
+
+        return dl.attribute(
+            inputs, baselines, additional_forward_args=additional_forward_args
+        )
+
+
+class NeuronDeepLiftShap(NeuronAttribution):
+    def __init__(self, model, layer):
+        r"""
+        Args:
+
+            model (torch.nn.Module):  The reference to PyTorch model instance.
+            layer (torch.nn.Module): Layer for which neuron attributions are computed.
+                          Attributions for a particular neuron for the input or output
+                          of this layer are computed using the argument neuron_index
+                          in the attribute method.
+                          Currently, only layers with a single tensor input and output
+                          are supported.
+        """
+        super(NeuronAttribution, self).__init__(model, layer)
+
+    def attribute(
+        self,
+        inputs,
+        neuron_index,
+        baselines=None,
+        additional_forward_args=None,
+        attribute_to_neuron_input=False,
+    ):
+        r"""
+        Extends NeuronAttribution and uses LayerDeepLiftShap alogrithms and
+        approximates SHAP values for given input `layer` and `neuron_index`.
+        For each input sample - baseline pair it computes DeepLift attributions
+        with respect to inputs or outputs of given `layer` and `neuron_index`
+        averages resulting attributions across baselines. Whether to compute the
+        attributions with respect to the inputs or outputs of the layer is defined
+        by the input flag `attribute_to_layer_input`.
+        More details about the algorithm can be found here:
+
+        http://papers.nips.cc/paper/7062-a-unified-approach-to-interpreting-model-predictions.pdf
+
+        Note that the explanation model:
+            1. Assumes that input features are independent of one another
+            2. Is linear, meaning that the explanations are modeled through
+               the additive composition of feature effects.
+        Although, it assumes a linear model for each explanation, the overall
+        model across multiple explanations can be complex and non-linear.
+        Args:
+
+            inputs (tensor or tuple of tensors):  Input for which layer
+                        attributions are computed. If forward_func takes a
+                        single tensor as input, a single input tensor should be
+                        provided. If forward_func takes multiple tensors as input,
+                        a tuple of the input tensors should be provided. It is
+                        assumed that for all given input tensors, dimension 0
+                        corresponds to the number of examples (aka batch size),
+                        and if multiple input tensors are provided, the examples
+                        must be aligned appropriately.
+            neuron_index (int or tuple): Index of neuron in output of given
+                        layer for which attribution is desired. Length of
+                        this tuple must be one less than the number of
+                        dimensions in the output of the given layer (since
+                        dimension 0 corresponds to number of examples).
+                        An integer may be provided instead of a tuple of
+                        length 1.
+            baselines (tensor or tuple of tensors, optional): Baselines define
+                        reference samples which are compared with the inputs.
+                        In order to assign attribution scores DeepLift computes
+                        the differences between the inputs and references and
+                        corresponding outputs.
+                        If inputs is a single tensor, baselines must also be a
+                        single tensor with exactly the same dimensions as inputs.
+                        If inputs is a tuple of tensors, baselines must also be
+                        a tuple of tensors, with matching dimensions to inputs.
+                        Default: zero tensor for each input tensor
+            additional_forward_args (tuple, optional): If the forward function
+                        requires additional arguments other than the inputs for
+                        which attributions should not be computed, this argument
+                        can be provided. It must be either a single additional
+                        argument of a Tensor or arbitrary (non-tuple) type or a tuple
+                        containing multiple additional arguments including tensors
+                        or any arbitrary python types. These arguments are provided
+                        to forward_func in order, following the arguments in inputs.
+                        Note that attributions are not computed with respect
+                        to these arguments.
+                        Default: None
+            attribute_to_neuron_input (bool, optional): Indicates whether to
+                        compute the attributions with respect to the neuron input
+                        or output. If `attribute_to_layer_input` is set to True
+                        then the attributions will be computed with respect to
+                        neuron inputs, otherwise it will be computed with respect
+                        to neuron outputs.
+                        Note that currently it assumes that both the inputs and
+                        outputs of internal layers are single tensors.
+                        Support for multiple tensors will be added later.
+                        Default: False
+        Returns:
+            **attributions** or 2-element tuple of **attributions**, **delta**:
+            - **attributions** (*tensor* or tuple of *tensors*):
+                        Computes attributions using Deeplift's rescale rule for
+                        particular neuron with respect to each input feature.
+                        Attributions will always be the same size as the provided
+                        inputs, with each value providing the attribution of the
+                        corresponding input index.
+                        If a single tensor is provided as inputs, a single tensor is
+                        returned. If a tuple is provided for inputs, a tuple of
+                        corresponding sized tensors is returned.
+
+        Examples::
+
+            >>> # ImageClassifier takes a single input tensor of images Nx3x32x32,
+            >>> # and returns an Nx10 tensor of class probabilities.
+            >>> net = ImageClassifier()
+            >>> # creates an instance of LayerDeepLift to interpret target
+            >>> # class 1 with respect to conv4 layer.
+            >>> dl = NeuronDeepLiftShap(net, net.conv4)
+            >>> input = torch.randn(1, 3, 32, 32, requires_grad=True)
+            >>> # Computes deeplift attribution scores for conv4 layer and neuron
+            >>> # index (4,1,2).
+            >>> attribution = dl.attribute(input, (4,1,2))
+        """
+        def grad_fn(forward_fn, inputs, target_ind=None, additional_forward_args=None):
+            _, grads = _forward_layer_eval_with_neuron_grads(
+                forward_fn,
+                inputs,
+                self.layer,
+                additional_forward_args,
+                neuron_index,
+                attribute_to_layer_input=attribute_to_neuron_input,
+            )
+            return grads
+
+        dl = DeepLiftShap(self.forward_func)
+        dl.gradient_func = grad_fn
+
+        return dl.attribute(
+            inputs, baselines, additional_forward_args=additional_forward_args
+        )

--- a/captum/attr/_core/neuron_deep_lift.py
+++ b/captum/attr/_core/neuron_deep_lift.py
@@ -128,6 +128,7 @@ class NeuronDeepLift(NeuronAttribution):
             >>> # index (4,1,2).
             >>> attribution = dl.attribute(input, (4,1,2))
         """
+
         def grad_fn(forward_fn, inputs, target_ind=None, additional_forward_args=None):
             _, grads = _forward_layer_eval_with_neuron_grads(
                 forward_fn,
@@ -262,6 +263,7 @@ class NeuronDeepLiftShap(NeuronAttribution):
             >>> # index (4,1,2).
             >>> attribution = dl.attribute(input, (4,1,2))
         """
+
         def grad_fn(forward_fn, inputs, target_ind=None, additional_forward_args=None):
             _, grads = _forward_layer_eval_with_neuron_grads(
                 forward_fn,

--- a/captum/attr/_core/neuron_gradient.py
+++ b/captum/attr/_core/neuron_gradient.py
@@ -20,11 +20,11 @@ class NeuronGradient(NeuronAttribution):
             forward_func (callable):  The forward function of the model or any
                           modification of it
             layer (torch.nn.Module): Layer for which neuron attributions are computed.
-                          Attributions for a particular neuron in the output of
-                          this layer are computed using the argument neuron_index
+                          Attributions for a particular neuron in the input or output
+                          of this layer are computed using the argument neuron_index
                           in the attribute method.
-                          Currently, only layers with a single tensor output are
-                          supported.
+                          Currently, only layers with a single tensor input and output
+                          are supported.
             device_ids (list(int)): Device ID list, necessary only if forward_func
                           applies a DataParallel model. This allows reconstruction of
                           intermediate outputs from batched results across devices.
@@ -33,7 +33,13 @@ class NeuronGradient(NeuronAttribution):
         """
         super().__init__(forward_func, layer, device_ids)
 
-    def attribute(self, inputs, neuron_index, additional_forward_args=None):
+    def attribute(
+        self,
+        inputs,
+        neuron_index,
+        additional_forward_args=None,
+        attribute_to_neuron_input=False,
+    ):
         r"""
             Computes the gradient of the output of a particular neuron with
             respect to the inputs of the network.
@@ -67,6 +73,16 @@ class NeuronGradient(NeuronAttribution):
                             Note that attributions are not computed with respect
                             to these arguments.
                             Default: None
+                attribute_to_neuron_input (bool, optional): Indicates whether to
+                            compute the attributions with respect to the neuron input
+                            or output. If `attribute_to_layer_input` is set to True
+                            then the attributions will be computed with respect to
+                            neuron's inputs, otherwise it will be computed with respect
+                            to neuron's outputs.
+                            Note that currently it assumes that both the inputs and
+                            outputs of internal layers are single tensors.
+                            Support for multiple tensors will be added later.
+                            Default: False
 
             Returns:
                 *tensor* or tuple of *tensors* of **attributions**:
@@ -111,6 +127,7 @@ class NeuronGradient(NeuronAttribution):
             additional_forward_args,
             neuron_index,
             device_ids=self.device_ids,
+            attribute_to_layer_input=attribute_to_neuron_input,
         )
 
         undo_gradient_requirements(inputs, gradient_mask)

--- a/captum/attr/_core/neuron_gradient.py
+++ b/captum/attr/_core/neuron_gradient.py
@@ -19,12 +19,15 @@ class NeuronGradient(NeuronAttribution):
 
             forward_func (callable):  The forward function of the model or any
                           modification of it
-            layer (torch.nn.Module): Layer for which neuron attributions are computed.
-                          Attributions for a particular neuron in the input or output
-                          of this layer are computed using the argument neuron_index
-                          in the attribute method.
-                          Currently, only layers with a single tensor input and output
-                          are supported.
+            layer (torch.nn.Module): Layer for which attributions are computed.
+                          Output size of attribute matches this layer's input or
+                          output dimensions, depending on whether we attribute to
+                          the inputs or outputs of the layer, corresponding to
+                          attribution of each neuron in the input or output of
+                          this layer.
+                          Currently, it is assumed that the inputs or the outputs
+                          of the layer, depending on which one is used for
+                          attribution, can only be a single tensor.
             device_ids (list(int)): Device ID list, necessary only if forward_func
                           applies a DataParallel model. This allows reconstruction of
                           intermediate outputs from batched results across devices.
@@ -79,8 +82,9 @@ class NeuronGradient(NeuronAttribution):
                             then the attributions will be computed with respect to
                             neuron's inputs, otherwise it will be computed with respect
                             to neuron's outputs.
-                            Note that currently it assumes that both the inputs and
-                            outputs of internal layers are single tensors.
+                            Note that currently it is assumed that either the inputs
+                            or the outputs of internal layers, depending on whether we
+                            attribute to the inputs or outputs, are single tensors.
                             Support for multiple tensors will be added later.
                             Default: False
 

--- a/captum/attr/_core/neuron_gradient.py
+++ b/captum/attr/_core/neuron_gradient.py
@@ -78,13 +78,13 @@ class NeuronGradient(NeuronAttribution):
                             Default: None
                 attribute_to_neuron_input (bool, optional): Indicates whether to
                             compute the attributions with respect to the neuron input
-                            or output. If `attribute_to_layer_input` is set to True
+                            or output. If `attribute_to_neuron_input` is set to True
                             then the attributions will be computed with respect to
                             neuron's inputs, otherwise it will be computed with respect
                             to neuron's outputs.
-                            Note that currently it is assumed that either the inputs
-                            or the outputs of internal layers, depending on whether we
-                            attribute to the inputs or outputs, are single tensors.
+                            Note that currently it is assumed that either the input
+                            or the output of internal neurons, depending on whether we
+                            attribute to the input or output, is a single tensor.
                             Support for multiple tensors will be added later.
                             Default: False
 

--- a/captum/attr/_core/neuron_integrated_gradients.py
+++ b/captum/attr/_core/neuron_integrated_gradients.py
@@ -13,11 +13,11 @@ class NeuronIntegratedGradients(NeuronAttribution):
             forward_func (callable):  The forward function of the model or any
                           modification of it
             layer (torch.nn.Module): Layer for which attributions are computed.
-                          Attributions for a particular neuron in the output of
-                          this layer are computed using the argument neuron_index
-                          in the attribute method.
-                          Currently, only layers with a single tensor output are
-                          supported.
+                          Attributions for a particular neuron in the input or
+                          output of this layer are computed using the argument
+                          neuron_index in the attribute method.
+                          Currently, only layers with a single tensor input or output
+                          are supported.
             device_ids (list(int)): Device ID list, necessary only if forward_func
                           applies a DataParallel model. This allows reconstruction of
                           intermediate outputs from batched results across devices.
@@ -35,6 +35,7 @@ class NeuronIntegratedGradients(NeuronAttribution):
         n_steps=50,
         method="gausslegendre",
         internal_batch_size=None,
+        attribute_to_neuron_input=False,
     ):
         r"""
             Approximates the integral of gradients for a particular neuron
@@ -105,6 +106,16 @@ class NeuronIntegratedGradients(NeuronAttribution):
                             If internal_batch_size is None, then all evaluations are
                             processed in one batch.
                             Default: None
+                attribute_to_neuron_input (bool, optional): Indicates whether to
+                            compute the attribution with respect to the neuron input
+                            or output. If `attribute_to_neuron_input` is set to True
+                            then the attributions will be computed with respect to
+                            neuron inputs, otherwise it will be computed with respect
+                            to neuron outputs.
+                            Note that currently it assumes that both the inputs and
+                            outputs of internal neurons are single tensors.
+                            Support for multiple tensors will be added later.
+                            Default: False
 
             Returns:
                 *tensor* or tuple of *tensors* of **attributions**:

--- a/captum/attr/_core/neuron_integrated_gradients.py
+++ b/captum/attr/_core/neuron_integrated_gradients.py
@@ -110,14 +110,14 @@ class NeuronIntegratedGradients(NeuronAttribution):
                             processed in one batch.
                             Default: None
                 attribute_to_neuron_input (bool, optional): Indicates whether to
-                            compute the attribution with respect to the neuron input
+                            compute the attributions with respect to the neuron input
                             or output. If `attribute_to_neuron_input` is set to True
                             then the attributions will be computed with respect to
-                            neuron inputs, otherwise it will be computed with respect
-                            to neuron outputs.
-                            Note that currently it is assumed that either the inputs
-                            or the outputs of internal layers, depending on whether we
-                            attribute to the inputs or outputs, are single tensors.
+                            neuron's inputs, otherwise it will be computed with respect
+                            to neuron's outputs.
+                            Note that currently it is assumed that either the input
+                            or the output of internal neuron, depending on whether we
+                            attribute to the input or output, is a single tensor.
                             Support for multiple tensors will be added later.
                             Default: False
 
@@ -153,7 +153,7 @@ class NeuronIntegratedGradients(NeuronAttribution):
         """
         ig = IntegratedGradients(self.forward_func)
         ig.gradient_func = construct_neuron_grad_fn(
-            self.layer, neuron_index, self.device_ids
+            self.layer, neuron_index, self.device_ids, attribute_to_neuron_input
         )
         # Return only attributions and not delta
         return ig.attribute(

--- a/captum/attr/_core/neuron_integrated_gradients.py
+++ b/captum/attr/_core/neuron_integrated_gradients.py
@@ -13,11 +13,14 @@ class NeuronIntegratedGradients(NeuronAttribution):
             forward_func (callable):  The forward function of the model or any
                           modification of it
             layer (torch.nn.Module): Layer for which attributions are computed.
-                          Attributions for a particular neuron in the input or
-                          output of this layer are computed using the argument
-                          neuron_index in the attribute method.
-                          Currently, only layers with a single tensor input or output
-                          are supported.
+                          Output size of attribute matches this layer's input or
+                          output dimensions, depending on whether we attribute to
+                          the inputs or outputs of the layer, corresponding to
+                          attribution of each neuron in the input or output of
+                          this layer.
+                          Currently, it is assumed that the inputs or the outputs
+                          of the layer, depending on which one is used for
+                          attribution, can only be a single tensor.
             device_ids (list(int)): Device ID list, necessary only if forward_func
                           applies a DataParallel model. This allows reconstruction of
                           intermediate outputs from batched results across devices.
@@ -112,8 +115,9 @@ class NeuronIntegratedGradients(NeuronAttribution):
                             then the attributions will be computed with respect to
                             neuron inputs, otherwise it will be computed with respect
                             to neuron outputs.
-                            Note that currently it assumes that both the inputs and
-                            outputs of internal neurons are single tensors.
+                            Note that currently it is assumed that either the inputs
+                            or the outputs of internal layers, depending on whether we
+                            attribute to the inputs or outputs, are single tensors.
                             Support for multiple tensors will be added later.
                             Default: False
 

--- a/captum/attr/_utils/gradient.py
+++ b/captum/attr/_utils/gradient.py
@@ -203,7 +203,6 @@ def _forward_layer_eval_with_neuron_grads(
     # If only one key exists (standard model), key list simply has one element.
     key_list = _sort_key_list(list(saved_layer.keys()), device_ids)
     if gradient_neuron_index is not None:
-        print('_neuron_gradients')
         inp_grads = _neuron_gradients(
             inputs, saved_layer, key_list, gradient_neuron_index
         )

--- a/captum/attr/_utils/gradient.py
+++ b/captum/attr/_utils/gradient.py
@@ -331,7 +331,9 @@ def compute_layer_gradients_and_eval(
             return all_grads, all_outputs
 
 
-def construct_neuron_grad_fn(layer, neuron_index, device_ids):
+def construct_neuron_grad_fn(
+    layer, neuron_index, device_ids=None, attribute_to_neuron_input=False
+):
     def grad_fn(forward_fn, inputs, target_ind=None, additional_forward_args=None):
         _, grads = _forward_layer_eval_with_neuron_grads(
             forward_fn,
@@ -340,6 +342,7 @@ def construct_neuron_grad_fn(layer, neuron_index, device_ids):
             additional_forward_args,
             neuron_index,
             device_ids=device_ids,
+            attribute_to_layer_input=attribute_to_neuron_input,
         )
         return grads
 

--- a/tests/attr/helpers/basic_models.py
+++ b/tests/attr/helpers/basic_models.py
@@ -121,21 +121,22 @@ class TanhDeepLiftModel(nn.Module):
 
 class ReLULinearDeepLiftModel(nn.Module):
     r"""
-        Architecture is based on:
-        https://github.com/marcoancona/DeepExplain/blob/master/deepexplain/
-        tests/test_tensorflow.py#L65
+        Simple architecture similar to:
+        https://github.com/marcoancona/DeepExplain/blob/master/deepexplain/tests/test_tensorflow.py#L65
     """
 
     def __init__(self):
         super().__init__()
         self.l1 = nn.Linear(3, 1, bias=False)
         self.l2 = nn.Linear(3, 1, bias=False)
-        self.l1.weight = nn.Parameter(torch.tensor([[3.0, 1.0, 0.0], [0.0, 1.0, 3.0]]))
-        self.l2.weight = nn.Parameter(torch.tensor([[2.0, 3.0, 0.0], [0.0, 1.0, 2.0]]))
+        self.l1.weight = nn.Parameter(torch.tensor([[3.0, 1.0, 0.0]]))
+        self.l2.weight = nn.Parameter(torch.tensor([[2.0, 3.0, 0.0]]))
         self.relu = nn.ReLU()
+        self.l3 = nn.Linear(2, 1, bias=False)
+        self.l3.weight = nn.Parameter(torch.tensor([[1.0, 1.0]]))
 
     def forward(self, x1, x2):
-        return self.relu(torch.cat([self.l1(x1), self.l2(x2)], axis=1)).sum(axis=1)
+        return self.l3(self.relu(torch.cat([self.l1(x1), self.l2(x2)], axis=1)))
 
 
 class TextModule(nn.Module):

--- a/tests/attr/helpers/utils.py
+++ b/tests/attr/helpers/utils.py
@@ -39,6 +39,16 @@ def assertAttributionComparision(test, attributions1, attributions2):
                 test.assertAlmostEqual(attr_row1, attr_row2, delta=0.05)
 
 
+def assert_delta(test, delta):
+    delta_condition = all(abs(delta.numpy().flatten()) < 0.00001)
+    test.assertTrue(
+        delta_condition,
+        "The sum of attribution values {} for relu layer is not "
+        "nearly equal to the difference between the endpoint for "
+        "some samples".format(delta),
+    )
+
+
 class BaseTest(unittest.TestCase):
     """
     This class provides a basic framework for all Captum tests by providing

--- a/tests/attr/test_data_parallel.py
+++ b/tests/attr/test_data_parallel.py
@@ -313,6 +313,7 @@ class Test(BaseGPUTest):
             inputs=(inp1, inp2),
             additional_forward_args=(inp3, 5),
             neuron_index=(3,),
+        )
 
     def test_multi_input_layer_deeplift(self):
         net = ReLULinearDeepLiftModel().cuda()
@@ -325,7 +326,7 @@ class Test(BaseGPUTest):
             net.model.l3,
             inputs=(inp1, inp2),
             additional_forward_args=None,
-            test_batches=True,
+            test_batches=False,
         )
 
     def test_multi_input_layer_deeplift_shap(self):
@@ -333,13 +334,21 @@ class Test(BaseGPUTest):
         inp1 = torch.tensor([[-10.0, 1.0, -5.0]], requires_grad=True).cuda()
         inp2 = torch.tensor([[3.0, 3.0, 1.0]], requires_grad=True).cuda()
 
+        base1 = torch.tensor(
+            [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]], requires_grad=True
+        ).cuda()
+        base2 = torch.tensor(
+            [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]], requires_grad=True
+        ).cuda()
+
         self._data_parallel_test_assert(
             LayerDeepLiftShap,
             net,
             net.model.l3,
             inputs=(inp1, inp2),
+            baselines=(base1, base2),
             additional_forward_args=None,
-            test_batches=True,
+            test_batches=False,
         )
 
     def test_multi_input_neuron_deeplift(self):
@@ -352,8 +361,9 @@ class Test(BaseGPUTest):
             net,
             net.model.l3,
             inputs=(inp1, inp2),
+            neuron_index=0,
             additional_forward_args=None,
-            test_batches=True,
+            test_batches=False,
         )
 
     def test_multi_input_neuron_deeplift_shap(self):
@@ -361,13 +371,22 @@ class Test(BaseGPUTest):
         inp1 = torch.tensor([[-10.0, 1.0, -5.0]], requires_grad=True).cuda()
         inp2 = torch.tensor([[3.0, 3.0, 1.0]], requires_grad=True).cuda()
 
+        base1 = torch.tensor(
+            [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]], requires_grad=True
+        ).cuda()
+        base2 = torch.tensor(
+            [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]], requires_grad=True
+        ).cuda()
+
         self._data_parallel_test_assert(
             NeuronDeepLiftShap,
             net,
             net.model.l3,
             inputs=(inp1, inp2),
+            neuron_index=0,
+            baselines=(base1, base2),
             additional_forward_args=None,
-            test_batches=True,
+            test_batches=False,
         )
 
     def _alt_device_list(self):

--- a/tests/attr/test_data_parallel.py
+++ b/tests/attr/test_data_parallel.py
@@ -323,7 +323,7 @@ class Test(BaseGPUTest):
         self._data_parallel_test_assert(
             LayerDeepLift,
             net,
-            net.model.l3,
+            net.l3,
             inputs=(inp1, inp2),
             additional_forward_args=None,
             test_batches=False,
@@ -344,7 +344,7 @@ class Test(BaseGPUTest):
         self._data_parallel_test_assert(
             LayerDeepLiftShap,
             net,
-            net.model.l3,
+            net.l3,
             inputs=(inp1, inp2),
             baselines=(base1, base2),
             additional_forward_args=None,
@@ -359,7 +359,7 @@ class Test(BaseGPUTest):
         self._data_parallel_test_assert(
             NeuronDeepLift,
             net,
-            net.model.l3,
+            net.l3,
             inputs=(inp1, inp2),
             neuron_index=0,
             additional_forward_args=None,
@@ -381,7 +381,7 @@ class Test(BaseGPUTest):
         self._data_parallel_test_assert(
             NeuronDeepLiftShap,
             net,
-            net.model.l3,
+            net.l3,
             inputs=(inp1, inp2),
             neuron_index=0,
             baselines=(base1, base2),

--- a/tests/attr/test_data_parallel.py
+++ b/tests/attr/test_data_parallel.py
@@ -8,6 +8,7 @@ from captum.attr._core.internal_influence import InternalInfluence
 from captum.attr._core.layer_activation import LayerActivation
 from captum.attr._core.layer_conductance import LayerConductance
 from captum.attr._core.layer_gradient_x_activation import LayerGradientXActivation
+from captum.attr._core.layer_deep_lift import LayerDeepLift, LayerDeepLiftShap
 
 from captum.attr._core.neuron_conductance import NeuronConductance
 from captum.attr._core.neuron_gradient import NeuronGradient
@@ -16,11 +17,13 @@ from captum.attr._core.neuron_guided_backprop_deconvnet import (
     NeuronDeconvolution,
     NeuronGuidedBackprop,
 )
+from captum.attr._core.neuron_deep_lift import NeuronDeepLift, NeuronDeepLiftShap
 
 from .helpers.basic_models import (
     BasicModel_MultiLayer,
     BasicModel_MultiLayer_MultiInput,
     BasicModel_ConvNet,
+    ReLULinearDeepLiftModel,
 )
 from .helpers.utils import BaseGPUTest
 
@@ -310,6 +313,61 @@ class Test(BaseGPUTest):
             inputs=(inp1, inp2),
             additional_forward_args=(inp3, 5),
             neuron_index=(3,),
+
+    def test_multi_input_layer_deeplift(self):
+        net = ReLULinearDeepLiftModel().cuda()
+        inp1 = torch.tensor([[-10.0, 1.0, -5.0]], requires_grad=True).cuda()
+        inp2 = torch.tensor([[3.0, 3.0, 1.0]], requires_grad=True).cuda()
+
+        self._data_parallel_test_assert(
+            LayerDeepLift,
+            net,
+            net.model.l3,
+            inputs=(inp1, inp2),
+            additional_forward_args=None,
+            test_batches=True,
+        )
+
+    def test_multi_input_layer_deeplift_shap(self):
+        net = ReLULinearDeepLiftModel().cuda()
+        inp1 = torch.tensor([[-10.0, 1.0, -5.0]], requires_grad=True).cuda()
+        inp2 = torch.tensor([[3.0, 3.0, 1.0]], requires_grad=True).cuda()
+
+        self._data_parallel_test_assert(
+            LayerDeepLiftShap,
+            net,
+            net.model.l3,
+            inputs=(inp1, inp2),
+            additional_forward_args=None,
+            test_batches=True,
+        )
+
+    def test_multi_input_neuron_deeplift(self):
+        net = ReLULinearDeepLiftModel().cuda()
+        inp1 = torch.tensor([[-10.0, 1.0, -5.0]], requires_grad=True).cuda()
+        inp2 = torch.tensor([[3.0, 3.0, 1.0]], requires_grad=True).cuda()
+
+        self._data_parallel_test_assert(
+            NeuronDeepLift,
+            net,
+            net.model.l3,
+            inputs=(inp1, inp2),
+            additional_forward_args=None,
+            test_batches=True,
+        )
+
+    def test_multi_input_neuron_deeplift_shap(self):
+        net = ReLULinearDeepLiftModel().cuda()
+        inp1 = torch.tensor([[-10.0, 1.0, -5.0]], requires_grad=True).cuda()
+        inp2 = torch.tensor([[3.0, 3.0, 1.0]], requires_grad=True).cuda()
+
+        self._data_parallel_test_assert(
+            NeuronDeepLiftShap,
+            net,
+            net.model.l3,
+            inputs=(inp1, inp2),
+            additional_forward_args=None,
+            test_batches=True,
         )
 
     def _alt_device_list(self):

--- a/tests/attr/test_layer_deeplift_basic.py
+++ b/tests/attr/test_layer_deeplift_basic.py
@@ -1,10 +1,8 @@
 from __future__ import print_function
 
-import numpy as np
-
 import torch
 
-from .helpers.utils import BaseTest, assertArraysAlmostEqual, assert_delta
+from .helpers.utils import BaseTest, assertTensorAlmostEqual, assert_delta
 from .helpers.basic_models import ReLULinearDeepLiftModel
 
 from captum.attr._core.layer_deep_lift import LayerDeepLift, LayerDeepLiftShap
@@ -22,7 +20,7 @@ class TestDeepLift(BaseTest):
             attribute_to_layer_input=True,
             return_convergence_delta=True,
         )
-        assertArraysAlmostEqual(np.array([[0.0, 15.0]]), attributions.detach().numpy())
+        assertTensorAlmostEqual(self, attributions, [[0.0, 15.0]])
         assert_delta(self, delta)
 
     def test_linear_layer_deeplift(self):
@@ -36,7 +34,7 @@ class TestDeepLift(BaseTest):
             attribute_to_layer_input=True,
             return_convergence_delta=True,
         )
-        assertArraysAlmostEqual(np.array([[0.0, 15.0]]), attributions.detach().numpy())
+        assertTensorAlmostEqual(self, attributions, [[0.0, 15.0]])
         assert_delta(self, delta)
 
         attributions, delta = layer_dl.attribute(
@@ -45,14 +43,15 @@ class TestDeepLift(BaseTest):
             attribute_to_layer_input=False,
             return_convergence_delta=True,
         )
-        assertArraysAlmostEqual(np.array([[15.0]]), attributions.detach().numpy())
+        assertTensorAlmostEqual(self, attributions, [[15.0]])
         assert_delta(self, delta)
 
     def test_relu_layer_deepliftshap(self):
         model = ReLULinearDeepLiftModel()
-        inputs, baselines = (
-            _create_inps_and_base_for_deepliftshap_neuron_layer_testing()
-        )
+        (
+            inputs,
+            baselines,
+        ) = _create_inps_and_base_for_deepliftshap_neuron_layer_testing()
         layer_dl_shap = LayerDeepLiftShap(model, model.relu)
         attributions, delta = layer_dl_shap.attribute(
             inputs,
@@ -60,14 +59,15 @@ class TestDeepLift(BaseTest):
             attribute_to_layer_input=True,
             return_convergence_delta=True,
         )
-        assertArraysAlmostEqual(np.array([[0.0, 15.0]]), attributions.detach().numpy())
+        assertTensorAlmostEqual(self, attributions, [[0.0, 15.0]])
         assert_delta(self, delta)
 
     def test_linear_layer_deepliftshap(self):
         model = ReLULinearDeepLiftModel()
-        inputs, baselines = (
-            _create_inps_and_base_for_deepliftshap_neuron_layer_testing()
-        )
+        (
+            inputs,
+            baselines,
+        ) = _create_inps_and_base_for_deepliftshap_neuron_layer_testing()
         layer_dl_shap = LayerDeepLiftShap(model, model.l3)
         attributions, delta = layer_dl_shap.attribute(
             inputs,
@@ -75,7 +75,7 @@ class TestDeepLift(BaseTest):
             attribute_to_layer_input=True,
             return_convergence_delta=True,
         )
-        assertArraysAlmostEqual(np.array([[0.0, 15.0]]), attributions.detach().numpy())
+        assertTensorAlmostEqual(self, attributions, [[0.0, 15.0]])
         assert_delta(self, delta)
         attributions, delta = layer_dl_shap.attribute(
             inputs,
@@ -83,7 +83,7 @@ class TestDeepLift(BaseTest):
             attribute_to_layer_input=False,
             return_convergence_delta=True,
         )
-        assertArraysAlmostEqual(np.array([[15.0]]), attributions.detach().numpy())
+        assertTensorAlmostEqual(self, attributions, [[15.0]])
         assert_delta(self, delta)
 
 

--- a/tests/attr/test_layer_deeplift_basic.py
+++ b/tests/attr/test_layer_deeplift_basic.py
@@ -7,8 +7,6 @@ import torch
 from .helpers.utils import BaseTest, assertArraysAlmostEqual, assert_delta
 from .helpers.basic_models import ReLULinearDeepLiftModel
 
-from captum.attr._core.deep_lift import DeepLift
-from captum.attr._core.neuron_deep_lift import NeuronDeepLift
 from captum.attr._core.layer_deep_lift import LayerDeepLift, LayerDeepLiftShap
 
 

--- a/tests/attr/test_layer_deeplift_basic.py
+++ b/tests/attr/test_layer_deeplift_basic.py
@@ -1,0 +1,119 @@
+from __future__ import print_function
+
+import numpy as np
+
+import torch
+
+from .helpers.utils import BaseTest, assertArraysAlmostEqual, assert_delta
+from .helpers.basic_models import ReLULinearDeepLiftModel
+
+from captum.attr._core.deep_lift import DeepLift
+from captum.attr._core.neuron_deep_lift import NeuronDeepLift
+from captum.attr._core.layer_deep_lift import LayerDeepLift, LayerDeepLiftShap
+
+
+class TestDeepLift(BaseTest):
+    def test_relu_layer_deeplift(self):
+        model = ReLULinearDeepLiftModel()
+        inputs, baselines = _create_inps_and_base_for_deeplift_neuron_layer_testing()
+
+        layer_dl = LayerDeepLift(model, model.relu)
+        attributions, delta = layer_dl.attribute(
+            inputs,
+            baselines,
+            attribute_to_layer_input=True,
+            return_convergence_delta=True,
+        )
+        assertArraysAlmostEqual(np.array([[0.0, 15.0]]), attributions.detach().numpy())
+        assert_delta(self, delta)
+
+    def test_linear_layer_deeplift(self):
+        model = ReLULinearDeepLiftModel()
+        inputs, baselines = _create_inps_and_base_for_deeplift_neuron_layer_testing()
+
+        layer_dl = LayerDeepLift(model, model.l3)
+        attributions, delta = layer_dl.attribute(
+            inputs,
+            baselines,
+            attribute_to_layer_input=True,
+            return_convergence_delta=True,
+        )
+        assertArraysAlmostEqual(np.array([[0.0, 15.0]]), attributions.detach().numpy())
+        assert_delta(self, delta)
+
+        attributions, delta = layer_dl.attribute(
+            inputs,
+            baselines,
+            attribute_to_layer_input=False,
+            return_convergence_delta=True,
+        )
+        assertArraysAlmostEqual(np.array([[15.0]]), attributions.detach().numpy())
+        assert_delta(self, delta)
+
+    def test_relu_layer_deepliftshap(self):
+        model = ReLULinearDeepLiftModel()
+        inputs, baselines = (
+            _create_inps_and_base_for_deepliftshap_neuron_layer_testing()
+        )
+        layer_dl_shap = LayerDeepLiftShap(model, model.relu)
+        attributions, delta = layer_dl_shap.attribute(
+            inputs,
+            baselines,
+            attribute_to_layer_input=True,
+            return_convergence_delta=True,
+        )
+        assertArraysAlmostEqual(np.array([[0.0, 15.0]]), attributions.detach().numpy())
+        assert_delta(self, delta)
+
+    def test_linear_layer_deepliftshap(self):
+        model = ReLULinearDeepLiftModel()
+        inputs, baselines = (
+            _create_inps_and_base_for_deepliftshap_neuron_layer_testing()
+        )
+        layer_dl_shap = LayerDeepLiftShap(model, model.l3)
+        attributions, delta = layer_dl_shap.attribute(
+            inputs,
+            baselines,
+            attribute_to_layer_input=True,
+            return_convergence_delta=True,
+        )
+        assertArraysAlmostEqual(np.array([[0.0, 15.0]]), attributions.detach().numpy())
+        assert_delta(self, delta)
+        attributions, delta = layer_dl_shap.attribute(
+            inputs,
+            baselines,
+            attribute_to_layer_input=False,
+            return_convergence_delta=True,
+        )
+        assertArraysAlmostEqual(np.array([[15.0]]), attributions.detach().numpy())
+        assert_delta(self, delta)
+
+
+def _create_inps_and_base_for_deeplift_neuron_layer_testing():
+    x1 = torch.tensor([[-10.0, 1.0, -5.0]], requires_grad=True)
+    x2 = torch.tensor([[3.0, 3.0, 1.0]], requires_grad=True)
+
+    b1 = torch.tensor([[0.0, 0.0, 0.0]], requires_grad=True)
+    b2 = torch.tensor([[0.0, 0.0, 0.0]], requires_grad=True)
+
+    inputs = (x1, x2)
+    baselines = (b1, b2)
+
+    return inputs, baselines
+
+
+def _create_inps_and_base_for_deepliftshap_neuron_layer_testing():
+    x1 = torch.tensor([[-10.0, 1.0, -5.0]], requires_grad=True)
+    x2 = torch.tensor([[3.0, 3.0, 1.0]], requires_grad=True)
+
+    b1 = torch.tensor(
+        [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], requires_grad=True
+    )
+    b2 = torch.tensor(
+        [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], requires_grad=True
+    )
+
+    inputs = (x1, x2)
+    baselines = (b1, b2)
+
+    return inputs, baselines

--- a/tests/attr/test_neuron_deeplift_basic.py
+++ b/tests/attr/test_neuron_deeplift_basic.py
@@ -1,0 +1,127 @@
+from __future__ import print_function
+
+import torch
+
+import numpy as np
+
+from .helpers.utils import BaseTest, assertArraysAlmostEqual
+from .helpers.basic_models import ReLULinearDeepLiftModel
+
+from captum.attr._core.neuron_deep_lift import NeuronDeepLift, NeuronDeepLiftShap
+from .test_layer_deeplift_basic import (
+    _create_inps_and_base_for_deeplift_neuron_layer_testing,
+    _create_inps_and_base_for_deepliftshap_neuron_layer_testing,
+)
+
+
+class Test(BaseTest):
+    def test_relu_neuron_deeplift(self):
+        model = ReLULinearDeepLiftModel()
+
+        x1 = torch.tensor([[-10.0, 1.0, -5.0]], requires_grad=True)
+        x2 = torch.tensor([[3.0, 3.0, 1.0]], requires_grad=True)
+
+        inputs = (x1, x2)
+        #baselines = _create_inps_and_base_for_deeplift_neuron_layer_testing()
+
+        neuron_dl = NeuronDeepLift(model, model.relu)
+        attributions = neuron_dl.attribute(
+            inputs, 0, attribute_to_neuron_input=True
+        )
+        assertArraysAlmostEqual(
+            np.array([[-30.0, 1.0, -0.0]]), attributions[0].detach().numpy()
+        )
+        assertArraysAlmostEqual(
+            np.array([[0.0, 0.0, 0.0]]), attributions[1].detach().numpy()
+        )
+
+        attributions = neuron_dl.attribute(
+            inputs, 0, attribute_to_neuron_input=False
+        )
+        assertArraysAlmostEqual(
+            np.array([[0.0, 0.0, 0.0]]), attributions[0].detach().numpy()
+        )
+        assertArraysAlmostEqual(
+            np.array([[0.0, 0.0, 0.0]]), attributions[1].detach().numpy()
+        )
+
+    def test_linear_neuron_deeplift(self):
+        model = ReLULinearDeepLiftModel()
+        inputs, baselines = _create_inps_and_base_for_deeplift_neuron_layer_testing()
+
+        neuron_dl = NeuronDeepLift(model, model.l3)
+        attributions = neuron_dl.attribute(
+            inputs, 0, baselines, attribute_to_neuron_input=True
+        )
+        assertArraysAlmostEqual(
+            np.array([[-0.0, 0.0, -0.0]]), attributions[0].detach().numpy()
+        )
+        assertArraysAlmostEqual(
+            np.array([[0.0, 0.0, 0.0]]), attributions[1].detach().numpy()
+        )
+
+        attributions = neuron_dl.attribute(
+            inputs, 0, baselines, attribute_to_neuron_input=False
+        )
+
+        assertArraysAlmostEqual(
+            np.array([[-0.0, 0.0, -0.0]]), attributions[0].detach().numpy()
+        )
+        assertArraysAlmostEqual(
+            np.array([[6.0, 9.0, 0.0]]), attributions[1].detach().numpy()
+        )
+
+    def test_relu_neuron_deeplift_shap(self):
+        model = ReLULinearDeepLiftModel()
+        inputs, baselines = (
+            _create_inps_and_base_for_deepliftshap_neuron_layer_testing()
+        )
+
+        neuron_dl = NeuronDeepLiftShap(model, model.relu)
+        attributions = neuron_dl.attribute(
+            inputs, 0, baselines, attribute_to_neuron_input=True
+        )
+        assertArraysAlmostEqual(
+            np.array([[-30.0, 1.0, -0.0]]), attributions[0].detach().numpy()
+        )
+        assertArraysAlmostEqual(
+            np.array([[0.0, 0.0, 0.0]]), attributions[1].detach().numpy()
+        )
+
+        attributions = neuron_dl.attribute(
+            inputs, 0, baselines, attribute_to_neuron_input=False
+        )
+        assertArraysAlmostEqual(
+            np.array([[0.0, 0.0, 0.0]]), attributions[0].detach().numpy()
+        )
+        assertArraysAlmostEqual(
+            np.array([[0.0, 0.0, 0.0]]), attributions[1].detach().numpy()
+        )
+
+    def test_linear_neuron_deeplift_shap(self):
+        model = ReLULinearDeepLiftModel()
+        inputs, baselines = (
+            _create_inps_and_base_for_deepliftshap_neuron_layer_testing()
+        )
+
+        neuron_dl = NeuronDeepLiftShap(model, model.l3)
+        attributions = neuron_dl.attribute(
+            inputs, 0, baselines, attribute_to_neuron_input=True
+        )
+        assertArraysAlmostEqual(
+            np.array([[-0.0, 0.0, -0.0]]), attributions[0].detach().numpy()
+        )
+        assertArraysAlmostEqual(
+            np.array([[0.0, 0.0, 0.0]]), attributions[1].detach().numpy()
+        )
+
+        attributions = neuron_dl.attribute(
+            inputs, 0, baselines, attribute_to_neuron_input=False
+        )
+
+        assertArraysAlmostEqual(
+            np.array([[-0.0, 0.0, -0.0]]), attributions[0].detach().numpy()
+        )
+        assertArraysAlmostEqual(
+            np.array([[6.0, 9.0, 0.0]]), attributions[1].detach().numpy()
+        )

--- a/tests/attr/test_neuron_deeplift_basic.py
+++ b/tests/attr/test_neuron_deeplift_basic.py
@@ -22,12 +22,10 @@ class Test(BaseTest):
         x2 = torch.tensor([[3.0, 3.0, 1.0]], requires_grad=True)
 
         inputs = (x1, x2)
-        #baselines = _create_inps_and_base_for_deeplift_neuron_layer_testing()
+        # baselines = _create_inps_and_base_for_deeplift_neuron_layer_testing()
 
         neuron_dl = NeuronDeepLift(model, model.relu)
-        attributions = neuron_dl.attribute(
-            inputs, 0, attribute_to_neuron_input=True
-        )
+        attributions = neuron_dl.attribute(inputs, 0, attribute_to_neuron_input=True)
         assertArraysAlmostEqual(
             np.array([[-30.0, 1.0, -0.0]]), attributions[0].detach().numpy()
         )
@@ -35,9 +33,7 @@ class Test(BaseTest):
             np.array([[0.0, 0.0, 0.0]]), attributions[1].detach().numpy()
         )
 
-        attributions = neuron_dl.attribute(
-            inputs, 0, attribute_to_neuron_input=False
-        )
+        attributions = neuron_dl.attribute(inputs, 0, attribute_to_neuron_input=False)
         assertArraysAlmostEqual(
             np.array([[0.0, 0.0, 0.0]]), attributions[0].detach().numpy()
         )

--- a/tests/attr/test_neuron_deeplift_basic.py
+++ b/tests/attr/test_neuron_deeplift_basic.py
@@ -2,9 +2,7 @@ from __future__ import print_function
 
 import torch
 
-import numpy as np
-
-from .helpers.utils import BaseTest, assertArraysAlmostEqual
+from .helpers.utils import BaseTest, assertTensorAlmostEqual
 from .helpers.basic_models import ReLULinearDeepLiftModel
 
 from captum.attr._core.neuron_deep_lift import NeuronDeepLift, NeuronDeepLiftShap
@@ -22,24 +20,15 @@ class Test(BaseTest):
         x2 = torch.tensor([[3.0, 3.0, 1.0]], requires_grad=True)
 
         inputs = (x1, x2)
-        # baselines = _create_inps_and_base_for_deeplift_neuron_layer_testing()
 
         neuron_dl = NeuronDeepLift(model, model.relu)
         attributions = neuron_dl.attribute(inputs, 0, attribute_to_neuron_input=True)
-        assertArraysAlmostEqual(
-            np.array([[-30.0, 1.0, -0.0]]), attributions[0].detach().numpy()
-        )
-        assertArraysAlmostEqual(
-            np.array([[0.0, 0.0, 0.0]]), attributions[1].detach().numpy()
-        )
+        assertTensorAlmostEqual(self, attributions[0], [[-30.0, 1.0, -0.0]])
+        assertTensorAlmostEqual(self, attributions[1], [[0.0, 0.0, 0.0]])
 
         attributions = neuron_dl.attribute(inputs, 0, attribute_to_neuron_input=False)
-        assertArraysAlmostEqual(
-            np.array([[0.0, 0.0, 0.0]]), attributions[0].detach().numpy()
-        )
-        assertArraysAlmostEqual(
-            np.array([[0.0, 0.0, 0.0]]), attributions[1].detach().numpy()
-        )
+        assertTensorAlmostEqual(self, attributions[0], [[0.0, 0.0, 0.0]])
+        assertTensorAlmostEqual(self, attributions[1], [[0.0, 0.0, 0.0]])
 
     def test_linear_neuron_deeplift(self):
         model = ReLULinearDeepLiftModel()
@@ -49,75 +38,53 @@ class Test(BaseTest):
         attributions = neuron_dl.attribute(
             inputs, 0, baselines, attribute_to_neuron_input=True
         )
-        assertArraysAlmostEqual(
-            np.array([[-0.0, 0.0, -0.0]]), attributions[0].detach().numpy()
-        )
-        assertArraysAlmostEqual(
-            np.array([[0.0, 0.0, 0.0]]), attributions[1].detach().numpy()
-        )
+        assertTensorAlmostEqual(self, attributions[0], [[-0.0, 0.0, -0.0]])
+        assertTensorAlmostEqual(self, attributions[1], [[0.0, 0.0, 0.0]])
 
         attributions = neuron_dl.attribute(
             inputs, 0, baselines, attribute_to_neuron_input=False
         )
 
-        assertArraysAlmostEqual(
-            np.array([[-0.0, 0.0, -0.0]]), attributions[0].detach().numpy()
-        )
-        assertArraysAlmostEqual(
-            np.array([[6.0, 9.0, 0.0]]), attributions[1].detach().numpy()
-        )
+        assertTensorAlmostEqual(self, attributions[0], [[-0.0, 0.0, -0.0]])
+        assertTensorAlmostEqual(self, attributions[1], [[6.0, 9.0, 0.0]])
 
     def test_relu_neuron_deeplift_shap(self):
         model = ReLULinearDeepLiftModel()
-        inputs, baselines = (
-            _create_inps_and_base_for_deepliftshap_neuron_layer_testing()
-        )
+        (
+            inputs,
+            baselines,
+        ) = _create_inps_and_base_for_deepliftshap_neuron_layer_testing()
 
         neuron_dl = NeuronDeepLiftShap(model, model.relu)
         attributions = neuron_dl.attribute(
             inputs, 0, baselines, attribute_to_neuron_input=True
         )
-        assertArraysAlmostEqual(
-            np.array([[-30.0, 1.0, -0.0]]), attributions[0].detach().numpy()
-        )
-        assertArraysAlmostEqual(
-            np.array([[0.0, 0.0, 0.0]]), attributions[1].detach().numpy()
-        )
+        assertTensorAlmostEqual(self, attributions[0], [[-30.0, 1.0, -0.0]])
+        assertTensorAlmostEqual(self, attributions[1], [[0.0, 0.0, 0.0]])
 
         attributions = neuron_dl.attribute(
             inputs, 0, baselines, attribute_to_neuron_input=False
         )
-        assertArraysAlmostEqual(
-            np.array([[0.0, 0.0, 0.0]]), attributions[0].detach().numpy()
-        )
-        assertArraysAlmostEqual(
-            np.array([[0.0, 0.0, 0.0]]), attributions[1].detach().numpy()
-        )
+        assertTensorAlmostEqual(self, attributions[0], [[0.0, 0.0, 0.0]])
+        assertTensorAlmostEqual(self, attributions[1], [[0.0, 0.0, 0.0]])
 
     def test_linear_neuron_deeplift_shap(self):
         model = ReLULinearDeepLiftModel()
-        inputs, baselines = (
-            _create_inps_and_base_for_deepliftshap_neuron_layer_testing()
-        )
+        (
+            inputs,
+            baselines,
+        ) = _create_inps_and_base_for_deepliftshap_neuron_layer_testing()
 
         neuron_dl = NeuronDeepLiftShap(model, model.l3)
         attributions = neuron_dl.attribute(
             inputs, 0, baselines, attribute_to_neuron_input=True
         )
-        assertArraysAlmostEqual(
-            np.array([[-0.0, 0.0, -0.0]]), attributions[0].detach().numpy()
-        )
-        assertArraysAlmostEqual(
-            np.array([[0.0, 0.0, 0.0]]), attributions[1].detach().numpy()
-        )
+        assertTensorAlmostEqual(self, attributions[0], [[-0.0, 0.0, -0.0]])
+        assertTensorAlmostEqual(self, attributions[1], [[0.0, 0.0, 0.0]])
 
         attributions = neuron_dl.attribute(
             inputs, 0, baselines, attribute_to_neuron_input=False
         )
 
-        assertArraysAlmostEqual(
-            np.array([[-0.0, 0.0, -0.0]]), attributions[0].detach().numpy()
-        )
-        assertArraysAlmostEqual(
-            np.array([[6.0, 9.0, 0.0]]), attributions[1].detach().numpy()
-        )
+        assertTensorAlmostEqual(self, attributions[0], [[-0.0, 0.0, -0.0]])
+        assertTensorAlmostEqual(self, attributions[1], [[6.0, 9.0, 0.0]])


### PR DESCRIPTION
1. Adds an option to attribute to neuron or layer inputs. Originally, we were attributing only to the outputs but we can also attribute to the inputs.
2. Adds separate implementation for NeuronDeepLift and LayerDeepLift.
3. Parallelization with `DataParallel` for DeepLift isn't trivial due to internal replication of the modules,  we'll need to override some parts of it but since this diff is already very large, I'm not doing it here ...
Currently, it accesses to internal module of `DataParallel` in case it is wrapped with `DataParallel` 

Fixes issue https://github.com/pytorch/captum/issues/91 