### PR TITLE
Feature/permutation feature importance

### DIFF
--- a/captum/attr/_core/perm_feature_importance.py
+++ b/captum/attr/_core/perm_feature_importance.py
@@ -13,8 +13,9 @@ def _permute_feature(x, feature_mask):
     while (perm == no_perm).all():
         perm = torch.randperm(n)
 
-    return (x[perm] * feature_mask.to(dtype=x.dtype)) +\
-           (x * feature_mask.bitwise_not().to(dtype=x.dtype))
+    return (x[perm] * feature_mask.to(dtype=x.dtype)) + (
+        x * feature_mask.bitwise_not().to(dtype=x.dtype)
+    )
 
 
 class PermutationFeatureImportance(FeatureAblation):

--- a/captum/attr/_core/perm_feature_importance.py
+++ b/captum/attr/_core/perm_feature_importance.py
@@ -4,7 +4,7 @@ import torch
 from .feature_ablation import FeatureAblation
 
 
-def permute_feature(x, feature_mask):
+def _permute_feature(x, feature_mask):
     n = x.size(0)
     assert n > 1, "cannot permute features with batch_size = 1"
 
@@ -21,7 +21,7 @@ def permute_feature(x, feature_mask):
 
 
 class PermutationFeatureImportance(FeatureAblation):
-    def __init__(self, forward_func=None, perm_fn=permute_feature):
+    def __init__(self, forward_func=None, perm_fn=_permute_feature):
         FeatureAblation.__init__(self, forward_func=forward_func)
         self.perm_fn = perm_fn
 

--- a/captum/attr/_core/perm_feature_importance.py
+++ b/captum/attr/_core/perm_feature_importance.py
@@ -13,11 +13,7 @@ def _permute_feature(x, feature_mask):
     while (perm == no_perm).all():
         perm = torch.randperm(n)
 
-    out = x.clone()
-    for i, j in enumerate(perm):
-        out[i, feature_mask] = x[j, feature_mask]
-
-    return out
+    return (x[perm] * feature_mask) + (x * feature_mask.bitwise_not())
 
 
 class PermutationFeatureImportance(FeatureAblation):

--- a/captum/attr/_core/perm_feature_importance.py
+++ b/captum/attr/_core/perm_feature_importance.py
@@ -32,9 +32,9 @@ class PermutationFeatureImportance(FeatureAblation):
         additional_forward_args=None,
         feature_mask=None,
         ablations_per_eval=1,
-        abs_attributions=False,
     ):
-        attribs = super().attribute(
+        return FeatureAblation.attribute(
+            self,
             inputs,
             baselines=None,
             target=target,
@@ -42,13 +42,6 @@ class PermutationFeatureImportance(FeatureAblation):
             feature_mask=feature_mask,
             ablations_per_eval=ablations_per_eval,
         )
-
-        f = torch.abs if abs_attributions else lambda x: x
-
-        if isinstance(attribs, tuple):
-            return tuple([f(a) for a in attribs])
-
-        return f(attribs)
 
     def _construct_ablated_input(
         self, feature_tensor, input_mask, baseline, start_feature, end_feature

--- a/captum/attr/_core/perm_feature_importance.py
+++ b/captum/attr/_core/perm_feature_importance.py
@@ -26,11 +26,12 @@ class PermutationFeatureImportance(FeatureAblation):
 
     def attribute(
         self,
-        inputs=None,
+        inputs,
         target=None,
         additional_forward_args=None,
         feature_mask=None,
         ablations_per_eval=1,
+        abs_attributions=False
     ):
         attribs = super().attribute(
             inputs,
@@ -41,10 +42,12 @@ class PermutationFeatureImportance(FeatureAblation):
             ablations_per_eval=ablations_per_eval,
         )
 
-        if isinstance(attribs, tuple):
-            return tuple([torch.abs(a) for a in attribs])
+        f = torch.abs if abs_attributions else lambda x: x
 
-        return torch.abs(attribs)
+        if isinstance(attribs, tuple):
+            return tuple([f(a) for a in attribs])
+
+        return f(attribs)
 
     def _construct_ablated_input(
         self, feature_tensor, input_mask, baseline, start_feature, end_feature

--- a/captum/attr/_core/perm_feature_importance.py
+++ b/captum/attr/_core/perm_feature_importance.py
@@ -58,6 +58,9 @@ class PermutationFeatureImportance(FeatureAblation):
         ).bool()
 
         output = torch.stack(
-            [self.perm_fn(x, mask.squeeze(0)) for x, mask in zip(feature_tensor, current_mask)]
+            [
+                self.perm_fn(x, mask.squeeze(0))
+                for x, mask in zip(feature_tensor, current_mask)
+            ]
         )
         return output, current_mask

--- a/captum/attr/_core/perm_feature_importance.py
+++ b/captum/attr/_core/perm_feature_importance.py
@@ -21,7 +21,7 @@ def permute_feature(x, feature_mask):
 
 class PermutationFeatureImportance(FeatureAblation):
     def __init__(self, forward_func=None, perm_fn=permute_feature):
-        super().__init__(forward_func=forward_func)
+        FeatureAblation.__init__(self, forward_func=forward_func)
         self.perm_fn = perm_fn
 
     def attribute(

--- a/captum/attr/_core/perm_feature_importance.py
+++ b/captum/attr/_core/perm_feature_importance.py
@@ -31,10 +31,6 @@ class PermutationFeatureImportance(FeatureAblation):
         feature_mask=None,
         ablations_per_eval=1,
     ):
-        assert feature_mask is None or feature_mask.shape[0] == 1, (
-            "feature_mask.shape[0] != 1: pass in one mask in "
-            "order to permute the same features for each input"
-        )
         return FeatureAblation.attribute(
             self,
             inputs,

--- a/captum/attr/_core/perm_feature_importance.py
+++ b/captum/attr/_core/perm_feature_importance.py
@@ -13,8 +13,8 @@ def _permute_feature(x, feature_mask):
     while (perm == no_perm).all():
         perm = torch.randperm(n)
 
-    #print("x.shape=", x.shape)
-    #print("mask.shape=", feature_mask.shape)
+    # print("x.shape=", x.shape)
+    # print("mask.shape=", feature_mask.shape)
     try:
         return (x[perm] * feature_mask) + (x * feature_mask.bitwise_not())
     except:
@@ -35,7 +35,9 @@ class PermutationFeatureImportance(FeatureAblation):
         feature_mask=None,
         ablations_per_eval=1,
     ):
-        assert feature_mask is None or feature_mask.shape[0] == 1, "feature_mask.shape[0] != 1: pass in one mask in order to permute the same features for each input"
+        assert (
+            feature_mask is None or feature_mask.shape[0] == 1
+        ), "feature_mask.shape[0] != 1: pass in one mask in order to permute the same features for each input"
         return FeatureAblation.attribute(
             self,
             inputs,
@@ -49,7 +51,9 @@ class PermutationFeatureImportance(FeatureAblation):
     def _construct_ablated_input(
         self, feature_tensor, input_mask, baseline, start_feature, end_feature
     ):
-        assert input_mask.shape[0] == 1, "input_mask.shape[0] != 1: pass in one mask in order to permute the same features for each input"
+        assert (
+            input_mask.shape[0] == 1
+        ), "input_mask.shape[0] != 1: pass in one mask in order to permute the same features for each input"
         current_mask = torch.stack(
             [input_mask == j for j in range(start_feature, end_feature)], dim=0
         ).bool()

--- a/captum/attr/_core/perm_feature_importance.py
+++ b/captum/attr/_core/perm_feature_importance.py
@@ -6,7 +6,7 @@ from .feature_ablation import FeatureAblation
 
 def permute_feature(x, feature_mask):
     n = x.size(0)
-    assert n > 1
+    assert n > 1, "cannot permute features with batch_size = 1"
 
     perm = torch.randperm(n)
     no_perm = torch.arange(n)
@@ -14,7 +14,6 @@ def permute_feature(x, feature_mask):
         perm = torch.randperm(n)
 
     out = x.clone()
-    feature_mask = feature_mask.squeeze(0)
     for i, j in enumerate(perm):
         out[i, feature_mask] = x[j, feature_mask]
 
@@ -59,9 +58,6 @@ class PermutationFeatureImportance(FeatureAblation):
         ).bool()
 
         output = torch.stack(
-            [
-                self.perm_fn(x, input_mask == j)
-                for x, j in zip(feature_tensor, range(start_feature, end_feature))
-            ]
+            [self.perm_fn(x, mask) for x, mask in zip(feature_tensor, current_mask)]
         )
         return output, current_mask

--- a/captum/attr/_core/perm_feature_importance.py
+++ b/captum/attr/_core/perm_feature_importance.py
@@ -29,9 +29,10 @@ class PermutationFeatureImportance(FeatureAblation):
         feature_mask=None,
         ablations_per_eval=1,
     ):
-        assert (
-            feature_mask is None or feature_mask.shape[0] == 1
-        ), "feature_mask.shape[0] != 1: pass in one mask in order to permute the same features for each input"
+        assert feature_mask is None or feature_mask.shape[0] == 1, (
+            "feature_mask.shape[0] != 1: pass in one mask in "
+            "order to permute the same features for each input"
+        )
         return FeatureAblation.attribute(
             self,
             inputs,
@@ -45,9 +46,10 @@ class PermutationFeatureImportance(FeatureAblation):
     def _construct_ablated_input(
         self, feature_tensor, input_mask, baseline, start_feature, end_feature
     ):
-        assert (
-            input_mask.shape[0] == 1
-        ), "input_mask.shape[0] != 1: pass in one mask in order to permute the same features for each input"
+        assert input_mask.shape[0] == 1, (
+            "input_mask.shape[0] != 1: pass in one mask in order to permute"
+            "the same features for each input"
+        )
         current_mask = torch.stack(
             [input_mask == j for j in range(start_feature, end_feature)], dim=0
         ).bool()

--- a/captum/attr/_core/perm_feature_importance.py
+++ b/captum/attr/_core/perm_feature_importance.py
@@ -13,7 +13,8 @@ def _permute_feature(x, feature_mask):
     while (perm == no_perm).all():
         perm = torch.randperm(n)
 
-    return (x[perm] * feature_mask) + (x * feature_mask.bitwise_not())
+    return (x[perm] * feature_mask.to(dtype=x.dtype)) +\
+           (x * feature_mask.bitwise_not().to(dtype=x.dtype))
 
 
 class PermutationFeatureImportance(FeatureAblation):

--- a/captum/attr/_core/perm_feature_importance.py
+++ b/captum/attr/_core/perm_feature_importance.py
@@ -60,8 +60,8 @@ class PermutationFeatureImportance(FeatureAblation):
 
         output = torch.stack(
             [
-                self.perm_fn(x, feature_mask)
-                for x, feature_mask in zip(feature_tensor, current_mask)
+                self.perm_fn(x, input_mask == j)
+                for x, j in zip(feature_tensor, range(start_feature, end_feature))
             ]
         )
         return output, current_mask

--- a/captum/attr/_core/perm_feature_importance.py
+++ b/captum/attr/_core/perm_feature_importance.py
@@ -31,7 +31,7 @@ class PermutationFeatureImportance(FeatureAblation):
         additional_forward_args=None,
         feature_mask=None,
         ablations_per_eval=1,
-        abs_attributions=False
+        abs_attributions=False,
     ):
         attribs = super().attribute(
             inputs,
@@ -56,11 +56,10 @@ class PermutationFeatureImportance(FeatureAblation):
             [input_mask == j for j in range(start_feature, end_feature)], dim=0
         ).bool()
 
-        output = []
-        for x, feature_mask in zip(feature_tensor, current_mask):
-            # TODO: support multiple permutations
-            output.append(self.perm_fn(x, feature_mask))
-
-        output = torch.stack(output)
-
+        output = torch.stack(
+            [
+                self.perm_fn(x, feature_mask)
+                for x, feature_mask in zip(feature_tensor, current_mask)
+            ]
+        )
         return output, current_mask

--- a/captum/attr/_core/perm_feature_importance.py
+++ b/captum/attr/_core/perm_feature_importance.py
@@ -6,6 +6,8 @@ from .feature_ablation import FeatureAblation
 
 def permute_feature(x, feature_mask):
     n = x.size(0)
+    assert n > 1
+
     perm = torch.randperm(n)
     no_perm = torch.arange(n)
     while (perm == no_perm).all():

--- a/captum/attr/_core/perm_feature_importance.py
+++ b/captum/attr/_core/perm_feature_importance.py
@@ -58,6 +58,6 @@ class PermutationFeatureImportance(FeatureAblation):
         ).bool()
 
         output = torch.stack(
-            [self.perm_fn(x, mask) for x, mask in zip(feature_tensor, current_mask)]
+            [self.perm_fn(x, mask.squeeze(0)) for x, mask in zip(feature_tensor, current_mask)]
         )
         return output, current_mask

--- a/captum/attr/_core/perm_feature_importance.py
+++ b/captum/attr/_core/perm_feature_importance.py
@@ -13,7 +13,13 @@ def _permute_feature(x, feature_mask):
     while (perm == no_perm).all():
         perm = torch.randperm(n)
 
-    return (x[perm] * feature_mask) + (x * feature_mask.bitwise_not())
+    #print("x.shape=", x.shape)
+    #print("mask.shape=", feature_mask.shape)
+    try:
+        return (x[perm] * feature_mask) + (x * feature_mask.bitwise_not())
+    except:
+        print("x.shape=", x.shape)
+        print("mask.shape=", feature_mask.shape)
 
 
 class PermutationFeatureImportance(FeatureAblation):
@@ -29,6 +35,7 @@ class PermutationFeatureImportance(FeatureAblation):
         feature_mask=None,
         ablations_per_eval=1,
     ):
+        assert feature_mask is None or feature_mask.shape[0] == 1, "feature_mask.shape[0] != 1: pass in one mask in order to permute the same features for each input"
         return FeatureAblation.attribute(
             self,
             inputs,
@@ -42,6 +49,7 @@ class PermutationFeatureImportance(FeatureAblation):
     def _construct_ablated_input(
         self, feature_tensor, input_mask, baseline, start_feature, end_feature
     ):
+        assert input_mask.shape[0] == 1, "input_mask.shape[0] != 1: pass in one mask in order to permute the same features for each input"
         current_mask = torch.stack(
             [input_mask == j for j in range(start_feature, end_feature)], dim=0
         ).bool()

--- a/captum/attr/_core/perm_feature_importance.py
+++ b/captum/attr/_core/perm_feature_importance.py
@@ -1,0 +1,54 @@
+import torch
+
+from .feature_ablation import FeatureAblation
+
+
+def permute_feature(x, feature_mask):
+    n = x.size(0)
+    perm = torch.randperm(n)
+    out = x.clone()
+    feature_mask = feature_mask[-1]
+    for i, j in enumerate(perm):
+        out[i][feature_mask] = x[j][feature_mask]
+
+    return out
+
+
+class PermutationFeatureImportance(FeatureAblation):
+    def __init__(self, forward_func=None, perm_fn=permute_feature):
+        super().__init__(forward_func=forward_func)
+        self.perm_fn = perm_fn
+
+    def attribute(
+        self,
+        inputs=None,
+        additional_forward_args=None,
+        feature_mask=None,
+        ablations_per_eval=1,
+    ):
+        attribs = super().attribute(
+            inputs,
+            additional_forward_args=additional_forward_args,
+            ablations_per_eval=ablations_per_eval,
+            baselines=None,
+        )
+
+        if isinstance(attribs, tuple):
+            return tuple([torch.abs(a) for a in attribs])
+
+        return torch.abs(attribs)
+
+    def _construct_ablated_input(
+        self, feature_tensor, input_mask, baseline, start_feature, end_feature
+    ):
+        current_mask = torch.stack(
+            [input_mask == j for j in range(start_feature, end_feature)], dim=0
+        ).bool()
+
+        output = []
+        for x, feature_mask in zip(feature_tensor, current_mask):
+            # TODO: support multiple permutations
+            output.append(self.perm_fn(x, feature_mask))
+        output = torch.stack(output)
+
+        return output, current_mask

--- a/captum/attr/_core/perm_feature_importance.py
+++ b/captum/attr/_core/perm_feature_importance.py
@@ -14,7 +14,7 @@ def permute_feature(x, feature_mask):
     out = x.clone()
     feature_mask = feature_mask.squeeze(0)
     for i, j in enumerate(perm):
-        out[i][feature_mask] = x[j][feature_mask]
+        out[i, feature_mask] = x[j, feature_mask]
 
     return out
 

--- a/captum/attr/_core/perm_feature_importance.py
+++ b/captum/attr/_core/perm_feature_importance.py
@@ -13,13 +13,7 @@ def _permute_feature(x, feature_mask):
     while (perm == no_perm).all():
         perm = torch.randperm(n)
 
-    # print("x.shape=", x.shape)
-    # print("mask.shape=", feature_mask.shape)
-    try:
-        return (x[perm] * feature_mask) + (x * feature_mask.bitwise_not())
-    except:
-        print("x.shape=", x.shape)
-        print("mask.shape=", feature_mask.shape)
+    return (x[perm] * feature_mask) + (x * feature_mask.bitwise_not())
 
 
 class PermutationFeatureImportance(FeatureAblation):

--- a/tests/attr/helpers/basic_models.py
+++ b/tests/attr/helpers/basic_models.py
@@ -4,6 +4,14 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 
+class MultiplyModel2Input(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x, y):
+        return x[:, 0] * x[:, 1] + y[:, 0] * y[:, 1]
+
+
 class BasicModel(nn.Module):
     def __init__(self):
         super().__init__()

--- a/tests/attr/helpers/basic_models.py
+++ b/tests/attr/helpers/basic_models.py
@@ -4,14 +4,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 
-class MultiplyModel2Input(nn.Module):
-    def __init__(self):
-        super().__init__()
-
-    def forward(self, x, y):
-        return x[:, 0] * x[:, 1] + y[:, 0] * y[:, 1]
-
-
 class BasicModel(nn.Module):
     def __init__(self):
         super().__init__()

--- a/tests/attr/test_perm_feature_importance.py
+++ b/tests/attr/test_perm_feature_importance.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+import unittest
+
+import torch
+import torch.nn as nn
+from captum.attr._core.perm_feature_importance import PermutationFeatureImportance, permute_feature
+
+from .helpers.basic_models import BasicModel, BasicModel2
+from .helpers.utils import assertTensorAlmostEqual, BaseTest
+
+
+class MultiplyNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x, y):
+        return x[:, 0] * x[:, 1] + y[:, 0] * y[:, 1]
+
+
+class Test(BaseTest):
+    def test_perm_fn(self):
+        for bs in [2, 10, 100]:
+            inp = torch.randn(bs, 50)
+
+            for i in range(inp.size(1)):
+                fm = torch.zeros_like(inp[0])
+                fm[i] = 1
+                fm = fm.bool()
+
+                perm_inp = permute_feature(inp, fm)
+
+                self.assertTrue((perm_inp[:, i] != inp[:, i]).any())
+                for j in range(inp.size(1)):
+                    if i == j:
+                        continue
+
+                    self.assertTrue((perm_inp[:, j] == inp[:, j]).all())
+
+    def test_single_input(self):
+        batch_size = 30
+        input_size = (3,)
+        net = BasicModel()
+
+        def forward_func(x):
+            return torch.sum(net(x))
+
+        fi = PermutationFeatureImportance(forward_func=forward_func)
+
+        inp = torch.randn((batch_size,) + input_size)
+
+        inp[:, 0] = 5
+        attribs = fi.attribute(inp)
+        self.assertTrue(attribs.squeeze(0).size() == input_size)
+        self.assertTrue((attribs[:, 0] == 0).all())
+        self.assertTrue((attribs[:, 1] != 0).all())
+        self.assertTrue((attribs[:, 2] != 0).all())
+
+    def test_multi_input(self):
+        batch_size = 5
+        input_size = (2,)
+        net = MultiplyNet()
+
+        labels = torch.randn(batch_size)
+
+        def forward_func(*x):
+            y = net(*x)
+            return torch.sum((y - labels) ** 2)
+
+        fi = PermutationFeatureImportance(forward_func=forward_func)
+
+        inp = (
+            torch.randn((batch_size,) + input_size),
+            torch.randn((batch_size,) + input_size),
+        )
+        inp[1][:, 1] = 4
+        attribs = fi.attribute(inp)
+
+        self.assertTrue(isinstance(attribs, tuple))
+        self.assertTrue(len(attribs) == 2)
+        self.assertTrue(attribs[0].squeeze(0).size() == input_size)
+        self.assertTrue(attribs[1].squeeze(0).size() == input_size)
+
+        for i in range(2):
+            self.assertTrue((attribs[0][:, i] != 0).all())
+            if i != 1:
+                self.assertTrue((attribs[1][:, i] != 0).all())
+
+        self.assertTrue((attribs[1][:, 1] == 0).all())
+
+    def test_mulitple_ablations(self):
+        ablations_per_eval = 4
+        batch_size = 25
+        input_size = (4,)
+
+        net = BasicModel()
+
+
+        inp = torch.randn((batch_size,) + input_size)
+        def forward_func(x):
+            if x.size(0) > batch_size:
+                self.assertTrue(ablations_per_eval * batch_size == x.size(0))
+
+                inputs = [x[i * batch_size:(i+1) * batch_size] for i in range(ablations_per_eval)]
+                for i in range(ablations_per_eval):
+                    for j in range(ablations_per_eval):
+                        if i == j:
+                            continue
+                        self.assertTrue((inputs[i] != inputs[j]).any())
+
+            y = net(x)
+            return y
+
+        fi = PermutationFeatureImportance(forward_func=forward_func)
+
+        attribs = fi.attribute(inp, ablations_per_eval=ablations_per_eval, target=1)
+        self.assertTrue(attribs.size() == (batch_size,) + input_size)

--- a/tests/attr/test_perm_feature_importance.py
+++ b/tests/attr/test_perm_feature_importance.py
@@ -9,16 +9,8 @@ from captum.attr._core.perm_feature_importance import (
     permute_feature,
 )
 
-from .helpers.basic_models import BasicModel
+from .helpers.basic_models import BasicModel, MultiplyModel2Input
 from .helpers.utils import BaseTest
-
-
-class MultiplyNet(nn.Module):
-    def __init__(self):
-        super().__init__()
-
-    def forward(self, x, y):
-        return x[:, 0] * x[:, 1] + y[:, 0] * y[:, 1]
 
 
 class Test(BaseTest):
@@ -84,7 +76,7 @@ class Test(BaseTest):
     def test_multi_input(self):
         batch_size = 5
         input_size = (2,)
-        net = MultiplyNet()
+        net = MultiplyModel2Input()
 
         labels = torch.randn(batch_size)
 

--- a/tests/attr/test_perm_feature_importance.py
+++ b/tests/attr/test_perm_feature_importance.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-import random
-
 import torch
 from captum.attr._core.perm_feature_importance import (
     PermutationFeatureImportance,
@@ -9,13 +7,12 @@ from captum.attr._core.perm_feature_importance import (
 )
 
 from .helpers.utils import BaseTest, assertArraysAlmostEqual, assertTensorAlmostEqual
-from .helpers.basic_models import BasicModel_ConvNet_One_Conv
 
 
 class Test(BaseTest):
     def _check_features_are_permuted(self, inp, perm_inp, mask):
         permuted_features = mask.expand_as(inp[0])
-        unpermuted_features = mask.expand_as(inp[0]).bitwise_not()
+        unpermuted_features = permuted_features.bitwise_not()
 
         self.assertTrue(inp.dtype == perm_inp.dtype)
         self.assertTrue(inp.shape == perm_inp.shape)
@@ -180,7 +177,6 @@ class Test(BaseTest):
             self.assertTrue(attribs is not None)
             self.assertTrue(attribs.shape == inp.shape)
 
-            y = forward_func(inp)
             fm = mask.expand_as(inp[0])
 
             features = set([x for x in mask.flatten()])

--- a/tests/attr/test_perm_feature_importance.py
+++ b/tests/attr/test_perm_feature_importance.py
@@ -175,7 +175,8 @@ class Test(BaseTest):
                         # two conditions should hold:
                         # 1) all values in attribs[feature_mask] are the same
                         # 2) since the batch_size = 2, this value should be
-                        #    equal to (inp[0, target] - inp[1, target], inp[1, target] - inp[0, target])
+                        #    equal to (inp[0, target] - inp[1, target],
+                        #              inp[1, target] - inp[0, target])
                         val = inp[0, target] - inp[1, target]
                         assertTensorAlmostEqual(self, sub_attrib[0, feature_mask], val)
                         assertTensorAlmostEqual(self, sub_attrib[1, feature_mask], -val)

--- a/tests/attr/test_perm_feature_importance.py
+++ b/tests/attr/test_perm_feature_importance.py
@@ -19,7 +19,9 @@ class Test(BaseTest):
 
         self.assertTrue(inp.dtype == perm_inp.dtype)
         self.assertTrue(inp.shape == perm_inp.shape)
-        self.assertTrue((inp[:, permuted_features] != perm_inp[:, permuted_features]).any())
+        self.assertTrue(
+            (inp[:, permuted_features] != perm_inp[:, permuted_features]).any()
+        )
         self.assertTrue(
             (inp[:, unpermuted_features] == perm_inp[:, unpermuted_features]).all()
         )
@@ -60,9 +62,8 @@ class Test(BaseTest):
             (3, 20, 1),
             (1, 1, 30),
             (1, 20, 1),
-
             # missing
-            (1,), # empty set (all features)
+            (1,),  # empty set (all features)
             (30,),
             (20, 30),
             (3, 20, 30),
@@ -155,23 +156,20 @@ class Test(BaseTest):
         assertTensorAlmostEqual(self, attribs[:, target], actual_diff)
 
     def test_broadcastable_masks(self):
-        # integration test to ensure that 
+        # integration test to ensure that
         # permutation function works with custom masks
         def forward_func(x):
             return x.view(x.shape[0], -1).sum(dim=-1)
 
         batch_size = 2
-        inp = torch.randn((batch_size,) + (3,4,4))
+        inp = torch.randn((batch_size,) + (3, 4, 4))
 
         feature_importance = PermutationFeatureImportance(forward_func=forward_func)
 
         masks = [
             torch.tensor([0]),
             torch.tensor([[0, 1, 2, 3]]),
-            torch.tensor([[[0, 1, 2, 3], 
-                           [3, 3, 4, 5],
-                           [6, 6, 4, 6],
-                           [7, 8, 9, 10] ]])
+            torch.tensor([[[0, 1, 2, 3], [3, 3, 4, 5], [6, 6, 4, 6], [7, 8, 9, 10]]]),
         ]
 
         for mask in masks:

--- a/tests/attr/test_perm_feature_importance.py
+++ b/tests/attr/test_perm_feature_importance.py
@@ -49,10 +49,12 @@ class Test(BaseTest):
 
         inp = torch.randn((batch_size,) + inp_size)
 
-        # to be broadcastable dimensions have
-        # match from end to beginning, by:
-        # 1. Equalling 1
-        # 2. Equally the dimension
+        # To be broadcastable dimensions have
+        # match from end to beginning, by equalling 1 or the dim.
+        #
+        # If a dimension is missing then it must be the
+        # last dim provided (from right to left). The missing
+        # dimensions are implied to be = 1
         #
         # Here I write them explicitly for clarity
         mask_sizes = [

--- a/tests/attr/test_perm_feature_importance.py
+++ b/tests/attr/test_perm_feature_importance.py
@@ -5,7 +5,7 @@ import random
 import torch
 from captum.attr._core.perm_feature_importance import (
     PermutationFeatureImportance,
-    permute_feature,
+    _permute_feature,
 )
 
 from .helpers.utils import BaseTest, assertTensorAlmostEqual
@@ -38,7 +38,7 @@ class Test(BaseTest):
 
                     # permute the feature
                     mask = flat_mask.view_as(inp[0])
-                    perm_inp = permute_feature(inp, mask)
+                    perm_inp = _permute_feature(inp, mask)
                     check_features_are_permuted(inp, perm_inp, mask)
 
                     flat_mask[feature_idx] = 0
@@ -49,7 +49,7 @@ class Test(BaseTest):
                     while mask.sum() == 0:
                         mask = torch.randint_like(inp[0], 0, 2).bool()
 
-                    perm_inp = permute_feature(inp, mask)
+                    perm_inp = _permute_feature(inp, mask)
                     check_features_are_permuted(inp, perm_inp, mask)
 
     def test_single_input(self):

--- a/tests/attr/test_perm_feature_importance.py
+++ b/tests/attr/test_perm_feature_importance.py
@@ -86,7 +86,7 @@ class Test(BaseTest):
         inp = torch.randn((batch_size,) + input_size) * 10
 
         inp[:, 0] = 5
-        for x in range(10):
+        for _ in range(10):
             attribs = feature_importance.attribute(inp)
 
             self.assertTrue(attribs.squeeze(0).size() == input_size)
@@ -188,7 +188,7 @@ class Test(BaseTest):
 
             fm = mask.expand_as(inp[0])
 
-            features = set([x for x in mask.flatten()])
+            features = set(mask.flatten())
             for feature in features:
                 m = (fm == feature).bool()
                 attribs_for_feature = attribs[:, m]

--- a/tests/attr/test_perm_feature_importance.py
+++ b/tests/attr/test_perm_feature_importance.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 
-import unittest
-
 import torch
 import torch.nn as nn
-from captum.attr._core.perm_feature_importance import PermutationFeatureImportance, permute_feature
+from captum.attr._core.perm_feature_importance import (
+    PermutationFeatureImportance,
+    permute_feature,
+)
 
-from .helpers.basic_models import BasicModel, BasicModel2
-from .helpers.utils import assertTensorAlmostEqual, BaseTest
+from .helpers.basic_models import BasicModel
+from .helpers.utils import BaseTest
 
 
 class MultiplyNet(nn.Module):
@@ -95,13 +96,16 @@ class Test(BaseTest):
 
         net = BasicModel()
 
-
         inp = torch.randn((batch_size,) + input_size)
+
         def forward_func(x):
             if x.size(0) > batch_size:
                 self.assertTrue(ablations_per_eval * batch_size == x.size(0))
 
-                inputs = [x[i * batch_size:(i+1) * batch_size] for i in range(ablations_per_eval)]
+                inputs = [
+                    x[i * batch_size : (i + 1) * batch_size]
+                    for i in range(ablations_per_eval)
+                ]
                 for i in range(ablations_per_eval):
                     for j in range(ablations_per_eval):
                         if i == j:

--- a/tests/attr/test_perm_feature_importance.py
+++ b/tests/attr/test_perm_feature_importance.py
@@ -26,7 +26,9 @@ class Test(BaseTest):
         def check_features_are_permuted(inp, perm_inp, mask):
             unpermuted_features = mask.bitwise_not()
             self.assertTrue((inp[:, mask] != perm_inp[:, mask]).any())
-            self.assertTrue((inp[:, unpermuted_features] == perm_inp[:, unpermuted_features]).all())
+            self.assertTrue(
+                (inp[:, unpermuted_features] == perm_inp[:, unpermuted_features]).all()
+            )
 
         sizes_to_test = [(10,), (4, 5), (3, 4, 5), (6, 7, 8, 9)]
         for bs in [2, 10]:

--- a/tests/attr/test_perm_feature_importance.py
+++ b/tests/attr/test_perm_feature_importance.py
@@ -147,7 +147,9 @@ class Test(BaseTest):
         feature_importance = PermutationFeatureImportance(forward_func=forward_func)
         for masks in masks_to_test:
             target = random.randint(0, 2)
-            attribs = feature_importance.attribute((inp1, inp2), feature_mask=masks, target=target)
+            attribs = feature_importance.attribute(
+                (inp1, inp2), feature_mask=masks, target=target
+            )
             self.assertTrue(isinstance(attribs, tuple))
 
             target_mask = torch.zeros_like(inp1[0]).byte()
@@ -167,7 +169,7 @@ class Test(BaseTest):
                     # if the mask doesn't contain feature - skip
                     if feature_mask.sum() == 0:
                         continue
-                    
+
                     feature_mask = feature_mask.expand_as(inp[0])
 
                     # if this feature does contribute to the output
@@ -180,6 +182,6 @@ class Test(BaseTest):
                         assertTensorAlmostEqual(self, sub_attrib[0, feature_mask], val)
                         assertTensorAlmostEqual(self, sub_attrib[1, feature_mask], -val)
                     else:
-                        # if the feature doesn't contribute to the output 
+                        # if the feature doesn't contribute to the output
                         # -- then this means it should have attrib of 0
                         assertTensorAlmostEqual(self, sub_attrib[:, feature_mask], 0)

--- a/tests/attr/test_perm_feature_importance.py
+++ b/tests/attr/test_perm_feature_importance.py
@@ -23,13 +23,13 @@ class Test(BaseTest):
             )
 
         sizes_to_test = [(10,), (4, 5), (3, 4, 5), (6, 7, 8, 9)]
-        for bs in [2, 10]:
-            for si in sizes_to_test:
-                inp = torch.randn((bs,) + si)
+        for batch_size in [2, 10]:
+            for inp_size in sizes_to_test:
+                inp = torch.randn((batch_size,) + inp_size)
                 flat_mask = torch.zeros_like(inp[0]).flatten().bool()
 
                 # test random set of single features
-                num_features = inp.numel() // bs
+                num_features = inp.numel() // batch_size
                 num_features_to_test = min(num_features, random.randint(2, 30))
                 for _ in range(num_features_to_test):
                     feature_idx = random.randint(0, num_features - 1)


### PR DESCRIPTION
Implementation of blackbox feature permutation importance algorithm: https://christophm.github.io/interpretable-ml-book/feature-importance.html

Pseudo-code of the above, for a single batch of data:

```
perm_feature_importance(batch):
     feature_importance = {}
     initial_err = f(batch)
     for feature in features:
           batch_copy = permute_feature_across(batch, feature)
           err = f(batch_copy)
           diff = initial_err - err
           feature_importance[feature] = diff

     return feature_importance
           
permute_feature_across(batch, feature):
      batch_copy = batch.clone()
      batch_copy[:, feature] = batch[random_perm(n), feature] 
      return batch_copy
```


The basic idea is to permute each feature in a batch and see how different the output (or error/loss) is from the output/error/loss of the original batch. If the error increases => we know that this feature is important. If the error remains about the same => we know that the feature is not that important since the model was not very reliant on it. Finally, if the error decreases => we know likely know that the feature was negatively impacting the model's performance and hence was detrimental.

error/loss functions must be provided in the `forward_func`. See the test cases for examples.