### PR TITLE
Support inplace ReLUs for DeepLift

### DIFF
--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -295,44 +295,62 @@ class DeepLift(GradientAttribution):
     def _is_non_linear(self, module):
         return type(module) in SUPPORTED_NON_LINEAR.keys()
 
-    # we need forward hook to access and detach the inputs and outputs of a neuron
-    def _forward_hook(self, module, inputs, outputs):
-        input_attr_name = "input"
-        output_attr_name = "output"
-        self._detach_tensors(input_attr_name, output_attr_name, module, inputs, outputs)
-        if not _check_valid_module(inputs, outputs):
-            module.is_invalid = True
-            module.saved_grad = None
+    def _forward_pre_hook_ref(self, module, inputs):
+        inputs = _format_tensor_into_tuples(inputs)
+        module.input_ref = tuple(input.clone().detach() for input in inputs)
 
-            def tensor_backward_hook(grad):
-                if module.saved_grad is None:
-                    raise RuntimeError(
-                        """Module {} was detected as not supporting correctly module
+    def _forward_pre_hook(self, module, inputs):
+        """
+        For the modules that perform in-place operations such as ReLUs, we cannot
+        use inputs from forward hooks. This is because in that case inputs
+        and outputs are the same. We need access the inputs in pre-hooks and
+        set necessary hooks on inputs there.
+        """
+        inputs = _format_tensor_into_tuples(inputs)
+        module.input = tuple(input.clone().detach() for input in inputs)
+
+        def tensor_backward_hook(grad):
+            if module.saved_grad is None:
+                raise RuntimeError(
+                    """Module {} was detected as not supporting correctly module
                         backward hook. You should modify your hook to ignore the given
                         grad_inputs (recompute them by hand if needed) and save the
                         newly computed grad_inputs in module.saved_grad. See MaxPool1d
                         as an example.""".format(
-                            module
-                        )
+                        module
                     )
-                return module.saved_grad
+                )
+            return module.saved_grad
 
-            inputs[0].register_hook(tensor_backward_hook)
+        # the hook is set by default but it will be used only for
+        # failure cases and will be removed otherwise
+        handle = inputs[0].register_hook(tensor_backward_hook)
+        module.pre_hook = handle
+
+    def _forward_hook(self, module, inputs, outputs):
+        r"""
+        we need forward hook to access and detach the inputs and
+        outputs of a neuron
+        """
+        outputs = _format_tensor_into_tuples(outputs)
+        module.output = tuple(output.clone().detach() for output in outputs)
+
+        if not _check_valid_module(inputs, outputs[0]):
+            module.is_invalid = True
+            module.saved_grad = None
+            self.forward_handles.append(module.pre_hook)
         else:
             module.is_invalid = False
+            # removing the hook if there is no failure case
+            module.pre_hook.remove()
+        del module.pre_hook
 
     def _forward_hook_ref(self, module, inputs, outputs):
-        input_attr_name = "input_ref"
-        output_attr_name = "output_ref"
-        self._detach_tensors(input_attr_name, output_attr_name, module, inputs, outputs)
-
-    def _detach_tensors(
-        self, input_attr_name, output_attr_name, module, inputs, outputs
-    ):
-        inputs = _format_tensor_into_tuples(inputs)
+        r"""
+        Forward hook is used to access the output of the module
+        """
         outputs = _format_tensor_into_tuples(outputs)
-        setattr(module, input_attr_name, tuple(input.detach() for input in inputs))
-        setattr(module, output_attr_name, tuple(output.detach() for output in outputs))
+        module.output_ref = tuple(output.clone().detach() for output in outputs)
 
     def _backward_hook(self, module, grad_input, grad_output, eps=1e-10):
         r"""
@@ -342,6 +360,21 @@ class DeepLift(GradientAttribution):
          `grad_output` * delta_out / delta_in.
 
          """
+        # before accessing the attributes from the module we want
+        # to ensure that the properties exist, if not, then it is
+        # likely that the module is being reused.
+        attr_criteria = self.satisfies_attribute_criteria(module)
+        if not attr_criteria:
+            raise RuntimeError(
+                """A Module {} was detected that does not contain some of
+                    the input/output attributes that are required for DeepLift
+                    computations. This can occur, for example, if
+                    your module is being used more than once in the network.
+                    Please, ensure that module is being used only once in the
+                    network.""".format(
+                    module
+                )
+            )
         delta_in = tuple(
             inp - inp_ref for inp, inp_ref in zip(module.input, module.input_ref)
         )
@@ -361,6 +394,14 @@ class DeepLift(GradientAttribution):
 
         return multipliers
 
+    def satisfies_attribute_criteria(self, module):
+        return (
+            hasattr(module, "input_ref")
+            and hasattr(module, "output_ref")
+            and hasattr(module, "input")
+            and hasattr(module, "output")
+        )
+
     def _can_register_hook(self, module):
         # TODO find a better way of checking if a module is a container or not
         module_fullname = str(type(module))
@@ -375,15 +416,21 @@ class DeepLift(GradientAttribution):
         if not self._can_register_hook(module):
             return
         forward_handle_ref = module.register_forward_hook(self._forward_hook_ref)
+        forward_pre_handle_ref = module.register_forward_pre_hook(
+            self._forward_pre_hook_ref
+        )
         self.forward_handles_refs.append(forward_handle_ref)
+        self.forward_handles_refs.append(forward_pre_handle_ref)
 
     def _register_hooks(self, module):
         if not self._can_register_hook(module):
             return
         # adds forward hook to leaf nodes that are non-linear
         forward_handle = module.register_forward_hook(self._forward_hook)
+        pre_forward_handle = module.register_forward_pre_hook(self._forward_pre_hook)
         backward_handle = module.register_backward_hook(self._backward_hook)
         self.forward_handles.append(forward_handle)
+        self.forward_handles.append(pre_forward_handle)
         self.backward_handles.append(backward_handle)
 
     def _remove_hooks(self):
@@ -591,7 +638,6 @@ class DeepLiftShap(DeepLift):
         ) = self._expand_inputs_baselines_targets(
             baselines, inputs, target, additional_forward_args
         )
-
         attributions = super().attribute(
             exp_inp,
             exp_base,
@@ -669,6 +715,11 @@ def nonlinear(module, delta_in, delta_out, grad_input, grad_output, eps=1e-10):
         grad_input[0],
         grad_output[0] * delta_out[0] / delta_in[0],
     )
+
+    # If the module is invalid, save the newly computed gradients
+    # The original_grad_input will be overridden later in the Tensor hook
+    if module.is_invalid:
+        module.saved_grad = grad_input[0]
     return grad_input
 
 

--- a/tests/attr/helpers/basic_models.py
+++ b/tests/attr/helpers/basic_models.py
@@ -113,6 +113,17 @@ class ReLUDeepLiftModel(nn.Module):
         return 2 * self.relu1(x1) + 2 * self.relu2(x2 - 1.5)
 
 
+class BasicModelWithReusableModules(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.lin1 = nn.Linear(3, 2)
+        self.relu = nn.ReLU()
+        self.lin2 = nn.Linear(2, 2)
+
+    def forward(self, inputs):
+        return self.relu(self.lin2(self.relu(self.lin1(inputs))))
+
+
 class TanhDeepLiftModel(nn.Module):
     r"""
         Same as the ReLUDeepLiftModel, but with activations
@@ -134,13 +145,13 @@ class ReLULinearDeepLiftModel(nn.Module):
         https://github.com/marcoancona/DeepExplain/blob/master/deepexplain/tests/test_tensorflow.py#L65
     """
 
-    def __init__(self):
+    def __init__(self, inplace=False):
         super().__init__()
         self.l1 = nn.Linear(3, 1, bias=False)
         self.l2 = nn.Linear(3, 1, bias=False)
         self.l1.weight = nn.Parameter(torch.tensor([[3.0, 1.0, 0.0]]))
         self.l2.weight = nn.Parameter(torch.tensor([[2.0, 3.0, 0.0]]))
-        self.relu = nn.ReLU()
+        self.relu = nn.ReLU(inplace=inplace)
         self.l3 = nn.Linear(2, 1, bias=False)
         self.l3.weight = nn.Parameter(torch.tensor([[1.0, 1.0]]))
 

--- a/tests/attr/layer/test_layer_deeplift_basic.py
+++ b/tests/attr/layer/test_layer_deeplift_basic.py
@@ -12,7 +12,7 @@ from captum.attr._core.layer.layer_deep_lift import LayerDeepLift, LayerDeepLift
 
 class TestDeepLift(BaseTest):
     def test_relu_layer_deeplift(self):
-        model = ReLULinearDeepLiftModel()
+        model = ReLULinearDeepLiftModel(inplace=True)
         inputs, baselines = _create_inps_and_base_for_deeplift_neuron_layer_testing()
 
         layer_dl = LayerDeepLift(model, model.relu)
@@ -26,7 +26,7 @@ class TestDeepLift(BaseTest):
         assert_delta(self, delta)
 
     def test_linear_layer_deeplift(self):
-        model = ReLULinearDeepLiftModel()
+        model = ReLULinearDeepLiftModel(inplace=True)
         inputs, baselines = _create_inps_and_base_for_deeplift_neuron_layer_testing()
 
         layer_dl = LayerDeepLift(model, model.l3)
@@ -46,7 +46,7 @@ class TestDeepLift(BaseTest):
         self._relu_custom_attr_func_assert(attr_method, inputs, baselines, [[2.0]])
 
     def test_linear_layer_deeplift_batch(self):
-        model = ReLULinearDeepLiftModel()
+        model = ReLULinearDeepLiftModel(inplace=True)
         _, baselines = _create_inps_and_base_for_deeplift_neuron_layer_testing()
         x1 = torch.tensor(
             [[-10.0, 1.0, -5.0], [-10.0, 1.0, -5.0], [-10.0, 1.0, -5.0]],
@@ -93,7 +93,7 @@ class TestDeepLift(BaseTest):
         assert_delta(self, delta)
 
     def test_linear_layer_deepliftshap(self):
-        model = ReLULinearDeepLiftModel()
+        model = ReLULinearDeepLiftModel(inplace=True)
         (
             inputs,
             baselines,

--- a/tests/attr/neuron/test_neuron_deeplift_basic.py
+++ b/tests/attr/neuron/test_neuron_deeplift_basic.py
@@ -16,7 +16,7 @@ from ..layer.test_layer_deeplift_basic import (
 
 class Test(BaseTest):
     def test_relu_neuron_deeplift(self):
-        model = ReLULinearDeepLiftModel()
+        model = ReLULinearDeepLiftModel(inplace=True)
 
         x1 = torch.tensor([[-10.0, 1.0, -5.0]], requires_grad=True)
         x2 = torch.tensor([[3.0, 3.0, 1.0]], requires_grad=True)
@@ -24,13 +24,24 @@ class Test(BaseTest):
         inputs = (x1, x2)
 
         neuron_dl = NeuronDeepLift(model, model.relu)
-        attributions = neuron_dl.attribute(inputs, 0, attribute_to_neuron_input=True)
-        assertTensorAlmostEqual(self, attributions[0], [[-30.0, 1.0, -0.0]])
-        assertTensorAlmostEqual(self, attributions[1], [[0.0, 0.0, 0.0]])
-
         attributions = neuron_dl.attribute(inputs, 0, attribute_to_neuron_input=False)
         assertTensorAlmostEqual(self, attributions[0], [[0.0, 0.0, 0.0]])
         assertTensorAlmostEqual(self, attributions[1], [[0.0, 0.0, 0.0]])
+
+    def test_deeplift_compare_with_and_without_inplace(self):
+        model1 = ReLULinearDeepLiftModel(inplace=True)
+        model2 = ReLULinearDeepLiftModel()
+        x1 = torch.tensor([[-10.0, 1.0, -5.0]], requires_grad=True)
+        x2 = torch.tensor([[3.0, 3.0, 1.0]], requires_grad=True)
+        inputs = (x1, x2)
+        neuron_dl1 = NeuronDeepLift(model1, model1.relu)
+        attributions1 = neuron_dl1.attribute(inputs, 0, attribute_to_neuron_input=False)
+
+        neuron_dl2 = NeuronDeepLift(model2, model2.relu)
+        attributions2 = neuron_dl2.attribute(inputs, 0, attribute_to_neuron_input=False)
+
+        assertTensorAlmostEqual(self, attributions1[0], attributions2[0])
+        assertTensorAlmostEqual(self, attributions1[1], attributions2[1])
 
     def test_linear_neuron_deeplift(self):
         model = ReLULinearDeepLiftModel()
@@ -65,11 +76,6 @@ class Test(BaseTest):
         ) = _create_inps_and_base_for_deepliftshap_neuron_layer_testing()
 
         neuron_dl = NeuronDeepLiftShap(model, model.relu)
-        attributions = neuron_dl.attribute(
-            inputs, 0, baselines, attribute_to_neuron_input=True
-        )
-        assertTensorAlmostEqual(self, attributions[0], [[-30.0, 1.0, -0.0]])
-        assertTensorAlmostEqual(self, attributions[1], [[0.0, 0.0, 0.0]])
 
         attributions = neuron_dl.attribute(
             inputs, 0, baselines, attribute_to_neuron_input=False

--- a/tests/attr/test_deeplift_classification.py
+++ b/tests/attr/test_deeplift_classification.py
@@ -56,7 +56,7 @@ class Test(BaseTest):
     def test_softmax_classification_batch_multi_target(self):
         num_in = 40
         inputs = torch.arange(0.0, num_in * 3.0, requires_grad=True).reshape(3, num_in)
-        baselines = torch.range(1.0, num_in).unsqueeze(0)
+        baselines = torch.arange(1.0, num_in + 1).reshape(1, num_in)
         model = SoftmaxDeepLiftModel(num_in, 20, 10)
         dl = DeepLift(model)
 


### PR DESCRIPTION
Addresses the problem regarding inplace ReLUs: https://github.com/pytorch/captum/issues/199
To be able to support it I store the inputs in the `forward_pre_hooks` instead of the `forward_hooks`

Added test cases that ensures that it works with in-place ReLUs.
Plus, showing an error if a module gets reused. 