### PR TITLE
Add Gradient SHAP for layer and neuron

### DIFF
--- a/captum/attr/__init__.py
+++ b/captum/attr/__init__.py
@@ -15,12 +15,12 @@ from ._core.layer.layer_activation import LayerActivation  # noqa
 from ._core.layer.internal_influence import InternalInfluence  # noqa
 from ._core.layer.grad_cam import LayerGradCam  # noqa
 from ._core.layer.layer_deep_lift import LayerDeepLift, LayerDeepLiftShap  # noqa
-from ._core.layer.layer_gradient_shap import LayerGradientShap # noqa
+from ._core.layer.layer_gradient_shap import LayerGradientShap  # noqa
 from ._core.neuron.neuron_conductance import NeuronConductance  # noqa
 from ._core.neuron.neuron_gradient import NeuronGradient  # noqa
 from ._core.neuron.neuron_integrated_gradients import NeuronIntegratedGradients  # noqa
 from ._core.neuron.neuron_deep_lift import NeuronDeepLift, NeuronDeepLiftShap  # noqa
-from ._core.neuron.neuron_gradient_shap import NeuronGradientShap # noqa
+from ._core.neuron.neuron_gradient_shap import NeuronGradientShap  # noqa
 from ._core.neuron.neuron_guided_backprop_deconvnet import (
     NeuronDeconvolution,
     NeuronGuidedBackprop,

--- a/captum/attr/__init__.py
+++ b/captum/attr/__init__.py
@@ -15,10 +15,12 @@ from ._core.layer.layer_activation import LayerActivation  # noqa
 from ._core.layer.internal_influence import InternalInfluence  # noqa
 from ._core.layer.grad_cam import LayerGradCam  # noqa
 from ._core.layer.layer_deep_lift import LayerDeepLift, LayerDeepLiftShap  # noqa
+from ._core.layer.layer_gradient_shap import LayerGradientShap # noqa
 from ._core.neuron.neuron_conductance import NeuronConductance  # noqa
 from ._core.neuron.neuron_gradient import NeuronGradient  # noqa
 from ._core.neuron.neuron_integrated_gradients import NeuronIntegratedGradients  # noqa
 from ._core.neuron.neuron_deep_lift import NeuronDeepLift, NeuronDeepLiftShap  # noqa
+from ._core.neuron.neuron_gradient_shap import NeuronGradientShap # noqa
 from ._core.neuron.neuron_guided_backprop_deconvnet import (
     NeuronDeconvolution,
     NeuronGuidedBackprop,

--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -18,6 +18,7 @@ from .._utils.common import (
     _expand_additional_forward_args,
     _tensorize_baseline,
     _call_custom_attribution_func,
+    _compute_conv_delta_and_format_attrs,
     ExpansionTypes,
 )
 from .._utils.attribution import GradientAttribution
@@ -280,7 +281,8 @@ class DeepLift(GradientAttribution):
         self._remove_hooks()
 
         undo_gradient_requirements(inputs, gradient_mask)
-        return self._compute_conv_delta_and_format_attrs(
+        return _compute_conv_delta_and_format_attrs(
+            self,
             return_convergence_delta,
             attributions,
             baselines,
@@ -289,29 +291,6 @@ class DeepLift(GradientAttribution):
             target,
             is_inputs_tuple,
         )
-
-    def _compute_conv_delta_and_format_attrs(
-        self,
-        return_convergence_delta,
-        attributions,
-        start_point,
-        end_point,
-        additional_forward_args,
-        target,
-        is_inputs_tuple,
-    ):
-        if return_convergence_delta:
-            # computes convergence error
-            delta = self.compute_convergence_delta(
-                attributions,
-                start_point,
-                end_point,
-                additional_forward_args=additional_forward_args,
-                target=target,
-            )
-            return _format_attributions(is_inputs_tuple, attributions), delta
-        else:
-            return _format_attributions(is_inputs_tuple, attributions)
 
     def _is_non_linear(self, module):
         return type(module) in SUPPORTED_NON_LINEAR.keys()

--- a/captum/attr/_core/layer/layer_deep_lift.py
+++ b/captum/attr/_core/layer/layer_deep_lift.py
@@ -18,6 +18,7 @@ from ..._utils.common import (
     _validate_input,
     _tensorize_baseline,
     _call_custom_attribution_func,
+    _compute_conv_delta_and_format_attrs,
 )
 
 
@@ -244,9 +245,6 @@ class LayerDeepLift(LayerAttribution, DeepLift):
             additional_forward_args=additional_forward_args,
             attribute_to_layer_input=attribute_to_layer_input,
         )
-        # Fixme later: we need to do this because `_forward_layer_eval`
-        # always returns a tensor
-        attr_baselines = (attr_baselines,)
 
         # remove forward hook set for baselines
         for forward_handles_ref in self.forward_handles_refs:
@@ -261,8 +259,9 @@ class LayerDeepLift(LayerAttribution, DeepLift):
             additional_forward_args=additional_forward_args,
             attribute_to_layer_input=attribute_to_layer_input,
         )
-        # Fixme later: we need to do this because
-        # `compute_layer_gradients_and_eval` always returns a tensor
+        # Fixme later: we need to do this because `compute_layer_gradients_and_eval`
+        # and `_forward_layer_eval` always returns a tensor
+        attr_baselines = (attr_baselines,)
         attr_inputs = (attr_inputs,)
         gradients = (gradients,)
 
@@ -283,7 +282,8 @@ class LayerDeepLift(LayerAttribution, DeepLift):
 
         undo_gradient_requirements(inputs, gradient_mask)
 
-        return self._compute_conv_delta_and_format_attrs(
+        return _compute_conv_delta_and_format_attrs(
+            self,
             return_convergence_delta,
             attributions,
             baselines,

--- a/captum/attr/_core/layer/layer_deep_lift.py
+++ b/captum/attr/_core/layer/layer_deep_lift.py
@@ -193,7 +193,7 @@ class LayerDeepLift(LayerAttribution, DeepLift):
 
         Returns:
             **attributions** or 2-element tuple of **attributions**, **delta**:
-            - **attributions** (*tensor* or tuple of *tensors*):
+            - **attributions** (*tensor*):
                 Attribution score computed based on DeepLift's rescale rule with
                 respect to layer's inputs or outputs. Attributions will always be the
                 same size as the provided layer's inputs or outputs, depending on
@@ -449,7 +449,7 @@ class LayerDeepLiftShap(LayerDeepLift, DeepLiftShap):
 
         Returns:
             **attributions** or 2-element tuple of **attributions**, **delta**:
-            - **attributions** (*tensor* or tuple of *tensors*):
+            - **attributions** (*tensor*):
                         Attribution score computed based on DeepLift's rescale rule
                         with respect to layer's inputs or outputs. Attributions
                         will always be the same size as the provided layer's inputs

--- a/captum/attr/_core/layer/layer_gradient_shap.py
+++ b/captum/attr/_core/layer/layer_gradient_shap.py
@@ -66,9 +66,10 @@ class LayerGradientShap(LayerAttribution, GradientShap):
         gradients by randomly sampling from the distribution of baselines/references.
         It adds white noise to each input sample `n_samples` times, selects a
         random baseline from baselines' distribution and a random point along the
-        path between the baseline and the input, and computes the gradient of outputs
-        with respect to those selected random points. The final SHAP values represent
-        the expected values of gradients * (inputs - baselines).
+        path between the baseline and the input, and computes the gradient of
+        outputs with respect to selected random points in chosen `layer`.
+        The final SHAP values represent the expected values of
+        `gradients * (layer_attr_inputs - layer_attr_baselines)`.
 
         GradientShap makes an assumption that the input features are independent
         and that the explanation model is linear, meaning that the explanations
@@ -177,7 +178,7 @@ class LayerGradientShap(LayerAttribution, GradientShap):
                         tensor must correspond to the batch size. It will be
                         repeated for each `n_steps` for each randomly generated
                         input sample.
-                        Note that the gradients are not computed with respect
+                        Note that the attributions are not computed with respect
                         to these arguments.
                         Default: None
             return_convergence_delta (bool, optional): Indicates whether to return
@@ -198,10 +199,10 @@ class LayerGradientShap(LayerAttribution, GradientShap):
                         Default: False
         Returns:
             **attributions** or 2-element tuple of **attributions**, **delta**:
-            - **attributions** (*tensor* or tuple of *tensors*):
+            - **attributions** (*tensor*):
                         Attribution score computed based on GradientSHAP with
-                        respect to each input feature. Attributions will always be
-                        the same size as the provided layer's inputs or outputs,
+                        respect to layer's input or output. Attributions will always
+                        be the same size as the provided layer's inputs or outputs,
                         depending on whether we attribute to the inputs or outputs
                         of the layer. Since currently it is assumed that the inputs
                         and outputs of the layer must be single tensor, returned
@@ -350,5 +351,4 @@ class LayerInputBaselineXGradient(LayerAttribution, InputBaselineXGradient):
             inputs,
             additional_forward_args,
             target,
-            True,
         )

--- a/captum/attr/_core/layer/layer_gradient_shap.py
+++ b/captum/attr/_core/layer/layer_gradient_shap.py
@@ -87,9 +87,10 @@ class LayerGradientShap(LayerAttribution, GradientShap):
 
         Args:
 
-            inputs (tensor or tuple of tensors):  Input for which SHAP attribution
-                        values are computed. If `forward_func` takes a single
-                        tensor as input, a single input tensor should be provided.
+            inputs (tensor or tuple of tensors):  Input which are used to compute
+                        SHAP attribution values for a given `layer`. If `forward_func`
+                        takes a single tensor as input, a single input tensor should
+                        be provided.
                         If `forward_func` takes multiple tensors as input, a tuple
                         of the input tensors should be provided. It is assumed
                         that for all given input tensors, dimension 0 corresponds

--- a/captum/attr/_core/layer/layer_gradient_shap.py
+++ b/captum/attr/_core/layer/layer_gradient_shap.py
@@ -304,7 +304,7 @@ class LayerInputBaselineXGradient(LayerAttribution, InputBaselineXGradient):
             self._scale_input(input, baseline, rand_coefficient)
             for input, baseline in zip(inputs, baselines)
         )
-        grads, attr_inputs = compute_layer_gradients_and_eval(
+        grads, _ = compute_layer_gradients_and_eval(
             self.forward_func,
             self.layer,
             input_baseline_scaled,
@@ -323,6 +323,14 @@ class LayerInputBaselineXGradient(LayerAttribution, InputBaselineXGradient):
             attribute_to_layer_input=attribute_to_layer_input,
         )
 
+        attr_inputs = _forward_layer_eval(
+            self.forward_func,
+            inputs,
+            self.layer,
+            additional_forward_args=additional_forward_args,
+            device_ids=self.device_ids,
+            attribute_to_layer_input=attribute_to_layer_input,
+        )
         attr_inputs = (attr_inputs,)
         attr_baselines = (attr_baselines,)
         grads = (grads,)

--- a/captum/attr/_core/layer/layer_gradient_shap.py
+++ b/captum/attr/_core/layer/layer_gradient_shap.py
@@ -38,8 +38,8 @@ class LayerGradientShap(LayerAttribution, GradientShap):
                           If forward_func is given as the DataParallel model itself,
                           then it is not necessary to provide this argument.
         """
-        super(LayerAttribution, self).__init__(forward_func, layer, device_ids)
-        super(GradientShap, self).__init__(forward_func)
+        LayerAttribution.__init__(self, forward_func, layer, device_ids)
+        GradientShap.__init__(self, forward_func)
 
     def attribute(
         self,
@@ -283,8 +283,8 @@ class LayerInputBaselineXGradient(LayerAttribution, InputBaselineXGradient):
                           If forward_func is given as the DataParallel model itself,
                           then it is not necessary to provide this argument.
         """
-        super(LayerAttribution, self).__init__(forward_func, layer, device_ids)
-        super(InputBaselineXGradient, self).__init__(forward_func)
+        LayerAttribution.__init__(self, forward_func, layer, device_ids)
+        InputBaselineXGradient.__init__(self, forward_func)
 
     def attribute(
         self,

--- a/captum/attr/_core/layer/layer_gradient_shap.py
+++ b/captum/attr/_core/layer/layer_gradient_shap.py
@@ -1,26 +1,45 @@
 #!/usr/bin/env python3
+
 import torch
 
 import numpy as np
 
-from .._utils.attribution import GradientAttribution
-from .._utils.common import (
+from ..._utils.attribution import LayerAttribution
+from ..._utils.gradient import compute_layer_gradients_and_eval, _forward_layer_eval
+
+from ..gradient_shap import GradientShap, InputBaselineXGradient
+from ..._utils.common import (
     _format_callable_baseline,
     _compute_conv_delta_and_format_attrs,
 )
 
-from .noise_tunnel import NoiseTunnel
+from ..noise_tunnel import NoiseTunnel
 
 
-class GradientShap(GradientAttribution):
-    def __init__(self, forward_func):
+class LayerGradientShap(LayerAttribution, GradientShap):
+    def __init__(self, forward_func, layer, device_ids=None):
         r"""
         Args:
 
-            forward_func (function): The forward function of the model or
-                       any modification of it
+            forward_func (callable):  The forward function of the model or any
+                          modification of it
+            layer (torch.nn.Module): Layer for which attributions are computed.
+                          Output size of attribute matches this layer's input or
+                          output dimensions, depending on whether we attribute to
+                          the inputs or outputs of the layer, corresponding to
+                          attribution of each neuron in the input or output of
+                          this layer.
+                          Currently, it is assumed that the inputs or the outputs
+                          of the layer, depending on which one is used for
+                          attribution can only be a single tensor.
+            device_ids (list(int)): Device ID list, necessary only if forward_func
+                          applies a DataParallel model. This allows reconstruction of
+                          intermediate outputs from batched results across devices.
+                          If forward_func is given as the DataParallel model itself,
+                          then it is not necessary to provide this argument.
         """
-        GradientAttribution.__init__(self, forward_func)
+        super(LayerAttribution, self).__init__(forward_func, layer, device_ids)
+        super(GradientShap, self).__init__(forward_func)
 
     def attribute(
         self,
@@ -31,10 +50,11 @@ class GradientShap(GradientAttribution):
         target=None,
         additional_forward_args=None,
         return_convergence_delta=False,
+        attribute_to_layer_input=False,
     ):
         r"""
-        Implements gradient SHAP based on the implementation from SHAP's primary
-        author. For reference, please, view:
+        Implements gradient SHAP for layer based on the implementation from SHAP's
+        primary author. For reference, please, view:
 
         https://github.com/slundberg/shap\
         #deep-learning-example-with-gradientexplainer-tensorflowkeraspytorch-models
@@ -99,7 +119,7 @@ class GradientShap(GradientAttribution):
                                 for corresponding input tensor.
 
                         - callable function, optionally takes `inputs` as an
-                            argument and either returns a single tensor
+                            argument and either returns a single tensor, scalar
                             or a tuple of those.
 
                         It is recommended that the number of samples in the baselines'
@@ -164,21 +184,32 @@ class GradientShap(GradientAttribution):
                         is set to True convergence delta will be returned in
                         a tuple following attributions.
                         Default: False
+            attribute_to_layer_input (bool, optional): Indicates whether to
+                        compute the attribution with respect to the layer input
+                        or output. If `attribute_to_layer_input` is set to True
+                        then the attributions will be computed with respect to
+                        layer input, otherwise it will be computed with respect
+                        to layer output.
+                        Note that currently it is assumed that either the input
+                        or the output of internal layer, depending on whether we
+                        attribute to the input or output, is a single tensor.
+                        Support for multiple tensors will be added later.
+                        Default: False
         Returns:
             **attributions** or 2-element tuple of **attributions**, **delta**:
             - **attributions** (*tensor* or tuple of *tensors*):
-                        Attribution score computed based on GradientSHAP with respect
-                        to each input feature. Attributions will always be
-                        the same size as the provided inputs, with each value
-                        providing the attribution of the corresponding input index.
-                        If a single tensor is provided as inputs, a single tensor is
-                        returned. If a tuple is provided for inputs, a tuple of
-                        corresponding sized tensors is returned.
+                        Attribution score computed based on GradientSHAP with
+                        respect to each input feature. Attributions will always be
+                        the same size as the provided layer's inputs or outputs,
+                        depending on whether we attribute to the inputs or outputs
+                        of the layer. Since currently it is assumed that the inputs
+                        and outputs of the layer must be single tensor, returned
+                        attributions have the shape of that tensor.
             - **delta** (*tensor*, returned if return_convergence_delta=True):
                         This is computed using the property that the total
                         sum of forward_func(inputs) - forward_func(baselines)
                         must be very close to the total sum of the attributions
-                        based on GradientSHAP.
+                        based on layer gradient SHAP.
                         Delta is calculated for each example in the input after adding
                         `n_samples` times gaussian noise to each of them. Therefore,
                         the dimensionality of the deltas tensor is equal to the
@@ -191,18 +222,20 @@ class GradientShap(GradientAttribution):
                 >>> # ImageClassifier takes a single input tensor of images Nx3x32x32,
                 >>> # and returns an Nx10 tensor of class probabilities.
                 >>> net = ImageClassifier()
-                >>> gradient_shap = GradientShap(net)
+                >>> layer_grad_shap = LayerGradientShap(net, net.linear1)
                 >>> input = torch.randn(3, 3, 32, 32, requires_grad=True)
                 >>> # choosing baselines randomly
                 >>> baselines = torch.randn(20, 3, 32, 32)
-                >>> # Computes gradient shap for the input
-                >>> # Attribution size matches input size: 3x3x32x32
-                >>> attribution = gradient_shap.attribute(input, baselines,
-                                                                 target=5)
+                >>> # Computes gradient SHAP of output layer when target is equal
+                >>> # to 0 with respect to the layer linear1.
+                >>> # Attribution size matches to the size of the linear1 layer
+                >>> attribution = layer_grad_shap.attribute(input, baselines,
+                                                            target=5)
 
         """
-        input_min_baseline_x_grad = InputBaselineXGradient(self.forward_func)
-        input_min_baseline_x_grad.gradient_func = self.gradient_func
+        input_min_baseline_x_grad = LayerInputBaselineXGradient(
+            self.forward_func, self.layer, device_ids=self.layer
+        )
 
         nt = NoiseTunnel(input_min_baseline_x_grad)
 
@@ -220,23 +253,36 @@ class GradientShap(GradientAttribution):
             target=target,
             additional_forward_args=additional_forward_args,
             return_convergence_delta=return_convergence_delta,
+            attribute_to_layer_input=attribute_to_layer_input,
         )
 
         return attributions
 
-    def has_convergence_delta(self):
-        return True
 
-
-class InputBaselineXGradient(GradientAttribution):
-    def __init__(self, forward_func):
+class LayerInputBaselineXGradient(LayerAttribution, InputBaselineXGradient):
+    def __init__(self, forward_func, layer, device_ids=None):
         r"""
         Args:
 
-            forward_func (function): The forward function of the model or
-                       any modification of it
+            forward_func (callable):  The forward function of the model or any
+                          modification of it
+            layer (torch.nn.Module): Layer for which attributions are computed.
+                          Output size of attribute matches this layer's input or
+                          output dimensions, depending on whether we attribute to
+                          the inputs or outputs of the layer, corresponding to
+                          attribution of each neuron in the input or output of
+                          this layer.
+                          Currently, it is assumed that the inputs or the outputs
+                          of the layer, depending on which one is used for
+                          attribution can only be a single tensor.
+            device_ids (list(int)): Device ID list, necessary only if forward_func
+                          applies a DataParallel model. This allows reconstruction of
+                          intermediate outputs from batched results across devices.
+                          If forward_func is given as the DataParallel model itself,
+                          then it is not necessary to provide this argument.
         """
-        GradientAttribution.__init__(self, forward_func)
+        super(LayerAttribution, self).__init__(forward_func, layer, device_ids)
+        super(InputBaselineXGradient, self).__init__(forward_func)
 
     def attribute(
         self,
@@ -245,11 +291,8 @@ class InputBaselineXGradient(GradientAttribution):
         target=None,
         additional_forward_args=None,
         return_convergence_delta=False,
+        attribute_to_layer_input=False,
     ):
-        # Keeps track whether original input is a tuple or not before
-        # converting it into a tuple.
-        is_inputs_tuple = isinstance(inputs, tuple)
-
         rand_coefficient = torch.tensor(
             np.random.uniform(0.0, 1.0, inputs[0].shape[0]),
             device=inputs[0].device,
@@ -260,18 +303,36 @@ class InputBaselineXGradient(GradientAttribution):
             self._scale_input(input, baseline, rand_coefficient)
             for input, baseline in zip(inputs, baselines)
         )
-        grads = self.gradient_func(
-            self.forward_func, input_baseline_scaled, target, additional_forward_args
+        grads, attr_inputs = compute_layer_gradients_and_eval(
+            self.forward_func,
+            self.layer,
+            input_baseline_scaled,
+            target,
+            additional_forward_args,
+            device_ids=self.device_ids,
+            attribute_to_layer_input=attribute_to_layer_input,
         )
 
+        attr_baselines = _forward_layer_eval(
+            self.forward_func,
+            baselines,
+            self.layer,
+            additional_forward_args=additional_forward_args,
+            device_ids=self.device_ids,
+            attribute_to_layer_input=attribute_to_layer_input,
+        )
+
+        attr_inputs = (attr_inputs,)
+        attr_baselines = (attr_baselines,)
+        grads = (grads,)
+
         input_baseline_diffs = tuple(
-            input - baseline for input, baseline in zip(inputs, baselines)
+            input - baseline for input, baseline in zip(attr_inputs, attr_baselines)
         )
         attributions = tuple(
             input_baseline_diff * grad
             for input_baseline_diff, grad in zip(input_baseline_diffs, grads)
         )
-
         return _compute_conv_delta_and_format_attrs(
             self,
             return_convergence_delta,
@@ -280,22 +341,5 @@ class InputBaselineXGradient(GradientAttribution):
             inputs,
             additional_forward_args,
             target,
-            is_inputs_tuple,
+            True,
         )
-
-    def has_convergence_delta(self):
-        return True
-
-    def _scale_input(self, input, baseline, rand_coefficient):
-        # batch size
-        bsz = input.shape[0]
-        inp_shape_wo_bsz = input.shape[1:]
-        inp_shape = (bsz,) + tuple([1] * len(inp_shape_wo_bsz))
-
-        # expand and reshape the indices
-        rand_coefficient = rand_coefficient.view(inp_shape).requires_grad_()
-
-        input_baseline_scaled = (
-            rand_coefficient * input + (1 - rand_coefficient) * baseline
-        )
-        return input_baseline_scaled

--- a/captum/attr/_core/layer/layer_gradient_shap.py
+++ b/captum/attr/_core/layer/layer_gradient_shap.py
@@ -235,7 +235,7 @@ class LayerGradientShap(LayerAttribution, GradientShap):
 
         """
         input_min_baseline_x_grad = LayerInputBaselineXGradient(
-            self.forward_func, self.layer, device_ids=self.layer
+            self.forward_func, self.layer, device_ids=self.device_ids
         )
 
         nt = NoiseTunnel(input_min_baseline_x_grad)

--- a/captum/attr/_core/neuron/neuron_gradient_shap.py
+++ b/captum/attr/_core/neuron/neuron_gradient_shap.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 
 from ..gradient_shap import GradientShap
-from ..._utils.attribution import NeuronAttribution
+from ..._utils.attribution import NeuronAttribution, GradientAttribution
 from ..._utils.gradient import construct_neuron_grad_fn
 
 
-class NeuronGradientShap(NeuronAttribution):
+class NeuronGradientShap(NeuronAttribution, GradientAttribution):
     def __init__(self, forward_func, layer, device_ids=None):
         r"""
         Args:
@@ -26,7 +26,8 @@ class NeuronGradientShap(NeuronAttribution):
                           If forward_func is given as the DataParallel model itself,
                           then it is not necessary to provide this argument.
         """
-        super().__init__(forward_func, layer, device_ids)
+        NeuronAttribution.__init__(self, forward_func, layer, device_ids)
+        GradientAttribution.__init__(self, forward_func)
 
     def attribute(
         self,

--- a/captum/attr/_core/neuron/neuron_gradient_shap.py
+++ b/captum/attr/_core/neuron/neuron_gradient_shap.py
@@ -1,40 +1,47 @@
 #!/usr/bin/env python3
-import torch
 
-import numpy as np
-
-from .._utils.attribution import GradientAttribution
-from .._utils.common import (
-    _format_callable_baseline,
-    _compute_conv_delta_and_format_attrs,
-)
-
-from .noise_tunnel import NoiseTunnel
+from ..gradient_shap import GradientShap
+from ..._utils.attribution import NeuronAttribution
+from ..._utils.gradient import construct_neuron_grad_fn
 
 
-class GradientShap(GradientAttribution):
-    def __init__(self, forward_func):
+class NeuronGradientShap(NeuronAttribution):
+    def __init__(self, forward_func, layer, device_ids=None):
         r"""
         Args:
 
-            forward_func (function): The forward function of the model or
-                       any modification of it
+            forward_func (callable):  The forward function of the model or any
+                          modification of it
+            layer (torch.nn.Module): Layer for which attributions are computed.
+                          Output size of attribute matches this layer's input or
+                          output dimensions, depending on whether we attribute to
+                          the inputs or outputs of the layer, corresponding to
+                          attribution of each neuron in the input or output of
+                          this layer.
+                          Currently, it is assumed that the inputs or the outputs
+                          of the layer, depending on which one is used for
+                          attribution, can only be a single tensor.
+            device_ids (list(int)): Device ID list, necessary only if forward_func
+                          applies a DataParallel model. This allows reconstruction of
+                          intermediate outputs from batched results across devices.
+                          If forward_func is given as the DataParallel model itself,
+                          then it is not necessary to provide this argument.
         """
-        GradientAttribution.__init__(self, forward_func)
+        super().__init__(forward_func, layer, device_ids)
 
     def attribute(
         self,
         inputs,
-        baselines,
+        neuron_index,
+        baselines=None,
         n_samples=5,
         stdevs=0.0,
-        target=None,
         additional_forward_args=None,
-        return_convergence_delta=False,
+        attribute_to_neuron_input=False,
     ):
         r"""
-        Implements gradient SHAP based on the implementation from SHAP's primary
-        author. For reference, please, view:
+        Implements gradient SHAP for a neuron in a hidden layer based on the
+        implementation from SHAP's primary author. For reference, please, view:
 
         https://github.com/slundberg/shap\
         #deep-learning-example-with-gradientexplainer-tensorflowkeraspytorch-models
@@ -75,6 +82,13 @@ class GradientShap(GradientAttribution):
                         that for all given input tensors, dimension 0 corresponds
                         to the number of examples, and if multiple input tensors
                         are provided, the examples must be aligned appropriately.
+            neuron_index (int or tuple): Index of neuron in output of given
+                        layer for which attribution is desired. Length of
+                        this tuple must be one less than the number of
+                        dimensions in the output of the given layer (since
+                        dimension 0 corresponds to number of examples).
+                        An integer may be provided instead of a tuple of
+                        length 1.
             baselines (scalar, tensor, tuple of scalars or tensors, callable, optional):
                         Baselines define the starting point from which expectation
                         is computed and can be provided as:
@@ -122,31 +136,6 @@ class GradientShap(GradientAttribution):
                         corresponds to the input with the same index in the inputs
                         tuple.
                         Default: 0.0
-            target (int, tuple, tensor or list, optional):  Output indices for
-                        which gradients are computed (for classification cases,
-                        this is usually the target class).
-                        If the network returns a scalar value per example,
-                        no target index is necessary.
-                        For general 2D outputs, targets can be either:
-
-                        - a single integer or a tensor containing a single
-                            integer, which is applied to all input examples
-
-                        - a list of integers or a 1D tensor, with length matching
-                            the number of examples in inputs (dim 0). Each integer
-                            is applied as the target for the corresponding example.
-
-                        For outputs with > 2 dimensions, targets can be either:
-
-                        - A single tuple, which contains #output_dims - 1
-                            elements. This target index is applied to all examples.
-
-                        - A list of tuples with length equal to the number of
-                            examples in inputs (dim 0), and each tuple containing
-                            #output_dims - 1 elements. Each tuple is applied as the
-                            target for the corresponding example.
-
-                        Default: None
             additional_forward_args (tuple, optional): If the forward function
                         requires additional arguments other than the inputs for
                         which attributions should not be computed, this argument
@@ -159,11 +148,18 @@ class GradientShap(GradientAttribution):
                         Note that the gradients are not computed with respect
                         to these arguments.
                         Default: None
-            return_convergence_delta (bool, optional): Indicates whether to return
-                        convergence delta or not. If `return_convergence_delta`
-                        is set to True convergence delta will be returned in
-                        a tuple following attributions.
+            attribute_to_neuron_input (bool, optional): Indicates whether to
+                        compute the attributions with respect to the neuron input
+                        or output. If `attribute_to_neuron_input` is set to True
+                        then the attributions will be computed with respect to
+                        neuron's inputs, otherwise it will be computed with respect
+                        to neuron's outputs.
+                        Note that currently it is assumed that either the input
+                        or the output of internal neuron, depending on whether we
+                        attribute to the input or output, is a single tensor.
+                        Support for multiple tensors will be added later.
                         Default: False
+
         Returns:
             **attributions** or 2-element tuple of **attributions**, **delta**:
             - **attributions** (*tensor* or tuple of *tensors*):
@@ -174,128 +170,35 @@ class GradientShap(GradientAttribution):
                         If a single tensor is provided as inputs, a single tensor is
                         returned. If a tuple is provided for inputs, a tuple of
                         corresponding sized tensors is returned.
-            - **delta** (*tensor*, returned if return_convergence_delta=True):
-                        This is computed using the property that the total
-                        sum of forward_func(inputs) - forward_func(baselines)
-                        must be very close to the total sum of the attributions
-                        based on GradientSHAP.
-                        Delta is calculated for each example in the input after adding
-                        `n_samples` times gaussian noise to each of them. Therefore,
-                        the dimensionality of the deltas tensor is equal to the
-                        `number of examples in the input` * `n_samples`
-                        The deltas are ordered by each input example and `n_samples`
-                        noisy samples generated for it.
 
             Examples::
 
                 >>> # ImageClassifier takes a single input tensor of images Nx3x32x32,
                 >>> # and returns an Nx10 tensor of class probabilities.
                 >>> net = ImageClassifier()
-                >>> gradient_shap = GradientShap(net)
+                >>> neuron_grad_shap = NeuronGradientShap(net, net.linear2)
                 >>> input = torch.randn(3, 3, 32, 32, requires_grad=True)
                 >>> # choosing baselines randomly
                 >>> baselines = torch.randn(20, 3, 32, 32)
-                >>> # Computes gradient shap for the input
+                >>> # Computes gradient SHAP of first neuron in linear2 layer
+                >>> # with respect to the input's of the network.
                 >>> # Attribution size matches input size: 3x3x32x32
-                >>> attribution = gradient_shap.attribute(input, baselines,
-                                                                 target=5)
+                >>> attribution = neuron_grad_shap.attribute(input, neuron_ind=0
+                                                             baselines)
 
         """
-        input_min_baseline_x_grad = InputBaselineXGradient(self.forward_func)
-        input_min_baseline_x_grad.gradient_func = self.gradient_func
+        gs = GradientShap(self.forward_func)
+        gs.gradient_func = construct_neuron_grad_fn(
+            self.layer,
+            neuron_index,
+            self.device_ids,
+            attribute_to_neuron_input=attribute_to_neuron_input,
+        )
 
-        nt = NoiseTunnel(input_min_baseline_x_grad)
-
-        # since `baselines` is a distribution, we can generate it using a function
-        # rather than passing it as an input argument
-        baselines = _format_callable_baseline(baselines, inputs)
-
-        attributions = nt.attribute(
+        return gs.attribute(
             inputs,
-            nt_type="smoothgrad",
+            baselines,
             n_samples=n_samples,
             stdevs=stdevs,
-            draw_baseline_from_distrib=True,
-            baselines=baselines,
-            target=target,
             additional_forward_args=additional_forward_args,
-            return_convergence_delta=return_convergence_delta,
         )
-
-        return attributions
-
-    def has_convergence_delta(self):
-        return True
-
-
-class InputBaselineXGradient(GradientAttribution):
-    def __init__(self, forward_func):
-        r"""
-        Args:
-
-            forward_func (function): The forward function of the model or
-                       any modification of it
-        """
-        GradientAttribution.__init__(self, forward_func)
-
-    def attribute(
-        self,
-        inputs,
-        baselines=None,
-        target=None,
-        additional_forward_args=None,
-        return_convergence_delta=False,
-    ):
-        # Keeps track whether original input is a tuple or not before
-        # converting it into a tuple.
-        is_inputs_tuple = isinstance(inputs, tuple)
-
-        rand_coefficient = torch.tensor(
-            np.random.uniform(0.0, 1.0, inputs[0].shape[0]),
-            device=inputs[0].device,
-            dtype=inputs[0].dtype,
-        )
-
-        input_baseline_scaled = tuple(
-            self._scale_input(input, baseline, rand_coefficient)
-            for input, baseline in zip(inputs, baselines)
-        )
-        grads = self.gradient_func(
-            self.forward_func, input_baseline_scaled, target, additional_forward_args
-        )
-
-        input_baseline_diffs = tuple(
-            input - baseline for input, baseline in zip(inputs, baselines)
-        )
-        attributions = tuple(
-            input_baseline_diff * grad
-            for input_baseline_diff, grad in zip(input_baseline_diffs, grads)
-        )
-
-        return _compute_conv_delta_and_format_attrs(
-            self,
-            return_convergence_delta,
-            attributions,
-            baselines,
-            inputs,
-            additional_forward_args,
-            target,
-            is_inputs_tuple,
-        )
-
-    def has_convergence_delta(self):
-        return True
-
-    def _scale_input(self, input, baseline, rand_coefficient):
-        # batch size
-        bsz = input.shape[0]
-        inp_shape_wo_bsz = input.shape[1:]
-        inp_shape = (bsz,) + tuple([1] * len(inp_shape_wo_bsz))
-
-        # expand and reshape the indices
-        rand_coefficient = rand_coefficient.view(inp_shape).requires_grad_()
-
-        input_baseline_scaled = (
-            rand_coefficient * input + (1 - rand_coefficient) * baseline
-        )
-        return input_baseline_scaled

--- a/captum/attr/_core/neuron/neuron_gradient_shap.py
+++ b/captum/attr/_core/neuron/neuron_gradient_shap.py
@@ -12,15 +12,14 @@ class NeuronGradientShap(NeuronAttribution):
 
             forward_func (callable):  The forward function of the model or any
                           modification of it
-            layer (torch.nn.Module): Layer for which attributions are computed.
-                          Output size of attribute matches this layer's input or
-                          output dimensions, depending on whether we attribute to
-                          the inputs or outputs of the layer, corresponding to
-                          attribution of each neuron in the input or output of
-                          this layer.
+            layer (torch.nn.Module): Layer for which neuron attributions are computed.
+                          The output size of the attribute method matches the
+                          dimensions of the inputs or ouputs of the neuron with
+                          index `neuron_index` in this layer, depending on whether
+                          we attribute to the inputs or outputs of the neuron.
                           Currently, it is assumed that the inputs or the outputs
-                          of the layer, depending on which one is used for
-                          attribution, can only be a single tensor.
+                          of the neurons in this layer, depending on which one is
+                          used for attribution, can only be a single tensor.
             device_ids (list(int)): Device ID list, necessary only if forward_func
                           applies a DataParallel model. This allows reconstruction of
                           intermediate outputs from batched results across devices.
@@ -53,9 +52,10 @@ class NeuronGradientShap(NeuronAttribution):
         gradients by randomly sampling from the distribution of baselines/references.
         It adds white noise to each input sample `n_samples` times, selects a
         random baseline from baselines' distribution and a random point along the
-        path between the baseline and the input, and computes the gradient of outputs
-        with respect to those selected random points. The final SHAP values represent
-        the expected values of gradients * (inputs - baselines).
+        path between the baseline and the input, and computes the gradient of the
+        neuron with index `neuron_index` with respect to those selected random
+        points. The final SHAP values represent the expected values of
+        `gradients * (inputs - baselines)`.
 
         GradientShap makes an assumption that the input features are independent
         and that the explanation model is linear, meaning that the explanations

--- a/captum/attr/_core/noise_tunnel.py
+++ b/captum/attr/_core/noise_tunnel.py
@@ -13,6 +13,7 @@ from .._utils.common import (
     _format_input,
     _format_attributions,
     _format_additional_forward_args,
+    _format_tensor_into_tuples,
     _expand_additional_forward_args,
     _expand_target,
     ExpansionTypes,
@@ -282,6 +283,7 @@ class NoiseTunnel(Attribution):
 
         if self.is_delta_supported and return_convergence_delta:
             attributions, delta = attributions
+        attributions = _format_tensor_into_tuples(attributions)
 
         expected_attributions = []
         expected_attributions_sq = []

--- a/captum/attr/_utils/common.py
+++ b/captum/attr/_utils/common.py
@@ -164,6 +164,30 @@ def _format_attributions(is_inputs_tuple, attributions):
     return attributions if is_inputs_tuple else attributions[0]
 
 
+def _compute_conv_delta_and_format_attrs(
+    attr_algo,
+    return_convergence_delta,
+    attributions,
+    start_point,
+    end_point,
+    additional_forward_args,
+    target,
+    is_inputs_tuple,
+):
+    if return_convergence_delta:
+        # computes convergence error
+        delta = attr_algo.compute_convergence_delta(
+            attributions,
+            start_point,
+            end_point,
+            additional_forward_args=additional_forward_args,
+            target=target,
+        )
+        return _format_attributions(is_inputs_tuple, attributions), delta
+    else:
+        return _format_attributions(is_inputs_tuple, attributions)
+
+
 def _zeros(inputs):
     r"""
     Takes a tuple of tensors as input and returns a tuple that has the same

--- a/captum/attr/_utils/common.py
+++ b/captum/attr/_utils/common.py
@@ -172,7 +172,7 @@ def _compute_conv_delta_and_format_attrs(
     end_point,
     additional_forward_args,
     target,
-    is_inputs_tuple,
+    is_inputs_tuple=False,
 ):
     if return_convergence_delta:
         # computes convergence error

--- a/tests/attr/helpers/classification_models.py
+++ b/tests/attr/helpers/classification_models.py
@@ -32,7 +32,7 @@ class SoftmaxModel(nn.Module):
         https://adventuresinmachinelearning.com/pytorch-tutorial-deep-learning/
     """
 
-    def __init__(self, num_in, num_hidden, num_out):
+    def __init__(self, num_in, num_hidden, num_out, inplace=False):
         super().__init__()
         self.num_in = num_in
         self.num_hidden = num_hidden
@@ -40,8 +40,8 @@ class SoftmaxModel(nn.Module):
         self.lin1 = nn.Linear(num_in, num_hidden)
         self.lin2 = nn.Linear(num_hidden, num_hidden)
         self.lin3 = nn.Linear(num_hidden, num_out)
-        self.relu1 = nn.ReLU()
-        self.relu2 = nn.ReLU()
+        self.relu1 = nn.ReLU(inplace=inplace)
+        self.relu2 = nn.ReLU(inplace=inplace)
         self.softmax = nn.Softmax(dim=1)
 
     def forward(self, input):

--- a/tests/attr/layer/test_layer_gradient_shap.py
+++ b/tests/attr/layer/test_layer_gradient_shap.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+import torch
+
+from ..helpers.utils import BaseTest
+
+from ..helpers.utils import assertTensorAlmostEqual
+from ..helpers.classification_models import SoftmaxModel
+from ..helpers.basic_models import BasicModel_MultiLayer
+
+from captum.attr._core.layer.layer_gradient_shap import LayerGradientShap
+
+from ..test_gradient_shap import _assert_attribution_delta
+
+
+class Test(BaseTest):
+    def test_basic_multilayer(self):
+        model = BasicModel_MultiLayer(inplace=True)
+        model.eval()
+
+        inputs = torch.tensor([[1.0, -20.0, 10.0]])
+        baselines = torch.randn(30, 3)
+        expected = [[-2.147, 0.0]]
+
+        self._assert_attributions(
+            model, model.linear2, (inputs,), (baselines,), 0, expected
+        )
+
+    def test_classification(self):
+        def custom_baseline_fn(inputs):
+            num_in = inputs[0].shape[1]
+            return (torch.arange(0.0, num_in * 4.0).reshape(4, num_in),)
+
+        num_in = 40
+        n_samples = 10
+
+        # 10-class classification model
+        model = SoftmaxModel(num_in, 20, 10)
+        model.eval()
+
+        inputs = torch.arange(0.0, num_in * 2.0).reshape(2, num_in)
+        baselines = custom_baseline_fn
+        expected = torch.zeros(2, 20)
+
+        self._assert_attributions(
+            model, model.relu1, (inputs,), baselines, 1, expected, n_samples
+        )
+
+    def _assert_attributions(
+        self, model, layer, inputs, baselines, target, expected, n_samples=5
+    ):
+        lgs = LayerGradientShap(model, layer)
+        attrs, delta = lgs.attribute(
+            inputs,
+            baselines=baselines,
+            target=target,
+            n_samples=n_samples,
+            stdevs=0.009,
+            return_convergence_delta=True,
+        )
+        assertTensorAlmostEqual(self, attrs[0], expected, 0.005)
+        _assert_attribution_delta(self, inputs, attrs, n_samples, delta, True)

--- a/tests/attr/neuron/test_neuron_gradient_shap.py
+++ b/tests/attr/neuron/test_neuron_gradient_shap.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+import torch
+
+from ..helpers.utils import BaseTest
+
+from ..helpers.utils import assertTensorAlmostEqual
+from ..helpers.classification_models import SoftmaxModel
+from ..helpers.basic_models import BasicModel_MultiLayer
+
+from captum.attr._core.neuron.neuron_gradient_shap import NeuronGradientShap
+from captum.attr._core.neuron.neuron_integrated_gradients import (
+    NeuronIntegratedGradients,
+)
+
+
+class Test(BaseTest):
+    def test_basic_multilayer(self):
+        model = BasicModel_MultiLayer(inplace=True)
+        model.eval()
+
+        inputs = torch.tensor([[1.0, 20.0, 10.0]])
+        baselines = torch.randn(2, 3)
+
+        self._assert_attributions(model, model.linear1, (inputs,), (baselines,), 0)
+
+    def test_classification(self):
+        def custom_baseline_fn(inputs):
+            num_in = inputs[0].shape[1]
+            return (torch.arange(0.0, num_in * 5.0).reshape(5, num_in),)
+
+        num_in = 40
+        n_samples = 100
+
+        # 10-class classification model
+        model = SoftmaxModel(num_in, 20, 10)
+        model.eval()
+
+        inputs = torch.arange(0.0, num_in * 2.0).reshape(2, num_in)
+        baselines = custom_baseline_fn
+
+        self._assert_attributions(
+            model, model.relu1, (inputs,), baselines, 1, n_samples
+        )
+
+    def _assert_attributions(
+        self, model, layer, inputs, baselines, neuron_ind, n_samples=5
+    ):
+        ngs = NeuronGradientShap(model, layer)
+        nig = NeuronIntegratedGradients(model, layer)
+        attrs_gs = ngs.attribute(
+            inputs, neuron_ind, baselines=baselines, n_samples=n_samples, stdevs=0.09
+        )
+
+        if callable(baselines):
+            baselines = baselines(inputs)
+
+        baselines = torch.mean(baselines[0], axis=0, keepdim=True)
+        attrs_ig = nig.attribute(inputs, neuron_ind, baselines=baselines)
+
+        assertTensorAlmostEqual(self, attrs_gs[0], attrs_ig[0], 0.5)

--- a/tests/attr/test_data_parallel.py
+++ b/tests/attr/test_data_parallel.py
@@ -4,6 +4,8 @@ import unittest
 
 import torch
 
+from captum.attr._utils.attribution import NeuronAttribution
+
 from captum.attr._core.feature_ablation import FeatureAblation
 from captum.attr._core.gradient_shap import GradientShap
 
@@ -431,17 +433,29 @@ class Test(BaseGPUTest):
         net.eval()
         inputs = torch.tensor([[1.0, -20.0, 10.0], [11.0, 10.0, -11.0]]).cuda()
         baselines = torch.randn(30, 3).cuda()
-        self._data_parallel_test_assert(
-            attr_method_class,
-            net,
-            layer,
-            alt_device_ids=alt_device_ids,
-            inputs=inputs,
-            target=0,
-            baselines=baselines,
-            additional_forward_args=None,
-            test_batches=False,
-        )
+        if isinstance(attr_method_class, NeuronAttribution):
+            self._data_parallel_test_assert(
+                attr_method_class,
+                net,
+                layer,
+                alt_device_ids=alt_device_ids,
+                inputs=inputs,
+                baselines=baselines,
+                additional_forward_args=None,
+                test_batches=False,
+            )
+        else:
+            self._data_parallel_test_assert(
+                attr_method_class,
+                net,
+                layer,
+                alt_device_ids=alt_device_ids,
+                inputs=inputs,
+                target=0,
+                baselines=baselines,
+                additional_forward_args=None,
+                test_batches=False,
+            )
 
     def test_simple_feature_ablation(self):
         net = BasicModel_ConvNet().cuda()

--- a/tests/attr/test_data_parallel.py
+++ b/tests/attr/test_data_parallel.py
@@ -4,8 +4,6 @@ import unittest
 
 import torch
 
-from captum.attr._utils.attribution import NeuronAttribution
-
 from captum.attr._core.feature_ablation import FeatureAblation
 from captum.attr._core.gradient_shap import GradientShap
 

--- a/tests/attr/test_data_parallel.py
+++ b/tests/attr/test_data_parallel.py
@@ -397,53 +397,48 @@ class Test(BaseGPUTest):
             test_batches=False,
         )
 
-    def test_basic_gradient_shap(self):
+    def test_basic_gradient_shap_helper(self):
         net = BasicModel_MultiLayer(inplace=True).cuda()
-        net.eval()
+        self._basic_gradient_shap_helper(net, GradientShap, None)
 
-        inputs = torch.tensor([[1.0, -20.0, 10.0], [11.0, 10.0, -11.0]]).cuda()
-        baselines = torch.randn(30, 3).cuda()
-        self._data_parallel_test_assert(
-            GradientShap,
-            net,
-            None,
-            inputs=inputs,
-            target=0,
-            baselines=baselines,
-            additional_forward_args=None,
-            test_batches=False,
-        )
+    def test_basic_gradient_shap_helper_with_alt_devices(self):
+        net = BasicModel_MultiLayer(inplace=True).cuda()
+        self._basic_gradient_shap_helper(net, GradientShap, None, True)
 
     def test_basic_neuron_gradient_shap(self):
         net = BasicModel_MultiLayer(inplace=True).cuda()
-        net.eval()
+        self._basic_gradient_shap_helper(net, NeuronGradientShap, net.linear2, False)
 
-        inputs = torch.tensor([[1.0, -20.0, 10.0], [11.0, 10.0, -11.0]]).cuda()
-        baselines = torch.randn(30, 3).cuda()
-        self._data_parallel_test_assert(
-            NeuronGradientShap,
-            net,
-            net.linear2,
-            inputs=inputs,
-            neuron_index=0,
-            baselines=baselines,
-            additional_forward_args=None,
-            test_batches=False,
-        )
+    def test_basic_neuron_gradient_shap_with_alt_devices(self):
+        net = BasicModel_MultiLayer(inplace=True).cuda()
+        self._basic_gradient_shap_helper(net, NeuronGradientShap, net.linear2, True)
 
     def test_basic_layer_gradient_shap(self):
         net = BasicModel_MultiLayer(inplace=True).cuda()
-        net.eval()
+        self._basic_gradient_shap_helper(
+            net, LayerGradientShap, net.linear1,
+        )
 
+    def test_basic_layer_gradient_shap_with_alt_devices(self):
+        net = BasicModel_MultiLayer(inplace=True).cuda()
+        self._basic_gradient_shap_helper(
+            net, LayerGradientShap, net.linear1, True,
+        )
+
+    def _basic_gradient_shap_helper(
+        self, net, attr_method_class, layer, alt_device_ids=False
+    ):
+        net.eval()
         inputs = torch.tensor([[1.0, -20.0, 10.0], [11.0, 10.0, -11.0]]).cuda()
         baselines = torch.randn(30, 3).cuda()
         self._data_parallel_test_assert(
-            LayerGradientShap,
+            attr_method_class,
             net,
-            net.linear1,
+            layer,
+            alt_device_ids=alt_device_ids,
             inputs=inputs,
-            baselines=baselines,
             target=0,
+            baselines=baselines,
             additional_forward_args=None,
             test_batches=False,
         )

--- a/tests/attr/test_data_parallel.py
+++ b/tests/attr/test_data_parallel.py
@@ -443,6 +443,7 @@ class Test(BaseGPUTest):
             net.linear1,
             inputs=inputs,
             baselines=baselines,
+            target=0,
             additional_forward_args=None,
             test_batches=False,
         )
@@ -507,6 +508,7 @@ class Test(BaseGPUTest):
                     )
                 else:
                     attributions_orig = attr_orig.attribute(**kwargs)
+            self.setUp()
             if batch_size:
                 attributions_dp = attr_dp.attribute(
                     internal_batch_size=batch_size, **kwargs

--- a/tests/attr/test_data_parallel.py
+++ b/tests/attr/test_data_parallel.py
@@ -438,6 +438,7 @@ class Test(BaseGPUTest):
                 layer,
                 alt_device_ids=alt_device_ids,
                 inputs=inputs,
+                neuron_index=0,
                 baselines=baselines,
                 additional_forward_args=None,
                 test_batches=False,

--- a/tests/attr/test_data_parallel.py
+++ b/tests/attr/test_data_parallel.py
@@ -5,6 +5,7 @@ import unittest
 import torch
 
 from captum.attr._core.feature_ablation import FeatureAblation
+from captum.attr._core.gradient_shap import GradientShap
 
 from captum.attr._core.layer.grad_cam import LayerGradCam
 from captum.attr._core.layer.internal_influence import InternalInfluence
@@ -12,6 +13,7 @@ from captum.attr._core.layer.layer_activation import LayerActivation
 from captum.attr._core.layer.layer_conductance import LayerConductance
 from captum.attr._core.layer.layer_gradient_x_activation import LayerGradientXActivation
 from captum.attr._core.layer.layer_deep_lift import LayerDeepLift, LayerDeepLiftShap
+from captum.attr._core.layer.layer_gradient_shap import LayerGradientShap
 
 from captum.attr._core.neuron.neuron_conductance import NeuronConductance
 from captum.attr._core.neuron.neuron_gradient import NeuronGradient
@@ -23,6 +25,7 @@ from captum.attr._core.neuron.neuron_guided_backprop_deconvnet import (
     NeuronGuidedBackprop,
 )
 from captum.attr._core.neuron.neuron_deep_lift import NeuronDeepLift, NeuronDeepLiftShap
+from captum.attr._core.neuron.neuron_gradient_shap import NeuronGradientShap
 
 from .helpers.basic_models import (
     BasicModel_MultiLayer,
@@ -390,6 +393,56 @@ class Test(BaseGPUTest):
             inputs=(inp1, inp2),
             neuron_index=0,
             baselines=(base1, base2),
+            additional_forward_args=None,
+            test_batches=False,
+        )
+
+    def test_basic_gradient_shap(self):
+        net = BasicModel_MultiLayer(inplace=True).cuda()
+        net.eval()
+
+        inputs = torch.tensor([[1.0, -20.0, 10.0], [11.0, 10.0, -11.0]]).cuda()
+        baselines = torch.randn(30, 3).cuda()
+        self._data_parallel_test_assert(
+            GradientShap,
+            net,
+            None,
+            inputs=inputs,
+            target=0,
+            baselines=baselines,
+            additional_forward_args=None,
+            test_batches=False,
+        )
+
+    def test_basic_neuron_gradient_shap(self):
+        net = BasicModel_MultiLayer(inplace=True).cuda()
+        net.eval()
+
+        inputs = torch.tensor([[1.0, -20.0, 10.0], [11.0, 10.0, -11.0]]).cuda()
+        baselines = torch.randn(30, 3).cuda()
+        self._data_parallel_test_assert(
+            NeuronGradientShap,
+            net,
+            net.linear2,
+            inputs=inputs,
+            neuron_index=0,
+            baselines=baselines,
+            additional_forward_args=None,
+            test_batches=False,
+        )
+
+    def test_basic_layer_gradient_shap(self):
+        net = BasicModel_MultiLayer(inplace=True).cuda()
+        net.eval()
+
+        inputs = torch.tensor([[1.0, -20.0, 10.0], [11.0, 10.0, -11.0]]).cuda()
+        baselines = torch.randn(30, 3).cuda()
+        self._data_parallel_test_assert(
+            LayerGradientShap,
+            net,
+            net.linear1,
+            inputs=inputs,
+            baselines=baselines,
             additional_forward_args=None,
             test_batches=False,
         )

--- a/tests/attr/test_data_parallel.py
+++ b/tests/attr/test_data_parallel.py
@@ -433,7 +433,7 @@ class Test(BaseGPUTest):
         net.eval()
         inputs = torch.tensor([[1.0, -20.0, 10.0], [11.0, 10.0, -11.0]]).cuda()
         baselines = torch.randn(30, 3).cuda()
-        if isinstance(attr_method_class, NeuronAttribution):
+        if attr_method_class == NeuronGradientShap:
             self._data_parallel_test_assert(
                 attr_method_class,
                 net,

--- a/tests/attr/test_gradient_shap.py
+++ b/tests/attr/test_gradient_shap.py
@@ -212,7 +212,10 @@ def _assert_attribution_delta(
     if not is_layer:
         for input, attribution in zip(inputs, attributions):
             test.assertEqual(attribution.shape, input.shape)
-    bsz = inputs[0].shape[0]
+    if isinstance(inputs, tuple):
+        bsz = inputs[0].shape[0]
+    else:
+        bsz = inputs.shape[0]
     test.assertEqual([bsz * n_samples], list(delta.shape))
 
     delta = torch.mean(delta.reshape(bsz, -1), dim=1)

--- a/tests/attr/test_gradient_shap.py
+++ b/tests/attr/test_gradient_shap.py
@@ -41,7 +41,7 @@ class Test(BaseTest):
         )
         attributions_without_delta = gradient_shap.attribute((x1, x2), baselines)
 
-        self._assert_attribution_delta(inputs, attributions, n_samples, delta)
+        _assert_attribution_delta(self, inputs, attributions, n_samples, delta)
         # Compare with integrated gradients
         ig = IntegratedGradients(model)
         baselines = (torch.zeros(batch_size, 3), torch.zeros(batch_size, 4))
@@ -108,7 +108,7 @@ class Test(BaseTest):
             stdevs=0.009,
             return_convergence_delta=True,
         )
-        self._assert_attribution_delta((inputs,), (attributions,), n_samples, delta)
+        _assert_attribution_delta(self, (inputs,), (attributions,), n_samples, delta)
 
         attributions, delta = gradient_shap.attribute(
             inputs,
@@ -118,7 +118,7 @@ class Test(BaseTest):
             stdevs=0.00001,
             return_convergence_delta=True,
         )
-        self._assert_attribution_delta((inputs,), (attributions,), n_samples, delta)
+        _assert_attribution_delta(self, (inputs,), (attributions,), n_samples, delta)
 
         with self.assertRaises(AssertionError):
             attributions, delta = gradient_shap.attribute(
@@ -150,7 +150,7 @@ class Test(BaseTest):
             stdevs=0.009,
             return_convergence_delta=True,
         )
-        self._assert_attribution_delta((inputs,), (attributions,), n_samples, delta)
+        _assert_attribution_delta(self, (inputs,), (attributions,), n_samples, delta)
 
         # try to call `compute_convergence_delta` externally
         with self.assertRaises(AssertionError):
@@ -165,7 +165,7 @@ class Test(BaseTest):
         external_delta = gradient_shap.compute_convergence_delta(
             attributions, chosen_baselines, inputs, target=target_extendes
         )
-        self._assert_delta(external_delta)
+        _assert_delta(self, external_delta)
 
         # Compare with integrated gradients
         ig = IntegratedGradients(model)
@@ -192,28 +192,11 @@ class Test(BaseTest):
             n_samples=n_samples,
             return_convergence_delta=True,
         )
-        self._assert_attribution_delta(inputs, attributions, n_samples, delta)
+        _assert_attribution_delta(self, inputs, attributions, n_samples, delta)
 
         ig = IntegratedGradients(model)
         attributions_ig = ig.attribute(inputs, baselines=baselines)
         self._assert_shap_ig_comparision(attributions, attributions_ig)
-
-    def _assert_delta(self, delta):
-        delta_condition = all(abs(delta.numpy().flatten()) < 0.0006)
-        self.assertTrue(
-            delta_condition,
-            "Sum of SHAP values {} does"
-            " not match the difference of endpoints.".format(delta),
-        )
-
-    def _assert_attribution_delta(self, inputs, attributions, n_samples, delta):
-        for input, attribution in zip(inputs, attributions):
-            self.assertEqual(attribution.shape, input.shape)
-        bsz = inputs[0].shape[0]
-        self.assertEqual([bsz * n_samples], list(delta.shape))
-
-        delta = torch.mean(delta.reshape(bsz, -1), dim=1)
-        self._assert_delta(delta)
 
     def _assert_shap_ig_comparision(self, attributions1, attributions2):
         for attribution1, attribution2 in zip(attributions1, attributions2):
@@ -221,3 +204,25 @@ class Test(BaseTest):
                 attribution1.detach().numpy(), attribution2.detach().numpy()
             ):
                 assertArraysAlmostEqual(attr_row1, attr_row2, delta=0.005)
+
+
+def _assert_attribution_delta(
+    test, inputs, attributions, n_samples, delta, is_layer=False
+):
+    if not is_layer:
+        for input, attribution in zip(inputs, attributions):
+            test.assertEqual(attribution.shape, input.shape)
+    bsz = inputs[0].shape[0]
+    test.assertEqual([bsz * n_samples], list(delta.shape))
+
+    delta = torch.mean(delta.reshape(bsz, -1), dim=1)
+    _assert_delta(test, delta)
+
+
+def _assert_delta(test, delta):
+    delta_condition = all(abs(delta.numpy().flatten()) < 0.0006)
+    test.assertTrue(
+        delta_condition,
+        "Sum of SHAP values {} does"
+        " not match the difference of endpoints.".format(delta),
+    )


### PR DESCRIPTION
This PR adds Gradient SHAP for layer and neuron with documentation and tests cases including tests for data parallel.
It also moves `_compute_conv_delta_and_format_attrs ` function to `common.py` in order to be able to use it both in DeepLift and Gradient SHAP.
Some of the auxiliary test functions  are also shared between Gradient SHAP and DeepLift now.