### PR TITLE
Extend interpretable embedding with multiple args

### DIFF
--- a/captum/attr/_models/base.py
+++ b/captum/attr/_models/base.py
@@ -5,10 +5,10 @@ import torch
 import warnings
 
 from functools import reduce
-from torch.nn import Embedding
+from torch.nn import Module
 
 
-class InterpretableEmbeddingBase(Embedding):
+class InterpretableEmbeddingBase(Module):
     r"""
         Since some embedding vectors, e.g. word are created and assigned in
         the embedding layers of Pytorch models we need a way to access
@@ -21,11 +21,18 @@ class InterpretableEmbeddingBase(Embedding):
     """
 
     def __init__(self, embedding, full_name):
-        super().__init__(embedding.num_embeddings, embedding.embedding_dim)
+        Module.__init__(self)
+        self.num_embeddings = (
+            embedding.num_embeddings if hasattr(embedding, "num_embeddings") else None
+        )
+        self.embedding_dim = (
+            embedding.embedding_dim if hasattr(embedding, "embedding_dim") else None
+        )
+
         self.embedding = embedding
         self.full_name = full_name
 
-    def forward(self, input):
+    def forward(self, input, *other_inputs, **kwargs):
         r"""
          The forward function of a wrapper embedding layer that takes and returns
          embedding layer. It allows embeddings to be created outside of the model
@@ -33,8 +40,15 @@ class InterpretableEmbeddingBase(Embedding):
 
          Args:
 
-            inputs (tensor): Input embedding tensor containing the embedding vectors
-                    of each word or token in the sequence.
+            input (tensor): Embedding tensor generated using the `self.embedding`
+                    layer using `other_inputs` and `kwargs` of necessary.
+            *other_inputs (Any, optional): A sequence of additional inputs that the
+                    forward function takes. Since forward functions can take any
+                    type and number of arguments, this will ensure that we can
+                    execute the forward pass using interpretable embedding layer
+            **kwargs (Any, optional): Similar to `other_inputs` we want to make sure
+                    that our forward pass supports arbitrary number and type of
+                    key-value arguments
 
          Returns:
 
@@ -45,22 +59,25 @@ class InterpretableEmbeddingBase(Embedding):
         """
         return input
 
-    def indices_to_embeddings(self, input):
+    def indices_to_embeddings(self, *input, **kwargs):
         r"""
         Maps indices to corresponding embedding vectors. E.g. word embeddings
 
         Args:
 
-            input (tensor): A tensor of input indices. A typical example of an
-                   input index is word or token index.
-
+            *input (Any, Optional): This can be a tensor(s) of input indices or any
+                    other variable necessary to comput the embeddings. A typical
+                    example of input indices are word or token indices.
+            **kwargs (Any, optional): Similar to `input` this can be any sequence
+                    of key-value arguments necessary to compute final embedding
+                    tensor.
         Returns:
 
             tensor:
             A tensor of word embeddings corresponding to the
             indices specified in the input
         """
-        return self.embedding(input)
+        return self.embedding(*input, **kwargs)
 
 
 class TokenReferenceBase:

--- a/captum/attr/_models/base.py
+++ b/captum/attr/_models/base.py
@@ -22,8 +22,8 @@ class InterpretableEmbeddingBase(Module):
 
     def __init__(self, embedding, full_name):
         Module.__init__(self)
-        self.num_embeddings = getattr(embedding, 'num_embeddings', None)
-        self.embedding_dim = getattr(embedding, 'embedding_dim', None)
+        self.num_embeddings = getattr(embedding, "num_embeddings", None)
+        self.embedding_dim = getattr(embedding, "embedding_dim", None)
 
         self.embedding = embedding
         self.full_name = full_name

--- a/captum/attr/_models/base.py
+++ b/captum/attr/_models/base.py
@@ -22,12 +22,8 @@ class InterpretableEmbeddingBase(Module):
 
     def __init__(self, embedding, full_name):
         Module.__init__(self)
-        self.num_embeddings = (
-            embedding.num_embeddings if hasattr(embedding, "num_embeddings") else None
-        )
-        self.embedding_dim = (
-            embedding.embedding_dim if hasattr(embedding, "embedding_dim") else None
-        )
+        self.num_embeddings = getattr(embedding, 'num_embeddings', None)
+        self.embedding_dim = getattr(embedding, 'embedding_dim', None)
 
         self.embedding = embedding
         self.full_name = full_name

--- a/tests/attr/models/test_base.py
+++ b/tests/attr/models/test_base.py
@@ -7,13 +7,15 @@ import unittest
 
 from torch.nn import Embedding
 
+from ..helpers.utils import assertArraysAlmostEqual
+
 from captum.attr._models.base import (
     configure_interpretable_embedding_layer,
     remove_interpretable_embedding_layer,
     InterpretableEmbeddingBase,
 )
 
-from ..helpers.basic_models import BasicEmbeddingModel
+from ..helpers.basic_models import BasicEmbeddingModel, TextModule
 
 
 class Test(unittest.TestCase):
@@ -59,14 +61,72 @@ class Test(unittest.TestCase):
         remove_interpretable_embedding_layer(model, interpretable_embedding1)
         self.assertTrue(model.embedding1.__class__ is Embedding)
 
+    def test_custom_module(self):
+        input = torch.tensor([[3, 2, 0], [1, 2, 4]])
+        model = BasicEmbeddingModel()
+        output = model(input)
+        expected = model.embedding2(input)
+        # in this case we make interpretable the custom embedding layer - TextModule
+        interpretable_embedding = configure_interpretable_embedding_layer(
+            model, "embedding2"
+        )
+        actual = interpretable_embedding.indices_to_embeddings(input)
+
+        # using assertArraysAlmostEqual instead of assertTensorAlmostEqual because
+        # it is important and necessary that each element in comparing tensors
+        # match exactly, even if we take `max` instead of `sum` in the
+        # assertTensorAlmostEqual it will not guarantee that all elements will
+        # match exactly in the comparing tensors.
+        # We should keep this in mind during refactoring or using
+        # any of those functions.
+        assertArraysAlmostEqual(expected, actual, 0.0)
+        self.assertTrue(model.embedding2.__class__ is InterpretableEmbeddingBase)
+        remove_interpretable_embedding_layer(model, interpretable_embedding)
+        self.assertTrue(model.embedding2.__class__ is TextModule)
+        self._assert_embeddings_equal(input, output, interpretable_embedding)
+
+    def test_nested_multi_embeddings(self):
+        input = torch.tensor([[3, 2, 0], [1, 2, 4]])
+        input2 = torch.tensor([[0, 1, 0], [2, 6, 8]])
+        model = BasicEmbeddingModel(nested_second_embedding=True)
+        output = model(input, input2)
+        expected = model.embedding2(input, input2)
+        # in this case we make interpretable the custom embedding layer - TextModule
+        interpretable_embedding = configure_interpretable_embedding_layer(
+            model, "embedding2"
+        )
+        actual = interpretable_embedding.indices_to_embeddings(
+            input, another_input=input2
+        )
+
+        # using assertArraysAlmostEqual instead of assertTensorAlmostEqual because
+        # it is important and necessary that each element in comparing tensors
+        # match exactly, even if we take `max` instead of `sum` in the
+        # assertTensorAlmostEqual it will not guarantee that all elements will
+        # match exactly in the comparing tensors.
+        # We should keep this in mind during refactoring or using
+        # any of those functions.
+        assertArraysAlmostEqual(expected, actual, 0.0)
+        self.assertTrue(model.embedding2.__class__ is InterpretableEmbeddingBase)
+        remove_interpretable_embedding_layer(model, interpretable_embedding)
+        self.assertTrue(model.embedding2.__class__ is TextModule)
+        self._assert_embeddings_equal(input, output, interpretable_embedding)
+
     def _assert_embeddings_equal(
-        self, input, output, interpretable_embedding, embedding_dim, num_embeddings
+        self,
+        input,
+        output,
+        interpretable_embedding,
+        embedding_dim=None,
+        num_embeddings=None,
     ):
-        self.assertEqual(embedding_dim, interpretable_embedding.embedding_dim)
-        self.assertEqual(num_embeddings, interpretable_embedding.num_embeddings)
+        if interpretable_embedding.embedding_dim is not None:
+            self.assertEqual(embedding_dim, interpretable_embedding.embedding_dim)
+            self.assertEqual(num_embeddings, interpretable_embedding.num_embeddings)
 
         # dim - [4, 100]
         emb_shape = interpretable_embedding.indices_to_embeddings(input).shape
         self.assertEqual(emb_shape[0], input.shape[0])
-        self.assertEqual(emb_shape[1], interpretable_embedding.embedding_dim)
+        if interpretable_embedding.embedding_dim is not None:
+            self.assertEqual(emb_shape[1], interpretable_embedding.embedding_dim)
         self.assertEqual(input.shape, output.shape)

--- a/tutorials/IMDB_TorchText_Interpret.ipynb
+++ b/tutorials/IMDB_TorchText_Interpret.ipynb
@@ -15,14 +15,14 @@
    "source": [
     "This notebook loads pretrained CNN model for sentiment analysis on IMDB dataset. It makes predictions on test samples and interprets those predictions using integrated gradients method.\n",
     "\n",
-    "The model was trained using an open source sentiment analysis tutorials described in:https://github.com/bentrevett/pytorch-sentiment-analysis/blob/master/4%20-%20Convolutional%20Sentiment%20Analysis.ipynb\n",
-    "  \n",
+    "The model was trained using an open source sentiment analysis tutorials described in: https://github.com/bentrevett/pytorch-sentiment-analysis/blob/master/4%20-%20Convolutional%20Sentiment%20Analysis.ipynb\n",
+    "\n",
     "**Note:** Before running this tutorial, please install the spacy package, and its NLP modules for English language."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,13 +127,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "model = torch.load('models/imdb-model-cnn.pt')\n",
     "model.eval()\n",
-    "model.to(device)"
+    "model = model.to(device)"
    ]
   },
   {
@@ -268,7 +268,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -301,7 +301,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -367,7 +367,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -401,7 +401,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -438,7 +438,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -448,7 +448,7 @@
        "<IPython.core.display.Image object>"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -467,7 +467,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/tutorials/IMDB_TorchText_Interpret.ipynb
+++ b/tutorials/IMDB_TorchText_Interpret.ipynb
@@ -15,8 +15,8 @@
    "source": [
     "This notebook loads pretrained CNN model for sentiment analysis on IMDB dataset. It makes predictions on test samples and interprets those predictions using integrated gradients method.\n",
     "\n",
-    "The model was trained using an open source sentiment analysis tutorials described in: https://github.com/bentrevett/pytorch-sentiment-analysis/blob/master/4%20-%20Convolutional%20Sentiment%20Analysis.ipynb\n  ",
-    "\n  ",
+    "The model was trained using an open source sentiment analysis tutorials described in:https://github.com/bentrevett/pytorch-sentiment-analysis/blob/master/4%20-%20Convolutional%20Sentiment%20Analysis.ipynb\n",
+    "  \n",
     "**Note:** Before running this tutorial, please install the spacy package, and its NLP modules for English language."
    ]
   },
@@ -96,7 +96,7 @@
     "        #text = [batch size, sent len]\n",
     "        \n",
     "        embedded = self.embedding(text)\n",
-    "                \n",
+    "\n",
     "        #embedded = [batch size, sent len, emb dim]\n",
     "        \n",
     "        embedded = embedded.unsqueeze(1)\n",
@@ -127,12 +127,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
     "model = torch.load('models/imdb-model-cnn.pt')\n",
-    "model.eval()"
+    "model.eval()\n",
+    "model.to(device)"
    ]
   },
   {
@@ -267,7 +268,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -308,7 +309,6 @@
     "vis_data_records_ig = []\n",
     "\n",
     "def interpret_sentence(model, sentence, min_len = 7, label = 0):\n",
-    "    model.eval()\n",
     "    text = [tok.text for tok in nlp.tokenizer(sentence)]\n",
     "    if len(text) < min_len:\n",
     "        text += ['pad'] * (min_len - len(text))\n",
@@ -317,7 +317,7 @@
     "    \n",
     "    model.zero_grad()\n",
     "\n",
-    "    input_indices = torch.LongTensor(indexed)\n",
+    "    input_indices = torch.tensor(indexed, device=device)\n",
     "    input_indices = input_indices.unsqueeze(0)\n",
     "    \n",
     "    # input_indices dim: [sequence_length]\n",
@@ -344,7 +344,7 @@
     "def add_attributions_to_visualizer(attributions, text, pred, pred_ind, label, delta, vis_data_records):\n",
     "    attributions = attributions.sum(dim=2).squeeze(0)\n",
     "    attributions = attributions / torch.norm(attributions)\n",
-    "    attributions = attributions.detach().numpy()\n",
+    "    attributions = attributions.cpu().detach().numpy()\n",
     "\n",
     "    # storing couple samples in an array for visualization purposes\n",
     "    vis_data_records.append(visualization.VisualizationDataRecord(\n",

--- a/tutorials/IMDB_TorchText_Interpret.ipynb
+++ b/tutorials/IMDB_TorchText_Interpret.ipynb
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -50,7 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "device = torch.device(\"cuda:5\" if torch.cuda.is_available() else \"cpu\")\n"
+    "device = torch.device(\"cuda:5\" if torch.cuda.is_available() else \"cpu\")"
    ]
   },
   {
@@ -268,7 +268,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -301,7 +301,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -354,7 +354,7 @@
     "                            Label.vocab.itos[label],\n",
     "                            Label.vocab.itos[1],\n",
     "                            attributions.sum(),       \n",
-    "                            text[:len(attributions)],\n",
+    "                            text,\n",
     "                            delta))"
    ]
   },
@@ -367,7 +367,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -401,7 +401,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -438,7 +438,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -448,7 +448,7 @@
        "<IPython.core.display.Image object>"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -467,7 +467,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
This PR extends InterpretableEmbeddingBase to be more generic and support nested embeddings of any types and number of inputs.
I've also added test cases and documentation related to this PR.

In addition to that it looks like in the IMDB tutorial the device was missing and some minor fixes. Adding that as well. 