### PR TITLE
Add support for custom attribution function in DeepLift/DeepLiftShap

### DIFF
--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -186,9 +186,10 @@ class DeepLift(GradientAttribution):
                         In case this function is not provided, we use the default
                         logic defined as: multipliers * (inputs - baselines)
                         It is assumed that all input arguments, `multipliers`,
-                        `inputs` and `outputs` are provided in tuples of same length.
-                        `custom_attribution_func` returns a tuple of attribution
-                        tensors that have the same length as the `inputs`.
+                        `inputs` and `baselines` are provided in tuples of same
+                        length. `custom_attribution_func` returns a tuple of
+                        attribution tensors that have the same length as the
+                        `inputs`.
 
                         Default: None
 
@@ -539,10 +540,11 @@ class DeepLiftShap(DeepLift):
                             - custom_attribution_func(multipliers, inputs, baselines)
                         In case this function is not provided we use the default
                         logic defined as: multipliers * (inputs - baselines)
-                        It is assumed that `custom_attribution_func` returns a
-                        tuple of attribution tensors that have the same shape and
-                        dimensionality as the `inputs`.
-
+                        It is assumed that all input arguments, `multipliers`,
+                        `inputs` and `baselines` are provided in tuples of same
+                        length. `custom_attribution_func` returns a tuple of
+                        attribution tensors that have the same length as the
+                        `inputs`.
                         Default: None
 
         Returns:

--- a/captum/attr/_core/layer_deep_lift.py
+++ b/captum/attr/_core/layer_deep_lift.py
@@ -188,6 +188,7 @@ class LayerDeepLift(LayerAttribution, DeepLift):
                         `inputs` and `outputs` are provided in tuples of same length.
                         `custom_attribution_func` returns a tuple of attribution
                         tensors that have the same length as the `inputs`.
+                        Default: None
 
         Returns:
             **attributions** or 2-element tuple of **attributions**, **delta**:
@@ -440,9 +441,11 @@ class LayerDeepLiftShap(LayerDeepLift, DeepLiftShap):
                         In case this function is not provided, we use the default
                         logic defined as: multipliers * (inputs - baselines)
                         It is assumed that all input arguments, `multipliers`,
-                        `inputs` and `outputs` are provided in tuples of same length.
-                        `custom_attribution_func` returns a tuple of attribution
-                        tensors that have the same length as the `inputs`.
+                        `inputs` and `baselines` are provided in tuples of same
+                        length. `custom_attribution_func` returns a tuple of
+                        attribution tensors that have the same length as the
+                        `inputs`.
+                        Default: None
 
         Returns:
             **attributions** or 2-element tuple of **attributions**, **delta**:

--- a/captum/attr/_core/layer_deep_lift.py
+++ b/captum/attr/_core/layer_deep_lift.py
@@ -185,7 +185,7 @@ class LayerDeepLift(LayerAttribution, DeepLift):
                         In case this function is not provided, we use the default
                         logic defined as: multipliers * (inputs - baselines)
                         It is assumed that all input arguments, `multipliers`,
-                        `inputs` and `outputs` are provided in tuples of same length.
+                        `inputs` and `baselines` are provided in tuples of same length.
                         `custom_attribution_func` returns a tuple of attribution
                         tensors that have the same length as the `inputs`.
                         Default: None

--- a/captum/attr/_core/neuron_deep_lift.py
+++ b/captum/attr/_core/neuron_deep_lift.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from .._utils.attribution import NeuronAttribution
 from .._utils.gradient import construct_neuron_grad_fn
 
@@ -27,6 +28,7 @@ class NeuronDeepLift(NeuronAttribution):
         baselines=None,
         additional_forward_args=None,
         attribute_to_neuron_input=False,
+        custom_attribution_func=None,
     ):
         r""""
         Implements DeepLIFT algorithm for the neuron based on the following paper:
@@ -159,7 +161,10 @@ class NeuronDeepLift(NeuronAttribution):
         )
 
         return dl.attribute(
-            inputs, baselines, additional_forward_args=additional_forward_args
+            inputs,
+            baselines,
+            additional_forward_args=additional_forward_args,
+            custom_attribution_func=custom_attribution_func,
         )
 
 
@@ -185,6 +190,7 @@ class NeuronDeepLiftShap(NeuronAttribution):
         baselines=None,
         additional_forward_args=None,
         attribute_to_neuron_input=False,
+        custom_attribution_func=None,
     ):
         r"""
         Extends NeuronAttribution and uses LayerDeepLiftShap algorithms and
@@ -306,5 +312,8 @@ class NeuronDeepLiftShap(NeuronAttribution):
         )
 
         return dl.attribute(
-            inputs, baselines, additional_forward_args=additional_forward_args
+            inputs,
+            baselines,
+            additional_forward_args=additional_forward_args,
+            custom_attribution_func=custom_attribution_func,
         )

--- a/captum/attr/_core/neuron_deep_lift.py
+++ b/captum/attr/_core/neuron_deep_lift.py
@@ -127,6 +127,21 @@ class NeuronDeepLift(NeuronAttribution):
                         attribute to the input or output, is a single tensor.
                         Support for multiple tensors will be added later.
                         Default: False
+            custom_attribution_func (callable, optional): A custom function for
+                        computing final attribution scores. This function can take
+                        at least one and at most three arguments with the
+                        following signature:
+                            - custom_attribution_func(multipliers)
+                            - custom_attribution_func(multipliers, inputs)
+                            - custom_attribution_func(multipliers, inputs, baselines)
+                        In case this function is not provided, we use the default
+                        logic defined as: multipliers * (inputs - baselines)
+                        It is assumed that all input arguments, `multipliers`,
+                        `inputs` and `baselines` are provided in tuples of same
+                        length. `custom_attribution_func` returns a tuple of
+                        attribution tensors that have the same length as the
+                        `inputs`.
+                        Default: None
 
         Returns:
             **attributions** or 2-element tuple of **attributions**, **delta**:
@@ -279,6 +294,22 @@ class NeuronDeepLiftShap(NeuronAttribution):
                         attribute to the input or output, is a single tensor.
                         Support for multiple tensors will be added later.
                         Default: False
+            custom_attribution_func (callable, optional): A custom function for
+                        computing final attribution scores. This function can take
+                        at least one and at most three arguments with the
+                        following signature:
+                            - custom_attribution_func(multipliers)
+                            - custom_attribution_func(multipliers, inputs)
+                            - custom_attribution_func(multipliers, inputs, baselines)
+                        In case this function is not provided, we use the default
+                        logic defined as: multipliers * (inputs - baselines)
+                        It is assumed that all input arguments, `multipliers`,
+                        `inputs` and `baselines` are provided in tuples of same
+                        length. `custom_attribution_func` returns a tuple of
+                        attribution tensors that have the same length as the
+                        `inputs`.
+                        Default: None
+
         Returns:
             **attributions** or 2-element tuple of **attributions**, **delta**:
             - **attributions** (*tensor* or tuple of *tensors*):

--- a/captum/attr/_utils/attribution.py
+++ b/captum/attr/_utils/attribution.py
@@ -223,6 +223,15 @@ class GradientAttribution(Attribution):
 
         attributions = _format_tensor_into_tuples(attributions)
 
+        # verify that the attributions and end_point match on 1st dimension
+        for attribution, end_point_tnsr in zip(attributions, end_point):
+            assert end_point_tnsr.shape[0] == attribution.shape[0], (
+                "Attributions tensor and the end_point must match on the first"
+                " dimension but found attribution: {} and end_point: {}".format(
+                    attribution.shape[0], end_point_tnsr.shape[0]
+                )
+            )
+
         num_samples = end_point[0].shape[0]
         _validate_input(end_point, start_point)
         _validate_target(num_samples, target)

--- a/captum/attr/_utils/common.py
+++ b/captum/attr/_utils/common.py
@@ -313,6 +313,22 @@ def _expand_target(target, n_steps, expansion_type=ExpansionTypes.repeat):
     return target
 
 
+def _call_custom_attribution_func(
+    custom_attribution_func, multipliers, inputs, baselines
+):
+    custom_attr_func_params = signature(custom_attribution_func).parameters
+    assert len(custom_attr_func_params) in range(1, 4), (
+        "`custom_attribution_func`" " must take at least one and at most 3 arguments"
+    )
+
+    if len(custom_attr_func_params) == 1:
+        return custom_attribution_func(multipliers)
+    elif len(custom_attr_func_params) == 2:
+        return custom_attribution_func(multipliers, inputs)
+    elif len(custom_attr_func_params) == 3:
+        return custom_attribution_func(multipliers, inputs, baselines)
+
+
 class MaxList:
     """Keep track of N maximal items
 

--- a/captum/attr/_utils/common.py
+++ b/captum/attr/_utils/common.py
@@ -316,6 +316,12 @@ def _expand_target(target, n_steps, expansion_type=ExpansionTypes.repeat):
 def _call_custom_attribution_func(
     custom_attribution_func, multipliers, inputs, baselines
 ):
+    assert callable(custom_attribution_func), (
+        "`custom_attribution_func`"
+        " must be a callable function but {} provided".format(
+            type(custom_attribution_func)
+        )
+    )
     custom_attr_func_params = signature(custom_attribution_func).parameters
     assert len(custom_attr_func_params) in range(1, 4), (
         "`custom_attribution_func`" " must take at least one and at most 3 arguments"

--- a/tests/attr/helpers/basic_models.py
+++ b/tests/attr/helpers/basic_models.py
@@ -148,6 +148,15 @@ class ReLULinearDeepLiftModel(nn.Module):
         return self.l3(self.relu(torch.cat([self.l1(x1), self.l2(x2)], axis=1)))
 
 
+class Conv1dDeepLiftModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.seq = nn.Sequential(nn.Conv1d(4, 2, 1), nn.ReLU(), nn.Linear(1000, 1))
+
+    def forward(self, inputs):
+        return self.seq(inputs)
+
+
 class TextModule(nn.Module):
     r"""Basic model that has inner embedding layer. This layer can be pluged
     into a larger network such as `BasicEmbeddingModel` and help us to test

--- a/tests/attr/test_deeplift_basic.py
+++ b/tests/attr/test_deeplift_basic.py
@@ -160,10 +160,7 @@ class Test(BaseTest):
 
     def test_relu_deepliftshap_with_custom_attr_func(self):
         def custom_attr_func(multipliers, inputs, baselines):
-            return tuple(
-                multiplier * (input - baseline)
-                for multiplier, input, baseline in zip(multipliers, inputs, baselines)
-            )
+            return tuple(multiplier * 0.0 for multiplier in multipliers)
 
         model = ReLULinearDeepLiftModel()
         x1 = torch.tensor([[-10.0, 1.0, -5.0]])
@@ -173,19 +170,12 @@ class Test(BaseTest):
         inputs = (x1, x2)
         baselines = (b1, b2)
         dls = DeepLiftShap(model)
-        attr_w_func, delta_w_func = dls.attribute(
-            inputs,
-            baselines,
-            custom_attribution_func=custom_attr_func,
-            return_convergence_delta=True,
+        attr_w_func = dls.attribute(
+            inputs, baselines, custom_attribution_func=custom_attr_func
         )
-        attr, delta = dls.attribute(inputs, baselines, return_convergence_delta=True)
-        self.assertEqual(attr_w_func[0].shape, x1.shape)
-        self.assertEqual(attr_w_func[1].shape, x2.shape)
 
-        assertTensorAlmostEqual(self, attr[0], attr_w_func[0], 0.0)
-        assertTensorAlmostEqual(self, attr[1], attr_w_func[1], 0.0)
-        assertTensorAlmostEqual(self, delta_w_func, delta, 0.0)
+        assertTensorAlmostEqual(self, attr_w_func[0], [[0.0, 0.0, 0.0]], 0.0)
+        assertTensorAlmostEqual(self, attr_w_func[1], [[0.0, 0.0, 0.0]], 0.0)
 
     def test_relu_deepliftshap_with_hypothetical_contrib_func(self):
         model = Conv1dDeepLiftModel()
@@ -267,7 +257,7 @@ def _hypothetical_contrib_func(multipliers, inputs, baselines):
     r"""
     Implements hypothetical input contributions based on the logic described here:
     https://github.com/kundajelab/deeplift/pull/36/files
-    This is not using a dummy model for test purposes
+    This is using a dummy model for test purposes
     """
     # we assume that multiplies, inputs and baselines have the following shape:
     # tuple((bsz x len x channel), )

--- a/tests/attr/test_deeplift_basic.py
+++ b/tests/attr/test_deeplift_basic.py
@@ -14,7 +14,7 @@ from .helpers.utils import (
     BaseTest,
 )
 from .helpers.basic_models import ReLUDeepLiftModel, TanhDeepLiftModel
-from .helpers.basic_models import ReLULinearDeepLiftModel
+from .helpers.basic_models import ReLULinearDeepLiftModel, Conv1dDeepLiftModel
 
 
 class Test(BaseTest):
@@ -78,6 +78,19 @@ class Test(BaseTest):
         # expected = [[[0.0, 0.0]], [[6.0, 2.0]]]
         self._deeplift_assert(model, DeepLift(model), inputs, baselines)
 
+    def test_relu_deeplift_with_hypothetical_contrib_func(self):
+        model = Conv1dDeepLiftModel()
+        rand_seq_data = torch.abs(torch.randn(2, 4, 1000))
+        rand_seq_ref = torch.abs(torch.randn(2, 4, 1000))
+        dls = DeepLift(model)
+        attr = dls.attribute(
+            rand_seq_data,
+            rand_seq_ref,
+            custom_attribution_func=_hypothetical_contrib_func,
+            target=(1, 0),
+        )
+        self.assertEqual(attr.shape, rand_seq_data.shape)
+
     def test_relu_deepliftshap_batch_4D_input(self):
         x1 = torch.ones(4, 1, 1, 1)
         x2 = torch.tensor([[[[2.0]]]] * 4)
@@ -104,7 +117,7 @@ class Test(BaseTest):
         model = ReLUDeepLiftModel()
         self._deeplift_assert(model, DeepLiftShap(model), inputs, baselines)
 
-    def test_relu_deepliftshap_baselines_as_function(self):
+    def test_relu_deepliftshap_baselines_as_func(self):
         model = ReLULinearDeepLiftModel()
         x1 = torch.tensor([[-10.0, 1.0, -5.0]])
         x2 = torch.tensor([[3.0, 3.0, 1.0]])
@@ -145,7 +158,51 @@ class Test(BaseTest):
         assertTensorAlmostEqual(self, attributions[0], attributions_with_func[0])
         assertTensorAlmostEqual(self, attributions[1], attributions_with_func[1])
 
-    def _deeplift_assert(self, model, attr_method, inputs, baselines):
+    def test_relu_deepliftshap_with_custom_attr_func(self):
+        def custom_attr_func(multipliers, inputs, baselines):
+            return tuple(
+                multiplier * (input - baseline)
+                for multiplier, input, baseline in zip(multipliers, inputs, baselines)
+            )
+
+        model = ReLULinearDeepLiftModel()
+        x1 = torch.tensor([[-10.0, 1.0, -5.0]])
+        x2 = torch.tensor([[3.0, 3.0, 1.0]])
+        b1 = torch.tensor([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
+        b2 = torch.tensor([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
+        inputs = (x1, x2)
+        baselines = (b1, b2)
+        dls = DeepLiftShap(model)
+        attr_w_func, delta_w_func = dls.attribute(
+            inputs,
+            baselines,
+            custom_attribution_func=custom_attr_func,
+            return_convergence_delta=True,
+        )
+        attr, delta = dls.attribute(inputs, baselines, return_convergence_delta=True)
+        self.assertEqual(attr_w_func[0].shape, x1.shape)
+        self.assertEqual(attr_w_func[1].shape, x2.shape)
+
+        assertTensorAlmostEqual(self, attr[0], attr_w_func[0], 0.0)
+        assertTensorAlmostEqual(self, attr[1], attr_w_func[1], 0.0)
+        assertTensorAlmostEqual(self, delta_w_func, delta, 0.0)
+
+    def test_relu_deepliftshap_with_hypothetical_contrib_func(self):
+        model = Conv1dDeepLiftModel()
+        rand_seq_data = torch.abs(torch.randn(2, 4, 1000))
+        rand_seq_ref = torch.abs(torch.randn(3, 4, 1000))
+        dls = DeepLiftShap(model)
+        attr = dls.attribute(
+            rand_seq_data,
+            rand_seq_ref,
+            custom_attribution_func=_hypothetical_contrib_func,
+            target=(0, 0),
+        )
+        self.assertEqual(attr.shape, rand_seq_data.shape)
+
+    def _deeplift_assert(
+        self, model, attr_method, inputs, baselines, custom_attr_func=None
+    ):
         input_bsz = len(inputs[0])
         if callable(baselines):
             baseline_parameters = signature(baselines).parameters
@@ -162,9 +219,14 @@ class Test(BaseTest):
         for _ in range(5):
             model.zero_grad()
             attributions, delta = attr_method.attribute(
-                inputs, baselines, return_convergence_delta=True
+                inputs,
+                baselines,
+                return_convergence_delta=True,
+                custom_attribution_func=custom_attr_func,
             )
-            attributions_without_delta = attr_method.attribute(inputs, baselines)
+            attributions_without_delta = attr_method.attribute(
+                inputs, baselines, custom_attribution_func=custom_attr_func
+            )
 
             for attribution, attribution_without_delta in zip(
                 attributions, attributions_without_delta
@@ -199,3 +261,35 @@ class Test(BaseTest):
                 ig = IntegratedGradients(model)
                 attributions_ig = ig.attribute(inputs, baselines)
                 assertAttributionComparision(self, attributions, attributions_ig)
+
+
+def _hypothetical_contrib_func(multipliers, inputs, baselines):
+    r"""
+    Implements hypothetical input contributions based on the logic described here:
+    https://github.com/kundajelab/deeplift/pull/36/files
+    This is not using a dummy model for test purposes
+    """
+    # we assume that multiplies, inputs and baselines have the following shape:
+    # tuple((bsz x len x channel), )
+    assert len(multipliers[0].shape) == 3, multipliers[0].shape
+    assert len(inputs[0].shape) == 3, inputs[0].shape
+    assert len(baselines[0].shape) == 3, baselines[0].shape
+    assert len(multipliers) == len(inputs) and len(inputs) == len(baselines), (
+        "multipliers, inputs and baselines must have the same shape but"
+        "multipliers: {}, inputs: {}, baselines: {}".format(
+            len(multipliers), len(inputs), len(baselines)
+        )
+    )
+
+    attributions = []
+    for k in range(len(multipliers)):
+        sub_attributions = torch.zeros_like(inputs[k])
+        for i in range(inputs[k].shape[-1]):
+            hypothetical_input = torch.zeros_like(inputs[k])
+            hypothetical_input[:, :, i] = 1.0
+            hypothetical_input_ref_diff = hypothetical_input - baselines[k]
+            sub_attributions[:, :, i] = torch.sum(
+                hypothetical_input_ref_diff * multipliers[k], axis=-1
+            )
+        attributions.append(sub_attributions)
+    return tuple(attributions)

--- a/tests/attr/test_deeplift_classification.py
+++ b/tests/attr/test_deeplift_classification.py
@@ -57,8 +57,6 @@ class Test(BaseTest):
         num_in = 40
         inputs = torch.arange(0.0, num_in * 3.0, requires_grad=True).reshape(3, num_in)
         baselines = torch.range(1.0, num_in).unsqueeze(0)
-        print(inputs.shape)
-        print(baselines.shape)
         model = SoftmaxDeepLiftModel(num_in, 20, 10)
         dl = DeepLift(model)
 

--- a/tests/attr/test_layer_deeplift_basic.py
+++ b/tests/attr/test_layer_deeplift_basic.py
@@ -38,12 +38,6 @@ class TestDeepLift(BaseTest):
         assert_delta(self, delta)
 
     def test_relu_deeplift_with_custom_attr_func(self):
-        def custom_attr_func(multipliers, inputs, baselines):
-            return tuple(
-                multiplier * (input - baseline)
-                for multiplier, input, baseline in zip(multipliers, inputs, baselines)
-            )
-
         model = ReLULinearDeepLiftModel()
         inputs, baselines = _create_inps_and_base_for_deeplift_neuron_layer_testing()
         attr_method = LayerDeepLift(model, model.l3)
@@ -121,12 +115,6 @@ class TestDeepLift(BaseTest):
         assert_delta(self, delta)
 
     def test_relu_deepliftshap_with_custom_attr_func(self):
-        def custom_attr_func(multipliers, inputs, baselines):
-            return tuple(
-                multiplier * (input - baseline)
-                for multiplier, input, baseline in zip(multipliers, inputs, baselines)
-            )
-
         model = ReLULinearDeepLiftModel()
         (
             inputs,

--- a/tests/attr/test_neuron_deeplift_basic.py
+++ b/tests/attr/test_neuron_deeplift_basic.py
@@ -48,6 +48,12 @@ class Test(BaseTest):
         assertTensorAlmostEqual(self, attributions[0], [[-0.0, 0.0, -0.0]])
         assertTensorAlmostEqual(self, attributions[1], [[6.0, 9.0, 0.0]])
 
+    def test_relu_deeplift_with_custom_attr_func(self):
+        model = ReLULinearDeepLiftModel()
+        inputs, baselines = _create_inps_and_base_for_deeplift_neuron_layer_testing()
+        neuron_dl = NeuronDeepLift(model, model.l3)
+        self._relu_custom_attr_func_assert(neuron_dl, inputs, baselines)
+
     def test_relu_neuron_deeplift_shap(self):
         model = ReLULinearDeepLiftModel()
         (
@@ -88,3 +94,29 @@ class Test(BaseTest):
 
         assertTensorAlmostEqual(self, attributions[0], [[-0.0, 0.0, -0.0]])
         assertTensorAlmostEqual(self, attributions[1], [[6.0, 9.0, 0.0]])
+
+    def test_relu_deepliftshap_with_custom_attr_func(self):
+        model = ReLULinearDeepLiftModel()
+        (
+            inputs,
+            baselines,
+        ) = _create_inps_and_base_for_deepliftshap_neuron_layer_testing()
+        neuron_dl = NeuronDeepLiftShap(model, model.l3)
+        self._relu_custom_attr_func_assert(neuron_dl, inputs, baselines)
+
+    def _relu_custom_attr_func_assert(self, attr_method, inputs, baselines):
+        def custom_attr_func(multipliers, inputs, baselines):
+            return tuple(
+                multiplier * (input - baseline)
+                for multiplier, input, baseline in zip(multipliers, inputs, baselines)
+            )
+
+        attr_w_func = attr_method.attribute(
+            inputs, 0, baselines, custom_attribution_func=custom_attr_func
+        )
+        attr = attr_method.attribute(inputs, 0, baselines)
+        self.assertEqual(attr_w_func[0].shape, inputs[0].shape)
+        self.assertEqual(attr_w_func[1].shape, inputs[1].shape)
+
+        assertTensorAlmostEqual(self, attr[0], attr_w_func[0], 0.0)
+        assertTensorAlmostEqual(self, attr[1], attr_w_func[1], 0.0)


### PR DESCRIPTION
This PR adds:

1. support for custom attribution function in DeepLift based on the logic described in feature request: https://github.com/pytorch/captum/issues/35.
In case custom function is not provided the default logic is used.

2. test cases. I also added a test case using Avanti's logic on hypothetical input:
https://github.com/AvantiShri/shap/blob/0b0350ba3a42af275f6e99ca2e3c5877d7d94f8a/notebooks/deep_explainer/PyTorch%20Deep%20Explainer%20DeepSEA%20example.ipynb

3. documentation in DeepLift and DeepLiftSHAP. Once this is reviewed I'll add it in Layer and Neuron implementations as well.


