### PR TITLE
Enable DataParallel for DeepLift/LayerDeepLift/NeuronDeepLift and its SHAP variants

### DIFF
--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -262,7 +262,6 @@ class DeepLift(GradientAttribution):
 
         self.model.apply(self._register_hooks)
 
-        # input_base_target = _expand_target(target, 2, ExpansionTypes.repeat)
         additional_forward_args = _format_additional_forward_args(
             additional_forward_args
         )
@@ -276,7 +275,7 @@ class DeepLift(GradientAttribution):
         gradients = self.gradient_func(wrapped_forward_func, inputs,)
         if custom_attribution_func is None:
             attributions = tuple(
-                (input - baseline) * gradient  # [: len(input)]
+                (input - baseline) * gradient
                 for input, baseline, gradient in zip(inputs, baselines, gradients)
             )
         else:
@@ -872,9 +871,9 @@ def maxpool(
 
 def _compute_diffs(inputs, outputs):
     input, input_ref = inputs.chunk(2)
-    # if the model is a single non-linear mododule and we apply rescale rule on it
+    # if the model is a single non-linear module and we apply Rescale rule on it
     # we might not be able to perform chunk-ing because the output of the module is
-    # being replaced by model output.
+    # usually being replaced by model output.
     output, output_ref = outputs.chunk(2)
     delta_in = input - input_ref
     delta_out = output - output_ref

--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -453,6 +453,7 @@ class DeepLift(GradientAttribution):
             return self.model.module.register_forward_pre_hook(pre_hook)
         else:
             return self.model.register_forward_pre_hook(pre_hook)
+
     def has_convergence_delta(self):
         return True
 

--- a/captum/attr/_core/layer/layer_deep_lift.py
+++ b/captum/attr/_core/layer/layer_deep_lift.py
@@ -5,7 +5,6 @@ from ..._core.deep_lift import DeepLift, DeepLiftShap
 from ..._utils.gradient import (
     apply_gradient_requirements,
     undo_gradient_requirements,
-    _forward_layer_eval,
     compute_layer_gradients_and_eval,
 )
 
@@ -18,14 +17,13 @@ from ..._utils.common import (
     _tensorize_baseline,
     _call_custom_attribution_func,
     _compute_conv_delta_and_format_attrs,
-    _expand_target,
     _expand_additional_forward_args,
     ExpansionTypes,
 )
 
 
 class LayerDeepLift(LayerAttribution, DeepLift):
-    def __init__(self, model, layer, device_ids=None):
+    def __init__(self, model, layer):
         r"""
         Args:
 
@@ -36,7 +34,7 @@ class LayerDeepLift(LayerAttribution, DeepLift):
                           input or output depending on whether we attribute to the
                           inputs or outputs of the layer.
         """
-        LayerAttribution.__init__(self, model, layer, device_ids)
+        LayerAttribution.__init__(self, model, layer)
         DeepLift.__init__(self, model)
         self.model = model
 
@@ -286,7 +284,7 @@ class LayerDeepLift(LayerAttribution, DeepLift):
 
 
 class LayerDeepLiftShap(LayerDeepLift, DeepLiftShap):
-    def __init__(self, model, layer, device_ids=None):
+    def __init__(self, model, layer):
         r"""
         Args:
 
@@ -297,7 +295,7 @@ class LayerDeepLiftShap(LayerDeepLift, DeepLiftShap):
                           input or output depending on whether we attribute to the
                           inputs or outputs of the layer.
         """
-        LayerDeepLift.__init__(self, model, layer, device_ids)
+        LayerDeepLift.__init__(self, model, layer)
         DeepLiftShap.__init__(self, model)
 
     def attribute(

--- a/captum/attr/_core/layer/layer_deep_lift.py
+++ b/captum/attr/_core/layer/layer_deep_lift.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
-import warnings
 import torch
-import torch.nn as nn
 from ..._utils.attribution import LayerAttribution
 from ..._core.deep_lift import DeepLift, DeepLiftShap
 from ..._utils.gradient import (

--- a/captum/attr/_core/layer/layer_deep_lift.py
+++ b/captum/attr/_core/layer/layer_deep_lift.py
@@ -18,6 +18,7 @@ from ..._utils.common import (
     _call_custom_attribution_func,
     _compute_conv_delta_and_format_attrs,
     _expand_additional_forward_args,
+    _expand_target,
     ExpansionTypes,
 )
 
@@ -228,7 +229,6 @@ class LayerDeepLift(LayerAttribution, DeepLift):
         baselines = _tensorize_baseline(inputs, baselines)
 
         main_model_pre_hook = self._pre_hook_main_model()
-        main_model_hook = self._hook_main_model()
 
         self.model.apply(self._register_hooks)
 
@@ -238,9 +238,14 @@ class LayerDeepLift(LayerAttribution, DeepLift):
         input_base_additional_args = _expand_additional_forward_args(
             additional_forward_args, 2, ExpansionTypes.repeat
         )
-
+        expanded_target = _expand_target(
+            target, 2, expansion_type=ExpansionTypes.repeat
+        )
         wrapped_forward_func = self._construct_forward_func(
-            self.model, (inputs, baselines), target, input_base_additional_args,
+            self.model,
+            (inputs, baselines),
+            expanded_target,
+            input_base_additional_args,
         )
 
         def chunk_output_fn(out):
@@ -273,7 +278,6 @@ class LayerDeepLift(LayerAttribution, DeepLift):
             )
         # remove hooks from all activations
         main_model_pre_hook.remove()
-        main_model_hook.remove()
         self._remove_hooks()
 
         undo_gradient_requirements(inputs, gradient_mask)

--- a/captum/attr/_core/neuron/neuron_deep_lift.py
+++ b/captum/attr/_core/neuron/neuron_deep_lift.py
@@ -6,7 +6,7 @@ from ..deep_lift import DeepLift, DeepLiftShap
 
 
 class NeuronDeepLift(NeuronAttribution, GradientAttribution):
-    def __init__(self, model, layer, device_ids=None):
+    def __init__(self, model, layer):
         r"""
         Args:
 
@@ -18,13 +18,8 @@ class NeuronDeepLift(NeuronAttribution, GradientAttribution):
                           Currently, it is assumed that the inputs or the outputs
                           of the layer, depending on which one is used for
                           attribution, can only be a single tensor.
-            device_ids (list(int)): Device ID list, necessary only if forward_func
-                          applies a DataParallel model. This allows reconstruction of
-                          intermediate outputs from batched results across devices.
-                          If forward_func is given as the DataParallel model itself,
-                          then it is not necessary to provide this argument.
         """
-        NeuronAttribution.__init__(self, model, layer, device_ids)
+        NeuronAttribution.__init__(self, model, layer)
         GradientAttribution.__init__(self, model)
 
     def attribute(
@@ -191,7 +186,7 @@ class NeuronDeepLift(NeuronAttribution, GradientAttribution):
 
 
 class NeuronDeepLiftShap(NeuronAttribution, GradientAttribution):
-    def __init__(self, model, layer, device_ids=None):
+    def __init__(self, model, layer):
         r"""
         Args:
 
@@ -202,14 +197,8 @@ class NeuronDeepLiftShap(NeuronAttribution, GradientAttribution):
                           in the attribute method.
                           Currently, only layers with a single tensor input and output
                           are supported.
-            device_ids (list(int)): Device ID list, necessary only if forward_func
-                          applies a DataParallel model. This allows reconstruction of
-                          intermediate outputs from batched results across devices.
-                          If forward_func is given as the DataParallel model itself,
-                          then it is not necessary to provide this argument.
-
         """
-        NeuronAttribution.__init__(self, model, layer, device_ids)
+        NeuronAttribution.__init__(self, model, layer)
         GradientAttribution.__init__(self, model)
 
     def attribute(
@@ -353,7 +342,6 @@ class NeuronDeepLiftShap(NeuronAttribution, GradientAttribution):
         dl.gradient_func = construct_neuron_grad_fn(
             self.layer,
             neuron_index,
-            device_ids=self.device_ids,
             attribute_to_neuron_input=attribute_to_neuron_input,
             output_fn=lambda out: out.chunk(2)[0],
         )

--- a/captum/attr/_core/neuron/neuron_deep_lift.py
+++ b/captum/attr/_core/neuron/neuron_deep_lift.py
@@ -174,7 +174,6 @@ class NeuronDeepLift(NeuronAttribution, GradientAttribution):
             self.layer,
             neuron_index,
             attribute_to_neuron_input=attribute_to_neuron_input,
-            output_fn=lambda out: out.chunk(2)[0],
         )
 
         return dl.attribute(
@@ -343,7 +342,6 @@ class NeuronDeepLiftShap(NeuronAttribution, GradientAttribution):
             self.layer,
             neuron_index,
             attribute_to_neuron_input=attribute_to_neuron_input,
-            output_fn=lambda out: out.chunk(2)[0],
         )
 
         return dl.attribute(

--- a/captum/attr/_utils/common.py
+++ b/captum/attr/_utils/common.py
@@ -324,7 +324,8 @@ def _select_targets(output, target):
             return torch.gather(output, 1, target.reshape(len(output), 1))
         else:
             raise AssertionError(
-                "Tensor target dimension %r is not valid. %r" % (target.shape, output)
+                "Tensor target dimension %r is not valid. %r"
+                % (target.shape, output.shape)
             )
     elif isinstance(target, list):
         assert len(target) == num_examples, "Target list length does not match output!"

--- a/captum/attr/_utils/common.py
+++ b/captum/attr/_utils/common.py
@@ -344,7 +344,8 @@ def _select_targets(output, target):
 def _run_forward(forward_func, inputs, target=None, additional_forward_args=None):
     forward_func_args = signature(forward_func).parameters
     if len(forward_func_args) == 0:
-        return forward_func()
+        output = forward_func()
+        return output if target is None else _select_targets(output, target)
 
     # make everything a tuple so that it is easy to unpack without
     # using if-statements

--- a/captum/attr/_utils/common.py
+++ b/captum/attr/_utils/common.py
@@ -324,7 +324,7 @@ def _select_targets(output, target):
             return torch.gather(output, 1, target.reshape(len(output), 1))
         else:
             raise AssertionError(
-                "Tensor target dimension %r is not valid." % (target.shape,)
+                "Tensor target dimension %r is not valid. %r" % (target.shape, output)
             )
     elif isinstance(target, list):
         assert len(target) == num_examples, "Target list length does not match output!"
@@ -342,6 +342,10 @@ def _select_targets(output, target):
 
 
 def _run_forward(forward_func, inputs, target=None, additional_forward_args=None):
+    forward_func_args = signature(forward_func).parameters
+    if len(forward_func_args) == 0:
+        return forward_func()
+
     # make everything a tuple so that it is easy to unpack without
     # using if-statements
     inputs = _format_input(inputs)

--- a/captum/attr/_utils/gradient.py
+++ b/captum/attr/_utils/gradient.py
@@ -76,9 +76,9 @@ def compute_gradients(
                         will be passed to forward_fn.
             target_ind: Index of the target class for which gradients
                         must be computed (classification only).
-            args:       Additional input arguments that forward function requires.
-                        It takes an empty tuple (no additional arguments) if no
-                        additional arguments are required
+            additional_forward_args: Additional input arguments that forward
+                        function requires. It takes an empty tuple (no additional
+                        arguments) if no additional arguments are required
     """
     with torch.autograd.set_grad_enabled(True):
         # runs forward pass
@@ -119,6 +119,7 @@ def _forward_layer_eval(
     additional_forward_args=None,
     device_ids=None,
     attribute_to_layer_input=False,
+    output_fn=None,
 ):
     return _forward_layer_eval_with_neuron_grads(
         forward_fn,
@@ -128,6 +129,7 @@ def _forward_layer_eval(
         gradient_neuron_index=None,
         device_ids=device_ids,
         attribute_to_layer_input=attribute_to_layer_input,
+        output_fn=None,
     )
 
 
@@ -250,6 +252,7 @@ def _forward_layer_eval_with_neuron_grads(
     gradient_neuron_index=None,
     device_ids=None,
     attribute_to_layer_input=False,
+    output_fn=None,
 ):
     """
     This method computes forward evaluation for a particular layer using a
@@ -273,6 +276,7 @@ def _forward_layer_eval_with_neuron_grads(
         layer,
         additional_forward_args=additional_forward_args,
         attribute_to_layer_input=attribute_to_layer_input,
+        output_fn=output_fn,
     )
     device_ids = _extract_device_ids(forward_fn, saved_layer, device_ids)
     # Identifies correct device ordering based on device ids.
@@ -339,6 +343,9 @@ def compute_layer_gradients_and_eval(
                         will be passed to forward_fn.
             target_ind: Index of the target class for which gradients
                         must be computed (classification only).
+            output_fn:  An optional function that is applied to the layer inputs or
+                        outputs depending whether the `attribute_to_layer_input` is
+                        set to `True` or `False`
             args:       Additional input arguments that forward function requires.
                         It takes an empty tuple (no additional arguments) if no
                         additional arguments are required
@@ -362,6 +369,7 @@ def compute_layer_gradients_and_eval(
             additional_forward_args=additional_forward_args,
             attribute_to_layer_input=attribute_to_layer_input,
             forward_hook_with_return=True,
+            output_fn=output_fn,
         )
         assert output[0].numel() == 1, (
             "Target not provided when necessary, cannot"

--- a/captum/attr/_utils/gradient.py
+++ b/captum/attr/_utils/gradient.py
@@ -386,8 +386,6 @@ def compute_layer_gradients_and_eval(
         # If only one key exists (standard model), key list simply has one element.
         key_list = _sort_key_list(list(saved_layer.keys()), device_ids)
 
-        for device_id in key_list:
-            print("saved_layer[device_id]: ", saved_layer[device_id], is_layer_tuple)
         all_outputs = _reduce_list(
             [
                 saved_layer[device_id]
@@ -411,7 +409,6 @@ def compute_layer_gradients_and_eval(
             saved_grads = tuple(output_fn(saved_grad) for saved_grad in saved_grads)
 
         all_grads = _reduce_list(saved_grads)
-        print("all_outputs: ", all_outputs)
         if gradient_neuron_index is not None:
             inp_grads = _neuron_gradients(
                 inputs, saved_layer, key_list, gradient_neuron_index

--- a/captum/attr/_utils/gradient.py
+++ b/captum/attr/_utils/gradient.py
@@ -119,7 +119,6 @@ def _forward_layer_eval(
     additional_forward_args=None,
     device_ids=None,
     attribute_to_layer_input=False,
-    output_fn=None,
 ):
     return _forward_layer_eval_with_neuron_grads(
         forward_fn,
@@ -129,7 +128,6 @@ def _forward_layer_eval(
         gradient_neuron_index=None,
         device_ids=device_ids,
         attribute_to_layer_input=attribute_to_layer_input,
-        output_fn=None,
     )
 
 
@@ -141,7 +139,6 @@ def _forward_layer_distributed_eval(
     additional_forward_args=None,
     attribute_to_layer_input=False,
     forward_hook_with_return=False,
-    output_fn=None,
 ):
     r"""
     A helper function that allows to set a hook on model's `layer`, run the forward
@@ -181,8 +178,6 @@ def _forward_layer_distributed_eval(
             else:
                 saved_layer[eval_tsrs[0].device] = tuple(
                     eval_tsr.clone()
-                    if output_fn is None
-                    else output_fn(eval_tsr.clone())
                     for eval_tsr in eval_tsrs
                 )
 
@@ -255,7 +250,6 @@ def _forward_layer_eval_with_neuron_grads(
     gradient_neuron_index=None,
     device_ids=None,
     attribute_to_layer_input=False,
-    output_fn=None,
 ):
     """
     This method computes forward evaluation for a particular layer using a
@@ -279,7 +273,6 @@ def _forward_layer_eval_with_neuron_grads(
         layer,
         additional_forward_args=additional_forward_args,
         attribute_to_layer_input=attribute_to_layer_input,
-        output_fn=output_fn,
     )
     device_ids = _extract_device_ids(forward_fn, saved_layer, device_ids)
     # Identifies correct device ordering based on device ids.
@@ -372,7 +365,6 @@ def compute_layer_gradients_and_eval(
             additional_forward_args=additional_forward_args,
             attribute_to_layer_input=attribute_to_layer_input,
             forward_hook_with_return=True,
-            output_fn=output_fn,
         )
         assert output[0].numel() == 1, (
             "Target not provided when necessary, cannot"
@@ -423,7 +415,6 @@ def construct_neuron_grad_fn(
     neuron_index,
     device_ids=None,
     attribute_to_neuron_input=False,
-    output_fn=None,
 ):
     def grad_fn(forward_fn, inputs, target_ind=None, additional_forward_args=None):
         _, grads, _ = _forward_layer_eval_with_neuron_grads(
@@ -434,7 +425,6 @@ def construct_neuron_grad_fn(
             neuron_index,
             device_ids=device_ids,
             attribute_to_layer_input=attribute_to_neuron_input,
-            output_fn=output_fn,
         )
         return grads
 

--- a/captum/attr/_utils/gradient.py
+++ b/captum/attr/_utils/gradient.py
@@ -177,8 +177,7 @@ def _forward_layer_distributed_eval(
                 return eval_tsrs_to_return
             else:
                 saved_layer[eval_tsrs[0].device] = tuple(
-                    eval_tsr.clone()
-                    for eval_tsr in eval_tsrs
+                    eval_tsr.clone() for eval_tsr in eval_tsrs
                 )
 
     if attribute_to_layer_input:
@@ -411,10 +410,7 @@ def compute_layer_gradients_and_eval(
 
 
 def construct_neuron_grad_fn(
-    layer,
-    neuron_index,
-    device_ids=None,
-    attribute_to_neuron_input=False,
+    layer, neuron_index, device_ids=None, attribute_to_neuron_input=False,
 ):
     def grad_fn(forward_fn, inputs, target_ind=None, additional_forward_args=None):
         _, grads, _ = _forward_layer_eval_with_neuron_grads(

--- a/tests/attr/helpers/basic_models.py
+++ b/tests/attr/helpers/basic_models.py
@@ -113,6 +113,21 @@ class ReLUDeepLiftModel(nn.Module):
         return 2 * self.relu1(x1) + x3 * self.relu2(x2 - 1.5)
 
 
+class LinearMaxPoolLinearModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # kernel size -> 4
+        self.lin1 = nn.Linear(4, 4, bias=False)
+        self.lin1.weight = nn.Parameter(torch.eye(4, 4))
+        self.pool1 = nn.MaxPool1d(4)
+        self.lin2 = nn.Linear(1, 1, bias=False)
+        self.lin2.weight = nn.Parameter(torch.ones(1, 1))
+
+    def forward(self, x):
+        x = x.unsqueeze(1)
+        return self.lin2(self.pool1(self.lin1(x))[:, 0, :])
+
+
 class BasicModelWithReusableModules(nn.Module):
     def __init__(self):
         super().__init__()

--- a/tests/attr/helpers/basic_models.py
+++ b/tests/attr/helpers/basic_models.py
@@ -109,8 +109,8 @@ class ReLUDeepLiftModel(nn.Module):
         self.relu1 = nn.ReLU()
         self.relu2 = nn.ReLU()
 
-    def forward(self, x1, x2):
-        return 2 * self.relu1(x1) + 2 * self.relu2(x2 - 1.5)
+    def forward(self, x1, x2, x3=2):
+        return 2 * self.relu1(x1) + x3 * self.relu2(x2 - 1.5)
 
 
 class BasicModelWithReusableModules(nn.Module):
@@ -155,8 +155,8 @@ class ReLULinearDeepLiftModel(nn.Module):
         self.l3 = nn.Linear(2, 1, bias=False)
         self.l3.weight = nn.Parameter(torch.tensor([[1.0, 1.0]]))
 
-    def forward(self, x1, x2):
-        return self.l3(self.relu(torch.cat([self.l1(x1), self.l2(x2)], axis=1)))
+    def forward(self, x1, x2, x3=1):
+        return self.l3(self.relu(torch.cat([self.l1(x1), x3 * self.l2(x2)], axis=1)))
 
 
 class Conv1dDeepLiftModel(nn.Module):

--- a/tests/attr/layer/test_layer_deeplift_basic.py
+++ b/tests/attr/layer/test_layer_deeplift_basic.py
@@ -8,9 +8,14 @@ from ..helpers.utils import (
     BaseTest,
     assertTensorAlmostEqual,
     assertTensorTuplesAlmostEqual,
+    assertArraysAlmostEqual,
     assert_delta,
 )
-from ..helpers.basic_models import ReLULinearDeepLiftModel, BasicModel_MultiLayer
+from ..helpers.basic_models import (
+    ReLULinearDeepLiftModel,
+    BasicModel_MultiLayer,
+    LinearMaxPoolLinearModel,
+)
 
 from captum.attr._core.layer.layer_deep_lift import LayerDeepLift, LayerDeepLiftShap
 
@@ -183,6 +188,20 @@ class TestDeepLift(BaseTest):
         self._relu_custom_attr_func_assert(
             attr_method, inputs, baselines, [[2.0], [2.0]]
         )
+
+    def test_lin_maxpool_lin_classification(self):
+        inputs = torch.ones(2, 4)
+        baselines = torch.tensor([[1, 2, 3, 9], [4, 8, 6, 7]]).float()
+
+        model = LinearMaxPoolLinearModel()
+        dl = LayerDeepLift(model, model.pool1)
+        attrs, delta = dl.attribute(
+            inputs, baselines, target=0, return_convergence_delta=True
+        )
+        expected = [[[-8.0]], [[-7.0]]]
+        expected_delta = [0.0, 0.0]
+        assertArraysAlmostEqual(attrs.detach().numpy(), expected)
+        assertArraysAlmostEqual(delta.detach().numpy(), expected_delta)
 
     def _relu_custom_attr_func_assert(self, attr_method, inputs, baselines, expected):
         def custom_attr_func(multipliers, inputs, baselines):

--- a/tests/attr/layer/test_layer_deeplift_basic.py
+++ b/tests/attr/layer/test_layer_deeplift_basic.py
@@ -59,7 +59,7 @@ class TestDeepLift(BaseTest):
             attribute_to_layer_input=True,
             return_convergence_delta=True,
         )
-        assertTensorAlmostEqual(self, attributions, [[0.0, 45.0]])
+        assertTensorAlmostEqual(self, attributions[0], [[0.0, 45.0]])
         assert_delta(self, delta)
 
     def test_linear_layer_deeplift(self):

--- a/tests/attr/layer/test_layer_deeplift_basic.py
+++ b/tests/attr/layer/test_layer_deeplift_basic.py
@@ -47,6 +47,21 @@ class TestDeepLift(BaseTest):
         )
         assert_delta(self, delta)
 
+    def test_relu_layer_deeplift_add_args(self):
+        model = ReLULinearDeepLiftModel()
+        inputs, baselines = _create_inps_and_base_for_deeplift_neuron_layer_testing()
+
+        layer_dl = LayerDeepLift(model, model.relu)
+        attributions, delta = layer_dl.attribute(
+            inputs,
+            baselines,
+            additional_forward_args=3.0,
+            attribute_to_layer_input=True,
+            return_convergence_delta=True,
+        )
+        assertTensorAlmostEqual(self, attributions, [[0.0, 45.0]])
+        assert_delta(self, delta)
+
     def test_linear_layer_deeplift(self):
         model = ReLULinearDeepLiftModel(inplace=True)
         inputs, baselines = _create_inps_and_base_for_deeplift_neuron_layer_testing()

--- a/tests/attr/test_data_parallel.py
+++ b/tests/attr/test_data_parallel.py
@@ -534,7 +534,6 @@ class Test(BaseGPUTest):
             net,
             None,
             inputs=(inp1, inp2),
-            alt_device_ids=True,
             additional_forward_args=None,
             test_batches=False,
         )
@@ -553,7 +552,6 @@ class Test(BaseGPUTest):
             net,
             net.l3,
             inputs=(inp1, inp2),
-            alt_device_ids=True,
             additional_forward_args=None,
             test_batches=False,
         )
@@ -575,7 +573,6 @@ class Test(BaseGPUTest):
             net,
             net.l3,
             inputs=(inp1, inp2),
-            alt_device_ids=True,
             baselines=(base1, base2),
             additional_forward_args=None,
             test_batches=False,
@@ -802,7 +799,7 @@ class Test(BaseGPUTest):
             attr_orig = algorithm(model, target_layer)
             if alt_device_ids:
                 attr_dp = algorithm(
-                    dp_model, target_layer, device_ids=self._alt_device_list()
+                    dp_model.forward, target_layer, device_ids=self._alt_device_list()
                 )
             else:
                 attr_dp = algorithm(dp_model, target_layer)

--- a/tests/attr/test_deeplift_classification.py
+++ b/tests/attr/test_deeplift_classification.py
@@ -34,9 +34,9 @@ class Test(BaseTest):
         assertAttributionComparision(self, (attributions,), (attributions_ig,))
 
     def test_softmax_classification_zero_baseline(self):
-        num_in = 40
+        num_in = 20
         input = torch.arange(0.0, num_in * 1.0, requires_grad=True).unsqueeze(0)
-        baselines = 0 * input
+        baselines = 0.0
 
         model = SoftmaxDeepLiftModel(num_in, 20, 10)
         dl = DeepLift(model)
@@ -46,12 +46,13 @@ class Test(BaseTest):
     def test_softmax_classification_batch_zero_baseline(self):
         num_in = 40
         input = torch.arange(0.0, num_in * 3.0, requires_grad=True).reshape(3, num_in)
-        baselines = 0 * input
-
+        baselines = 0
         model = SoftmaxDeepLiftModel(num_in, 20, 10)
         dl = DeepLift(model)
 
-        self.softmax_classification(model, dl, input, baselines, torch.tensor(2))
+        self.softmax_classification(
+            model, dl, input, baselines, torch.tensor([2, 2, 2])
+        )
 
     def test_softmax_classification_batch_multi_target(self):
         num_in = 40
@@ -139,7 +140,7 @@ class Test(BaseTest):
             "some samples".format(delta),
         )
         # compare with integrated gradients
-        if inputs.shape == baselines.shape:
+        if isinstance(baselines, (int, float)) or inputs.shape == baselines.shape:
             ig = IntegratedGradients(model)
             attributions_ig = ig.attribute(inputs, baselines=baselines, target=target)
             assertAttributionComparision(self, attributions, attributions_ig)

--- a/tests/attr/test_deeplift_classification.py
+++ b/tests/attr/test_deeplift_classification.py
@@ -94,6 +94,15 @@ class Test(BaseTest):
 
         self.softmax_classification(model, dl, input, baseline, torch.tensor(2))
 
+    def test_convnet_with_maxpool3d_large_baselines(self):
+        input = 100 * torch.randn(2, 1, 10, 10, 10, requires_grad=True)
+        baseline = 600 * torch.randn(2, 1, 10, 10, 10)
+
+        model = BasicModel_ConvNet_MaxPool3d()
+        dl = DeepLift(model)
+
+        self.softmax_classification(model, dl, input, baseline, torch.tensor(2))
+
     def test_convnet_with_maxpool2d(self):
         input = 100 * torch.randn(2, 1, 10, 10, requires_grad=True)
         baseline = 20 * torch.randn(2, 1, 10, 10)
@@ -103,9 +112,27 @@ class Test(BaseTest):
 
         self.softmax_classification(model, dl, input, baseline, torch.tensor(2))
 
+    def test_convnet_with_maxpool2d_large_baselines(self):
+        input = 100 * torch.randn(2, 1, 10, 10, requires_grad=True)
+        baseline = 500 * torch.randn(2, 1, 10, 10)
+
+        model = BasicModel_ConvNet()
+        dl = DeepLift(model)
+
+        self.softmax_classification(model, dl, input, baseline, torch.tensor(2))
+
     def test_convnet_with_maxpool1d(self):
         input = 100 * torch.randn(2, 1, 10, requires_grad=True)
         baseline = 20 * torch.randn(2, 1, 10)
+
+        model = BasicModel_ConvNet_MaxPool1d()
+        dl = DeepLift(model)
+
+        self.softmax_classification(model, dl, input, baseline, torch.tensor(2))
+
+    def test_convnet_with_maxpool1d_large_baselines(self):
+        input = 100 * torch.randn(2, 1, 10, requires_grad=True)
+        baseline = 500 * torch.randn(2, 1, 10)
 
         model = BasicModel_ConvNet_MaxPool1d()
         dl = DeepLift(model)

--- a/tests/attr/test_targets.py
+++ b/tests/attr/test_targets.py
@@ -17,6 +17,7 @@ from captum.attr._core.layer.layer_conductance import LayerConductance
 from captum.attr._core.layer.layer_integrated_gradients import LayerIntegratedGradients
 from captum.attr._core.layer.layer_gradient_x_activation import LayerGradientXActivation
 from captum.attr._core.layer.layer_feature_ablation import LayerFeatureAblation
+from captum.attr._core.layer.layer_deep_lift import LayerDeepLift, LayerDeepLiftShap
 
 from captum.attr._core.neuron.neuron_conductance import NeuronConductance
 
@@ -389,6 +390,26 @@ class Test(BaseTest):
             additional_forward_args=(None, True),
             targets=[(1, 0, 0), (0, 1, 1), (1, 1, 1), (0, 0, 0)],
             test_batches=True,
+        )
+
+    def test_simple_target_layer_deeplift(self):
+        net = BasicModel_MultiLayer()
+        inp = torch.randn(4, 3)
+        self._target_batch_test_assert(
+            LayerDeepLift, net, inputs=inp, target_layer=net.relu, targets=[0, 1, 1, 0],
+        )
+
+    def test_simple_target_layer_deeplift_shap(self):
+        net = BasicModel_MultiLayer()
+        inp = torch.randn(4, 3)
+        baseline = torch.randn(6, 3)
+        self._target_batch_test_assert(
+            LayerDeepLiftShap,
+            net,
+            inputs=inp,
+            target_layer=net.relu,
+            targets=[0, 1, 1, 0],
+            baselines=baseline,
         )
 
     def test_simple_target_layer_ig(self):


### PR DESCRIPTION
This PR enables DataParallel models for DeepLift/LayerDeepLift/NeuronDeepLift and its SHAP variants.
This required to pass inputs and baselines as a tuple and concatenate those in the main module's forward_pre_hook. The output is then being chunked in the forward_hook of the same module.

In addition to that I also needed to extend `compute_layer_gradients_and_eval ` and `_forward_layer_eval_with_neuron_grads` and enable a custom function that in this case chunks the inputs of the selected `layer` and the outputs of the selected `neuron` in the layer and neuron variants.

I also enabled cross_max output for the maxpool functions.
