### PR TITLE
Fixing CUDA delta issue

### DIFF
--- a/captum/attr/_utils/attribution.py
+++ b/captum/attr/_utils/attribution.py
@@ -232,9 +232,9 @@ class GradientAttribution(Attribution):
                     self.forward_func, end_point, target, additional_forward_args
                 )
             )
-        row_sums = [_sum_rows(attribution) for attribution in attributions]
-        attr_sum = torch.stack([sum(row_sum) for row_sum in zip(*row_sums)])
-        return attr_sum - (end_point - start_point)
+            row_sums = [_sum_rows(attribution) for attribution in attributions]
+            attr_sum = torch.stack([sum(row_sum) for row_sum in zip(*row_sums)])
+            return attr_sum - (end_point - start_point)
 
 
 class InternalAttribution(GradientAttribution):

--- a/captum/attr/_utils/attribution.py
+++ b/captum/attr/_utils/attribution.py
@@ -233,7 +233,7 @@ class GradientAttribution(Attribution):
                 )
             )
         row_sums = [_sum_rows(attribution) for attribution in attributions]
-        attr_sum = torch.tensor([sum(row_sum) for row_sum in zip(*row_sums)])
+        attr_sum = torch.stack([sum(row_sum) for row_sum in zip(*row_sums)])
         return attr_sum - (end_point - start_point)
 
 

--- a/tests/attr/test_data_parallel.py
+++ b/tests/attr/test_data_parallel.py
@@ -420,6 +420,8 @@ class Test(BaseGPUTest):
             attr_dp = algorithm(dp_model)
 
         batch_sizes = [None]
+        delta_orig = None
+        delta_dp = None
         if test_batches:
             batch_sizes = [None, 1, 8]
         for batch_size in batch_sizes:
@@ -429,7 +431,7 @@ class Test(BaseGPUTest):
                 )
             else:
                 if attr_orig.has_convergence_delta():
-                    attributions_orig = attr_orig.attribute(
+                    attributions_orig, delta_orig = attr_orig.attribute(
                         return_convergence_delta=True, **kwargs
                     )
                 else:
@@ -440,7 +442,7 @@ class Test(BaseGPUTest):
                 )
             else:
                 if attr_orig.has_convergence_delta():
-                    attributions_dp = attr_dp.attribute(
+                    attributions_dp, delta_dp = attr_dp.attribute(
                         return_convergence_delta=True, **kwargs
                     )
                 else:
@@ -459,6 +461,13 @@ class Test(BaseGPUTest):
                         0,
                         delta=0.0001,
                     )
+
+            if delta_dp is not None:
+                self.assertAlmostEqual(
+                    torch.sum(torch.abs(delta_orig - delta_dp)),
+                    0,
+                    delta=0.0001,
+                )
 
 
 if __name__ == "__main__":

--- a/tests/attr/test_data_parallel.py
+++ b/tests/attr/test_data_parallel.py
@@ -428,13 +428,23 @@ class Test(BaseGPUTest):
                     internal_batch_size=batch_size, **kwargs
                 )
             else:
-                attributions_orig = attr_orig.attribute(**kwargs)
+                if attr_orig.has_convergence_delta():
+                    attributions_orig = attr_orig.attribute(
+                        return_convergence_delta=True, **kwargs
+                    )
+                else:
+                    attributions_orig = attr_orig.attribute(**kwargs)
             if batch_size:
                 attributions_dp = attr_dp.attribute(
                     internal_batch_size=batch_size, **kwargs
                 )
             else:
-                attributions_dp = attr_dp.attribute(**kwargs)
+                if attr_orig.has_convergence_delta():
+                    attributions_dp = attr_dp.attribute(
+                        return_convergence_delta=True, **kwargs
+                    )
+                else:
+                    attributions_dp = attr_dp.attribute(**kwargs)
 
             if isinstance(attributions_dp, torch.Tensor):
                 self.assertAlmostEqual(

--- a/tests/attr/test_data_parallel.py
+++ b/tests/attr/test_data_parallel.py
@@ -464,9 +464,7 @@ class Test(BaseGPUTest):
 
             if delta_dp is not None:
                 self.assertAlmostEqual(
-                    torch.sum(torch.abs(delta_orig - delta_dp)),
-                    0,
-                    delta=0.0001,
+                    torch.sum(torch.abs(delta_orig - delta_dp)), 0, delta=0.0001
                 )
 
 


### PR DESCRIPTION
Convergence delta was failing on GPUs since the total attribution tensor was not being created on the same device, this fixes that bug. Also, adds data parallel / CUDA tests for computing deltas whenever available.

Issue: #163 