### PR TITLE
Remove README.md section for direct install

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ pip install captum
 
 **Manual / Dev install**
 
-Alternatively, you can do a manual install. For a basic install, run:
+If you'd like to try our bleeding edge features (and don't mind potentially
+running into the occasional bug here or there), you can install the latest
+master directly from GitHub. For a basic install, run:
 ```bash
 git clone https://github.com/pytorch/captum.git
 cd captum

--- a/README.md
+++ b/README.md
@@ -48,16 +48,6 @@ or via `pip`:
 pip install captum
 ```
 
-
-##### Installing from latest master
-
-If you'd like to try our bleeding edge features (and don't mind potentially
-running into the occasional bug here or there), you can install the latest
-master directly from GitHub:
-```bash
-pip install git+https://github.com/pytorch/captum.git
-```
-
 **Manual / Dev install**
 
 Alternatively, you can do a manual install. For a basic install, run:


### PR DESCRIPTION
We need to run setup.py to build all Captum Insights JS via yarn. Unfortunately the direct install from GitHub doesn't do this, so removing steps from the README.md.

Fixes https://github.com/pytorch/captum/issues/192
