### PR TITLE
Redirect website to real root domain

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -92,6 +92,20 @@ class Footer extends React.Component {
           )}{" "}
           Copyright &copy; {currentYear} Facebook Inc.
         </section>
+        {process.env.NODE_ENV !== 'development' &&
+          <script dangerouslySetInnerHTML={{__html:`
+            (function() {
+              var BAD_BASE = '/captum/';
+              if (window.location.origin !== '${this.props.config.url}') {
+                var pathname = window.location.pathname;
+                var newPathname = pathname.slice(pathname.indexOf(BAD_BASE) === 0 ? BAD_BASE.length : 1);
+                var newLocation = '${this.props.config.url}${this.props.config.baseUrl}' + newPathname;
+                console.log('redirecting to ' + newLocation);
+                window.location.href = newLocation;
+              }
+            })();
+          `}} />
+        }
       </footer>
     );
   }


### PR DESCRIPTION
For "reasons", we don't actually have a CNAME set up in GitHub. The
result is that GitHub doesn't know that pytorch.org/captum should
actually redirect to captum.ai. This change puts a bit of JS on every
page in prod that will do that redirect. We should fix it properly but
at least we'll have something in place.