### PR TITLE
Add support for input forward arguments for embeddings that are only named

### DIFF
--- a/captum/attr/_models/base.py
+++ b/captum/attr/_models/base.py
@@ -28,7 +28,7 @@ class InterpretableEmbeddingBase(Module):
         self.embedding = embedding
         self.full_name = full_name
 
-    def forward(self, input, *other_inputs, **kwargs):
+    def forward(self, *inputs, **kwargs):
         r"""
          The forward function of a wrapper embedding layer that takes and returns
          embedding layer. It allows embeddings to be created outside of the model
@@ -38,22 +38,33 @@ class InterpretableEmbeddingBase(Module):
 
             input (tensor): Embedding tensor generated using the `self.embedding`
                     layer using `other_inputs` and `kwargs` of necessary.
-            *other_inputs (Any, optional): A sequence of additional inputs that the
+            *inputs (Any, optional): A sequence of inputs arguments that the
                     forward function takes. Since forward functions can take any
                     type and number of arguments, this will ensure that we can
-                    execute the forward pass using interpretable embedding layer
-            **kwargs (Any, optional): Similar to `other_inputs` we want to make sure
+                    execute the forward pass using interpretable embedding layer.
+                    Note that if inputs are specified it is assumed that the first
+                    argument is the embedding tensor generated using the `self.embedding`
+                    layer using all imput arguments provided in `inputs` and `kwargs`.
+            **kwargs (Any, optional): Similar to `inputs` we want to make sure
                     that our forward pass supports arbitrary number and type of
-                    key-value arguments
+                    key-value arguments. If `inputs` is not provided, `kwargs` must
+                    be provded and the first argument corresponds to the embedding
+                    tensor generated using the `self.embedding`.
 
          Returns:
 
-            tensor:
-            Returns output tensor which is the same as input tensor.
-            It passes embedding tensors to lower layers without any
-            modifications.
+            embedding_tensor (Tensor):
+                    Returns a tensor which is the same as first argument passed
+                    to the forward function.
+                    It passes pre-computed embedding tensors to lower layers
+                    without any modifications.
         """
-        return input
+        assert len(inputs) > 0 or len(kwargs) > 0, (
+            "No input arguments are provided to `InterpretableEmbeddingBase`."
+            "Input embedding tensor has to be provided as first argument to forward"
+            "function either through inputs argument or kwargs."
+        )
+        return inputs[0] if len(inputs) > 0 else list(kwargs.values())[0]
 
     def indices_to_embeddings(self, *input, **kwargs):
         r"""
@@ -171,14 +182,14 @@ def configure_interpretable_embedding_layer(model, embedding_layer_name="embeddi
         embedding_layer_name
     )
     warnings.warn(
-        """In order to make embedding layers more interpretable they will
-        be replaced with an interpretable embedding layer which wraps the
-        original embedding layer and takes word embedding vectors as inputs of
-        the forward function. This allows us to generate baselines for word
-        embeddings and compute attributions for each embedding dimension.
-        The original embedding layer must be set
-        back by calling `remove_interpretable_embedding_layer` function
-        after model interpretation is finished."""
+        "In order to make embedding layers more interpretable they will "
+        "be replaced with an interpretable embedding layer which wraps the "
+        "original embedding layer and takes word embedding vectors as inputs of "
+        "the forward function. This allows us to generate baselines for word "
+        "embeddings and compute attributions for each embedding dimension. "
+        "The original embedding layer must be set "
+        "back by calling `remove_interpretable_embedding_layer` function "
+        "after model interpretation is finished. "
     )
     interpretable_emb = InterpretableEmbeddingBase(
         embedding_layer, embedding_layer_name

--- a/captum/attr/_models/base.py
+++ b/captum/attr/_models/base.py
@@ -42,13 +42,19 @@ class InterpretableEmbeddingBase(Module):
                     execute the forward pass using interpretable embedding layer.
                     Note that if inputs are specified, it is assumed that the first
                     argument is the embedding tensor generated using the
-                    `self.embedding` layer using all imput arguments provided in
+                    `self.embedding` layer using all input arguments provided in
                     `inputs` and `kwargs`.
             **kwargs (Any, optional): Similar to `inputs` we want to make sure
                     that our forward pass supports arbitrary number and type of
                     key-value arguments. If `inputs` is not provided, `kwargs` must
-                    be provded and the first argument corresponds to the embedding
-                    tensor generated using the `self.embedding`.
+                    be provided and the first argument corresponds to the embedding
+                    tensor generated using the `self.embedding`. Note that we make
+                    here an assumption here that `kwargs` is an ordered dict which
+                    is new in python 3.6 and is not guaranteed that it will
+                    consistently remain that way in the newer versions. In case
+                    current implementation doesn't work for special use cases,
+                    it is encouraged to override `InterpretableEmbeddingBase` and
+                    address those specifics in descendant classes.
 
          Returns:
 

--- a/captum/attr/_models/base.py
+++ b/captum/attr/_models/base.py
@@ -36,8 +36,6 @@ class InterpretableEmbeddingBase(Module):
 
          Args:
 
-            input (tensor): Embedding tensor generated using the `self.embedding`
-                    layer using `other_inputs` and `kwargs` of necessary.
             *inputs (Any, optional): A sequence of inputs arguments that the
                     forward function takes. Since forward functions can take any
                     type and number of arguments, this will ensure that we can
@@ -61,7 +59,7 @@ class InterpretableEmbeddingBase(Module):
         """
         assert len(inputs) > 0 or len(kwargs) > 0, (
             "No input arguments are provided to `InterpretableEmbeddingBase`."
-            "Input embedding tensor has to be provided as first argument to forward"
+            "Input embedding tensor has to be provided as first argument to forward "
             "function either through inputs argument or kwargs."
         )
         return inputs[0] if len(inputs) > 0 else list(kwargs.values())[0]

--- a/captum/attr/_models/base.py
+++ b/captum/attr/_models/base.py
@@ -41,8 +41,9 @@ class InterpretableEmbeddingBase(Module):
                     type and number of arguments, this will ensure that we can
                     execute the forward pass using interpretable embedding layer.
                     Note that if inputs are specified it is assumed that the first
-                    argument is the embedding tensor generated using the `self.embedding`
-                    layer using all imput arguments provided in `inputs` and `kwargs`.
+                    argument is the embedding tensor generated using the
+                    `self.embedding` layer using all imput arguments provided in
+                    `inputs` and `kwargs`.
             **kwargs (Any, optional): Similar to `inputs` we want to make sure
                     that our forward pass supports arbitrary number and type of
                     key-value arguments. If `inputs` is not provided, `kwargs` must

--- a/captum/attr/_models/base.py
+++ b/captum/attr/_models/base.py
@@ -40,7 +40,7 @@ class InterpretableEmbeddingBase(Module):
                     forward function takes. Since forward functions can take any
                     type and number of arguments, this will ensure that we can
                     execute the forward pass using interpretable embedding layer.
-                    Note that if inputs are specified it is assumed that the first
+                    Note that if inputs are specified, it is assumed that the first
                     argument is the embedding tensor generated using the
                     `self.embedding` layer using all imput arguments provided in
                     `inputs` and `kwargs`.

--- a/tests/attr/helpers/basic_models.py
+++ b/tests/attr/helpers/basic_models.py
@@ -181,7 +181,8 @@ class TextModule(nn.Module):
         if self.second_embedding:
             self.inner_embedding2 = nn.Embedding(num_embeddings, embedding_dim)
 
-    def forward(self, input, another_input=None):
+    def forward(self, input=None, another_input=None):
+        assert input is not None, "The inputs to embedding module must be specified"
         embedding = self.inner_embedding(input)
         if self.second_embedding:
             another_embedding = self.inner_embedding2(
@@ -223,9 +224,9 @@ class BasicEmbeddingModel(nn.Module):
         self.relu = nn.ReLU()
         self.linear2 = nn.Linear(hidden_dim, output_dim)
 
-    def forward(self, input, another_input=None):
-        embedding1 = self.embedding1(input)
-        embedding2 = self.embedding2(input, another_input)
+    def forward(self, input1, input2, input3=None):
+        embedding1 = self.embedding1(input1)
+        embedding2 = self.embedding2(input2, input3)
         embeddings = embedding1 + embedding2
         return self.linear2(self.relu(self.linear1(embeddings))).squeeze()
 


### PR DESCRIPTION
It looks like some of the embedding modules support only named arguments such as the master version of Bert models: https://github.com/huggingface/transformers/blob/855ff0e91d8b3bd75a3b1c1316e2efd814373764/transformers/modeling_bert.py#L733

Making `InterpretableEmbeddingBase` more generic to support arguments which are only named.