### PR TITLE
Fixing Layer / Neuron Attributions with In-place Operations

### DIFF
--- a/captum/attr/_core/layer_activation.py
+++ b/captum/attr/_core/layer_activation.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+import torch
+
 from .._utils.attribution import LayerAttribution
 from .._utils.gradient import _forward_layer_eval
 
@@ -87,11 +89,12 @@ class LayerActivation(LayerAttribution):
                 >>> # attribution is layer output, with size Nx12x32x32
                 >>> attribution = layer_cond.attribute(input)
         """
-        return _forward_layer_eval(
-            self.forward_func,
-            inputs,
-            self.layer,
-            additional_forward_args,
-            device_ids=self.device_ids,
-            attribute_to_layer_input=attribute_to_layer_input,
-        )
+        with torch.no_grad():
+            return _forward_layer_eval(
+                self.forward_func,
+                inputs,
+                self.layer,
+                additional_forward_args,
+                device_ids=self.device_ids,
+                attribute_to_layer_input=attribute_to_layer_input,
+            )

--- a/captum/attr/_utils/gradient.py
+++ b/captum/attr/_utils/gradient.py
@@ -178,7 +178,7 @@ def _forward_layer_eval_with_neuron_grads(
             saved_layer[eval_tsr.device] = eval_tsr.clone()
 
     if attribute_to_layer_input:
-        hook = layer.register_forward_hook(forward_hook)
+        hook = layer.register_forward_pre_hook(forward_hook)
     else:
         hook = layer.register_forward_hook(forward_hook)
     _run_forward(forward_fn, inputs, additional_forward_args=additional_forward_args)
@@ -298,7 +298,7 @@ def compute_layer_gradients_and_eval(
                 return eval_tsr.clone()
 
         if attribute_to_layer_input:
-            hook = layer.register_forward_hook(forward_hook)
+            hook = layer.register_forward_pre_hook(forward_hook)
         else:
             hook = layer.register_forward_hook(forward_hook)
         output = _run_forward(forward_fn, inputs, target_ind, additional_forward_args)

--- a/captum/attr/_utils/gradient.py
+++ b/captum/attr/_utils/gradient.py
@@ -178,7 +178,7 @@ def _forward_layer_eval_with_neuron_grads(
             saved_layer[eval_tsr.device] = eval_tsr.clone()
 
     if attribute_to_layer_input:
-        hook = layer.register_forward_pre_hook(forward_hook)
+        hook = layer.register_forward_hook(forward_hook)
     else:
         hook = layer.register_forward_hook(forward_hook)
     _run_forward(forward_fn, inputs, additional_forward_args=additional_forward_args)
@@ -298,7 +298,7 @@ def compute_layer_gradients_and_eval(
                 return eval_tsr.clone()
 
         if attribute_to_layer_input:
-            hook = layer.register_forward_pre_hook(forward_hook)
+            hook = layer.register_forward_hook(forward_hook)
         else:
             hook = layer.register_forward_hook(forward_hook)
         output = _run_forward(forward_fn, inputs, target_ind, additional_forward_args)

--- a/tests/attr/helpers/basic_models.py
+++ b/tests/attr/helpers/basic_models.py
@@ -207,7 +207,6 @@ class BasicModel_MultiLayer(nn.Module):
         lin1_out = self.linear1(lin0_out)
         relu_out = self.relu(lin1_out)
         lin2_out = self.linear2(relu_out)
-        # used to test handling of inplace excess operations
         if multidim_output:
             stack_mid = torch.stack((lin2_out, 2 * lin2_out), dim=2)
             return torch.stack((stack_mid, 4 * stack_mid), dim=3)

--- a/tests/attr/helpers/basic_models.py
+++ b/tests/attr/helpers/basic_models.py
@@ -187,7 +187,7 @@ class BasicEmbeddingModel(nn.Module):
 
 
 class BasicModel_MultiLayer(nn.Module):
-    def __init__(self):
+    def __init__(self, inplace=False):
         super().__init__()
         # Linear 0 is simply identity transform
         self.linear0 = nn.Linear(3, 3)
@@ -196,7 +196,7 @@ class BasicModel_MultiLayer(nn.Module):
         self.linear1 = nn.Linear(3, 4)
         self.linear1.weight = nn.Parameter(torch.ones(4, 3))
         self.linear1.bias = nn.Parameter(torch.tensor([-10.0, 1.0, 1.0, 1.0]))
-        self.relu = nn.ReLU()
+        self.relu = nn.ReLU(inplace=inplace)
         self.linear2 = nn.Linear(4, 2)
         self.linear2.weight = nn.Parameter(torch.ones(2, 4))
         self.linear2.bias = nn.Parameter(torch.tensor([-1.0, 1.0]))
@@ -207,6 +207,7 @@ class BasicModel_MultiLayer(nn.Module):
         lin1_out = self.linear1(lin0_out)
         relu_out = self.relu(lin1_out)
         lin2_out = self.linear2(relu_out)
+        # used to test handling of inplace excess operations
         if multidim_output:
             stack_mid = torch.stack((lin2_out, 2 * lin2_out), dim=2)
             return torch.stack((stack_mid, 4 * stack_mid), dim=3)
@@ -224,10 +225,10 @@ class BasicModel_MultiLayer_MultiInput(nn.Module):
 
 
 class BasicModel_ConvNet_One_Conv(nn.Module):
-    def __init__(self):
+    def __init__(self, inplace=False):
         super().__init__()
         self.conv1 = nn.Conv2d(1, 2, 3, 1)
-        self.relu1 = nn.ReLU()
+        self.relu1 = nn.ReLU(inplace=inplace)
         self.softmax = nn.Softmax(dim=1)
         self.fc1 = nn.Linear(8, 4)
         self.conv1.weight = nn.Parameter(torch.ones(2, 1, 3, 3))
@@ -235,7 +236,7 @@ class BasicModel_ConvNet_One_Conv(nn.Module):
         self.fc1.weight = nn.Parameter(
             torch.cat([torch.ones(4, 5), -1 * torch.ones(4, 3)], dim=1)
         )
-        self.relu2 = nn.ReLU()
+        self.relu2 = nn.ReLU(inplace=inplace)
 
     def forward(self, x, x2=None):
         if x2 is not None:

--- a/tests/attr/test_data_parallel.py
+++ b/tests/attr/test_data_parallel.py
@@ -30,7 +30,7 @@ from .helpers.utils import BaseGPUTest
 
 class Test(BaseGPUTest):
     def test_simple_input_internal_inf(self):
-        net = BasicModel_MultiLayer().cuda()
+        net = BasicModel_MultiLayer(inplace=True).cuda()
         inp = torch.tensor(
             [
                 [0.0, 100.0, 0.0],

--- a/tests/attr/test_gradient.py
+++ b/tests/attr/test_gradient.py
@@ -89,6 +89,19 @@ class Test(BaseTest):
             eval.squeeze(0).tolist(), [-2.0, 9.0, 9.0, 9.0], delta=0.01
         )
 
+    def test_layer_gradient_linear1_inplace(self):
+        model = BasicModel_MultiLayer(inplace=True)
+        input = torch.tensor([[5.0, 2.0, 1.0]], requires_grad=True)
+        grads, eval = compute_layer_gradients_and_eval(
+            model, model.linear1, input, target_ind=1
+        )
+        assertArraysAlmostEqual(
+            grads.squeeze(0).tolist(), [0.0, 1.0, 1.0, 1.0], delta=0.01
+        )
+        assertArraysAlmostEqual(
+            eval.squeeze(0).tolist(), [-2.0, 9.0, 9.0, 9.0], delta=0.01
+        )
+
     def test_layer_gradient_output(self):
         model = BasicModel_MultiLayer()
         input = torch.tensor([[5.0, 2.0, 1.0]], requires_grad=True)

--- a/tests/attr/test_gradient.py
+++ b/tests/attr/test_gradient.py
@@ -102,6 +102,19 @@ class Test(BaseTest):
             eval.squeeze(0).tolist(), [-2.0, 9.0, 9.0, 9.0], delta=0.01
         )
 
+    def test_layer_gradient_relu_input_inplace(self):
+        model = BasicModel_MultiLayer(inplace=True)
+        input = torch.tensor([[5.0, 2.0, 1.0]], requires_grad=True)
+        grads, eval = compute_layer_gradients_and_eval(
+            model, model.relu, input, target_ind=1, attribute_to_layer_input=True
+        )
+        assertArraysAlmostEqual(
+            grads.squeeze(0).tolist(), [0.0, 1.0, 1.0, 1.0], delta=0.01
+        )
+        assertArraysAlmostEqual(
+            eval.squeeze(0).tolist(), [-2.0, 9.0, 9.0, 9.0], delta=0.01
+        )
+
     def test_layer_gradient_output(self):
         model = BasicModel_MultiLayer()
         input = torch.tensor([[5.0, 2.0, 1.0]], requires_grad=True)

--- a/tests/attr/test_guided_grad_cam.py
+++ b/tests/attr/test_guided_grad_cam.py
@@ -33,6 +33,18 @@ class Test(BaseTest):
         ]
         self._guided_grad_cam_test_assert(net, net.conv1, (inp, inp2), (ex, ex))
 
+    def test_simple_multi_input_conv_inplace(self):
+        net = BasicModel_ConvNet_One_Conv(inplace=True)
+        inp = torch.arange(16).view(1, 1, 4, 4).type(torch.FloatTensor)
+        inp2 = torch.ones((1, 1, 4, 4))
+        ex = [
+            [14.5, 29.0, 38.0, 19.0],
+            [29.0, 58.0, 76.0, 38.0],
+            [65.0, 130.0, 148.0, 74.0],
+            [32.5, 65.0, 74.0, 37.0],
+        ]
+        self._guided_grad_cam_test_assert(net, net.conv1, (inp, inp2), (ex, ex))
+
     def test_improper_dims_multi_input_conv(self):
         net = BasicModel_ConvNet_One_Conv()
         inp = torch.arange(16).view(1, 1, 4, 4).type(torch.FloatTensor)

--- a/tests/attr/test_guided_grad_cam.py
+++ b/tests/attr/test_guided_grad_cam.py
@@ -33,6 +33,20 @@ class Test(BaseTest):
         ]
         self._guided_grad_cam_test_assert(net, net.conv1, (inp, inp2), (ex, ex))
 
+    def test_simple_multi_input_relu_input_inplace(self):
+        net = BasicModel_ConvNet_One_Conv(inplace=True)
+        inp = torch.arange(16).view(1, 1, 4, 4).type(torch.FloatTensor)
+        inp2 = torch.ones((1, 1, 4, 4))
+        ex = [
+            [14.5, 29.0, 38.0, 19.0],
+            [29.0, 58.0, 76.0, 38.0],
+            [65.0, 130.0, 148.0, 74.0],
+            [32.5, 65.0, 74.0, 37.0],
+        ]
+        self._guided_grad_cam_test_assert(
+            net, net.relu1, (inp, inp2), (ex, ex), attribute_to_layer_input=True
+        )
+
     def test_simple_multi_input_conv_inplace(self):
         net = BasicModel_ConvNet_One_Conv(inplace=True)
         inp = torch.arange(16).view(1, 1, 4, 4).type(torch.FloatTensor)
@@ -73,6 +87,7 @@ class Test(BaseTest):
         expected,
         additional_input=None,
         interpolate_mode="nearest",
+        attribute_to_layer_input=False,
     ):
         guided_gc = GuidedGradCam(model, target_layer)
         attributions = guided_gc.attribute(
@@ -80,6 +95,7 @@ class Test(BaseTest):
             target=0,
             additional_forward_args=additional_input,
             interpolate_mode=interpolate_mode,
+            attribute_to_layer_input=attribute_to_layer_input,
         )
         if isinstance(test_input, tuple):
             for i in range(len(test_input)):

--- a/tests/attr/test_internal_influence.py
+++ b/tests/attr/test_internal_influence.py
@@ -25,6 +25,13 @@ class Test(BaseTest):
             net, net.linear1, inp, [[0.9, 1.0, 1.0, 1.0]]
         )
 
+    def test_simple_linear_internal_inf_inplace(self):
+        net = BasicModel_MultiLayer(inplace=True)
+        inp = torch.tensor([[0.0, 100.0, 0.0]])
+        self._internal_influence_test_assert(
+            net, net.linear1, inp, [[0.9, 1.0, 1.0, 1.0]]
+        )
+
     def test_simple_relu_internal_inf(self):
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[3.0, 4.0, 0.0]], requires_grad=True)

--- a/tests/attr/test_internal_influence.py
+++ b/tests/attr/test_internal_influence.py
@@ -25,6 +25,13 @@ class Test(BaseTest):
             net, net.linear1, inp, [[0.9, 1.0, 1.0, 1.0]]
         )
 
+    def test_simple_relu_input_internal_inf_inplace(self):
+        net = BasicModel_MultiLayer(inplace=True)
+        inp = torch.tensor([[0.0, 100.0, 0.0]])
+        self._internal_influence_test_assert(
+            net, net.relu, inp, [[0.9, 1.0, 1.0, 1.0]], attribute_to_layer_input=True
+        )
+
     def test_simple_linear_internal_inf_inplace(self):
         net = BasicModel_MultiLayer(inplace=True)
         inp = torch.tensor([[0.0, 100.0, 0.0]])
@@ -130,6 +137,7 @@ class Test(BaseTest):
         expected_activation,
         baseline=None,
         additional_args=None,
+        attribute_to_layer_input=False,
     ):
         for internal_batch_size in [None, 1, 20]:
             int_inf = InternalInfluence(model, target_layer)
@@ -141,6 +149,7 @@ class Test(BaseTest):
                 method="riemann_trapezoid",
                 additional_forward_args=additional_args,
                 internal_batch_size=internal_batch_size,
+                attribute_to_layer_input=attribute_to_layer_input,
             )
             for i in range(len(expected_activation)):
                 assertArraysAlmostEqual(

--- a/tests/attr/test_layer_activation.py
+++ b/tests/attr/test_layer_activation.py
@@ -19,11 +19,9 @@ class Test(BaseTest):
         self._layer_activation_test_assert(net, net.linear0, inp, [0.0, 100.0, 0.0])
 
     def test_simple_linear_activation(self):
-        net = BasicModel_MultiLayer()
-        inp = torch.tensor([[0.0, 100.0, 0.0]])
-        self._layer_activation_test_assert(
-            net, net.linear1, inp, [90.0, 101.0, 101.0, 101.0]
-        )
+        net = BasicModel_MultiLayer(inplace=True)
+        inp = torch.tensor([[2.0, -5.0, 4.0]])
+        self._layer_activation_test_assert(net, net.linear1, inp, [-9.0, 2.0, 2.0, 2.0])
 
     def test_simple_relu_activation(self):
         net = BasicModel_MultiLayer()

--- a/tests/attr/test_layer_activation.py
+++ b/tests/attr/test_layer_activation.py
@@ -19,6 +19,20 @@ class Test(BaseTest):
         self._layer_activation_test_assert(net, net.linear0, inp, [0.0, 100.0, 0.0])
 
     def test_simple_linear_activation(self):
+        net = BasicModel_MultiLayer()
+        inp = torch.tensor([[0.0, 100.0, 0.0]])
+        self._layer_activation_test_assert(
+            net, net.linear1, inp, [90.0, 101.0, 101.0, 101.0]
+        )
+
+    def test_simple_relu_activation_input_inplace(self):
+        net = BasicModel_MultiLayer(inplace=True)
+        inp = torch.tensor([[2.0, -5.0, 4.0]])
+        self._layer_activation_test_assert(
+            net, net.relu, inp, [-9.0, 2.0, 2.0, 2.0], attribute_to_layer_input=True
+        )
+
+    def test_simple_linear_activation_inplace(self):
         net = BasicModel_MultiLayer(inplace=True)
         inp = torch.tensor([[2.0, -5.0, 4.0]])
         self._layer_activation_test_assert(net, net.linear1, inp, [-9.0, 2.0, 2.0, 2.0])
@@ -58,10 +72,13 @@ class Test(BaseTest):
         test_input,
         expected_activation,
         additional_input=None,
+        attribute_to_layer_input=False,
     ):
         layer_act = LayerActivation(model, target_layer)
         attributions = layer_act.attribute(
-            test_input, additional_forward_args=additional_input
+            test_input,
+            additional_forward_args=additional_input,
+            attribute_to_layer_input=attribute_to_layer_input,
         )
         assertArraysAlmostEqual(
             attributions.squeeze(0).tolist(), expected_activation, delta=0.01

--- a/tests/attr/test_layer_activation.py
+++ b/tests/attr/test_layer_activation.py
@@ -3,13 +3,14 @@
 import unittest
 
 import torch
+import torch.nn as nn
 from captum.attr._core.layer_activation import LayerActivation
 
 from .helpers.basic_models import (
     BasicModel_MultiLayer,
     BasicModel_MultiLayer_MultiInput,
 )
-from .helpers.utils import assertArraysAlmostEqual, BaseTest
+from .helpers.utils import assertArraysAlmostEqual, BaseTest, assertTensorAlmostEqual
 
 
 class Test(BaseTest):
@@ -28,9 +29,7 @@ class Test(BaseTest):
     def test_simple_relu_activation_input_inplace(self):
         net = BasicModel_MultiLayer(inplace=True)
         inp = torch.tensor([[2.0, -5.0, 4.0]])
-        self._layer_activation_test_assert(
-            net, net.relu, inp, [-9.0, 2.0, 2.0, 2.0], attribute_to_layer_input=True
-        )
+        self._layer_activation_test_assert(net, net.relu, inp, [-9.0, 2.0, 2.0, 2.0], attribute_to_layer_input=True)
 
     def test_simple_linear_activation_inplace(self):
         net = BasicModel_MultiLayer(inplace=True)
@@ -65,6 +64,14 @@ class Test(BaseTest):
             net, net.model.relu, (inp1, inp2), [90.0, 101.0, 101.0, 101.0], (inp3, 5)
         )
 
+    def test_sequential_in_place(self):
+        model = nn.Sequential(nn.Conv2d(3, 4, 3),
+                              nn.ReLU(inplace=True))
+        layer_act = LayerActivation(model, model[0])
+        input = torch.randn(1, 3, 5, 5)
+        assertTensorAlmostEqual(self, layer_act.attribute(input), model[0](input))
+
+
     def _layer_activation_test_assert(
         self,
         model,
@@ -76,9 +83,7 @@ class Test(BaseTest):
     ):
         layer_act = LayerActivation(model, target_layer)
         attributions = layer_act.attribute(
-            test_input,
-            additional_forward_args=additional_input,
-            attribute_to_layer_input=attribute_to_layer_input,
+            test_input, additional_forward_args=additional_input, attribute_to_layer_input=attribute_to_layer_input
         )
         assertArraysAlmostEqual(
             attributions.squeeze(0).tolist(), expected_activation, delta=0.01

--- a/tests/attr/test_layer_activation.py
+++ b/tests/attr/test_layer_activation.py
@@ -29,7 +29,9 @@ class Test(BaseTest):
     def test_simple_relu_activation_input_inplace(self):
         net = BasicModel_MultiLayer(inplace=True)
         inp = torch.tensor([[2.0, -5.0, 4.0]])
-        self._layer_activation_test_assert(net, net.relu, inp, [-9.0, 2.0, 2.0, 2.0], attribute_to_layer_input=True)
+        self._layer_activation_test_assert(
+            net, net.relu, inp, [-9.0, 2.0, 2.0, 2.0], attribute_to_layer_input=True
+        )
 
     def test_simple_linear_activation_inplace(self):
         net = BasicModel_MultiLayer(inplace=True)
@@ -65,12 +67,10 @@ class Test(BaseTest):
         )
 
     def test_sequential_in_place(self):
-        model = nn.Sequential(nn.Conv2d(3, 4, 3),
-                              nn.ReLU(inplace=True))
+        model = nn.Sequential(nn.Conv2d(3, 4, 3), nn.ReLU(inplace=True))
         layer_act = LayerActivation(model, model[0])
         input = torch.randn(1, 3, 5, 5)
         assertTensorAlmostEqual(self, layer_act.attribute(input), model[0](input))
-
 
     def _layer_activation_test_assert(
         self,
@@ -83,7 +83,9 @@ class Test(BaseTest):
     ):
         layer_act = LayerActivation(model, target_layer)
         attributions = layer_act.attribute(
-            test_input, additional_forward_args=additional_input, attribute_to_layer_input=attribute_to_layer_input
+            test_input,
+            additional_forward_args=additional_input,
+            attribute_to_layer_input=attribute_to_layer_input,
         )
         assertArraysAlmostEqual(
             attributions.squeeze(0).tolist(), expected_activation, delta=0.01

--- a/tests/attr/test_neuron_gradient.py
+++ b/tests/attr/test_neuron_gradient.py
@@ -26,6 +26,11 @@ class Test(BaseTest):
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         self._gradient_input_test_assert(net, net.linear1, inp, (0,), [1.0, 1.0, 1.0])
 
+    def test_simple_gradient_input_linear1_inplace(self):
+        net = BasicModel_MultiLayer(inplace=True)
+        inp = torch.tensor([[0.0, 5.0, 4.0]])
+        self._gradient_input_test_assert(net, net.linear1, inp, (0,), [1.0, 1.0, 1.0])
+
     def test_simple_gradient_input_relu(self):
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 5.0, 4.0]], requires_grad=True)

--- a/tests/attr/test_neuron_gradient.py
+++ b/tests/attr/test_neuron_gradient.py
@@ -26,6 +26,13 @@ class Test(BaseTest):
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         self._gradient_input_test_assert(net, net.linear1, inp, (0,), [1.0, 1.0, 1.0])
 
+    def test_simple_gradient_input_relu_inplace(self):
+        net = BasicModel_MultiLayer(inplace=True)
+        inp = torch.tensor([[0.0, 5.0, 4.0]])
+        self._gradient_input_test_assert(
+            net, net.relu, inp, (0,), [1.0, 1.0, 1.0], attribute_to_neuron_input=True
+        )
+
     def test_simple_gradient_input_linear1_inplace(self):
         net = BasicModel_MultiLayer(inplace=True)
         inp = torch.tensor([[0.0, 5.0, 4.0]])
@@ -87,10 +94,14 @@ class Test(BaseTest):
         test_neuron,
         expected_input_gradient,
         additional_input=None,
+        attribute_to_neuron_input=False,
     ):
         grad = NeuronGradient(model, target_layer)
         attributions = grad.attribute(
-            test_input, test_neuron, additional_forward_args=additional_input
+            test_input,
+            test_neuron,
+            additional_forward_args=additional_input,
+            attribute_to_neuron_input=attribute_to_neuron_input,
         )
         if isinstance(expected_input_gradient, tuple):
             for i in range(len(expected_input_gradient)):


### PR DESCRIPTION
This PR fixes neuron / layer attributions with in-place operations by keeping appropriate clones of intermediate values to ensure that they are not modified by future operations.

Addresses Issue: #156