### PR TITLE
Fixing Class Hierarchy for Multiple Inheritance

### DIFF
--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -42,7 +42,7 @@ class DeepLift(GradientAttribution):
 
             model (nn.Module):  The reference to PyTorch model instance.
         """
-        super().__init__(model)
+        GradientAttribution.__init__(self, model)
         if isinstance(model, nn.DataParallel):
             warnings.warn(
                 """Although input model is of type `nn.DataParallel` it will run
@@ -424,7 +424,7 @@ class DeepLiftShap(DeepLift):
 
             model (nn.Module):  The reference to PyTorch model instance.
         """
-        super().__init__(model)
+        DeepLift.__init__(self, model)
 
     def attribute(
         self,

--- a/captum/attr/_core/feature_ablation.py
+++ b/captum/attr/_core/feature_ablation.py
@@ -22,7 +22,7 @@ class FeatureAblation(PerturbationAttribution):
             forward_func (callable): The forward function of the model or
                         any modification of it
         """
-        super().__init__(forward_func)
+        PerturbationAttribution.__init__(self, forward_func)
         self.use_weights = False
 
     def attribute(

--- a/captum/attr/_core/gradient_shap.py
+++ b/captum/attr/_core/gradient_shap.py
@@ -17,7 +17,7 @@ class GradientShap(GradientAttribution):
             forward_func (function): The forward function of the model or
                        any modification of it
         """
-        super().__init__(forward_func)
+        GradientAttribution.__init__(self, forward_func)
 
     def attribute(
         self,
@@ -231,7 +231,7 @@ class InputBaselineXGradient(GradientAttribution):
             forward_func (function): The forward function of the model or
                        any modification of it
         """
-        super().__init__(forward_func)
+        GradientAttribution.__init__(self, forward_func)
 
     def attribute(
         self,

--- a/captum/attr/_core/guided_backprop_deconvnet.py
+++ b/captum/attr/_core/guided_backprop_deconvnet.py
@@ -15,7 +15,7 @@ class ModifiedReluGradientAttribution(GradientAttribution):
 
             model (nn.Module):  The reference to PyTorch model instance.
         """
-        super().__init__(model)
+        GradientAttribution.__init__(self, model)
         self.model = model
         self.backward_hooks = []
         self.use_relu_grad_output = use_relu_grad_output
@@ -84,7 +84,9 @@ class GuidedBackprop(ModifiedReluGradientAttribution):
 
             model (nn.Module):  The reference to PyTorch model instance.
         """
-        super().__init__(model, use_relu_grad_output=False)
+        ModifiedReluGradientAttribution.__init__(
+            self, model, use_relu_grad_output=False
+        )
 
     def attribute(self, inputs, target=None, additional_forward_args=None):
         r""""
@@ -180,7 +182,7 @@ class Deconvolution(ModifiedReluGradientAttribution):
 
             model (nn.Module):  The reference to PyTorch model instance.
         """
-        super().__init__(model, use_relu_grad_output=True)
+        ModifiedReluGradientAttribution.__init__(self, model, use_relu_grad_output=True)
 
     def attribute(self, inputs, target=None, additional_forward_args=None):
         r""""

--- a/captum/attr/_core/guided_grad_cam.py
+++ b/captum/attr/_core/guided_grad_cam.py
@@ -24,7 +24,7 @@ class GuidedGradCam(GradientAttribution):
                           If forward_func is given as the DataParallel model itself,
                           then it is not necessary to provide this argument.
         """
-        super().__init__(model)
+        GradientAttribution.__init__(self, model)
         self.grad_cam = LayerGradCam(model, layer, device_ids)
         self.guided_backprop = GuidedBackprop(model)
 

--- a/captum/attr/_core/input_x_gradient.py
+++ b/captum/attr/_core/input_x_gradient.py
@@ -12,7 +12,7 @@ class InputXGradient(GradientAttribution):
             forward_func (callable):  The forward function of the model or any
                           modification of it
         """
-        super().__init__(forward_func)
+        GradientAttribution.__init__(self, forward_func)
 
     def attribute(self, inputs, target=None, additional_forward_args=None):
         r""""

--- a/captum/attr/_core/integrated_gradients.py
+++ b/captum/attr/_core/integrated_gradients.py
@@ -23,7 +23,7 @@ class IntegratedGradients(GradientAttribution):
             forward_func (callable):  The forward function of the model or any
                           modification of it
         """
-        super().__init__(forward_func)
+        GradientAttribution.__init__(self, forward_func)
 
     def attribute(
         self,

--- a/captum/attr/_core/layer/grad_cam.py
+++ b/captum/attr/_core/layer/grad_cam.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 import torch
 
-from ..._utils.attribution import LayerAttribution
+from ..._utils.attribution import LayerAttribution, GradientAttribution
 from ..._utils.common import _format_input, _format_additional_forward_args
 from ..._utils.gradient import compute_layer_gradients_and_eval
 
 
-class LayerGradCam(LayerAttribution):
+class LayerGradCam(LayerAttribution, GradientAttribution):
     def __init__(self, forward_func, layer, device_ids=None):
         r"""
         Args
@@ -25,7 +25,8 @@ class LayerGradCam(LayerAttribution):
                           If forward_func is given as the DataParallel model itself,
                           then it is not necessary to provide this argument.
         """
-        super().__init__(forward_func, layer, device_ids)
+        LayerAttribution.__init__(self, forward_func, layer, device_ids)
+        GradientAttribution.__init__(self, forward_func)
 
     def attribute(
         self,

--- a/captum/attr/_core/layer/internal_influence.py
+++ b/captum/attr/_core/layer/internal_influence.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import torch
 from ..._utils.approximation_methods import approximation_parameters
-from ..._utils.attribution import LayerAttribution
+from ..._utils.attribution import LayerAttribution, GradientAttribution
 from ..._utils.batching import _batched_operator
 from ..._utils.common import (
     _reshape_and_sum,
@@ -14,7 +14,7 @@ from ..._utils.common import (
 from ..._utils.gradient import compute_layer_gradients_and_eval
 
 
-class InternalInfluence(LayerAttribution):
+class InternalInfluence(LayerAttribution, GradientAttribution):
     def __init__(self, forward_func, layer, device_ids=None):
         r"""
         Args:
@@ -36,7 +36,8 @@ class InternalInfluence(LayerAttribution):
                           If forward_func is given as the DataParallel model itself,
                           then it is not necessary to provide this argument.
         """
-        super().__init__(forward_func, layer, device_ids)
+        LayerAttribution.__init__(self, forward_func, layer, device_ids)
+        GradientAttribution.__init__(self, forward_func)
 
     def attribute(
         self,

--- a/captum/attr/_core/layer/layer_activation.py
+++ b/captum/attr/_core/layer/layer_activation.py
@@ -27,7 +27,7 @@ class LayerActivation(LayerAttribution):
                           If forward_func is given as the DataParallel model itself,
                           then it is not necessary to provide this argument.
         """
-        super().__init__(forward_func, layer, device_ids)
+        LayerAttribution.__init__(self, forward_func, layer, device_ids)
 
     def attribute(
         self, inputs, additional_forward_args=None, attribute_to_layer_input=False

--- a/captum/attr/_core/layer/layer_conductance.py
+++ b/captum/attr/_core/layer/layer_conductance.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import torch
 from ..._utils.approximation_methods import approximation_parameters
-from ..._utils.attribution import LayerAttribution
+from ..._utils.attribution import LayerAttribution, GradientAttribution
 from ..._utils.batching import _batched_operator
 from ..._utils.common import (
     _reshape_and_sum,
@@ -14,7 +14,7 @@ from ..._utils.common import (
 from ..._utils.gradient import compute_layer_gradients_and_eval
 
 
-class LayerConductance(LayerAttribution):
+class LayerConductance(LayerAttribution, GradientAttribution):
     def __init__(self, forward_func, layer, device_ids=None):
         r"""
         Args:
@@ -36,7 +36,8 @@ class LayerConductance(LayerAttribution):
                           If forward_func is given as the DataParallel model itself,
                           then it is not necessary to provide this argument.
         """
-        super().__init__(forward_func, layer, device_ids)
+        LayerAttribution.__init__(self, forward_func, layer, device_ids)
+        GradientAttribution.__init__(self, forward_func)
 
     def has_convergence_delta(self):
         return True

--- a/captum/attr/_core/layer/layer_deep_lift.py
+++ b/captum/attr/_core/layer/layer_deep_lift.py
@@ -43,8 +43,8 @@ class LayerDeepLift(LayerAttribution, DeepLift):
             )
             model = model.module
 
-        super(LayerAttribution, self).__init__(model, layer)
-        super(DeepLift, self).__init__(model)
+        LayerAttribution.__init__(self, model, layer)
+        DeepLift.__init__(self, model)
 
     def attribute(
         self,
@@ -308,8 +308,8 @@ class LayerDeepLiftShap(LayerDeepLift, DeepLiftShap):
                           Currently, it is assumed that both inputs and ouputs of
                           the layer can only be a single tensor.
         """
-        super(DeepLiftShap, self).__init__(model)
-        super(LayerDeepLift, self).__init__(model, layer)
+        LayerDeepLift.__init__(self, model, layer)
+        DeepLiftShap.__init__(self, model)
 
     def attribute(
         self,

--- a/captum/attr/_core/layer/layer_gradient_x_activation.py
+++ b/captum/attr/_core/layer/layer_gradient_x_activation.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-from ..._utils.attribution import LayerAttribution
+from ..._utils.attribution import LayerAttribution, GradientAttribution
 from ..._utils.common import _format_input, _format_additional_forward_args
 from ..._utils.gradient import compute_layer_gradients_and_eval
 
 
-class LayerGradientXActivation(LayerAttribution):
+class LayerGradientXActivation(LayerAttribution, GradientAttribution):
     def __init__(self, forward_func, layer, device_ids=None):
         r"""
         Args:
@@ -26,7 +26,8 @@ class LayerGradientXActivation(LayerAttribution):
                           If forward_func is given as the DataParallel model itself,
                           then it is not necessary to provide this argument.
         """
-        super().__init__(forward_func, layer, device_ids)
+        LayerAttribution.__init__(self, forward_func, layer, device_ids)
+        GradientAttribution.__init__(self, forward_func)
 
     def attribute(
         self,

--- a/captum/attr/_core/neuron/neuron_conductance.py
+++ b/captum/attr/_core/neuron/neuron_conductance.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import torch
 from ..._utils.approximation_methods import approximation_parameters
-from ..._utils.attribution import NeuronAttribution
+from ..._utils.attribution import NeuronAttribution, GradientAttribution
 from ..._utils.batching import _batched_operator
 from ..._utils.common import (
     _reshape_and_sum,
@@ -16,7 +16,7 @@ from ..._utils.common import (
 from ..._utils.gradient import compute_layer_gradients_and_eval
 
 
-class NeuronConductance(NeuronAttribution):
+class NeuronConductance(NeuronAttribution, GradientAttribution):
     def __init__(self, forward_func, layer, device_ids=None):
         r"""
         Args:
@@ -44,7 +44,8 @@ class NeuronConductance(NeuronAttribution):
                           If forward_func is given as the DataParallel model itself,
                           then it is not necessary to provide this argument.
         """
-        super().__init__(forward_func, layer, device_ids)
+        NeuronAttribution.__init__(self, forward_func, layer, device_ids)
+        GradientAttribution.__init__(self, forward_func)
 
     def attribute(
         self,

--- a/captum/attr/_core/neuron/neuron_deep_lift.py
+++ b/captum/attr/_core/neuron/neuron_deep_lift.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-from ..._utils.attribution import NeuronAttribution
+from ..._utils.attribution import NeuronAttribution, GradientAttribution
 from ..._utils.gradient import construct_neuron_grad_fn
 
 from ..deep_lift import DeepLift, DeepLiftShap
 
 
-class NeuronDeepLift(NeuronAttribution):
+class NeuronDeepLift(NeuronAttribution, GradientAttribution):
     def __init__(self, model, layer):
         r"""
         Args:
@@ -19,7 +19,8 @@ class NeuronDeepLift(NeuronAttribution):
                           of the layer, depending on which one is used for
                           attribution, can only be a single tensor.
         """
-        super(NeuronAttribution, self).__init__(model, layer)
+        NeuronAttribution.__init__(self, model, layer)
+        GradientAttribution.__init__(self, model)
 
     def attribute(
         self,
@@ -183,7 +184,7 @@ class NeuronDeepLift(NeuronAttribution):
         )
 
 
-class NeuronDeepLiftShap(NeuronAttribution):
+class NeuronDeepLiftShap(NeuronAttribution, GradientAttribution):
     def __init__(self, model, layer):
         r"""
         Args:
@@ -196,7 +197,8 @@ class NeuronDeepLiftShap(NeuronAttribution):
                           Currently, only layers with a single tensor input and output
                           are supported.
         """
-        super(NeuronAttribution, self).__init__(model, layer)
+        NeuronAttribution.__init__(self, model, layer)
+        GradientAttribution.__init__(self, model)
 
     def attribute(
         self,

--- a/captum/attr/_core/neuron/neuron_gradient.py
+++ b/captum/attr/_core/neuron/neuron_gradient.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from ..._utils.attribution import NeuronAttribution
+from ..._utils.attribution import NeuronAttribution, GradientAttribution
 from ..._utils.common import (
     _format_input,
     _format_additional_forward_args,
@@ -12,7 +12,7 @@ from ..._utils.gradient import (
 )
 
 
-class NeuronGradient(NeuronAttribution):
+class NeuronGradient(NeuronAttribution, GradientAttribution):
     def __init__(self, forward_func, layer, device_ids=None):
         r"""
         Args:
@@ -34,7 +34,8 @@ class NeuronGradient(NeuronAttribution):
                           If forward_func is given as the DataParallel model itself,
                           then it is not necessary to provide this argument.
         """
-        super().__init__(forward_func, layer, device_ids)
+        NeuronAttribution.__init__(self, forward_func, layer, device_ids)
+        GradientAttribution.__init__(self, forward_func)
 
     def attribute(
         self,

--- a/captum/attr/_core/neuron/neuron_guided_backprop_deconvnet.py
+++ b/captum/attr/_core/neuron/neuron_guided_backprop_deconvnet.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-from ..._utils.attribution import NeuronAttribution
+from ..._utils.attribution import NeuronAttribution, GradientAttribution
 from ..._utils.gradient import construct_neuron_grad_fn
 from ..guided_backprop_deconvnet import GuidedBackprop, Deconvolution
 
 
-class NeuronDeconvolution(NeuronAttribution):
+class NeuronDeconvolution(NeuronAttribution, GradientAttribution):
     def __init__(self, model, layer, device_ids=None):
         r"""
         Args:
@@ -25,7 +25,8 @@ class NeuronDeconvolution(NeuronAttribution):
                           If forward_func is given as the DataParallel model itself,
                           then it is not necessary to provide this argument.
         """
-        super().__init__(model, layer, device_ids)
+        NeuronAttribution.__init__(self, model, layer, device_ids)
+        GradientAttribution.__init__(self, model)
         self.deconv = Deconvolution(model)
 
     def attribute(
@@ -128,7 +129,7 @@ class NeuronDeconvolution(NeuronAttribution):
         return self.deconv.attribute(inputs, None, additional_forward_args)
 
 
-class NeuronGuidedBackprop(NeuronAttribution):
+class NeuronGuidedBackprop(NeuronAttribution, GradientAttribution):
     def __init__(self, model, layer, device_ids=None):
         r"""
         Args:
@@ -146,7 +147,8 @@ class NeuronGuidedBackprop(NeuronAttribution):
                           If forward_func is given as the DataParallel model itself,
                           then it is not necessary to provide this argument.
         """
-        super().__init__(model, layer, device_ids)
+        NeuronAttribution.__init__(self, model, layer, device_ids)
+        GradientAttribution.__init__(self, model)
         self.guided_backprop = GuidedBackprop(model)
 
     def attribute(

--- a/captum/attr/_core/neuron/neuron_integrated_gradients.py
+++ b/captum/attr/_core/neuron/neuron_integrated_gradients.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-from ..._utils.attribution import NeuronAttribution
+from ..._utils.attribution import NeuronAttribution, GradientAttribution
 from ..._utils.gradient import construct_neuron_grad_fn
 
 from ..integrated_gradients import IntegratedGradients
 
 
-class NeuronIntegratedGradients(NeuronAttribution):
+class NeuronIntegratedGradients(NeuronAttribution, GradientAttribution):
     def __init__(self, forward_func, layer, device_ids=None):
         r"""
         Args:
@@ -27,7 +27,8 @@ class NeuronIntegratedGradients(NeuronAttribution):
                           If forward_func is given as the DataParallel model itself,
                           then it is not necessary to provide this argument.
         """
-        super().__init__(forward_func, layer, device_ids)
+        NeuronAttribution.__init__(self, forward_func, layer, device_ids)
+        GradientAttribution.__init__(self, forward_func)
 
     def attribute(
         self,

--- a/captum/attr/_core/noise_tunnel.py
+++ b/captum/attr/_core/noise_tunnel.py
@@ -38,7 +38,7 @@ class NoiseTunnel(Attribution):
         self.attribution_method = attribution_method
         self.is_delta_supported = self.attribution_method.has_convergence_delta()
 
-        super().__init__()
+        Attribution.__init__(self, self.attribution_method.forward_func)
 
     def attribute(
         self,

--- a/captum/attr/_core/saliency.py
+++ b/captum/attr/_core/saliency.py
@@ -15,7 +15,7 @@ class Saliency(GradientAttribution):
             forward_func (callable): The forward function of the model or
                         any modification of it
         """
-        super().__init__(forward_func)
+        GradientAttribution.__init__(self, forward_func)
 
     def attribute(self, inputs, target=None, abs=True, additional_forward_args=None):
         r""""

--- a/captum/attr/_utils/attribution.py
+++ b/captum/attr/_utils/attribution.py
@@ -20,6 +20,15 @@ class Attribution:
     to extend and override core `attribute` method.
     """
 
+    def __init__(self, forward_func):
+        r"""
+        Args:
+            forward_func (callable or torch.nn.Module): This can either be an instance
+                        of pytorch model or any modification of model's forward
+                        function.
+        """
+        self.forward_func = forward_func
+
     def attribute(self, inputs, **kwargs):
         r"""
         This method computes and returns the attribution values for each input tensor.
@@ -117,8 +126,7 @@ class GradientAttribution(Attribution):
                         of pytorch model or any modification of model's forward
                         function.
         """
-        super().__init__()
-        self.forward_func = forward_func
+        Attribution.__init__(self, forward_func)
         self.gradient_func = compute_gradients
 
     def compute_convergence_delta(
@@ -271,11 +279,10 @@ class PerturbationAttribution(Attribution):
                         of pytorch model or any modification of model's forward
                         function.
         """
-        super().__init__()
-        self.forward_func = forward_func
+        Attribution.__init__(self, forward_func)
 
 
-class InternalAttribution(GradientAttribution):
+class InternalAttribution(Attribution):
     r"""
     Shared base class for LayerAttrubution and NeuronAttribution,
     attribution types that require a model and a particular layer.
@@ -294,9 +301,9 @@ class InternalAttribution(GradientAttribution):
                         applies a DataParallel model, which allows reconstruction of
                         intermediate outputs from batched results across devices.
                         If forward_func is given as the DataParallel model itself,
-                        then it is not neccesary to provide this argument.
+                        then it is not necessary to provide this argument.
         """
-        super().__init__(forward_func)
+        Attribution.__init__(self, forward_func)
         self.layer = layer
         self.device_ids = device_ids
 
@@ -322,9 +329,9 @@ class LayerAttribution(InternalAttribution):
                         applies a DataParallel model, which allows reconstruction of
                         intermediate outputs from batched results across devices.
                         If forward_func is given as the DataParallel model itself,
-                        then it is not neccesary to provide this argument.
+                        then it is not necessary to provide this argument.
         """
-        super().__init__(forward_func, layer, device_ids)
+        InternalAttribution.__init__(self, forward_func, layer, device_ids)
 
     def interpolate(layer_attribution, interpolate_dims, interpolate_mode="nearest"):
         r"""
@@ -382,9 +389,9 @@ class NeuronAttribution(InternalAttribution):
                         applies a DataParallel model, which allows reconstruction of
                         intermediate outputs from batched results across devices.
                         If forward_func is given as the DataParallel model itself,
-                        then it is not neccesary to provide this argument.
+                        then it is not necessary to provide this argument.
         """
-        super().__init__(forward_func, layer, device_ids)
+        InternalAttribution.__init__(self, forward_func, layer, device_ids)
 
     def attribute(self, inputs, neuron_index, **kwargs):
         r"""


### PR DESCRIPTION
Summary: Remove all instances of super in class hierarchy and switch to direct initializations to support multiple / diamond inheritance appropriately.

Differential Revision: D18642075

