### PR TITLE
Fix url formatting in GradientSHAP implementations

### DIFF
--- a/captum/attr/_core/gradient_shap.py
+++ b/captum/attr/_core/gradient_shap.py
@@ -40,7 +40,8 @@ class GradientShap(GradientAttribution):
         #deep-learning-example-with-gradientexplainer-tensorflowkeraspytorch-models
 
         A Unified Approach to Interpreting Model Predictions
-        http://papers.nips.cc/paper/7062-a-unified-approach-to-interpreting-model-predictions
+        http://papers.nips.cc/paper\
+        7062-a-unified-approach-to-interpreting-model-predictions
 
         GradientShap approximates SHAP values by computing the expectations of
         gradients by randomly sampling from the distribution of baselines/references.

--- a/captum/attr/_core/layer/layer_gradient_shap.py
+++ b/captum/attr/_core/layer/layer_gradient_shap.py
@@ -60,7 +60,8 @@ class LayerGradientShap(LayerAttribution, GradientShap):
         #deep-learning-example-with-gradientexplainer-tensorflowkeraspytorch-models
 
         A Unified Approach to Interpreting Model Predictions
-        http://papers.nips.cc/paper/7062-a-unified-approach-to-interpreting-model-predictions
+        http://papers.nips.cc/paper\
+        7062-a-unified-approach-to-interpreting-model-predictions
 
         GradientShap approximates SHAP values by computing the expectations of
         gradients by randomly sampling from the distribution of baselines/references.

--- a/captum/attr/_core/neuron/neuron_gradient_shap.py
+++ b/captum/attr/_core/neuron/neuron_gradient_shap.py
@@ -47,7 +47,8 @@ class NeuronGradientShap(NeuronAttribution, GradientAttribution):
         #deep-learning-example-with-gradientexplainer-tensorflowkeraspytorch-models
 
         A Unified Approach to Interpreting Model Predictions
-        http://papers.nips.cc/paper/7062-a-unified-approach-to-interpreting-model-predictions
+        http://papers.nips.cc/paper\
+        7062-a-unified-approach-to-interpreting-model-predictions
 
         GradientShap approximates SHAP values by computing the expectations of
         gradients by randomly sampling from the distribution of baselines/references.


### PR DESCRIPTION
There was a linter error about long URL in the documentation. I forgot to push that change.
Pushing it separately in this PR.