### PR TITLE
Match BSD license in JS files

### DIFF
--- a/scripts/versions.js
+++ b/scripts/versions.js
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2019-present, Facebook, Inc.
  *
- * This source code is licensed under the MIT license found in the
+ * This source code is licensed under the BSD license found in the
  * LICENSE file in the root directory of this source tree.
  *
  * @format

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2017-present, Facebook, Inc.
  *
- * This source code is licensed under the MIT license found in the
+ * This source code is licensed under the BSD license found in the
  * LICENSE file in the root directory of this source tree.
  *
  * @format

--- a/website/core/Tutorial.js
+++ b/website/core/Tutorial.js
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2019-present, Facebook, Inc.
  *
- * This source code is licensed under the MIT license found in the
+ * This source code is licensed under the BSD license found in the
  * LICENSE file in the root directory of this source tree.
  *
  * @format

--- a/website/core/TutorialSidebar.js
+++ b/website/core/TutorialSidebar.js
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2019-present, Facebook, Inc.
  *
- * This source code is licensed under the MIT license found in the
+ * This source code is licensed under the BSD license found in the
  * LICENSE file in the root directory of this source tree.
  *
  * @format

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2017-present, Facebook, Inc.
  *
- * This source code is licensed under the MIT license found in the
+ * This source code is licensed under the BSD license found in the
  * LICENSE file in the root directory of this source tree.
  *
  * @format

--- a/website/pages/tutorials/index.js
+++ b/website/pages/tutorials/index.js
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2019-present, Facebook, Inc.
  *
- * This source code is licensed under the MIT license found in the
+ * This source code is licensed under the BSD license found in the
  * LICENSE file in the root directory of this source tree.
  *
  * @format

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2017-present, Facebook, Inc.
  *
- * This source code is licensed under the MIT license found in the
+ * This source code is licensed under the BSD license found in the
  * LICENSE file in the root directory of this source tree.
  *
  * @format


### PR DESCRIPTION
We had MIT in here before. Really an excuse to test the website update.