### PR TITLE
Add layer integrated gradients

### DIFF
--- a/captum/attr/__init__.py
+++ b/captum/attr/__init__.py
@@ -18,6 +18,7 @@ from ._core.layer.internal_influence import InternalInfluence  # noqa
 from ._core.layer.grad_cam import LayerGradCam  # noqa
 from ._core.layer.layer_deep_lift import LayerDeepLift, LayerDeepLiftShap  # noqa
 from ._core.layer.layer_gradient_shap import LayerGradientShap  # noqa
+from ._core.layer.layer_integrated_gradients import LayerIntegratedGradients  # noqa
 from ._core.neuron.neuron_feature_ablation import NeuronFeatureAblation  # noqa
 from ._core.neuron.neuron_conductance import NeuronConductance  # noqa
 from ._core.neuron.neuron_gradient import NeuronGradient  # noqa
@@ -35,7 +36,6 @@ from ._models.base import (
     configure_interpretable_embedding_layer,
     remove_interpretable_embedding_layer,
 )  # noqa
-from ._utils import visualization  # noqa
 from ._utils.attribution import Attribution  # noqa
 from ._utils.attribution import GradientAttribution  # noqa
 from ._utils.attribution import LayerAttribution  # noqa
@@ -69,6 +69,7 @@ __all__ = [
     "LayerDeepLift",
     "LayerDeepLiftShap",
     "LayerGradientShap",
+    "LayerIntegratedGradients",
     "NeuronConductance",
     "NeuronFeatureAblation",
     "NeuronGradient",

--- a/captum/attr/__init__.py
+++ b/captum/attr/__init__.py
@@ -70,6 +70,7 @@ __all__ = [
     "LayerDeepLiftShap",
     "LayerGradientShap",
     "LayerIntegratedGradients",
+    "LayerGradientShap",
     "NeuronConductance",
     "NeuronFeatureAblation",
     "NeuronGradient",

--- a/captum/attr/__init__.py
+++ b/captum/attr/__init__.py
@@ -70,7 +70,6 @@ __all__ = [
     "LayerDeepLiftShap",
     "LayerGradientShap",
     "LayerIntegratedGradients",
-    "LayerGradientShap",
     "NeuronConductance",
     "NeuronFeatureAblation",
     "NeuronGradient",

--- a/captum/attr/_core/layer/layer_conductance.py
+++ b/captum/attr/_core/layer/layer_conductance.py
@@ -49,7 +49,7 @@ class LayerConductance(LayerAttribution, GradientAttribution):
         target=None,
         additional_forward_args=None,
         n_steps=50,
-        method="riemann_trapezoid",
+        method="gausslegendre",
         internal_batch_size=None,
         return_convergence_delta=False,
         attribute_to_layer_input=False,

--- a/captum/attr/_core/layer/layer_integrated_gradients.py
+++ b/captum/attr/_core/layer/layer_integrated_gradients.py
@@ -3,27 +3,22 @@ import torch
 
 from torch.nn.parallel.scatter_gather import scatter
 
-from captum.attr._utils.approximation_methods import approximation_parameters
 from captum.attr._utils.common import (
+    _tensorize_baseline,
     _validate_input,
     _format_additional_forward_args,
     _format_attributions,
     _format_input_baseline,
-    _reshape_and_sum,
-    _tensorize_baseline,
-    _expand_additional_forward_args,
-    _expand_target,
 )
 
-from captum.attr._utils.attribution import LayerAttribution, GradientAttribution
-from captum.attr._utils.gradient import (
-    _run_forward,
-    _forward_layer_distributed_eval,
-    _gather_distributed_tensors,
-)
+from captum.attr._utils.gradient import _forward_layer_eval
+
+from captum.attr._utils.attribution import LayerAttribution
+from captum.attr._core.integrated_gradients import IntegratedGradients
+from captum.attr._utils.gradient import _run_forward
 
 
-class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
+class LayerIntegratedGradients(LayerAttribution, IntegratedGradients):
     def __init__(self, forward_func, layer, device_ids=None):
         r"""
         Args:
@@ -31,7 +26,7 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
                           modification of it
         """
         LayerAttribution.__init__(self, forward_func, layer, device_ids=device_ids)
-        GradientAttribution.__init__(self, forward_func)
+        IntegratedGradients.__init__(self, forward_func)
 
     def attribute(
         self,
@@ -41,164 +36,104 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
         additional_forward_args=None,
         n_steps=50,
         method="gausslegendre",
+        internal_batch_size=None,
         return_convergence_delta=False,
+        attribute_to_layer_input=False,
     ):
-        # Keeps track whether original input is a tuple or not before
-        # converting it into a tuple.
-        is_inputs_tuple = isinstance(inputs, tuple)
+        inps, baselines = _format_input_baseline(inputs, baselines)
+        _validate_input(inps, baselines, n_steps, method)
 
-        inputs, baselines = _format_input_baseline(inputs, baselines)
-        _validate_input(inputs, baselines, n_steps, method)
-
-        baselines = _tensorize_baseline(inputs, baselines)
+        baselines = _tensorize_baseline(inps, baselines)
         additional_forward_args = _format_additional_forward_args(
             additional_forward_args
         )
 
-        # apply number of steps to additional forward args, inputs,
-        # baselines and targets
-        expanded_inputs = tuple(torch.cat([input] * n_steps, dim=0) for input in inputs)
-        expanded_baselines = tuple(
-            torch.cat([baseline] * n_steps, dim=0) for baseline in baselines
-        )
-        expanded_target = _expand_target(target, n_steps)
-        # currently, the number of steps is applied only to additional forward arguments
-        # that are nd-tensors. It is assumed that the first dimension is
-        # the number of batches.
-        # dim -> (bsz * #steps x additional_forward_args[0].shape[1:], ...)
-        expanded_additional_args = (
-            _expand_additional_forward_args(additional_forward_args, n_steps)
-            if additional_forward_args is not None
-            else None
-        )
-
         if self.device_ids is None:
             self.device_ids = getattr(self.forward_func, "device_ids", None)
-
-        # retrieve step size and scaling factor for specified approximation method
-        step_sizes_func, alphas_func = approximation_parameters(method)
-        step_sizes, alphas = step_sizes_func(n_steps), alphas_func(n_steps)
-        num_examples = len(inputs[0])
-        expanded_alphas = torch.tensor(alphas).repeat_interleave(num_examples)[:, None]
-
-        # distribute expanded_alphas on multiple devices
-        if self.device_ids is None:
-            scattered_expanded_alphas = (expanded_alphas.to(inputs[0].device),)
-        else:
-            scattered_expanded_alphas = scatter(
-                expanded_alphas, target_gpus=self.device_ids
-            )
-
-        scattered_expanded_alphas_dict = {
-            scattered_expanded_alpha.device: scattered_expanded_alpha
-            for scattered_expanded_alpha in scattered_expanded_alphas
-        }
-
-        # The outputs of the `self.layer` for given expanded_inputs and additional args.
-        # This returns a dictionary of {device_id1: output1, device_id2: output2}
-        inputs_layer_dict = _forward_layer_distributed_eval(
+        inputs_layer = _forward_layer_eval(
             self.forward_func,
-            expanded_inputs,
+            inps,
             self.layer,
-            additional_forward_args=expanded_additional_args,
+            device_ids=self.device_ids,
+            additional_forward_args=additional_forward_args,
+            attribute_to_layer_input=attribute_to_layer_input,
         )
 
-        # The outputs of the `self.layer` for given expanded_baselines and
-        # additional args.
-        # This returns a dictionary of {device_id1: output1,
-        #                               device_id2: output2, ...}
-        # `baselines_layer_dict`s ordering is aligned with the
-        # `inputs_layer_dict`s ordering.
-        baselines_layer_dict = _forward_layer_distributed_eval(
+        baselines_layer = _forward_layer_eval(
             self.forward_func,
-            expanded_baselines,
+            baselines,
             self.layer,
-            additional_forward_args=expanded_additional_args,
+            device_ids=self.device_ids,
+            additional_forward_args=additional_forward_args,
+            attribute_to_layer_input=attribute_to_layer_input,
         )
 
-        # scale features and compute gradients. (batch size is abbreviated as bsz)
-        # scaled_features_dict' dim -> (device_id: bsz *
-        #                               steps x inputs[0].shape[1:], ...)
-        scaled_features_dict = {
-            input_device: baselines_layer_dict[input_device]
-            + (
-                scattered_expanded_alphas_dict[input_device]
-                * (
-                    inputs_layer_dict[input_device] - baselines_layer_dict[input_device]
-                ).view(inputs_layer_dict[input_device].shape[0], -1)
-            ).view(inputs_layer_dict[input_device].shape)
-            for input_device in inputs_layer_dict.keys()
-        }
+        # inputs -> these inputs are scaled
+        def gradient_func(
+            forward_fn, inputs, target_ind=None, additional_forward_args=None
+        ):
+            if self.device_ids is None:
+                scattered_inputs = inputs
+            else:
+                scattered_inputs = scatter(inputs, target_gpus=self.device_ids)
 
-        def layer_forward_hook(module, inputs, outputs):
-            outputs = scaled_features_dict[outputs.device]
-            return outputs
+            scattered_inputs_dict = {
+                scattered_input[0].device: scattered_input
+                for scattered_input in scattered_inputs
+            }
 
-        hook = self.layer.register_forward_hook(layer_forward_hook)
-        output = _run_forward(
-            self.forward_func,
-            expanded_inputs,
-            expanded_target,
-            expanded_additional_args,
+            with torch.autograd.set_grad_enabled(True):
+
+                def layer_forward_hook(module, hook_inputs, hook_outputs=None):
+                    result = scattered_inputs_dict[hook_inputs[0].device]
+                    return (
+                        result[0]
+                        if isinstance(result, tuple) and hook_outputs is not None
+                        else result
+                    )
+
+                if attribute_to_layer_input:
+                    hook = self.layer.register_forward_pre_hook(layer_forward_hook)
+                else:
+                    hook = self.layer.register_forward_hook(layer_forward_hook)
+
+                output = _run_forward(
+                    self.forward_func, additional_forward_args, target_ind,
+                )
+                hook.remove()
+                assert output[0].numel() == 1, (
+                    "Target not provided when necessary, cannot"
+                    " take gradient with respect to multiple outputs."
+                )
+                # torch.unbind(forward_out) is a list of scalar tensor tuples and
+                # contains batch_size * #steps elements
+                grads = torch.autograd.grad(torch.unbind(output), inputs)
+            return grads
+
+        self.gradient_func = gradient_func
+        all_inputs = (
+            (inps + additional_forward_args)
+            if additional_forward_args is not None
+            else inps
         )
-        hook.remove()
-
-        if self.device_ids is None:
-            scattered_ouputs = (output,)
-        else:
-            scattered_ouputs = scatter(output, target_gpus=self.device_ids)
-
-        # grads: dim -> (bsz * #steps x inputs[0].shape[1:], ...
-        grads_dict = {
-            scattered_ouput.device: self.gradient_func(
-                self.forward_func,
-                scaled_features_dict[scattered_ouput.device],
-                outputs=scattered_ouput,
-            )[
-                0
-            ]  # TODO fixme assumes that layer output is a tensor
-            for scattered_ouput in scattered_ouputs
-        }
-
-        grads = _gather_distributed_tensors(grads_dict, device_ids=self.device_ids)
-        grads = (grads,)
-        # flattening grads so that we can multilpy it with step-size
-        # calling contiguous to avoid `memory whole` problems
-        scaled_grads = [
-            grad.contiguous().view(n_steps, -1)
-            * torch.tensor(step_sizes).view(n_steps, 1).to(grad.device)
-            for grad in grads
-        ]
-
-        # aggregates across all steps for each tensor in the input tuple
-        # total_grads has the same dimensionality as inputs
-        total_grads = [
-            _reshape_and_sum(
-                scaled_grad, n_steps, grad.shape[0] // n_steps, grad.shape[1:]
-            )
-            for (scaled_grad, grad) in zip(scaled_grads, grads)
-        ]
-
-        # gather inputs and baseline layer outputs similar to gradients
-        inputs_layer = _gather_distributed_tensors(
-            inputs_layer_dict, device_ids=self.device_ids
+        attributions = IntegratedGradients.attribute(
+            self,
+            inputs_layer,
+            baselines=baselines_layer,
+            target=target,
+            additional_forward_args=all_inputs,
+            n_steps=n_steps,
+            method=method,
+            internal_batch_size=internal_batch_size,
+            return_convergence_delta=False,
         )
-        inputs_layer = (inputs_layer,)
-        baselines_layer = _gather_distributed_tensors(
-            baselines_layer_dict, device_ids=self.device_ids
-        )
-        baselines_layer = (baselines_layer,)
 
-        # computes attribution for each tensor in input tuple
-        # attributions has the same dimensionality as output of the input layer
-        attributions = tuple(
-            total_grad * (input[:num_examples] - baseline[:num_examples])
-            for total_grad, input, baseline in zip(
-                total_grads, inputs_layer, baselines_layer
-            )
-        )
+        # TODO this needs to be formated properly -
+        # it assumes that layer returns a tensor
+        attributions = (attributions,)
+
         if return_convergence_delta:
-            start_point, end_point = baselines, inputs
+            start_point, end_point = baselines, inps
             # computes approximation error based on the completeness axiom
             delta = self.compute_convergence_delta(
                 attributions,
@@ -207,8 +142,9 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
                 additional_forward_args=additional_forward_args,
                 target=target,
             )
-            return _format_attributions(is_inputs_tuple, attributions), delta
-        return _format_attributions(is_inputs_tuple, attributions)
+            # TODO this needs to be checked of tensor properly: len(attributions) > 1
+            return _format_attributions(len(attributions) > 1, attributions), delta
+        return _format_attributions(len(attributions) > 1, attributions)
 
     def has_convergence_delta(self):
         return True

--- a/captum/attr/_core/layer/layer_integrated_gradients.py
+++ b/captum/attr/_core/layer/layer_integrated_gradients.py
@@ -62,8 +62,7 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
             torch.cat([baseline] * n_steps, dim=0) for baseline in baselines
         )
         expanded_target = _expand_target(target, n_steps)
-
-        # currently, number of steps is applied only to additional forward arguments
+        # currently, the number of steps is applied only to additional forward arguments
         # that are nd-tensors. It is assumed that the first dimension is
         # the number of batches.
         # dim -> (bsz * #steps x additional_forward_args[0].shape[1:], ...)
@@ -191,7 +190,7 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
         baselines_layer = (baselines_layer,)
 
         # computes attribution for each tensor in input tuple
-        # attributions has the same dimensionality as inputs
+        # attributions has the same dimensionality as output of the input layer
         attributions = tuple(
             total_grad * (input[:num_examples] - baseline[:num_examples])
             for total_grad, input, baseline in zip(

--- a/captum/attr/_core/layer/layer_integrated_gradients.py
+++ b/captum/attr/_core/layer/layer_integrated_gradients.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+import torch
+
+from torch.nn.parallel.scatter_gather import scatter
+
+from captum.attr._utils.approximation_methods import approximation_parameters
+from captum.attr._utils.common import (
+    _validate_input,
+    _format_additional_forward_args,
+    _format_attributions,
+    _format_input_baseline,
+    _reshape_and_sum,
+    _tensorize_baseline,
+    _expand_additional_forward_args,
+    _expand_target,
+)
+
+from captum.attr._utils.attribution import LayerAttribution, GradientAttribution
+from captum.attr._utils.gradient import (
+    _run_forward,
+    _forward_layer_distributed_eval,
+    _gather_distributed_tensors,
+)
+
+
+class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
+    def __init__(self, forward_func, layer, device_ids=None):
+        r"""
+        Args:
+            forward_func (callable):  The forward function of the model or any
+                          modification of it
+        """
+        LayerAttribution.__init__(self, forward_func, layer, device_ids=device_ids)
+        GradientAttribution.__init__(self, forward_func)
+
+    def attribute(
+        self,
+        inputs,
+        baselines=None,
+        target=None,
+        additional_forward_args=None,
+        n_steps=50,
+        method="gausslegendre",
+        return_convergence_delta=False,
+    ):
+        # Keeps track whether original input is a tuple or not before
+        # converting it into a tuple.
+        is_inputs_tuple = isinstance(inputs, tuple)
+
+        inputs, baselines = _format_input_baseline(inputs, baselines)
+        _validate_input(inputs, baselines, n_steps, method)
+
+        baselines = _tensorize_baseline(inputs, baselines)
+        additional_forward_args = _format_additional_forward_args(
+            additional_forward_args
+        )
+
+        # apply number of steps to additional forward args, inputs,
+        # baselines and targets
+        expanded_inputs = tuple(torch.cat([input] * n_steps, dim=0) for input in inputs)
+        expanded_baselines = tuple(
+            torch.cat([baseline] * n_steps, dim=0) for baseline in baselines
+        )
+        expanded_target = _expand_target(target, n_steps)
+
+        # currently, number of steps is applied only to additional forward arguments
+        # that are nd-tensors. It is assumed that the first dimension is
+        # the number of batches.
+        # dim -> (bsz * #steps x additional_forward_args[0].shape[1:], ...)
+        expanded_additional_args = (
+            _expand_additional_forward_args(additional_forward_args, n_steps)
+            if additional_forward_args is not None
+            else None
+        )
+
+        if self.device_ids is None:
+            self.device_ids = getattr(self.forward_func, "device_ids", None)
+
+        # retrieve step size and scaling factor for specified approximation method
+        step_sizes_func, alphas_func = approximation_parameters(method)
+        step_sizes, alphas = step_sizes_func(n_steps), alphas_func(n_steps)
+        num_examples = len(inputs[0])
+        expanded_alphas = torch.tensor(alphas).repeat_interleave(num_examples)[:, None]
+
+        # distribute expanded_alphas on multiple devices
+        if self.device_ids is None:
+            scattered_expanded_alphas = (expanded_alphas.to(inputs[0].device),)
+        else:
+            scattered_expanded_alphas = scatter(
+                expanded_alphas, target_gpus=self.device_ids
+            )
+
+        scattered_expanded_alphas_dict = {
+            scattered_expanded_alpha.device: scattered_expanded_alpha
+            for scattered_expanded_alpha in scattered_expanded_alphas
+        }
+
+        # The outputs of the `self.layer` for given expanded_inputs and additional args.
+        # This returns a dictionary of {device_id1: output1, device_id2: output2}
+        inputs_layer_dict = _forward_layer_distributed_eval(
+            self.forward_func,
+            expanded_inputs,
+            self.layer,
+            additional_forward_args=expanded_additional_args,
+        )
+
+        # The outputs of the `self.layer` for given expanded_baselines and
+        # additional args.
+        # This returns a dictionary of {device_id1: output1,
+        #                               device_id2: output2, ...}
+        # `baselines_layer_dict`s ordering is aligned with the
+        # `inputs_layer_dict`s ordering.
+        baselines_layer_dict = _forward_layer_distributed_eval(
+            self.forward_func,
+            expanded_baselines,
+            self.layer,
+            additional_forward_args=expanded_additional_args,
+        )
+
+        # scale features and compute gradients. (batch size is abbreviated as bsz)
+        # scaled_features_dict' dim -> (device_id: bsz *
+        #                               steps x inputs[0].shape[1:], ...)
+        scaled_features_dict = {
+            input_device: baselines_layer_dict[input_device]
+            + (
+                scattered_expanded_alphas_dict[input_device]
+                * (
+                    inputs_layer_dict[input_device] - baselines_layer_dict[input_device]
+                ).view(inputs_layer_dict[input_device].shape[0], -1)
+            ).view(inputs_layer_dict[input_device].shape)
+            for input_device in inputs_layer_dict.keys()
+        }
+
+        def layer_forward_hook(module, inputs, outputs):
+            outputs = scaled_features_dict[outputs.device]
+            return outputs
+
+        hook = self.layer.register_forward_hook(layer_forward_hook)
+        output = _run_forward(
+            self.forward_func,
+            expanded_inputs,
+            expanded_target,
+            expanded_additional_args,
+        )
+        hook.remove()
+
+        if self.device_ids is None:
+            scattered_ouputs = (output,)
+        else:
+            scattered_ouputs = scatter(output, target_gpus=self.device_ids)
+
+        # grads: dim -> (bsz * #steps x inputs[0].shape[1:], ...
+        grads_dict = {
+            scattered_ouput.device: self.gradient_func(
+                self.forward_func,
+                scaled_features_dict[scattered_ouput.device],
+                outputs=scattered_ouput,
+            )[
+                0
+            ]  # TODO fixme assumes that layer output is a tensor
+            for scattered_ouput in scattered_ouputs
+        }
+
+        grads = _gather_distributed_tensors(grads_dict, device_ids=self.device_ids)
+        grads = (grads,)
+        # flattening grads so that we can multilpy it with step-size
+        # calling contiguous to avoid `memory whole` problems
+        scaled_grads = [
+            grad.contiguous().view(n_steps, -1)
+            * torch.tensor(step_sizes).view(n_steps, 1).to(grad.device)
+            for grad in grads
+        ]
+
+        # aggregates across all steps for each tensor in the input tuple
+        # total_grads has the same dimensionality as inputs
+        total_grads = [
+            _reshape_and_sum(
+                scaled_grad, n_steps, grad.shape[0] // n_steps, grad.shape[1:]
+            )
+            for (scaled_grad, grad) in zip(scaled_grads, grads)
+        ]
+
+        # gather inputs and baseline layer outputs similar to gradients
+        inputs_layer = _gather_distributed_tensors(
+            inputs_layer_dict, device_ids=self.device_ids
+        )
+        inputs_layer = (inputs_layer,)
+        baselines_layer = _gather_distributed_tensors(
+            baselines_layer_dict, device_ids=self.device_ids
+        )
+        baselines_layer = (baselines_layer,)
+
+        # computes attribution for each tensor in input tuple
+        # attributions has the same dimensionality as inputs
+        attributions = tuple(
+            total_grad * (input[:num_examples] - baseline[:num_examples])
+            for total_grad, input, baseline in zip(
+                total_grads, inputs_layer, baselines_layer
+            )
+        )
+        if return_convergence_delta:
+            start_point, end_point = baselines, inputs
+            # computes approximation error based on the completeness axiom
+            delta = self.compute_convergence_delta(
+                attributions,
+                start_point,
+                end_point,
+                additional_forward_args=additional_forward_args,
+                target=target,
+            )
+            return _format_attributions(is_inputs_tuple, attributions), delta
+        return _format_attributions(is_inputs_tuple, attributions)
+
+    def has_convergence_delta(self):
+        return True

--- a/captum/attr/_utils/common.py
+++ b/captum/attr/_utils/common.py
@@ -90,6 +90,8 @@ def _validate_noise_tunnel_type(nt_type, supported_noise_tunnel_types):
 
 
 def _format_tensor_into_tuples(inputs):
+    if inputs is None:
+        return None
     if not isinstance(inputs, tuple):
         assert isinstance(
             inputs, torch.Tensor
@@ -344,6 +346,9 @@ def _expand_additional_forward_args(
                 "Currently only `repeat` and `repeat_interleave`"
                 " expansion_types are supported"
             )
+
+    if additional_forward_args is None:
+        return None
 
     return tuple(
         _expand_tensor_forward_arg(additional_forward_arg, n_steps, expansion_type)

--- a/captum/attr/_utils/gradient.py
+++ b/captum/attr/_utils/gradient.py
@@ -62,7 +62,7 @@ def undo_gradient_requirements(inputs, grad_required):
 
 
 def compute_gradients(
-    forward_fn, inputs, target_ind=None, additional_forward_args=None, outputs=None
+    forward_fn, inputs, target_ind=None, additional_forward_args=None
 ):
     r"""
         Computes gradients of the output with respect to inputs for an
@@ -81,15 +81,12 @@ def compute_gradients(
                         additional arguments are required
     """
     with torch.autograd.set_grad_enabled(True):
-        if outputs is None:
-            # runs forward pass
-            outputs = _run_forward(
-                forward_fn, inputs, target_ind, additional_forward_args
-            )
-            assert outputs[0].numel() == 1, (
-                "Target not provided when necessary, cannot"
-                " take gradient with respect to multiple outputs."
-            )
+        # runs forward pass
+        outputs = _run_forward(forward_fn, inputs, target_ind, additional_forward_args)
+        assert outputs[0].numel() == 1, (
+            "Target not provided when necessary, cannot"
+            " take gradient with respect to multiple outputs."
+        )
         # torch.unbind(forward_out) is a list of scalar tensor tuples and
         # contains batch_size * #steps elements
         grads = torch.autograd.grad(torch.unbind(outputs), inputs)

--- a/tests/attr/helpers/basic_models.py
+++ b/tests/attr/helpers/basic_models.py
@@ -220,15 +220,17 @@ class BasicEmbeddingModel(nn.Module):
         self.embedding2 = TextModule(
             num_embeddings, embedding_dim, nested_second_embedding
         )
-        self.linear1 = nn.Linear(embedding_dim, hidden_dim)
+        self.linear1 = nn.Linear(embedding_dim, hidden_dim, bias=False)
+        self.linear1.weight = nn.Parameter(torch.ones(hidden_dim, embedding_dim))
         self.relu = nn.ReLU()
         self.linear2 = nn.Linear(hidden_dim, output_dim)
+        self.linear2.weight = nn.Parameter(torch.ones(output_dim, hidden_dim))
 
     def forward(self, input1, input2, input3=None):
         embedding1 = self.embedding1(input1)
         embedding2 = self.embedding2(input2, input3)
         embeddings = embedding1 + embedding2
-        return self.linear2(self.relu(self.linear1(embeddings))).squeeze()
+        return self.linear2(self.relu(self.linear1(embeddings))).sum(1)
 
 
 class BasicModel_MultiLayer(nn.Module):

--- a/tests/attr/layer/test_layer_integrated_gradients.py
+++ b/tests/attr/layer/test_layer_integrated_gradients.py
@@ -49,6 +49,13 @@ class Test(BaseTest):
         self._assert_compare_with_layer_conductance(model, input)
 
     def test_compare_with_layer_conductance_attr_to_inputs(self):
+        # Note that Layer Conductance and Layer Integrated Gradients (IG) aren't
+        # exactly the same. Layer IG computes partial derivative of the output
+        # with respect to the layer and sums along the straight line. While Layer
+        # Conductance also computes the same partial derivatives it doesn't use
+        # the straight line but a path defined by F(i) - F(i - 1).
+        # However, in some cases when that path becomes close to a straight line,
+        # Layer IG and Layer Conductance become numerically very close.
         model = BasicModel_MultiLayer()
         input = torch.tensor([[50.0, 50.0, 50.0]], requires_grad=True)
         self._assert_compare_with_layer_conductance(model, input, True)

--- a/tests/attr/layer/test_layer_integrated_gradients.py
+++ b/tests/attr/layer/test_layer_integrated_gradients.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+import torch
+
+from ..helpers.utils import assertArraysAlmostEqual
+
+from captum.attr._models.base import (
+    configure_interpretable_embedding_layer,
+    remove_interpretable_embedding_layer,
+)
+
+from captum.attr._core.integrated_gradients import IntegratedGradients
+from captum.attr._core.layer.layer_integrated_gradients import LayerIntegratedGradients
+from captum.attr._core.layer.layer_conductance import LayerConductance
+
+from ..helpers.utils import BaseTest
+from ..helpers.basic_models import (
+    BasicEmbeddingModel,
+    BasicModel_MultiLayer,
+)
+
+
+class Test(BaseTest):
+    def test_compare_with_emb_patching(self):
+        input1 = torch.tensor([[2, 5, 0, 1]])
+        baseline1 = torch.tensor([[0, 0, 0, 0]])
+        # these ones will be use as an additional forward args
+        input2 = torch.tensor([[0, 2, 4, 1]])
+        input3 = torch.tensor([[2, 3, 0, 1]])
+
+        self._assert_compare_with_emb_patching(
+            input1, baseline1, additional_args=(input2, input3)
+        )
+
+    def test_compare_with_emb_patching_batch(self):
+        input1 = torch.tensor([[2, 5, 0, 1], [3, 1, 1, 0]])
+        baseline1 = torch.tensor([[0, 0, 0, 0]])
+        # these ones will be use as an additional forward args
+        input2 = torch.tensor([[0, 2, 4, 1], [2, 3, 5, 7]])
+        input3 = torch.tensor([[3, 5, 6, 7], [2, 3, 0, 1]])
+
+        self._assert_compare_with_emb_patching(
+            input1, baseline1, additional_args=(input2, input3)
+        )
+
+    def test_compare_with_layer_conductance(self):
+        model = BasicModel_MultiLayer()
+        lc = LayerConductance(model, model.linear0)
+        # when we use input=torch.tensor()[[50.0, 50.0, 50.0]]),
+        # F(x) - F(x - 1) is equal to 1
+        # therefore layer conductance is nearly the same as layer integrated gradients
+        # for large number of steps.
+        input = torch.tensor([[50.0, 50.0, 50.0]], requires_grad=True)
+        attribution, delta = lc.attribute(
+            input, target=0, n_steps=1500, return_convergence_delta=True,
+        )
+        lig = LayerIntegratedGradients(model, model.linear0)
+        attributions2, delta2 = lig.attribute(
+            input, target=0, n_steps=1500, return_convergence_delta=True,
+        )
+        assertArraysAlmostEqual(attribution, attributions2, 0.01)
+        assertArraysAlmostEqual(delta, delta2, 0.05)
+
+    def _assert_compare_with_emb_patching(self, input, baseline, additional_args):
+        model = BasicEmbeddingModel(nested_second_embedding=True)
+        lig = LayerIntegratedGradients(model, model.embedding1)
+
+        attributions, delta = lig.attribute(
+            input,
+            baselines=baseline,
+            additional_forward_args=additional_args,
+            return_convergence_delta=True,
+        )
+
+        # now let's interpret with standard integrated gradients and
+        # the embeddings for monkey patching
+        interpretable_embedding = configure_interpretable_embedding_layer(
+            model, "embedding1"
+        )
+        input_emb = interpretable_embedding.indices_to_embeddings(input)
+        baseline_emb = interpretable_embedding.indices_to_embeddings(baseline)
+        ig = IntegratedGradients(model)
+        attributions_with_ig, delta_with_ig = ig.attribute(
+            input_emb,
+            baselines=baseline_emb,
+            additional_forward_args=additional_args,
+            target=0,
+            return_convergence_delta=True,
+        )
+        remove_interpretable_embedding_layer(model, interpretable_embedding)
+
+        assertArraysAlmostEqual(attributions, attributions_with_ig)
+        assertArraysAlmostEqual(delta, delta_with_ig)

--- a/tests/attr/models/test_base.py
+++ b/tests/attr/models/test_base.py
@@ -128,4 +128,4 @@ class Test(unittest.TestCase):
         self.assertEqual(emb_shape[0], input.shape[0])
         if interpretable_embedding.embedding_dim is not None:
             self.assertEqual(emb_shape[1], interpretable_embedding.embedding_dim)
-        self.assertEqual(input.shape, output.shape)
+        self.assertEqual(input.shape[0], output.shape[0])

--- a/tests/attr/test_data_parallel.py
+++ b/tests/attr/test_data_parallel.py
@@ -168,7 +168,6 @@ class Test(BaseGPUTest):
             inputs=(inp1, inp2),
             additional_forward_args=(inp3, 5),
             target=1,
-            test_batches=True,
         )
 
     def test_multi_dim_layer_integrated_gradients(self):

--- a/tests/attr/test_data_parallel.py
+++ b/tests/attr/test_data_parallel.py
@@ -168,6 +168,7 @@ class Test(BaseGPUTest):
             inputs=(inp1, inp2),
             additional_forward_args=(inp3, 5),
             target=1,
+            test_batches=True,
         )
 
     def test_multi_dim_layer_integrated_gradients(self):

--- a/tests/attr/test_targets.py
+++ b/tests/attr/test_targets.py
@@ -14,6 +14,7 @@ from captum.attr._core.occlusion import Occlusion
 
 from captum.attr._core.layer.internal_influence import InternalInfluence
 from captum.attr._core.layer.layer_conductance import LayerConductance
+from captum.attr._core.layer.layer_integrated_gradients import LayerIntegratedGradients
 from captum.attr._core.layer.layer_gradient_x_activation import LayerGradientXActivation
 
 from captum.attr._core.neuron.neuron_conductance import NeuronConductance
@@ -387,6 +388,29 @@ class Test(BaseTest):
             additional_forward_args=(None, True),
             targets=[(1, 0, 0), (0, 1, 1), (1, 1, 1), (0, 0, 0)],
             test_batches=True,
+        )
+
+    def test_simple_target_layer_ig(self):
+        net = BasicModel_MultiLayer()
+        inp = torch.randn(4, 3)
+        self._target_batch_test_assert(
+            LayerIntegratedGradients,
+            net,
+            inputs=inp,
+            target_layer=net.relu,
+            targets=[0, 1, 1, 0],
+        )
+
+    def test_multi_target_layer_ig(self):
+        net = BasicModel_MultiLayer()
+        inp = torch.randn(4, 3)
+        self._target_batch_test_assert(
+            LayerIntegratedGradients,
+            net,
+            inputs=inp,
+            target_layer=net.relu,
+            additional_forward_args=(None, True),
+            targets=[(1, 0, 0), (0, 1, 1), (1, 1, 1), (0, 0, 0)],
         )
 
     def test_simple_target_layer_gradient_x_act(self):


### PR DESCRIPTION
This PR adds vanilla integrated gradients implementation for layers. This is especially useful for computing IG for word embeddings and it will help us to avoid pre-computing embedding layers separately before the forward pass and wrapping that layer, e.g. in the IMDB tutorial.

The following things will be added in separate PRs:
1. Documentation
2. Tutorial changes using LayerIntegratedGradients for IMDB and Bert models
