### PR TITLE
Add CITATION file

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -1,0 +1,8 @@
+@misc{captum2019github,
+  author = {Kokhlikyan, Narine and Miglani, Vivek and Martin, Miguel and Wang, Edward and Reynolds, Jonathan and Melnikov, Alexander and Lunova, Natalia and Reblitz-Richardson, Orion},
+  title = {PyTorch Captum},
+  year = {2019},
+  publisher = {GitHub},
+  journal = {GitHub repository},
+  howpublished = {\url{https://github.com/pytorch/captum}},
+}


### PR DESCRIPTION
Adding a `CITATION` file that we can update in the future as papers, etc. are published, similar to core PyTorch at https://github.com/pytorch/pytorch/blob/master/CITATION

Addresses https://github.com/pytorch/captum/issues/161