### PR TITLE
Adding ReLU flag for GradCAM implementation

### DIFF
--- a/captum/attr/_core/guided_grad_cam.py
+++ b/captum/attr/_core/guided_grad_cam.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import warnings
-import torch.nn.functional as F
 
 from .._utils.attribution import GradientAttribution, LayerAttribution
 from .._utils.common import _format_input, _format_attributions
@@ -171,13 +170,12 @@ class GuidedGradCam(GradientAttribution):
         """
         is_inputs_tuple = isinstance(inputs, tuple)
         inputs = _format_input(inputs)
-        grad_cam_attr = F.relu(
-            self.grad_cam.attribute(
-                inputs=inputs,
-                target=target,
-                additional_forward_args=additional_forward_args,
-                attribute_to_layer_input=attribute_to_layer_input,
-            )
+        grad_cam_attr = self.grad_cam.attribute(
+            inputs=inputs,
+            target=target,
+            additional_forward_args=additional_forward_args,
+            attribute_to_layer_input=attribute_to_layer_input,
+            relu_attributions=True,
         )
         guided_backprop_attr = self.guided_backprop.attribute(
             inputs=inputs,

--- a/captum/attr/_core/layer/grad_cam.py
+++ b/captum/attr/_core/layer/grad_cam.py
@@ -130,7 +130,7 @@ class LayerGradCam(LayerAttribution):
                             apply a ReLU operation on the final attribution,
                             returning only non-negative attributions. Setting this
                             flag to True matches the original GradCAM algorithm,
-                            otherwise by default, both positive and negative
+                            otherwise, by default, both positive and negative
                             attributions are returned.
                             Default: False
 
@@ -187,5 +187,4 @@ class LayerGradCam(LayerAttribution):
         scaled_act = torch.sum(summed_grads * layer_eval, dim=1, keepdim=True)
         if relu_attributions:
             return F.relu(scaled_act)
-        else:
-            return scaled_act
+        return scaled_act

--- a/captum/attr/_core/layer/grad_cam.py
+++ b/captum/attr/_core/layer/grad_cam.py
@@ -51,7 +51,7 @@ class LayerGradCam(LayerAttribution):
             For providing more flexibility to the user, we choose to not perform the
             ReLU internally by default and return the sign information. To match the
             original GradCAM algorithm, it is necessary to pass the parameter
-            relu_attributions=True to perform ReLU on the returned
+            relu_attributions=True to apply ReLU on the final
             attributions or alternatively only visualize the positive attributions.
 
             Note: this procedure sums over the second dimension (# of channels),
@@ -127,7 +127,7 @@ class LayerGradCam(LayerAttribution):
                             Support for multiple tensors will be added later.
                             Default: False
                 relu_attributions (bool, optional): Indicates whether to
-                            perform a ReLU operation on the final attribution,
+                            apply a ReLU operation on the final attribution,
                             returning only non-negative attributions. Setting this
                             flag to True matches the original GradCAM algorithm,
                             otherwise by default, both positive and negative

--- a/tests/attr/layer/test_grad_cam.py
+++ b/tests/attr/layer/test_grad_cam.py
@@ -25,6 +25,33 @@ class Test(BaseTest):
         inp = 1.0 * torch.arange(16).view(1, 1, 4, 4).type(torch.FloatTensor)
         self._grad_cam_test_assert(net, net.relu1, inp, [[0.0, 4.0], [28.0, 32.5]])
 
+    def test_simple_input_conv_without_final_relu(self):
+        net = BasicModel_ConvNet_One_Conv()
+        inp = 1.0 * torch.arange(16).view(1, 1, 4, 4).type(torch.FloatTensor)
+        inp.requires_grad_()
+        # Adding negative value to test final relu is not applied by default
+        inp[0, 0, 1, 1] = -4.0
+        self._grad_cam_test_assert(
+            net, net.conv1, inp, 0.5625 * inp, attribute_to_layer_input=True
+        )
+
+    def test_simple_input_conv_fc_with_final_relu(self):
+        net = BasicModel_ConvNet_One_Conv()
+        inp = 1.0 * torch.arange(16).view(1, 1, 4, 4).type(torch.FloatTensor)
+        inp.requires_grad_()
+        # Adding negative value to test final relu is applied
+        inp[0, 0, 1, 1] = -4.0
+        exp = 0.5625 * inp
+        exp[0, 0, 1, 1] = 0.0
+        self._grad_cam_test_assert(
+            net,
+            net.conv1,
+            inp,
+            exp,
+            attribute_to_layer_input=True,
+            relu_attributions=True,
+        )
+
     def test_simple_multi_input_conv(self):
         net = BasicModel_ConvNet_One_Conv()
         inp = torch.arange(16).view(1, 1, 4, 4).type(torch.FloatTensor)
@@ -40,10 +67,16 @@ class Test(BaseTest):
         test_input,
         expected_activation,
         additional_input=None,
+        attribute_to_layer_input=False,
+        relu_attributions=False,
     ):
         layer_gc = LayerGradCam(model, target_layer)
         attributions = layer_gc.attribute(
-            test_input, target=0, additional_forward_args=additional_input
+            test_input,
+            target=0,
+            additional_forward_args=additional_input,
+            attribute_to_layer_input=attribute_to_layer_input,
+            relu_attributions=relu_attributions,
         )
         assertTensorAlmostEqual(self, attributions, expected_activation, delta=0.01)
 

--- a/tests/attr/layer/test_grad_cam.py
+++ b/tests/attr/layer/test_grad_cam.py
@@ -17,17 +17,17 @@ class Test(BaseTest):
 
     def test_simple_input_conv(self):
         net = BasicModel_ConvNet_One_Conv()
-        inp = 1.0 * torch.arange(16).view(1, 1, 4, 4).type(torch.FloatTensor)
+        inp = torch.arange(16).view(1, 1, 4, 4).float()
         self._grad_cam_test_assert(net, net.conv1, inp, [[11.25, 13.5], [20.25, 22.5]])
 
     def test_simple_input_conv_relu(self):
         net = BasicModel_ConvNet_One_Conv()
-        inp = 1.0 * torch.arange(16).view(1, 1, 4, 4).type(torch.FloatTensor)
+        inp = torch.arange(16).view(1, 1, 4, 4).float()
         self._grad_cam_test_assert(net, net.relu1, inp, [[0.0, 4.0], [28.0, 32.5]])
 
     def test_simple_input_conv_without_final_relu(self):
         net = BasicModel_ConvNet_One_Conv()
-        inp = 1.0 * torch.arange(16).view(1, 1, 4, 4).type(torch.FloatTensor)
+        inp = torch.arange(16).view(1, 1, 4, 4).float()
         inp.requires_grad_()
         # Adding negative value to test final relu is not applied by default
         inp[0, 0, 1, 1] = -4.0
@@ -37,7 +37,7 @@ class Test(BaseTest):
 
     def test_simple_input_conv_fc_with_final_relu(self):
         net = BasicModel_ConvNet_One_Conv()
-        inp = 1.0 * torch.arange(16).view(1, 1, 4, 4).type(torch.FloatTensor)
+        inp = torch.arange(16).view(1, 1, 4, 4).float()
         inp.requires_grad_()
         # Adding negative value to test final relu is applied
         inp[0, 0, 1, 1] = -4.0
@@ -54,7 +54,7 @@ class Test(BaseTest):
 
     def test_simple_multi_input_conv(self):
         net = BasicModel_ConvNet_One_Conv()
-        inp = torch.arange(16).view(1, 1, 4, 4).type(torch.FloatTensor)
+        inp = torch.arange(16).view(1, 1, 4, 4).float()
         inp2 = torch.ones((1, 1, 4, 4))
         self._grad_cam_test_assert(
             net, net.conv1, (inp, inp2), [[14.5, 19.0], [32.5, 37.0]]


### PR DESCRIPTION
This adds a flag to perform the final ReLU operation, which allows results to match the original algorithm exactly.