### PR TITLE
Adding Layer Ablation

### DIFF
--- a/captum/attr/_core/layer/layer_feature_ablation.py
+++ b/captum/attr/_core/layer/layer_feature_ablation.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+import torch
+from torch.nn.parallel.scatter_gather import scatter
+
+from ..._utils.attribution import LayerAttribution, PerturbationAttribution
+from ..._utils.common import (
+    _format_input,
+    _format_additional_forward_args,
+    _run_forward,
+    _extract_device,
+)
+from ..._utils.gradient import _forward_layer_eval
+
+from ..feature_ablation import FeatureAblation
+
+
+class LayerFeatureAblation(LayerAttribution, PerturbationAttribution):
+    def __init__(self, forward_func, layer, device_ids=None):
+        r"""
+        Args:
+
+            forward_func (callable):  The forward function of the model or any
+                          modification of it
+            layer (torch.nn.Module): Layer for which attributions are computed.
+                          Output size of attribute matches this layer's input or
+                          output dimensions, depending on whether we attribute to
+                          the inputs or outputs of the layer, corresponding to
+                          attribution of each neuron in the input or output of
+                          this layer.
+                          Currently, it is assumed that the inputs or the outputs
+                          of the layer, depending on which one is used for
+                          attribution, can only be a single tensor.
+            device_ids (list(int)): Device ID list, necessary only if forward_func
+                          applies a DataParallel model. This allows reconstruction of
+                          intermediate outputs from batched results across devices.
+                          If forward_func is given as the DataParallel model itself
+                          (or otherwise has a device_ids attribute with the device
+                          ID list), then it is not necessary to provide this
+                          argument.
+        """
+        LayerAttribution.__init__(self, forward_func, layer, device_ids)
+        PerturbationAttribution.__init__(self, forward_func)
+
+    def attribute(
+        self,
+        inputs,
+        layer_baselines=None,
+        target=None,
+        additional_forward_args=None,
+        layer_mask=None,
+        attribute_to_layer_input=False,
+        ablations_per_eval=1,
+    ):
+        r"""
+            A perturbation based approach to computing layer attribution, involving
+            replacing values in the input / output of a layer with a given baseline /
+            reference, and computing the difference in output. By default, each
+            neuron (scalar input / output value) within the layer is replaced
+            independently.
+            Passing a layer mask allows grouping neurons to be
+            ablated together.
+            Each neuron in the group will be given the same attribution value
+            equal to the change in target as a result of ablating the entire neuron
+            group.
+
+            Args:
+
+                inputs (tensor or tuple of tensors):  Input for which layer
+                            attributions are computed. If forward_func takes a single
+                            tensor as input, a single input tensor should be provided.
+                            If forward_func takes multiple tensors as input, a tuple
+                            of the input tensors should be provided. It is assumed
+                            that for all given input tensors, dimension 0 corresponds
+                            to the number of examples, and if multiple input tensors
+                            are provided, the examples must be aligned appropriately.
+                layer_baselines (scalar, tensor, tuple of scalars or tensors, optional):
+                            Layer baselines define reference values which replace each
+                            layer input / output value when ablated.
+                            Layer baselines should be a single tensor with dimensions
+                            matching the input / output of the target layer (or
+                            broadcastable to match it), based
+                            on whether we are attributing to the input or output
+                            of the target layer.
+                            In the cases when `baselines` is not provided, we internally
+                            use zero as the baseline for each neuron.
+                            Default: None
+                target (int, tuple, tensor or list, optional):  Output indices for
+                            which difference is computed (for classification cases,
+                            this is usually the target class).
+                            If the network returns a scalar value per example,
+                            no target index is necessary.
+                            For general 2D outputs, targets can be either:
+
+                            - a single integer or a tensor containing a single
+                                integer, which is applied to all input examples
+
+                            - a list of integers or a 1D tensor, with length matching
+                                the number of examples in inputs (dim 0). Each integer
+                                is applied as the target for the corresponding example.
+
+                            For outputs with > 2 dimensions, targets can be either:
+
+                            - A single tuple, which contains #output_dims - 1
+                                elements. This target index is applied to all examples.
+
+                            - A list of tuples with length equal to the number of
+                                examples in inputs (dim 0), and each tuple containing
+                                #output_dims - 1 elements. Each tuple is applied as the
+                                target for the corresponding example.
+
+                            Default: None
+                additional_forward_args (tuple, optional): If the forward function
+                            requires additional arguments other than the inputs for
+                            which attributions should not be computed, this argument
+                            can be provided. It must be either a single additional
+                            argument of a Tensor or arbitrary (non-tuple) type or a
+                            tuple containing multiple additional arguments including
+                            tensors or any arbitrary python types. These arguments
+                            are provided to forward_func in order following the
+                            arguments in inputs.
+                            Note that attributions are not computed with respect
+                            to these arguments.
+                            Default: None
+                layer_mask (tensor, optional):
+                            layer_mask defines a mask for the layer, grouping
+                            elements of the layer input / output which should be
+                            ablated together.
+                            layer_mask should be a single tensor with dimensions
+                            matching the input / output of the target layer (or
+                            broadcastable to match it), based
+                            on whether we are attributing to the input or output
+                            of the target layer. layer_mask
+                            should contain integers in the range 0 to num_groups
+                            - 1, and all elements with the same value are
+                            considered to be in the same group.
+                            If None, then a layer mask is constructed which assigns
+                            each neuron within the layer as a separate group, which
+                            is ablated independently.
+                            Default: None
+                attribute_to_layer_input (bool, optional): Indicates whether to
+                            compute the attributions with respect to the layer input
+                            or output. If `attribute_to_layer_input` is set to True
+                            then the attributions will be computed with respect to
+                            layer's inputs, otherwise it will be computed with respect
+                            to layer's outputs.
+                            Note that currently it is assumed that either the input
+                            or the output of the layer, depending on whether we
+                            attribute to the input or output, is a single tensor.
+                            Support for multiple tensors will be added later.
+                            Default: False
+                ablations_per_eval (int, optional): Allows ablation of multiple neuron
+                            (groups) to be processed simultaneously in one call
+                            to forward_fn.
+                            Each forward pass will contain a maximum of
+                            ablations_per_eval * #examples samples.
+                            For DataParallel models, each batch is split among the
+                            available devices, so evaluations on each available
+                            device contain at most
+                            (ablations_per_eval * #examples) / num_devices
+                            samples.
+                            Default: 1
+
+            Returns:
+                *tensor* of **attributions**:
+                - **attributions** (*tensor*):
+                            Attribution of each neuron in given layer input or
+                            output. Attributions will always be the same size as
+                            the input or output of the given layer, depending on
+                            whether we attribute to the inputs or outputs
+                            of the layer which is decided by the input flag
+                            `attribute_to_layer_input`.
+
+            Examples::
+
+            >>> # SimpleClassifier takes a single input tensor of size Nx4x4,
+            >>> # and returns an Nx3 tensor of class probabilities.
+            >>> # It contains an attribute conv1, which is an instance of nn.conv2d,
+            >>> # and the output of this layer has dimensions Nx12x3x3.
+            >>> net = SimpleClassifier()
+            >>> # Generating random input with size 2 x 4 x 4
+            >>> input = torch.randn(2, 4, 4)
+            >>> # Defining LayerFeatureAblation interpreter
+            >>> ablator = LayerFeatureAblation(net, net.conv1)
+            >>> # Computes ablation attribution, ablating each of the 108
+            >>> # neurons independently.
+            >>> attr = ablator.attribute(input, target=1)
+
+            >>> # Alternatively, we may want to ablate neurons in groups, e.g.
+            >>> # grouping all the layer outputs in the same row.
+            >>> # This can be done by creating a layer mask as follows, which
+            >>> # defines the groups of layer inputs / outouts, e.g.:
+            >>> # +---+---+---+
+            >>> # | 0 | 0 | 0 |
+            >>> # +---+---+---+
+            >>> # | 1 | 1 | 1 |
+            >>> # +---+---+---+
+            >>> # | 2 | 2 | 2 |
+            >>> # +---+---+---+
+            >>> # With this mask, all the 36 neurons in a row / channel are ablated
+            >>> # simultaneously, and the attribution for each neuron in the same
+            >>> # group (0 - 2) per example are the same.
+            >>> # The attributions can be calculated as follows:
+            >>> # layer mask has dimensions 1 x 3 x 3
+            >>> layer_mask = torch.tensor([[[0,0,0],[1,1,1],
+            >>>                             [2,2,2]]])
+            >>> attr = ablator.attribute(input, target=1,
+            >>>                          layer_mask=layer_mask)
+        """
+
+        def layer_forward_func(*args):
+            layer_input = args[0]
+            original_inputs = args[1:]
+
+            device_ids = self.device_ids
+            if device_ids is None:
+                device_ids = getattr(self.forward_func, "device_ids", None)
+
+            all_layer_inputs = {}
+            if device_ids is not None:
+                scattered_layer_input = scatter(layer_input, target_gpus=device_ids)
+                for tensor in scattered_layer_input:
+                    all_layer_inputs[tensor.device] = tensor
+            else:
+                all_layer_inputs[layer_input.device] = layer_input
+
+            def forward_hook(module, inp, out=None):
+                device = _extract_device(module, inp, out)
+                if device not in all_layer_inputs:
+                    raise AssertionError(
+                        "Layer input not placed on appropriate "
+                        "device. If using a DataParallel model, either provide the "
+                        "DataParallel model as forward_func or provide device ids"
+                        " to the constructor."
+                    )
+                return all_layer_inputs[device]
+
+            if attribute_to_layer_input:
+                hook = self.layer.register_forward_pre_hook(forward_hook)
+            else:
+                hook = self.layer.register_forward_hook(forward_hook)
+            eval = _run_forward(self.forward_func, original_inputs, target=target)
+            hook.remove()
+            return eval
+
+        with torch.no_grad():
+            inputs = _format_input(inputs)
+            additional_forward_args = _format_additional_forward_args(
+                additional_forward_args
+            )
+            layer_eval = _forward_layer_eval(
+                self.forward_func,
+                inputs,
+                self.layer,
+                additional_forward_args,
+                device_ids=self.device_ids,
+                attribute_to_layer_input=attribute_to_layer_input,
+            )
+            all_inputs = (
+                (inputs + additional_forward_args)
+                if additional_forward_args is not None
+                else inputs
+            )
+
+            ablator = FeatureAblation(layer_forward_func)
+
+            return ablator.attribute(
+                layer_eval,
+                baselines=layer_baselines,
+                additional_forward_args=all_inputs,
+                feature_mask=layer_mask,
+                ablations_per_eval=ablations_per_eval,
+            )

--- a/tests/attr/helpers/basic_models.py
+++ b/tests/attr/helpers/basic_models.py
@@ -281,6 +281,7 @@ class BasicModel_ConvNet_One_Conv(nn.Module):
         self.fc1.weight = nn.Parameter(
             torch.cat([torch.ones(4, 5), -1 * torch.ones(4, 3)], dim=1)
         )
+        self.fc1.bias = nn.Parameter(torch.zeros(4))
         self.relu2 = nn.ReLU(inplace=inplace)
 
     def forward(self, x, x2=None):

--- a/tests/attr/layer/test_layer_ablation.py
+++ b/tests/attr/layer/test_layer_ablation.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+
+import unittest
+
+import torch
+from captum.attr._core.layer.layer_feature_ablation import LayerFeatureAblation
+
+from ..helpers.basic_models import (
+    BasicModel_ConvNet_One_Conv,
+    BasicModel_MultiLayer,
+    BasicModel_MultiLayer_MultiInput,
+)
+from ..helpers.utils import assertTensorAlmostEqual, BaseTest
+
+
+class Test(BaseTest):
+    def test_simple_ablation_with_mask(self):
+        net = BasicModel_MultiLayer()
+        inp = torch.tensor([[20.0, 50.0, 30.0]], requires_grad=True)
+        self._ablation_test_assert(
+            net,
+            net.linear0,
+            inp,
+            [280.0, 280.0, 120.0],
+            layer_mask=torch.tensor([[0, 0, 1]]),
+            ablations_per_eval=(1, 2, 3),
+            attribute_to_layer_input=True,
+        )
+
+    def test_multi_input_ablation(self):
+        net = BasicModel_MultiLayer_MultiInput()
+        inp1 = torch.tensor([[23.0, 100.0, 0.0], [20.0, 50.0, 30.0]])
+        inp2 = torch.tensor([[20.0, 50.0, 30.0], [0.0, 100.0, 0.0]])
+        inp3 = torch.tensor([[0.0, 100.0, 10.0], [2.0, 10.0, 3.0]])
+        baseline = torch.tensor([[1.0, 2.0, 3.0]])
+        self._ablation_test_assert(
+            net,
+            net.model.linear1,
+            (inp1, inp2, inp3),
+            [[168.0, 992.0, 148.0], [84.0, 632.0, 120.0]],
+            additional_input=(1,),
+            baselines=baseline,
+            ablations_per_eval=(1, 2, 3),
+            attribute_to_layer_input=True,
+        )
+        self._ablation_test_assert(
+            net,
+            net.model.linear0,
+            (inp1, inp2, inp3),
+            [[168.0, 992.0, 148.0], [84.0, 632.0, 120.0]],
+            additional_input=(1,),
+            baselines=baseline,
+            ablations_per_eval=(1, 2, 3),
+            attribute_to_layer_input=False,
+        )
+
+    def test_multi_input_ablation_with_layer_mask(self):
+        net = BasicModel_MultiLayer_MultiInput()
+        inp1 = torch.tensor([[23.0, 100.0, 0.0], [20.0, 50.0, 30.0]])
+        inp2 = torch.tensor([[20.0, 50.0, 30.0], [0.0, 100.0, 0.0]])
+        inp3 = torch.tensor([[0.0, 100.0, 10.0], [2.0, 10.0, 3.0]])
+        baseline = torch.tensor([[1.0, 2.0, 3.0]])
+        layer_mask = torch.tensor([[0, 1, 0], [0, 1, 2]])
+        self._ablation_test_assert(
+            net,
+            net.model.linear1,
+            (inp1, inp2, inp3),
+            [[316.0, 992.0, 316.0], [84.0, 632.0, 120.0]],
+            additional_input=(1,),
+            baselines=baseline,
+            ablations_per_eval=(1, 2, 3),
+            layer_mask=layer_mask,
+            attribute_to_layer_input=True,
+        )
+        self._ablation_test_assert(
+            net,
+            net.model.linear0,
+            (inp1, inp2, inp3),
+            [[316.0, 992.0, 316.0], [84.0, 632.0, 120.0]],
+            additional_input=(1,),
+            baselines=baseline,
+            layer_mask=layer_mask,
+            ablations_per_eval=(1, 2, 3),
+        )
+
+    def test_simple_multi_input_conv_intermediate(self):
+        net = BasicModel_ConvNet_One_Conv(inplace=True)
+        inp = torch.arange(16).view(1, 1, 4, 4).type(torch.FloatTensor)
+        inp2 = torch.ones((1, 1, 4, 4))
+        self._ablation_test_assert(
+            net,
+            net.relu1,
+            (inp, inp2),
+            [[[4.0, 13.0], [40.0, 49.0]], [[0, 0], [-15.0, -24.0]]],
+            ablations_per_eval=(1, 2, 4, 8, 12, 16),
+        )
+        self._ablation_test_assert(
+            net,
+            net.relu1,
+            (inp, inp2),
+            [[[4.0, 13.0], [40.0, 49.0]], [[0, 0], [-15.0, -24.0]]],
+            baselines=torch.tensor(
+                [[[-4.0, -13.0], [-2.0, -2.0]], [[0, 0], [0.0, 0.0]]]
+            ),
+            ablations_per_eval=(1, 2, 4, 8, 12, 16),
+            attribute_to_layer_input=True,
+        )
+        self._ablation_test_assert(
+            net,
+            net.relu1,
+            (inp, inp2),
+            [[[17.0, 17.0], [67.0, 67.0]], [[0, 0], [-39.0, -39.0]]],
+            ablations_per_eval=(1, 2, 4),
+            layer_mask=torch.tensor([[[[0, 0], [1, 1]], [[2, 2], [3, 3]]]]),
+        )
+
+    def _ablation_test_assert(
+        self,
+        model,
+        layer,
+        test_input,
+        expected_ablation,
+        layer_mask=None,
+        additional_input=None,
+        ablations_per_eval=(1,),
+        baselines=None,
+        target=0,
+        attribute_to_layer_input=False,
+    ):
+        for batch_size in ablations_per_eval:
+            ablation = LayerFeatureAblation(model, layer)
+            attributions = ablation.attribute(
+                test_input,
+                target=target,
+                layer_mask=layer_mask,
+                additional_forward_args=additional_input,
+                layer_baselines=baselines,
+                ablations_per_eval=batch_size,
+                attribute_to_layer_input=attribute_to_layer_input,
+            )
+            assertTensorAlmostEqual(self, attributions, expected_ablation)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/attr/test_targets.py
+++ b/tests/attr/test_targets.py
@@ -16,6 +16,7 @@ from captum.attr._core.layer.internal_influence import InternalInfluence
 from captum.attr._core.layer.layer_conductance import LayerConductance
 from captum.attr._core.layer.layer_integrated_gradients import LayerIntegratedGradients
 from captum.attr._core.layer.layer_gradient_x_activation import LayerGradientXActivation
+from captum.attr._core.layer.layer_feature_ablation import LayerFeatureAblation
 
 from captum.attr._core.neuron.neuron_conductance import NeuronConductance
 
@@ -434,6 +435,17 @@ class Test(BaseTest):
             target_layer=net.relu,
             additional_forward_args=(None, True),
             targets=[(1, 0, 0), (0, 1, 1), (1, 1, 1), (0, 0, 0)],
+        )
+
+    def test_simple_target_layer_ablation_tensor(self):
+        net = BasicModel_MultiLayer()
+        inp = torch.randn(4, 3)
+        self._target_batch_test_assert(
+            LayerFeatureAblation,
+            net,
+            inputs=inp,
+            target_layer=net.relu,
+            targets=torch.tensor([0, 1, 1, 0]),
         )
 
     def test_simple_target_neuron_conductance(self):


### PR DESCRIPTION
This PR adds layer ablation, which computes the attribution of the input / output of a layer, by setting each neuron or group of neurons to a given baseline and measuring the difference in output value. This is analogous to feature ablation for layer attribution, with baselines and feature masks given with respect to the layer input / output size.

Differential Revision: D18670637

