### PR TITLE
render() accepts no parameters in the new API

### DIFF
--- a/tutorials/CIFAR_TorchVision_Captum_Insights.ipynb
+++ b/tutorials/CIFAR_TorchVision_Captum_Insights.ipynb
@@ -147,7 +147,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "visualizer.render(debug=False)"
+    "visualizer.render()"
    ]
   },
   {


### PR DESCRIPTION
The API changed after upgrading to widgets (per T55268540).
The old render(blocking, debug, port) does not work anymore