### PR TITLE
Removing Method Loop from IG tests

### DIFF
--- a/tests/attr/neuron/test_neuron_integrated_gradients.py
+++ b/tests/attr/neuron/test_neuron_integrated_gradients.py
@@ -99,7 +99,7 @@ class Test(BaseTest):
             attributions = grad.attribute(
                 test_input,
                 test_neuron,
-                n_steps=500,
+                n_steps=200,
                 method="gausslegendre",
                 additional_forward_args=additional_input,
                 internal_batch_size=internal_batch_size,

--- a/tests/attr/test_integrated_gradients_basic.py
+++ b/tests/attr/test_integrated_gradients_basic.py
@@ -21,78 +21,78 @@ import torch
 
 class Test(BaseTest):
     def test_multivariable_vanilla(self):
-        self._assert_multi_variable("vanilla")
+        self._assert_multi_variable("vanilla", "riemann_right")
 
     def test_multivariable_smoothgrad(self):
-        self._assert_multi_variable("smoothgrad")
+        self._assert_multi_variable("smoothgrad", "riemann_left")
 
     def test_multivariable_smoothgrad_sq(self):
-        self._assert_multi_variable("smoothgrad_sq")
+        self._assert_multi_variable("smoothgrad_sq", "riemann_middle")
 
     def test_multivariable_vargrad(self):
-        self._assert_multi_variable("vargrad")
+        self._assert_multi_variable("vargrad", "riemann_trapezoid")
 
     def test_multi_argument_vanilla(self):
-        self._assert_multi_argument("vanilla")
+        self._assert_multi_argument("vanilla", "gausslegendre")
 
     def test_multi_argument_smoothgrad(self):
-        self._assert_multi_argument("smoothgrad")
+        self._assert_multi_argument("smoothgrad", "riemann_right")
 
     def test_multi_argument_smoothgrad_sq(self):
-        self._assert_multi_argument("smoothgrad_sq")
+        self._assert_multi_argument("smoothgrad_sq", "riemann_left")
 
     def test_multi_argument_vargrad(self):
-        self._assert_multi_argument("vargrad")
+        self._assert_multi_argument("vargrad", "riemann_middle")
 
     def test_univariable_vanilla(self):
-        self._assert_univariable("vanilla")
+        self._assert_univariable("vanilla", "riemann_trapezoid")
 
     def test_univariable_smoothgrad(self):
-        self._assert_univariable("smoothgrad")
+        self._assert_univariable("smoothgrad", "gausslegendre")
 
     def test_univariable_smoothgrad_sq(self):
-        self._assert_univariable("smoothgrad_sq")
+        self._assert_univariable("smoothgrad_sq", "riemann_right")
 
     def test_univariable_vargrad(self):
-        self._assert_univariable("vargrad")
+        self._assert_univariable("vargrad", "riemann_left")
 
     def test_multi_tensor_input_vanilla(self):
-        self._assert_multi_tensor_input("vanilla")
+        self._assert_multi_tensor_input("vanilla", "riemann_middle")
 
     def test_multi_tensor_input_smoothgrad(self):
-        self._assert_multi_tensor_input("smoothgrad")
+        self._assert_multi_tensor_input("smoothgrad", "riemann_trapezoid")
 
     def test_multi_tensor_input_smoothgrad_sq(self):
-        self._assert_multi_tensor_input("smoothgrad_sq")
+        self._assert_multi_tensor_input("smoothgrad_sq", "gausslegendre")
 
     def test_multi_tensor_input_vargrad(self):
-        self._assert_multi_tensor_input("vargrad")
+        self._assert_multi_tensor_input("vargrad", "riemann_right")
 
     def test_batched_input_vanilla(self):
-        self._assert_batched_tensor_input("vanilla")
+        self._assert_batched_tensor_input("vanilla", "riemann_left")
 
     def test_batched_input_smoothgrad(self):
-        self._assert_batched_tensor_input("smoothgrad")
+        self._assert_batched_tensor_input("smoothgrad", "riemann_middle")
 
     def test_batched_input_smoothgrad_sq(self):
-        self._assert_batched_tensor_input("smoothgrad_sq")
+        self._assert_batched_tensor_input("smoothgrad_sq", "riemann_trapezoid")
 
     def test_batched_input_vargrad(self):
-        self._assert_batched_tensor_input("vargrad")
+        self._assert_batched_tensor_input("vargrad", "gausslegendre")
 
     def test_batched_multi_input_vanilla(self):
-        self._assert_batched_tensor_multi_input("vanilla")
+        self._assert_batched_tensor_multi_input("vanilla", "riemann_right")
 
     def test_batched_multi_input_smoothgrad(self):
-        self._assert_batched_tensor_multi_input("smoothgrad")
+        self._assert_batched_tensor_multi_input("smoothgrad", "riemann_left")
 
     def test_batched_multi_input_smoothgrad_sq(self):
-        self._assert_batched_tensor_multi_input("smoothgrad_sq")
+        self._assert_batched_tensor_multi_input("smoothgrad_sq", "riemann_middle")
 
     def test_batched_multi_input_vargrad(self):
-        self._assert_batched_tensor_multi_input("vargrad")
+        self._assert_batched_tensor_multi_input("vargrad", "riemann_trapezoid")
 
-    def _assert_multi_variable(self, type):
+    def _assert_multi_variable(self, type, approximation_method="gausslegendre"):
         model = BasicModel2()
 
         input1 = torch.tensor([3.0])
@@ -102,14 +102,22 @@ class Test(BaseTest):
         baseline2 = torch.tensor([0.0])
 
         attributions1 = self._compute_attribution_and_evaluate(
-            model, (input1, input2), (baseline1, baseline2), type=type
+            model,
+            (input1, input2),
+            (baseline1, baseline2),
+            type=type,
+            approximation_method=approximation_method,
         )
         if type == "vanilla":
             assertArraysAlmostEqual(attributions1[0].tolist(), [1.5], delta=0.05)
             assertArraysAlmostEqual(attributions1[1].tolist(), [-0.5], delta=0.05)
         model = BasicModel3()
         attributions2 = self._compute_attribution_and_evaluate(
-            model, (input1, input2), (baseline1, baseline2), type=type
+            model,
+            (input1, input2),
+            (baseline1, baseline2),
+            type=type,
+            approximation_method=approximation_method,
         )
         if type == "vanilla":
             assertArraysAlmostEqual(attributions2[0].tolist(), [1.5], delta=0.05)
@@ -120,22 +128,31 @@ class Test(BaseTest):
                 sum(attribution for attribution in attributions2),
             )
 
-    def _assert_univariable(self, type):
+    def _assert_univariable(self, type, approximation_method="gausslegendre"):
         model = BasicModel()
         self._compute_attribution_and_evaluate(
             model,
             torch.tensor([1.0], requires_grad=True),
             torch.tensor([0.0]),
             type=type,
+            approximation_method=approximation_method,
         )
         self._compute_attribution_and_evaluate(
-            model, torch.tensor([0.0]), torch.tensor([0.0]), type=type
+            model,
+            torch.tensor([0.0]),
+            torch.tensor([0.0]),
+            type=type,
+            approximation_method=approximation_method,
         )
         self._compute_attribution_and_evaluate(
-            model, torch.tensor([-1.0], requires_grad=True), 0.00001, type=type,
+            model,
+            torch.tensor([-1.0], requires_grad=True),
+            0.00001,
+            type=type,
+            approximation_method=approximation_method,
         )
 
-    def _assert_multi_argument(self, type):
+    def _assert_multi_argument(self, type, approximation_method="gausslegendre"):
         model = BasicModel4_MultiArgs()
         self._compute_attribution_and_evaluate(
             model,
@@ -146,6 +163,7 @@ class Test(BaseTest):
             baselines=(0.0, torch.zeros((1, 3))),
             additional_forward_args=torch.arange(1.0, 4.0).reshape(1, 3),
             type=type,
+            approximation_method=approximation_method,
         )
         # uses batching with an integer variable and nd-tensors as
         # additional forward arguments
@@ -158,6 +176,7 @@ class Test(BaseTest):
             baselines=(torch.zeros((2, 3)), 0.0),
             additional_forward_args=(torch.arange(1.0, 7.0).reshape(2, 3), 1),
             type=type,
+            approximation_method=approximation_method,
         )
         # uses batching with an integer variable and python list
         # as additional forward arguments
@@ -171,6 +190,7 @@ class Test(BaseTest):
             baselines=(0.0, 0.00001),
             additional_forward_args=([2, 3], 1),
             type=type,
+            approximation_method=approximation_method,
         )
         # similar to previous case plus baseline consists of a tensor and
         # a single example
@@ -183,9 +203,10 @@ class Test(BaseTest):
             baselines=(torch.zeros((1, 3)), 0.00001),
             additional_forward_args=([2, 3], 1),
             type=type,
+            approximation_method=approximation_method,
         )
 
-    def _assert_multi_tensor_input(self, type):
+    def _assert_multi_tensor_input(self, type, approximation_method="gausslegendre"):
         model = BasicModel6_MultiTensor()
         self._compute_attribution_and_evaluate(
             model,
@@ -194,19 +215,26 @@ class Test(BaseTest):
                 torch.tensor([[3.0, 3.5, 2.2]], requires_grad=True),
             ),
             type=type,
+            approximation_method=approximation_method,
         )
 
-    def _assert_batched_tensor_input(self, type):
+    def _assert_batched_tensor_input(self, type, approximation_method="gausslegendre"):
         model = BasicModel_MultiLayer()
         input = (
             torch.tensor(
                 [[1.5, 2.0, 1.3], [0.5, 0.1, 2.3], [1.5, 2.0, 1.3]], requires_grad=True
             ),
         )
-        self._compute_attribution_and_evaluate(model, input, type=type, target=0)
-        self._compute_attribution_batch_helper_evaluate(model, input, target=0)
+        self._compute_attribution_and_evaluate(
+            model, input, type=type, target=0, approximation_method=approximation_method
+        )
+        self._compute_attribution_batch_helper_evaluate(
+            model, input, target=0, approximation_method=approximation_method
+        )
 
-    def _assert_batched_tensor_multi_input(self, type):
+    def _assert_batched_tensor_multi_input(
+        self, type, approximation_method="gausslegendre"
+    ):
         model = BasicModel_MultiLayer()
         input = (
             torch.tensor(
@@ -216,8 +244,12 @@ class Test(BaseTest):
                 [[0.3, 1.9, 2.4], [0.5, 0.6, 2.1], [1.2, 2.1, 0.2]], requires_grad=True
             ),
         )
-        self._compute_attribution_and_evaluate(model, input, type=type, target=0)
-        self._compute_attribution_batch_helper_evaluate(model, input, target=0)
+        self._compute_attribution_and_evaluate(
+            model, input, type=type, target=0, approximation_method=approximation_method
+        )
+        self._compute_attribution_batch_helper_evaluate(
+            model, input, target=0, approximation_method=approximation_method
+        )
 
     def _compute_attribution_and_evaluate(
         self,
@@ -227,6 +259,7 @@ class Test(BaseTest):
         target=None,
         additional_forward_args=None,
         type="vanilla",
+        approximation_method="gausslegendre",
     ):
         r"""
             attrib_type: 'vanilla', 'smoothgrad', 'smoothgrad_sq', 'vargrad'
@@ -241,90 +274,87 @@ class Test(BaseTest):
         if baselines is None:
             baselines = _tensorize_baseline(inputs, _zeros(inputs))
 
-        for method in [
-            "riemann_right",
-            "riemann_left",
-            "riemann_middle",
-            "riemann_trapezoid",
-            "gausslegendre",
-        ]:
-            if type == "vanilla":
-                attributions, delta = ig.attribute(
-                    inputs,
-                    baselines,
-                    additional_forward_args=additional_forward_args,
-                    method=method,
-                    n_steps=100,
-                    target=target,
-                    return_convergence_delta=True,
-                )
-                model.zero_grad()
-                attributions_without_delta, delta = ig.attribute(
-                    inputs,
-                    baselines,
-                    additional_forward_args=additional_forward_args,
-                    method=method,
-                    n_steps=100,
-                    target=target,
-                    return_convergence_delta=True,
-                )
-                model.zero_grad()
-                self.assertEqual([inputs[0].shape[0]], list(delta.shape))
-                delta_external = ig.compute_convergence_delta(
-                    attributions,
-                    baselines,
-                    inputs,
-                    target=target,
-                    additional_forward_args=additional_forward_args,
-                )
-                assertArraysAlmostEqual(delta, delta_external, 0.0)
-            else:
-                nt = NoiseTunnel(ig)
-                n_samples = 5
-                attributions, delta = nt.attribute(
-                    inputs,
-                    nt_type=type,
-                    n_samples=n_samples,
-                    stdevs=0.00000002,
-                    baselines=baselines,
-                    target=target,
-                    additional_forward_args=additional_forward_args,
-                    method=method,
-                    n_steps=100,
-                    return_convergence_delta=True,
-                )
-                attributions_without_delta = nt.attribute(
-                    inputs,
-                    nt_type=type,
-                    n_samples=n_samples,
-                    stdevs=0.00000002,
-                    baselines=baselines,
-                    target=target,
-                    additional_forward_args=additional_forward_args,
-                    method=method,
-                    n_steps=100,
-                )
-                self.assertEqual([inputs[0].shape[0] * n_samples], list(delta.shape))
+        if type == "vanilla":
+            attributions, delta = ig.attribute(
+                inputs,
+                baselines,
+                additional_forward_args=additional_forward_args,
+                method=approximation_method,
+                n_steps=500,
+                target=target,
+                return_convergence_delta=True,
+            )
+            model.zero_grad()
+            attributions_without_delta, delta = ig.attribute(
+                inputs,
+                baselines,
+                additional_forward_args=additional_forward_args,
+                method=approximation_method,
+                n_steps=500,
+                target=target,
+                return_convergence_delta=True,
+            )
+            model.zero_grad()
+            self.assertEqual([inputs[0].shape[0]], list(delta.shape))
+            delta_external = ig.compute_convergence_delta(
+                attributions,
+                baselines,
+                inputs,
+                target=target,
+                additional_forward_args=additional_forward_args,
+            )
+            assertArraysAlmostEqual(delta, delta_external, 0.0)
+        else:
+            nt = NoiseTunnel(ig)
+            n_samples = 5
+            attributions, delta = nt.attribute(
+                inputs,
+                nt_type=type,
+                n_samples=n_samples,
+                stdevs=0.00000002,
+                baselines=baselines,
+                target=target,
+                additional_forward_args=additional_forward_args,
+                method=approximation_method,
+                n_steps=500,
+                return_convergence_delta=True,
+            )
+            attributions_without_delta = nt.attribute(
+                inputs,
+                nt_type=type,
+                n_samples=n_samples,
+                stdevs=0.00000002,
+                baselines=baselines,
+                target=target,
+                additional_forward_args=additional_forward_args,
+                method=approximation_method,
+                n_steps=500,
+            )
+            self.assertEqual([inputs[0].shape[0] * n_samples], list(delta.shape))
 
-            for input, attribution in zip(inputs, attributions):
-                self.assertEqual(attribution.shape, input.shape)
-            # TODO (T57097503): Separate tests for different
-            # integration methods and decrease threshold.
-            self.assertTrue(all(abs(delta.numpy().flatten()) < 0.4))
+        for input, attribution in zip(inputs, attributions):
+            self.assertEqual(attribution.shape, input.shape)
+        self.assertTrue(all(abs(delta.numpy().flatten()) < 0.07))
 
-            # compare attributions retrieved with and without
-            # `return_convergence_delta` flag
-            for attribution, attribution_without_delta in zip(
-                attributions, attributions_without_delta
-            ):
-                assertTensorAlmostEqual(
-                    self, attribution, attribution_without_delta, delta=0.05
-                )
+        # compare attributions retrieved with and without
+        # `return_convergence_delta` flag
+        for attribution, attribution_without_delta in zip(
+            attributions, attributions_without_delta
+        ):
+            assertTensorAlmostEqual(
+                self, attribution, attribution_without_delta, delta=0.05
+            )
 
         return attributions
 
     def _compute_attribution_batch_helper_evaluate(
-        self, model, inputs, baselines=None, target=None, additional_forward_args=None
+        self,
+        model,
+        inputs,
+        baselines=None,
+        target=None,
+        additional_forward_args=None,
+        approximation_method="gausslegendre",
     ):
         ig = IntegratedGradients(model)
         if not isinstance(inputs, tuple):
@@ -335,44 +365,37 @@ class Test(BaseTest):
 
         if baselines is None:
             baselines = _tensorize_baseline(inputs, _zeros(inputs))
-        for method in [
-            "riemann_right",
-            "riemann_left",
-            "riemann_middle",
-            "riemann_trapezoid",
-            "gausslegendre",
-        ]:
-            for internal_batch_size in [None, 1, 20]:
-                attributions, delta = ig.attribute(
-                    inputs,
-                    baselines,
+
+        for internal_batch_size in [None, 1, 20]:
+            attributions, delta = ig.attribute(
+                inputs,
+                baselines,
+                additional_forward_args=additional_forward_args,
+                method=approximation_method,
+                n_steps=100,
+                target=target,
+                internal_batch_size=internal_batch_size,
+                return_convergence_delta=True,
+            )
+            total_delta = 0
+            for i in range(inputs[0].shape[0]):
+                attributions_indiv, delta_indiv = ig.attribute(
+                    tuple(input[i : i + 1] for input in inputs),
+                    tuple(baseline[i : i + 1] for baseline in baselines),
                     additional_forward_args=additional_forward_args,
-                    method=method,
+                    method=approximation_method,
                     n_steps=100,
                     target=target,
                     internal_batch_size=internal_batch_size,
                     return_convergence_delta=True,
                 )
-                total_delta = 0
-                for i in range(inputs[0].shape[0]):
-                    attributions_indiv, delta_indiv = ig.attribute(
-                        tuple(input[i : i + 1] for input in inputs),
-                        tuple(baseline[i : i + 1] for baseline in baselines),
-                        additional_forward_args=additional_forward_args,
-                        method=method,
-                        n_steps=100,
-                        target=target,
-                        return_convergence_delta=True,
+                total_delta += abs(delta_indiv).sum().item()
+                for j in range(len(attributions)):
+                    assertArraysAlmostEqual(
+                        attributions[j][i : i + 1].squeeze(0).tolist(),
+                        attributions_indiv[j].squeeze(0).tolist(),
                     )
-                    total_delta += abs(delta_indiv).sum().item()
-                    for j in range(len(attributions)):
-                        assertArraysAlmostEqual(
-                            attributions[j][i : i + 1].squeeze(0).tolist(),
-                            attributions_indiv[j].squeeze(0).tolist(),
-                        )
-                self.assertAlmostEqual(
-                    abs(delta).sum().item(), total_delta, delta=0.005
-                )
+            self.assertAlmostEqual(abs(delta).sum().item(), total_delta, delta=0.005)
 
 
 if __name__ == "__main__":

--- a/tests/attr/test_integrated_gradients_classification.py
+++ b/tests/attr/test_integrated_gradients_classification.py
@@ -13,118 +13,125 @@ from .helpers.utils import assertTensorAlmostEqual
 
 class Test(BaseTest):
     def test_sigmoid_classification_vanilla(self):
-        self._assert_sigmoid_classification("vanilla")
+        self._assert_sigmoid_classification("vanilla", "riemann_right")
 
     def test_sigmoid_classification_smoothgrad(self):
-        self._assert_sigmoid_classification("smoothgrad")
+        self._assert_sigmoid_classification("smoothgrad", "riemann_left")
 
     def test_sigmoid_classification_smoothgrad_sq(self):
-        self._assert_sigmoid_classification("smoothgrad_sq")
+        self._assert_sigmoid_classification("smoothgrad_sq", "riemann_middle")
 
     def test_sigmoid_classification_vargrad(self):
-        self._assert_sigmoid_classification("vargrad")
+        self._assert_sigmoid_classification("vargrad", "riemann_trapezoid")
 
     def test_softmax_classification_vanilla(self):
-        self._assert_softmax_classification("vanilla")
+        self._assert_softmax_classification("vanilla", "gausslegendre")
 
     def test_softmax_classification_smoothgrad(self):
-        self._assert_softmax_classification("smoothgrad")
+        self._assert_softmax_classification("smoothgrad", "riemann_right")
 
     def test_softmax_classification_smoothgrad_sq(self):
-        self._assert_softmax_classification("smoothgrad_sq")
+        self._assert_softmax_classification("smoothgrad_sq", "riemann_left")
 
     def test_softmax_classification_vargrad(self):
-        self._assert_softmax_classification("vargrad")
+        self._assert_softmax_classification("vargrad", "riemann_middle")
 
     def test_softmax_classification_vanilla_batch(self):
-        self._assert_softmax_classification_batch("vanilla")
+        self._assert_softmax_classification_batch("vanilla", "riemann_trapezoid")
 
     def test_softmax_classification_smoothgrad_batch(self):
-        self._assert_softmax_classification_batch("smoothgrad")
+        self._assert_softmax_classification_batch("smoothgrad", "gausslegendre")
 
     def test_softmax_classification_smoothgrad_sq_batch(self):
-        self._assert_softmax_classification_batch("smoothgrad_sq")
+        self._assert_softmax_classification_batch("smoothgrad_sq", "riemann_right")
 
     def test_softmax_classification_vargrad_batch(self):
-        self._assert_softmax_classification_batch("vargrad")
+        self._assert_softmax_classification_batch("vargrad", "riemann_left")
 
-    def _assert_sigmoid_classification(self, type="vanilla"):
+    def _assert_sigmoid_classification(
+        self, type="vanilla", approximation_method="gausslegendre"
+    ):
         num_in = 20
         input = torch.arange(0.0, num_in * 1.0, requires_grad=True).unsqueeze(0)
         target = torch.tensor(0)
         # TODO add test cases for multiple different layers
         model = SigmoidModel(num_in, 5, 1)
-        self._validate_completness(model, input, target, type)
+        self._validate_completness(model, input, target, type, approximation_method)
 
-    def _assert_softmax_classification(self, type="vanilla"):
+    def _assert_softmax_classification(
+        self, type="vanilla", approximation_method="gausslegendre"
+    ):
         num_in = 40
         input = torch.arange(0.0, num_in * 1.0, requires_grad=True).unsqueeze(0)
         target = torch.tensor(5)
         # 10-class classification model
         model = SoftmaxModel(num_in, 20, 10)
-        self._validate_completness(model, input, target, type)
+        self._validate_completness(model, input, target, type, approximation_method)
 
-    def _assert_softmax_classification_batch(self, type="vanilla"):
+    def _assert_softmax_classification_batch(
+        self, type="vanilla", approximation_method="gausslegendre"
+    ):
         num_in = 40
         input = torch.arange(0.0, num_in * 3.0, requires_grad=True).reshape(3, num_in)
         target = torch.tensor([5, 5, 2])
         baseline = torch.zeros(1, num_in)
         # 10-class classification model
         model = SoftmaxModel(num_in, 20, 10)
-        self._validate_completness(model, input, target, type, baseline)
+        self._validate_completness(
+            model, input, target, type, approximation_method, baseline
+        )
 
     def _validate_completness(
-        self, model, inputs, target, type="vanilla", baseline=None
+        self,
+        model,
+        inputs,
+        target,
+        type="vanilla",
+        approximation_method="gausslegendre",
+        baseline=None,
     ):
         ig = IntegratedGradients(model.forward)
-        for method in [
-            "riemann_right",
-            "riemann_left",
-            "riemann_middle",
-            "riemann_trapezoid",
-            "gausslegendre",
-        ]:
-            model.zero_grad()
-            if type == "vanilla":
-                attributions, delta = ig.attribute(
-                    inputs,
-                    baselines=baseline,
-                    target=target,
-                    method=method,
-                    n_steps=1000,
-                    return_convergence_delta=True,
-                )
-                delta_expected = ig.compute_convergence_delta(
-                    attributions, baseline, inputs, target
-                )
-                assertTensorAlmostEqual(self, delta_expected, delta)
+        model.zero_grad()
+        if type == "vanilla":
+            attributions, delta = ig.attribute(
+                inputs,
+                baselines=baseline,
+                target=target,
+                method=approximation_method,
+                n_steps=200,
+                return_convergence_delta=True,
+            )
+            delta_expected = ig.compute_convergence_delta(
+                attributions, baseline, inputs, target
+            )
+            assertTensorAlmostEqual(self, delta_expected, delta)
 
-                delta_condition = all(abs(delta.numpy().flatten()) < 0.003)
-                self.assertTrue(
-                    delta_condition,
-                    "The sum of attribution values {} is not "
-                    "nearly equal to the difference between the endpoint for "
-                    "some samples".format(delta),
-                )
-                self.assertEqual([inputs.shape[0]], list(delta.shape))
-            else:
-                nt = NoiseTunnel(ig)
-                n_samples = 10
-                attributions, delta = nt.attribute(
-                    inputs,
-                    baselines=baseline,
-                    nt_type=type,
-                    n_samples=n_samples,
-                    stdevs=0.0002,
-                    n_steps=1000,
-                    target=target,
-                    method=method,
-                    return_convergence_delta=True,
-                )
-                self.assertEqual([inputs.shape[0] * n_samples], list(delta.shape))
+            delta_condition = all(abs(delta.numpy().flatten()) < 0.005)
+            self.assertTrue(
+                delta_condition,
+                "The sum of attribution values {} is not "
+                "nearly equal to the difference between the endpoint for "
+                "some samples".format(delta),
+            )
+            self.assertEqual([inputs.shape[0]], list(delta.shape))
+        else:
+            nt = NoiseTunnel(ig)
+            n_samples = 10
+            attributions, delta = nt.attribute(
+                inputs,
+                baselines=baseline,
+                nt_type=type,
+                n_samples=n_samples,
+                stdevs=0.0002,
+                n_steps=100,
+                target=target,
+                method=approximation_method,
+                return_convergence_delta=True,
+            )
+            self.assertEqual([inputs.shape[0] * n_samples], list(delta.shape))
 
-            self.assertTrue(all(abs(delta.numpy().flatten()) < 0.05))
-            self.assertEqual(attributions.shape, inputs.shape)
+        self.assertTrue(all(abs(delta.numpy().flatten()) < 0.05))
+        self.assertEqual(attributions.shape, inputs.shape)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary: Removes loop over approximation method from IG tests and switches to testing a single method in each test, which should avoid test timeouts.

Differential Revision: D18586650

