### PR TITLE
Adding Neuron Ablation

### DIFF
--- a/captum/attr/__init__.py
+++ b/captum/attr/__init__.py
@@ -17,6 +17,7 @@ from ._core.layer.internal_influence import InternalInfluence  # noqa
 from ._core.layer.grad_cam import LayerGradCam  # noqa
 from ._core.layer.layer_deep_lift import LayerDeepLift, LayerDeepLiftShap  # noqa
 from ._core.layer.layer_gradient_shap import LayerGradientShap  # noqa
+from ._core.neuron.neuron_feature_ablation import NeuronFeatureAblation  # noqa
 from ._core.neuron.neuron_conductance import NeuronConductance  # noqa
 from ._core.neuron.neuron_gradient import NeuronGradient  # noqa
 from ._core.neuron.neuron_integrated_gradients import NeuronIntegratedGradients  # noqa
@@ -60,6 +61,7 @@ __all__ = [
     "LayerDeepLift",
     "LayerDeepLiftShap",
     "NeuronConductance",
+    "NeuronFeatureAblation",
     "NeuronGradient",
     "NeuronIntegratedGradients",
     "NeuronDeepLift",

--- a/captum/attr/_core/neuron/neuron_feature_ablation.py
+++ b/captum/attr/_core/neuron/neuron_feature_ablation.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+import torch
+
+from ..._utils.attribution import NeuronAttribution, PerturbationAttribution
+from ..._utils.common import _verify_select_column
+from ..._utils.gradient import _forward_layer_eval
+
+from ..feature_ablation import FeatureAblation
+
+
+class NeuronFeatureAblation(NeuronAttribution, PerturbationAttribution):
+    def __init__(self, forward_func, layer, device_ids=None):
+        r"""
+        Args:
+
+            forward_func (callable):  The forward function of the model or any
+                          modification of it
+            layer (torch.nn.Module): Layer for which attributions are computed.
+                          Attributions for a particular neuron in the input or output
+                          of this layer are computed using the argument neuron_index
+                          in the attribute method.
+                          Currently, it is assumed that the inputs or the outputs
+                          of the layer, depending on which one is used for
+                          attribution, can only be a single tensor.
+            device_ids (list(int)): Device ID list, necessary only if forward_func
+                          applies a DataParallel model. This allows reconstruction of
+                          intermediate outputs from batched results across devices.
+                          If forward_func is given as the DataParallel model itself,
+                          then it is not necessary to provide this argument.
+        """
+        NeuronAttribution.__init__(self, forward_func, layer, device_ids)
+        PerturbationAttribution.__init__(self, forward_func)
+
+    def attribute(
+        self,
+        inputs,
+        neuron_index,
+        baselines=None,
+        additional_forward_args=None,
+        feature_mask=None,
+        attribute_to_neuron_input=False,
+        ablations_per_eval=1,
+    ):
+        r"""
+            A perturbation based approach to computing neuron attribution,
+            involving replacing each input feature with a given baseline /
+            reference, and computing the difference in the neuron's input / output.
+            By default, each scalar value within
+            each input tensor is taken as a feature and replaced independently. Passing
+            a feature mask, allows grouping features to be ablated together. This can
+            be used in cases such as images, where an entire segment or region
+            can be ablated, measuring the importance of the segment (feature group).
+            Each input scalar in the group will be given the same attribution value
+            equal to the change in target as a result of ablating the entire feature
+            group.
+
+
+            Args:
+
+                inputs (tensor or tuple of tensors):  Input for which neuron
+                            attributions are computed. If forward_func takes a single
+                            tensor as input, a single input tensor should be provided.
+                            If forward_func takes multiple tensors as input, a tuple
+                            of the input tensors should be provided. It is assumed
+                            that for all given input tensors, dimension 0 corresponds
+                            to the number of examples, and if multiple input tensors
+                            are provided, the examples must be aligned appropriately.
+                neuron_index (int or tuple): Index of neuron in output of given
+                              layer for which attribution is desired. The length of
+                              this tuple must be one less than the number of
+                              dimensions in the output of the given layer (since
+                              dimension 0 corresponds to number of examples).
+                              An integer may be provided instead of a tuple of
+                              length 1.
+                baselines (scalar, tensor, tuple of scalars or tensors, optional):
+                            Baselines define reference value which replaces each
+                            feature when ablated.
+                            Baselines can be provided as:
+                            - a single tensor, if inputs is a single tensor, with
+                                exactly the same dimensions as inputs or
+                                broadcastable to match the dimensions of inputs
+                            - a single scalar, if inputs is a single tensor, which will
+                                be broadcasted for each input value in input tensor.
+                            - a tuple of tensors or scalars, the baseline corresponding
+                                to each tensor in the inputs' tuple can be:
+                                - either a tensor with
+                                    exactly the same dimensions as inputs or
+                                    broadcastable to match the dimensions of inputs
+                                - or a scalar, corresponding to a tensor in the
+                                    inputs' tuple. This scalar value is broadcasted
+                                    for corresponding input tensor.
+                            In the cases when `baselines` is not provided, we internally
+                            use zero scalar corresponding to each input tensor.
+                            Default: None
+                additional_forward_args (tuple, optional): If the forward function
+                            requires additional arguments other than the inputs for
+                            which attributions should not be computed, this argument
+                            can be provided. It must be either a single additional
+                            argument of a Tensor or arbitrary (non-tuple) type or a
+                            tuple containing multiple additional arguments including
+                            tensors or any arbitrary python types. These arguments
+                            are provided to forward_func in order following the
+                            arguments in inputs.
+                            Note that attributions are not computed with respect
+                            to these arguments.
+                            Default: None
+                feature_mask (tensor or tuple of tensors, optional):
+                            feature_mask defines a mask for the input, grouping
+                            features which should be ablated together. feature_mask
+                            should contain the same number of tensors as inputs.
+                            Each tensor should
+                            be the same size as the corresponding input or
+                            broadcastable to match the input tensor. Each tensor
+                            should contain integers in the range 0 to num_features
+                            - 1, and indices corresponding to the same feature should
+                            have the same value.
+                            Note that features within each input tensor are ablated
+                            independently (not across tensors).
+                            If None, then a feature mask is constructed which assigns
+                            each scalar within a tensor as a separate feature, which
+                            is ablated independently.
+                            Default: None
+                attribute_to_neuron_input (bool, optional): Indicates whether to
+                            compute the attributions with respect to the neuron input
+                            or output. If `attribute_to_neuron_input` is set to True
+                            then the attributions will be computed with respect to
+                            neuron's inputs, otherwise it will be computed with respect
+                            to neuron's outputs.
+                            Note that currently it is assumed that either the input
+                            or the output of internal neurons, depending on whether we
+                            attribute to the input or output, is a single tensor.
+                            Support for multiple tensors will be added later.
+                            Default: False
+                ablations_per_eval (int, optional): Allows ablation of multiple features
+                            to be processed simultaneously in one call to forward_fn.
+                            Each forward pass will contain a maximum of
+                            ablations_per_eval * #examples samples.
+                            For DataParallel models, each batch is split among the
+                            available devices, so evaluations on each available
+                            device contain at most
+                            (ablations_per_eval * #examples) / num_devices
+                            samples.
+                            Default: 1
+
+            Returns:
+                *tensor* or tuple of *tensors* of **attributions**:
+                - **attributions** (*tensor* or tuple of *tensors*):
+                            Attributions of particular neuron with respect to each input
+                            feature. Attributions will always be the same size as the
+                            provided inputs, with each value providing the attribution
+                            of the corresponding input index.
+                            If a single tensor is provided as inputs, a single tensor is
+                            returned. If a tuple is provided for inputs, a tuple of
+                            corresponding sized tensors is returned.
+
+        Examples::
+
+            >>> # SimpleClassifier takes a single input tensor of size Nx4x4,
+            >>> # and returns an Nx3 tensor of class probabilities.
+            >>> # It contains an attribute conv1, which is an instance of nn.conv2d,
+            >>> # and the output of this layer has dimensions Nx12x3x3.
+            >>> net = SimpleClassifier()
+            >>> # Generating random input with size 2 x 4 x 4
+            >>> input = torch.randn(2, 4, 4)
+            >>> # Defining NeuronFeatureAblation interpreter
+            >>> ablator = NeuronFeatureAblation(net, net.conv1)
+            >>> # To compute neuron attribution, we need to provide the neuron
+            >>> # index for which attribution is desired. Since the layer output
+            >>> # is Nx12x3x3, we need a tuple in the form (0..11,0..2,0..2)
+            >>> # which indexes a particular neuron in the layer output.
+            >>> # For this example, we choose the index (4,1,2).
+            >>> # Computes neuron gradient for neuron with
+            >>> # index (4,1,2).
+            >>> # Computes ablation attribution, ablating each of the 16
+            >>> # scalar inputs independently.
+            >>> attr = ablator.attribute(input, neuron_index=(4,1,2))
+
+            >>> # Alternatively, we may want to ablate features in groups, e.g.
+            >>> # grouping each 2x2 square of the inputs and ablating them together.
+            >>> # This can be done by creating a feature mask as follows, which
+            >>> # defines the feature groups, e.g.:
+            >>> # +---+---+---+---+
+            >>> # | 0 | 0 | 1 | 1 |
+            >>> # +---+---+---+---+
+            >>> # | 0 | 0 | 1 | 1 |
+            >>> # +---+---+---+---+
+            >>> # | 2 | 2 | 3 | 3 |
+            >>> # +---+---+---+---+
+            >>> # | 2 | 2 | 3 | 3 |
+            >>> # +---+---+---+---+
+            >>> # With this mask, all inputs with the same value are ablated
+            >>> # simultaneously, and the attribution for each input in the same
+            >>> # group (0, 1, 2, and 3) per example are the same.
+            >>> # The attributions can be calculated as follows:
+            >>> # feature mask has dimensions 1 x 4 x 4
+            >>> feature_mask = torch.tensor([[[0,0,1,1],[0,0,1,1],
+            >>>                             [2,2,3,3],[2,2,3,3]]])
+            >>> attr = ablator.attribute(input, neuron_index=(4,1,2),
+            >>>                          feature_mask=feature_mask)
+        """
+
+        def neuron_forward_func(*args):
+            with torch.no_grad():
+                layer_eval = _forward_layer_eval(
+                    self.forward_func,
+                    args,
+                    self.layer,
+                    device_ids=self.device_ids,
+                    attribute_to_layer_input=attribute_to_neuron_input,
+                )
+                return _verify_select_column(layer_eval, neuron_index)
+
+        ablator = FeatureAblation(neuron_forward_func)
+
+        return ablator.attribute(
+            inputs,
+            baselines=baselines,
+            additional_forward_args=additional_forward_args,
+            feature_mask=feature_mask,
+            ablations_per_eval=ablations_per_eval,
+        )

--- a/tests/attr/neuron/test_neuron_ablation.py
+++ b/tests/attr/neuron/test_neuron_ablation.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+
+import unittest
+
+import torch
+from captum.attr._core.neuron.neuron_feature_ablation import NeuronFeatureAblation
+
+from ..helpers.basic_models import (
+    BasicModel_ConvNet_One_Conv,
+    BasicModel_MultiLayer,
+    BasicModel_MultiLayer_MultiInput,
+)
+from ..helpers.utils import assertTensorAlmostEqual, BaseTest
+
+
+class Test(BaseTest):
+    def test_simple_ablation_with_mask(self):
+        net = BasicModel_MultiLayer()
+        inp = torch.tensor([[20.0, 50.0, 30.0]], requires_grad=True)
+        self._ablation_test_assert(
+            net,
+            net.linear2,
+            inp,
+            [280.0, 280.0, 120.0],
+            feature_mask=torch.tensor([[0, 0, 1]]),
+            ablations_per_eval=(1, 2, 3),
+        )
+
+    def test_multi_sample_ablation_with_mask(self):
+        net = BasicModel_MultiLayer()
+        inp = torch.tensor([[2.0, 10.0, 3.0], [20.0, 50.0, 30.0]], requires_grad=True)
+        mask = torch.tensor([[0, 0, 1], [1, 1, 0]])
+        self._ablation_test_assert(
+            net,
+            net.linear2,
+            inp,
+            [[41.0, 41.0, 12.0], [280.0, 280.0, 120.0]],
+            feature_mask=mask,
+            ablations_per_eval=(1, 2, 3),
+        )
+
+    def test_multi_input_ablation_with_mask(self):
+        net = BasicModel_MultiLayer_MultiInput()
+        inp1 = torch.tensor([[23.0, 100.0, 0.0], [20.0, 50.0, 30.0]])
+        inp2 = torch.tensor([[20.0, 50.0, 30.0], [0.0, 100.0, 0.0]])
+        inp3 = torch.tensor([[0.0, 100.0, 10.0], [2.0, 10.0, 3.0]])
+        mask1 = torch.tensor([[1, 1, 1], [0, 1, 0]])
+        mask2 = torch.tensor([[0, 1, 2]])
+        mask3 = torch.tensor([[0, 1, 2], [0, 0, 0]])
+        expected = (
+            [[492.0, 492.0, 492.0], [200.0, 200.0, 200.0]],
+            [[80.0, 200.0, 120.0], [0.0, 400.0, 0.0]],
+            [[0.0, 400.0, 40.0], [60.0, 60.0, 60.0]],
+        )
+        self._ablation_test_assert(
+            net,
+            net.model.linear2,
+            (inp1, inp2, inp3),
+            expected,
+            additional_input=(1,),
+            feature_mask=(mask1, mask2, mask3),
+        )
+        self._ablation_test_assert(
+            net,
+            net.model.linear2,
+            (inp1, inp2),
+            expected[0:1],
+            additional_input=(inp3, 1),
+            feature_mask=(mask1, mask2),
+            ablations_per_eval=(1, 2, 3),
+        )
+        expected_with_baseline = (
+            [[468.0, 468.0, 468.0], [184.0, 192.0, 184.0]],
+            [[68.0, 188.0, 108.0], [-12.0, 388.0, -12.0]],
+            [[-16.0, 384.0, 24.0], [12.0, 12.0, 12.0]],
+        )
+        self._ablation_test_assert(
+            net,
+            net.model.linear2,
+            (inp1, inp2, inp3),
+            expected_with_baseline,
+            additional_input=(1,),
+            feature_mask=(mask1, mask2, mask3),
+            baselines=(2, 3.0, 4),
+            ablations_per_eval=(1, 2, 3),
+        )
+
+    def test_multi_input_ablation(self):
+        net = BasicModel_MultiLayer_MultiInput()
+        inp1 = torch.tensor([[23.0, 100.0, 0.0], [20.0, 50.0, 30.0]])
+        inp2 = torch.tensor([[20.0, 50.0, 30.0], [0.0, 100.0, 0.0]])
+        inp3 = torch.tensor([[0.0, 100.0, 10.0], [2.0, 10.0, 3.0]])
+        baseline1 = torch.tensor([[3.0, 0.0, 0.0]])
+        baseline2 = torch.tensor([[0.0, 1.0, 0.0]])
+        baseline3 = torch.tensor([[1.0, 2.0, 3.0]])
+        self._ablation_test_assert(
+            net,
+            net.model.linear2,
+            (inp1, inp2, inp3),
+            (
+                [[80.0, 400.0, 0.0], [68.0, 200.0, 120.0]],
+                [[80.0, 196.0, 120.0], [0.0, 396.0, 0.0]],
+                [[-4.0, 392.0, 28.0], [4.0, 32.0, 0.0]],
+            ),
+            additional_input=(1,),
+            baselines=(baseline1, baseline2, baseline3),
+            ablations_per_eval=(1, 2, 3),
+        )
+        baseline1_exp = torch.tensor([[3.0, 0.0, 0.0], [3.0, 0.0, 2.0]])
+        baseline2_exp = torch.tensor([[0.0, 1.0, 0.0], [0.0, 1.0, 4.0]])
+        baseline3_exp = torch.tensor([[3.0, 2.0, 4.0], [1.0, 2.0, 3.0]])
+        self._ablation_test_assert(
+            net,
+            net.model.linear2,
+            (inp1, inp2, inp3),
+            (
+                [[80.0, 400.0, 0.0], [68.0, 200.0, 112.0]],
+                [[80.0, 196.0, 120.0], [0.0, 396.0, -16.0]],
+                [[-12.0, 392.0, 24.0], [4.0, 32.0, 0.0]],
+            ),
+            additional_input=(1,),
+            baselines=(baseline1_exp, baseline2_exp, baseline3_exp),
+            ablations_per_eval=(1, 2, 3),
+        )
+
+    def test_simple_multi_input_conv(self):
+        net = BasicModel_ConvNet_One_Conv()
+        inp = torch.arange(16).view(1, 1, 4, 4).type(torch.FloatTensor)
+        inp2 = torch.ones((1, 1, 4, 4))
+        self._ablation_test_assert(
+            net,
+            net.relu2,
+            (inp, inp2),
+            (67 * torch.ones_like(inp), 13 * torch.ones_like(inp2)),
+            feature_mask=(torch.tensor(0), torch.tensor(1)),
+            ablations_per_eval=(1, 2, 4, 8, 12, 16),
+        )
+        self._ablation_test_assert(
+            net,
+            net.relu2,
+            (inp, inp2),
+            (
+                [
+                    [0.0, 2.0, 4.0, 3.0],
+                    [4.0, 9.0, 10.0, 7.0],
+                    [4.0, 13.0, 14.0, 11.0],
+                    [0.0, 0.0, 0.0, 0.0],
+                ],
+                [
+                    [1.0, 2.0, 2.0, 1.0],
+                    [1.0, 2.0, 2.0, 1.0],
+                    [1.0, 2.0, 2.0, 1.0],
+                    [0.0, 0.0, 0.0, 0.0],
+                ],
+            ),
+            ablations_per_eval=(1, 3, 7, 14),
+        )
+
+    def test_simple_multi_input_conv_intermediate(self):
+        net = BasicModel_ConvNet_One_Conv(inplace=True)
+        inp = torch.arange(16).view(1, 1, 4, 4).type(torch.FloatTensor)
+        inp2 = torch.ones((1, 1, 4, 4))
+        self._ablation_test_assert(
+            net,
+            net.relu1,
+            (inp, inp2),
+            (torch.zeros_like(inp), torch.zeros_like(inp2)),
+            feature_mask=(torch.tensor(0), torch.tensor(1)),
+            ablations_per_eval=(1, 2, 4, 8, 12, 16),
+            neuron_index=(1, 0, 0),
+        )
+        self._ablation_test_assert(
+            net,
+            net.relu1,
+            (inp, inp2),
+            (45 * torch.ones_like(inp), 9 * torch.ones_like(inp2)),
+            feature_mask=(torch.tensor(0), torch.tensor(1)),
+            ablations_per_eval=(1, 2, 4, 8, 12, 16),
+            neuron_index=(1, 0, 0),
+            attribute_to_neuron_input=True,
+        )
+        self._ablation_test_assert(
+            net,
+            net.relu1,
+            (inp, inp2),
+            (
+                [
+                    [0.0, 1.0, 2.0, 0.0],
+                    [4.0, 5.0, 6.0, 0.0],
+                    [8.0, 9.0, 10.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0],
+                ],
+                [
+                    [1.0, 1.0, 1.0, 0.0],
+                    [1.0, 1.0, 1.0, 0.0],
+                    [1.0, 1.0, 1.0, 0.0],
+                    [0.0, 0.0, 0.0, 0.0],
+                ],
+            ),
+            ablations_per_eval=(1, 3, 7, 14),
+            neuron_index=(1, 0, 0),
+            attribute_to_neuron_input=True,
+        )
+
+    def _ablation_test_assert(
+        self,
+        model,
+        layer,
+        test_input,
+        expected_ablation,
+        feature_mask=None,
+        additional_input=None,
+        ablations_per_eval=(1,),
+        baselines=None,
+        neuron_index=0,
+        attribute_to_neuron_input=False,
+    ):
+        for batch_size in ablations_per_eval:
+            ablation = NeuronFeatureAblation(model, layer)
+            attributions = ablation.attribute(
+                test_input,
+                neuron_index=neuron_index,
+                feature_mask=feature_mask,
+                additional_forward_args=additional_input,
+                baselines=baselines,
+                ablations_per_eval=batch_size,
+                attribute_to_neuron_input=attribute_to_neuron_input,
+            )
+            if isinstance(expected_ablation, tuple):
+                for i in range(len(expected_ablation)):
+                    assertTensorAlmostEqual(self, attributions[i], expected_ablation[i])
+            else:
+                assertTensorAlmostEqual(self, attributions, expected_ablation)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds neuron ablation, which allows computing feature ablation for the input or output of a particular neuron. Each input feature (or group) is replaced with the corresponding baseline and the difference in neuron value is computed.

Differential Revision: D18670638

