### PR TITLE
Add documentation for Layer Integrated Gradients

### DIFF
--- a/captum/attr/_core/integrated_gradients.py
+++ b/captum/attr/_core/integrated_gradients.py
@@ -16,6 +16,21 @@ from .._utils.attribution import GradientAttribution
 
 
 class IntegratedGradients(GradientAttribution):
+    r"""
+    Integrated Gradients is an axiomatic model interpretability algorithms that
+    assigns an importance score to each input feature by approximating the
+    integral of gradients of model output with respect to the inputs
+    along the path (straight line) from given baselines / references to inputs.
+
+    Both baseline and reference can be provided as input arguments to attribute
+    method. To approximate the integral we can choose to use either a variant of
+    Riemann sum or Gauss-Legendre quadrature rule.
+
+    More details regarding the integrated gradient method can be found in the
+    original paper:
+    https://arxiv.org/abs/1703.01365
+
+    """
     def __init__(self, forward_func):
         r"""
         Args:
@@ -37,12 +52,13 @@ class IntegratedGradients(GradientAttribution):
         return_convergence_delta=False,
     ):
         r"""
-            Approximates the integral of gradients along the path from a baseline input
-            to the given input. If no baseline is provided, the default baseline
-            is the zero tensor.
-            More details regarding the integrated gradient method can be found in the
-            original paper here:
-            https://arxiv.org/abs/1703.01365
+            This method attributes the output of the model with given target index
+            (in case it is provided, otherwise it assumes that output is a
+            scalar) to the inputs of the model using the approach described above.
+
+            In addition to that is also returns (if `return_convergence_delta` is
+            set to True) integral approximation delta based on the completeness
+            property of integrated gradients.
 
             Args:
 
@@ -68,12 +84,12 @@ class IntegratedGradients(GradientAttribution):
 
                             - a tuple of tensors or scalars, the baseline corresponding
                                 to each tensor in the inputs' tuple can be:
-                                - either a tensor with matching dimensions to
-                                    corresponding tensor in the inputs' tuple
-                                    or the first dimension is one and the remaining
-                                    dimensions match with the corresponding
-                                    input tensor.
-                                - or a scalar, corresponding to a tensor in the
+                            - either a tensor with matching dimensions to
+                                corresponding tensor in the inputs' tuple
+                                or the first dimension is one and the remaining
+                                dimensions match with the corresponding
+                                input tensor.
+                            - or a scalar, corresponding to a tensor in the
                                     inputs' tuple. This scalar value is broadcasted
                                     for corresponding input tensor.
 
@@ -147,13 +163,12 @@ class IntegratedGradients(GradientAttribution):
             Returns:
                 **attributions** or 2-element tuple of **attributions**, **delta**:
                 - **attributions** (*tensor* or tuple of *tensors*):
-                        Integrated gradients with respect to each input feature.
-                        attributions will always be the same size as the provided
-                        inputs, with each value providing the attribution of the
-                        corresponding input index.
-                        If a single tensor is provided as inputs, a single tensor is
-                        returned. If a tuple is provided for inputs, a tuple of
-                        corresponding sized tensors is returned.
+                        Integrated gradients with respect to layer inputs or outputs.
+                        Attributions will always be the same size as
+                        the input or output of the given layer, depending on
+                        whether we attribute to the inputs or outputs
+                        of the layer which is decided by the input flag
+                        `attribute_to_layer_input`.
                 - **delta** (*tensor*, returned if return_convergence_delta=True):
                         The difference between the total approximated and true
                         integrated gradients. This is computed using the property

--- a/captum/attr/_core/integrated_gradients.py
+++ b/captum/attr/_core/integrated_gradients.py
@@ -19,7 +19,7 @@ class IntegratedGradients(GradientAttribution):
     r"""
     Integrated Gradients is an axiomatic model interpretability algorithms that
     assigns an importance score to each input feature by approximating the
-    integral of gradients of model output with respect to the inputs
+    integral of gradients of the model output with respect to the inputs
     along the path (straight line) from given baselines / references to inputs.
 
     Both baseline and reference can be provided as input arguments to attribute
@@ -56,8 +56,8 @@ class IntegratedGradients(GradientAttribution):
             (in case it is provided, otherwise it assumes that output is a
             scalar) to the inputs of the model using the approach described above.
 
-            In addition to that is also returns (if `return_convergence_delta` is
-            set to True) integral approximation delta based on the completeness
+            In addition to that is also returns, if `return_convergence_delta` is
+            set to True, integral approximation delta based on the completeness
             property of integrated gradients.
 
             Args:
@@ -84,14 +84,14 @@ class IntegratedGradients(GradientAttribution):
 
                             - a tuple of tensors or scalars, the baseline corresponding
                                 to each tensor in the inputs' tuple can be:
-                            - either a tensor with matching dimensions to
-                                corresponding tensor in the inputs' tuple
-                                or the first dimension is one and the remaining
-                                dimensions match with the corresponding
-                                input tensor.
-                            - or a scalar, corresponding to a tensor in the
-                                    inputs' tuple. This scalar value is broadcasted
-                                    for corresponding input tensor.
+                                - either a tensor with matching dimensions to
+                                    corresponding tensor in the inputs' tuple
+                                    or the first dimension is one and the remaining
+                                    dimensions match with the corresponding
+                                    input tensor.
+                                - or a scalar, corresponding to a tensor in the
+                                        inputs' tuple. This scalar value is broadcasted
+                                        for corresponding input tensor.
 
                             In the cases when `baselines` is not provided, we internally
                             use zero scalar corresponding to each input tensor.
@@ -163,12 +163,13 @@ class IntegratedGradients(GradientAttribution):
             Returns:
                 **attributions** or 2-element tuple of **attributions**, **delta**:
                 - **attributions** (*tensor* or tuple of *tensors*):
-                        Integrated gradients with respect to layer inputs or outputs.
-                        Attributions will always be the same size as
-                        the input or output of the given layer, depending on
-                        whether we attribute to the inputs or outputs
-                        of the layer which is decided by the input flag
-                        `attribute_to_layer_input`.
+                        Integrated gradients with respect to each input feature.
+                        attributions will always be the same size as the provided
+                        inputs, with each value providing the attribution of the
+                        corresponding input index.
+                        If a single tensor is provided as inputs, a single tensor is
+                        returned. If a tuple is provided for inputs, a tuple of
+                        corresponding sized tensors is returned.
                 - **delta** (*tensor*, returned if return_convergence_delta=True):
                         The difference between the total approximated and true
                         integrated gradients. This is computed using the property

--- a/captum/attr/_core/integrated_gradients.py
+++ b/captum/attr/_core/integrated_gradients.py
@@ -22,8 +22,8 @@ class IntegratedGradients(GradientAttribution):
     integral of gradients of the model output with respect to the inputs
     along the path (straight line) from given baselines / references to inputs.
 
-    Both baselines and references can be provided as input arguments to attribute
-    method. To approximate the integral we can choose to use either a variant of
+    Baselines can be provided as input arguments to attribute method.
+    To approximate the integral we can choose to use either a variant of
     Riemann sum or Gauss-Legendre quadrature rule.
 
     More details regarding the integrated gradient method can be found in the

--- a/captum/attr/_core/integrated_gradients.py
+++ b/captum/attr/_core/integrated_gradients.py
@@ -22,7 +22,7 @@ class IntegratedGradients(GradientAttribution):
     integral of gradients of the model output with respect to the inputs
     along the path (straight line) from given baselines / references to inputs.
 
-    Both baseline and reference can be provided as input arguments to attribute
+    Both baselines and references can be provided as input arguments to attribute
     method. To approximate the integral we can choose to use either a variant of
     Riemann sum or Gauss-Legendre quadrature rule.
 
@@ -31,6 +31,7 @@ class IntegratedGradients(GradientAttribution):
     https://arxiv.org/abs/1703.01365
 
     """
+
     def __init__(self, forward_func):
         r"""
         Args:
@@ -52,143 +53,143 @@ class IntegratedGradients(GradientAttribution):
         return_convergence_delta=False,
     ):
         r"""
-            This method attributes the output of the model with given target index
-            (in case it is provided, otherwise it assumes that output is a
-            scalar) to the inputs of the model using the approach described above.
+        This method attributes the output of the model with given target index
+        (in case it is provided, otherwise it assumes that output is a
+        scalar) to the inputs of the model using the approach described above.
 
-            In addition to that is also returns, if `return_convergence_delta` is
-            set to True, integral approximation delta based on the completeness
-            property of integrated gradients.
+        In addition to that is also returns, if `return_convergence_delta` is
+        set to True, integral approximation delta based on the completeness
+        property of integrated gradients.
 
-            Args:
+        Args:
 
-                inputs (tensor or tuple of tensors):  Input for which integrated
-                            gradients are computed. If forward_func takes a single
-                            tensor as input, a single input tensor should be provided.
-                            If forward_func takes multiple tensors as input, a tuple
-                            of the input tensors should be provided. It is assumed
-                            that for all given input tensors, dimension 0 corresponds
-                            to the number of examples, and if multiple input tensors
-                            are provided, the examples must be aligned appropriately.
-                baselines (scalar, tensor, tuple of scalars or tensors, optional):
-                            Baselines define the starting point from which integral
-                            is computed and can be provided as:
+            inputs (tensor or tuple of tensors):  Input for which integrated
+                        gradients are computed. If forward_func takes a single
+                        tensor as input, a single input tensor should be provided.
+                        If forward_func takes multiple tensors as input, a tuple
+                        of the input tensors should be provided. It is assumed
+                        that for all given input tensors, dimension 0 corresponds
+                        to the number of examples, and if multiple input tensors
+                        are provided, the examples must be aligned appropriately.
+            baselines (scalar, tensor, tuple of scalars or tensors, optional):
+                        Baselines define the starting point from which integral
+                        is computed and can be provided as:
 
-                            - a single tensor, if inputs is a single tensor, with
-                                exactly the same dimensions as inputs or the first
-                                dimension is one and the remaining dimensions match
-                                with inputs.
+                        - a single tensor, if inputs is a single tensor, with
+                            exactly the same dimensions as inputs or the first
+                            dimension is one and the remaining dimensions match
+                            with inputs.
 
-                            - a single scalar, if inputs is a single tensor, which will
-                                be broadcasted for each input value in input tensor.
+                        - a single scalar, if inputs is a single tensor, which will
+                            be broadcasted for each input value in input tensor.
 
-                            - a tuple of tensors or scalars, the baseline corresponding
-                                to each tensor in the inputs' tuple can be:
-                                - either a tensor with matching dimensions to
-                                    corresponding tensor in the inputs' tuple
-                                    or the first dimension is one and the remaining
-                                    dimensions match with the corresponding
-                                    input tensor.
-                                - or a scalar, corresponding to a tensor in the
-                                    inputs' tuple. This scalar value is broadcasted
-                                    for corresponding input tensor.
+                        - a tuple of tensors or scalars, the baseline corresponding
+                            to each tensor in the inputs' tuple can be:
+                            - either a tensor with matching dimensions to
+                                corresponding tensor in the inputs' tuple
+                                or the first dimension is one and the remaining
+                                dimensions match with the corresponding
+                                input tensor.
+                            - or a scalar, corresponding to a tensor in the
+                                inputs' tuple. This scalar value is broadcasted
+                                for corresponding input tensor.
 
-                            In the cases when `baselines` is not provided, we internally
-                            use zero scalar corresponding to each input tensor.
+                        In the cases when `baselines` is not provided, we internally
+                        use zero scalar corresponding to each input tensor.
 
-                            Default: None
-                target (int, tuple, tensor or list, optional):  Output indices for
-                            which gradients are computed (for classification cases,
-                            this is usually the target class).
-                            If the network returns a scalar value per example,
-                            no target index is necessary.
-                            For general 2D outputs, targets can be either:
+                        Default: None
+            target (int, tuple, tensor or list, optional):  Output indices for
+                        which gradients are computed (for classification cases,
+                        this is usually the target class).
+                        If the network returns a scalar value per example,
+                        no target index is necessary.
+                        For general 2D outputs, targets can be either:
 
-                            - a single integer or a tensor containing a single
-                                integer, which is applied to all input examples
+                        - a single integer or a tensor containing a single
+                            integer, which is applied to all input examples
 
-                            - a list of integers or a 1D tensor, with length matching
-                                the number of examples in inputs (dim 0). Each integer
-                                is applied as the target for the corresponding example.
+                        - a list of integers or a 1D tensor, with length matching
+                            the number of examples in inputs (dim 0). Each integer
+                            is applied as the target for the corresponding example.
 
-                            For outputs with > 2 dimensions, targets can be either:
+                        For outputs with > 2 dimensions, targets can be either:
 
-                            - A single tuple, which contains #output_dims - 1
-                                elements. This target index is applied to all examples.
+                        - A single tuple, which contains #output_dims - 1
+                            elements. This target index is applied to all examples.
 
-                            - A list of tuples with length equal to the number of
-                                examples in inputs (dim 0), and each tuple containing
-                                #output_dims - 1 elements. Each tuple is applied as the
-                                target for the corresponding example.
+                        - A list of tuples with length equal to the number of
+                            examples in inputs (dim 0), and each tuple containing
+                            #output_dims - 1 elements. Each tuple is applied as the
+                            target for the corresponding example.
 
-                            Default: None
-                additional_forward_args (tuple, optional): If the forward function
-                            requires additional arguments other than the inputs for
-                            which attributions should not be computed, this argument
-                            can be provided. It must be either a single additional
-                            argument of a Tensor or arbitrary (non-tuple) type or a
-                            tuple containing multiple additional arguments including
-                            tensors or any arbitrary python types. These arguments
-                            are provided to forward_func in order following the
-                            arguments in inputs.
-                            For a tensor, the first dimension of the tensor must
-                            correspond to the number of examples. It will be
-                            repeated for each of `n_steps` along the integrated
-                            path. For all other types, the given argument is used
-                            for all forward evaluations.
-                            Note that attributions are not computed with respect
-                            to these arguments.
-                            Default: None
-                n_steps (int, optional): The number of steps used by the approximation
-                            method. Default: 50.
-                method (string, optional): Method for approximating the integral,
-                            one of `riemann_right`, `riemann_left`, `riemann_middle`,
-                            `riemann_trapezoid` or `gausslegendre`.
-                            Default: `gausslegendre` if no method is provided.
-                internal_batch_size (int, optional): Divides total #steps * #examples
-                            data points into chunks of size internal_batch_size,
-                            which are computed (forward / backward passes)
-                            sequentially.
-                            For DataParallel models, each batch is split among the
-                            available devices, so evaluations on each available
-                            device contain internal_batch_size / num_devices examples.
-                            If internal_batch_size is None, then all evaluations are
-                            processed in one batch.
-                            Default: None
-                return_convergence_delta (bool, optional): Indicates whether to return
-                            convergence delta or not. If `return_convergence_delta`
-                            is set to True convergence delta will be returned in
-                            a tuple following attributions.
-                            Default: False
-            Returns:
-                **attributions** or 2-element tuple of **attributions**, **delta**:
-                - **attributions** (*tensor* or tuple of *tensors*):
-                        Integrated gradients with respect to each input feature.
-                        attributions will always be the same size as the provided
-                        inputs, with each value providing the attribution of the
-                        corresponding input index.
-                        If a single tensor is provided as inputs, a single tensor is
-                        returned. If a tuple is provided for inputs, a tuple of
-                        corresponding sized tensors is returned.
-                - **delta** (*tensor*, returned if return_convergence_delta=True):
-                        The difference between the total approximated and true
-                        integrated gradients. This is computed using the property
-                        that the total sum of forward_func(inputs) -
-                        forward_func(baselines) must equal the total sum of the
-                        integrated gradient.
-                        Delta is calculated per example, meaning that the number of
-                        elements in returned delta tensor is equal to the number of
-                        of examples in inputs.
+                        Default: None
+            additional_forward_args (tuple, optional): If the forward function
+                        requires additional arguments other than the inputs for
+                        which attributions should not be computed, this argument
+                        can be provided. It must be either a single additional
+                        argument of a Tensor or arbitrary (non-tuple) type or a
+                        tuple containing multiple additional arguments including
+                        tensors or any arbitrary python types. These arguments
+                        are provided to forward_func in order following the
+                        arguments in inputs.
+                        For a tensor, the first dimension of the tensor must
+                        correspond to the number of examples. It will be
+                        repeated for each of `n_steps` along the integrated
+                        path. For all other types, the given argument is used
+                        for all forward evaluations.
+                        Note that attributions are not computed with respect
+                        to these arguments.
+                        Default: None
+            n_steps (int, optional): The number of steps used by the approximation
+                        method. Default: 50.
+            method (string, optional): Method for approximating the integral,
+                        one of `riemann_right`, `riemann_left`, `riemann_middle`,
+                        `riemann_trapezoid` or `gausslegendre`.
+                        Default: `gausslegendre` if no method is provided.
+            internal_batch_size (int, optional): Divides total #steps * #examples
+                        data points into chunks of size internal_batch_size,
+                        which are computed (forward / backward passes)
+                        sequentially.
+                        For DataParallel models, each batch is split among the
+                        available devices, so evaluations on each available
+                        device contain internal_batch_size / num_devices examples.
+                        If internal_batch_size is None, then all evaluations are
+                        processed in one batch.
+                        Default: None
+            return_convergence_delta (bool, optional): Indicates whether to return
+                    convergence delta or not. If `return_convergence_delta`
+                        is set to True convergence delta will be returned in
+                        a tuple following attributions.
+                        Default: False
+        Returns:
+            **attributions** or 2-element tuple of **attributions**, **delta**:
+            - **attributions** (*tensor* or tuple of *tensors*):
+                    Integrated gradients with respect to each input feature.
+                    attributions will always be the same size as the provided
+                    inputs, with each value providing the attribution of the
+                    corresponding input index.
+                    If a single tensor is provided as inputs, a single tensor is
+                    returned. If a tuple is provided for inputs, a tuple of
+                    corresponding sized tensors is returned.
+            - **delta** (*tensor*, returned if return_convergence_delta=True):
+                    The difference between the total approximated and true
+                    integrated gradients. This is computed using the property
+                    that the total sum of forward_func(inputs) -
+                    forward_func(baselines) must equal the total sum of the
+                    integrated gradient.
+                    Delta is calculated per example, meaning that the number of
+                    elements in returned delta tensor is equal to the number of
+                    of examples in inputs.
 
-            Examples::
+        Examples::
 
-                >>> # ImageClassifier takes a single input tensor of images Nx3x32x32,
-                >>> # and returns an Nx10 tensor of class probabilities.
-                >>> net = ImageClassifier()
-                >>> ig = IntegratedGradients(net)
-                >>> input = torch.randn(2, 3, 32, 32, requires_grad=True)
-                >>> # Computes integrated gradients for class 3.
-                >>> attribution = ig.attribute(input, target=3)
+            >>> # ImageClassifier takes a single input tensor of images Nx3x32x32,
+            >>> # and returns an Nx10 tensor of class probabilities.
+            >>> net = ImageClassifier()
+            >>> ig = IntegratedGradients(net)
+            >>> input = torch.randn(2, 3, 32, 32, requires_grad=True)
+            >>> # Computes integrated gradients for class 3.
+            >>> attribution = ig.attribute(input, target=3)
         """
         # Keeps track whether original input is a tuple or not before
         # converting it into a tuple.

--- a/captum/attr/_core/integrated_gradients.py
+++ b/captum/attr/_core/integrated_gradients.py
@@ -90,8 +90,8 @@ class IntegratedGradients(GradientAttribution):
                                     dimensions match with the corresponding
                                     input tensor.
                                 - or a scalar, corresponding to a tensor in the
-                                        inputs' tuple. This scalar value is broadcasted
-                                        for corresponding input tensor.
+                                    inputs' tuple. This scalar value is broadcasted
+                                    for corresponding input tensor.
 
                             In the cases when `baselines` is not provided, we internally
                             use zero scalar corresponding to each input tensor.

--- a/captum/attr/_core/integrated_gradients.py
+++ b/captum/attr/_core/integrated_gradients.py
@@ -17,9 +17,9 @@ from .._utils.attribution import GradientAttribution
 
 class IntegratedGradients(GradientAttribution):
     r"""
-    Integrated Gradients is an axiomatic model interpretability algorithms that
+    Integrated Gradients is an axiomatic model interpretability algorithm that
     assigns an importance score to each input feature by approximating the
-    integral of gradients of the model output with respect to the inputs
+    integral of gradients of the model's output with respect to the inputs
     along the path (straight line) from given baselines / references to inputs.
 
     Baselines can be provided as input arguments to attribute method.
@@ -57,7 +57,7 @@ class IntegratedGradients(GradientAttribution):
         (in case it is provided, otherwise it assumes that output is a
         scalar) to the inputs of the model using the approach described above.
 
-        In addition to that is also returns, if `return_convergence_delta` is
+        In addition to that it also returns, if `return_convergence_delta` is
         set to True, integral approximation delta based on the completeness
         property of integrated gradients.
 

--- a/captum/attr/_core/integrated_gradients.py
+++ b/captum/attr/_core/integrated_gradients.py
@@ -26,7 +26,7 @@ class IntegratedGradients(GradientAttribution):
     To approximate the integral we can choose to use either a variant of
     Riemann sum or Gauss-Legendre quadrature rule.
 
-    More details regarding the integrated gradient method can be found in the
+    More details regarding the integrated gradients method can be found in the
     original paper:
     https://arxiv.org/abs/1703.01365
 

--- a/captum/attr/_core/layer/layer_integrated_gradients.py
+++ b/captum/attr/_core/layer/layer_integrated_gradients.py
@@ -29,7 +29,7 @@ class LayerIntegratedGradients(LayerAttribution, IntegratedGradients):
     features are layer inputs or outputs depending on whether we attribute to
     the former or to the latter one.
 
-    Both baseline and reference can be provided as input arguments to attribute
+    Both baselines and references can be provided as input arguments to attribute
     method. To approximate the integral we can choose to use either a variant of
     Riemann sum or Gauss-Legendre quadrature rule.
 
@@ -38,6 +38,7 @@ class LayerIntegratedGradients(LayerAttribution, IntegratedGradients):
     https://arxiv.org/abs/1703.01365
 
     """
+
     def __init__(self, forward_func, layer, device_ids=None):
         r"""
         Args:
@@ -74,7 +75,7 @@ class LayerIntegratedGradients(LayerAttribution, IntegratedGradients):
         return_convergence_delta=False,
         attribute_to_layer_input=False,
     ):
-    r"""
+        r"""
         This method attributes the output of the model with given target index
         (in case it is provided, otherwise it assumes that output is a
         scalar) to layer inputs or outputs of the model, depending on whether
@@ -227,7 +228,7 @@ class LayerIntegratedGradients(LayerAttribution, IntegratedGradients):
                 >>> # Computes layer integrated gradients for class 3.
                 >>> # attribution size matches layer output, Nx12x32x32
                 >>> attribution = lig.attribute(input, target=3)
-    """
+        """
         inps, baselines = _format_input_baseline(inputs, baselines)
         _validate_input(inps, baselines, n_steps, method)
 

--- a/captum/attr/_core/layer/layer_integrated_gradients.py
+++ b/captum/attr/_core/layer/layer_integrated_gradients.py
@@ -29,8 +29,8 @@ class LayerIntegratedGradients(LayerAttribution, IntegratedGradients):
     features are layer inputs or outputs depending on whether we attribute to
     the former or to the latter one.
 
-    Both baselines and references can be provided as input arguments to attribute
-    method. To approximate the integral we can choose to use either a variant of
+    Baselines can be provided as input arguments to attribute method.
+    To approximate the integral we can choose to use either a variant of
     Riemann sum or Gauss-Legendre quadrature rule.
 
     More details regarding the integrated gradient method can be found in the

--- a/captum/attr/_core/layer/layer_integrated_gradients.py
+++ b/captum/attr/_core/layer/layer_integrated_gradients.py
@@ -20,14 +20,14 @@ from captum.attr._utils.gradient import _run_forward
 
 class LayerIntegratedGradients(LayerAttribution, IntegratedGradients):
     r"""
-    Integrated Gradients is an axiomatic model interpretability algorithms that
-    assigns an importance score to each input feature by approximating the
-    integral of gradients of the model output with respect to the inputs
-    along the path (straight line) from given baselines / references to inputs.
+    Layer Integrated Gradients is a variant of Integrated Gradients that assigns
+    an importance score to layer inputs or outputs, depending on whether we
+    attribute to the former or to the latter one.
 
-    In this case since we apply integrated gradients to the layer, the input
-    features are layer inputs or outputs depending on whether we attribute to
-    the former or to the latter one.
+    Integrated Gradients is an axiomatic model interpretability algorithm that
+    attributes / assigns an importance score to each input feature by approximating
+    the integral of gradients of the model's output with respect to the inputs
+    along the path (straight line) from given baselines / references to inputs.
 
     Baselines can be provided as input arguments to attribute method.
     To approximate the integral we can choose to use either a variant of
@@ -50,9 +50,6 @@ class LayerIntegratedGradients(LayerAttribution, IntegratedGradients):
                           the inputs or outputs of the layer, corresponding to
                           the attribution of each neuron in the input or output
                           of this layer.
-                          Currently, it is assumed that the inputs or the outputs
-                          of the layer, depending on which one is used for
-                          attribution can only be a single tensor.
             device_ids (list(int)): Device ID list, necessary only if forward_func
                           applies a DataParallel model. This allows reconstruction of
                           intermediate outputs from batched results across devices.
@@ -82,7 +79,7 @@ class LayerIntegratedGradients(LayerAttribution, IntegratedGradients):
         `attribute_to_layer_input` is set to True or False, using the approach
         described above.
 
-        In addition to that is also returns, if `return_convergence_delta` is
+        In addition to that it also returns, if `return_convergence_delta` is
         set to True, integral approximation delta based on the completeness
         property of integrated gradients.
 

--- a/captum/attr/_core/layer/layer_integrated_gradients.py
+++ b/captum/attr/_core/layer/layer_integrated_gradients.py
@@ -19,11 +19,45 @@ from captum.attr._utils.gradient import _run_forward
 
 
 class LayerIntegratedGradients(LayerAttribution, IntegratedGradients):
+    r"""
+    Integrated Gradients is an axiomatic model interpretability algorithms that
+    assigns an importance score to each input feature by approximating the
+    integral of gradients of model output with respect to the inputs
+    along the path (straight line) from given baselines / references to inputs.
+
+    In this case since we apply integrated gradients to the layer, the input
+    features are layer inputs or outputs depending on whether we attribute to
+    the former or to the latter one.
+
+    Both baseline and reference can be provided as input arguments to attribute
+    method. To approximate the integral we can choose to use either a variant of
+    Riemann sum or Gauss-Legendre quadrature rule.
+
+    More details regarding the integrated gradient method can be found in the
+    original paper:
+    https://arxiv.org/abs/1703.01365
+
+    """
     def __init__(self, forward_func, layer, device_ids=None):
         r"""
         Args:
             forward_func (callable):  The forward function of the model or any
                           modification of it
+            layer (torch.nn.Module): Layer for which attributions are computed.
+                          Output size of attribute matches this layer's input or
+                          output dimensions, depending on whether we attribute to
+                          the inputs or outputs of the layer, corresponding to
+                          the attribution of each neuron in the input or output
+                          of this layer.
+                          Currently, it is assumed that the inputs or the outputs
+                          of the layer, depending on which one is used for
+                          attribution can only be a single tensor.
+            device_ids (list(int)): Device ID list, necessary only if forward_func
+                          applies a DataParallel model. This allows reconstruction of
+                          intermediate outputs from batched results across devices.
+                          If forward_func is given as the DataParallel model itself,
+                          then it is not necessary to provide this argument.
+
         """
         LayerAttribution.__init__(self, forward_func, layer, device_ids=device_ids)
         IntegratedGradients.__init__(self, forward_func)
@@ -40,6 +74,160 @@ class LayerIntegratedGradients(LayerAttribution, IntegratedGradients):
         return_convergence_delta=False,
         attribute_to_layer_input=False,
     ):
+    r"""
+        This method attributes the output of the model with given target index
+        (in case it is provided, otherwise it assumes that output is a
+        scalar) to layer inputs or outputs of the model, depending on whether
+        `attribute_to_layer_input` is set to True or False, using the approach
+        described above.
+
+        In addition to that is also returns (if `return_convergence_delta` is
+        set to True) integral approximation delta based on the completeness
+        property of integrated gradients.
+
+        Args:
+
+            inputs (tensor or tuple of tensors):  Input for which layer integrated
+                        gradients are computed. If forward_func takes a single
+                        tensor as input, a single input tensor should be provided.
+                        If forward_func takes multiple tensors as input, a tuple
+                        of the input tensors should be provided. It is assumed
+                        that for all given input tensors, dimension 0 corresponds
+                        to the number of examples, and if multiple input tensors
+                        are provided, the examples must be aligned appropriately.
+            baselines (scalar, tensor, tuple of scalars or tensors, optional):
+                        Baselines define the starting point from which integral
+                        is computed and can be provided as:
+
+                        - a single tensor, if inputs is a single tensor, with
+                            exactly the same dimensions as inputs or the first
+                            dimension is one and the remaining dimensions match
+                            with inputs.
+
+                        - a single scalar, if inputs is a single tensor, which will
+                                be broadcasted for each input value in input tensor.
+
+                        - a tuple of tensors or scalars, the baseline corresponding
+                            to each tensor in the inputs' tuple can be:
+                            - either a tensor with matching dimensions to
+                                corresponding tensor in the inputs' tuple
+                                or the first dimension is one and the remaining
+                                dimensions match with the corresponding
+                                input tensor.
+                            - or a scalar, corresponding to a tensor in the
+                                inputs' tuple. This scalar value is broadcasted
+                                for corresponding input tensor.
+
+                        In the cases when `baselines` is not provided, we internally
+                        use zero scalar corresponding to each input tensor.
+
+                        Default: None
+            target (int, tuple, tensor or list, optional):  Output indices for
+                        which gradients are computed (for classification cases,
+                        this is usually the target class).
+                        If the network returns a scalar value per example,
+                        no target index is necessary.
+                        For general 2D outputs, targets can be either:
+
+                        - a single integer or a tensor containing a single
+                            integer, which is applied to all input examples
+
+                        - a list of integers or a 1D tensor, with length matching
+                            the number of examples in inputs (dim 0). Each integer
+                            is applied as the target for the corresponding example.
+
+                        For outputs with > 2 dimensions, targets can be either:
+
+                        - A single tuple, which contains #output_dims - 1
+                            elements. This target index is applied to all examples.
+
+                        - A list of tuples with length equal to the number of
+                            examples in inputs (dim 0), and each tuple containing
+                            #output_dims - 1 elements. Each tuple is applied as the
+                            target for the corresponding example.
+
+                        Default: None
+            additional_forward_args (tuple, optional): If the forward function
+                        requires additional arguments other than the inputs for
+                        which attributions should not be computed, this argument
+                        can be provided. It must be either a single additional
+                        argument of a Tensor or arbitrary (non-tuple) type or a
+                        tuple containing multiple additional arguments including
+                        tensors or any arbitrary python types. These arguments
+                        are provided to forward_func in order following the
+                        arguments in inputs.
+                        For a tensor, the first dimension of the tensor must
+                        correspond to the number of examples. It will be
+                        repeated for each of `n_steps` along the integrated
+                        path. For all other types, the given argument is used
+                        for all forward evaluations.
+                        Note that attributions are not computed with respect
+                        to these arguments.
+                        Default: None
+            n_steps (int, optional): The number of steps used by the approximation
+                        method. Default: 50.
+            method (string, optional): Method for approximating the integral,
+                        one of `riemann_right`, `riemann_left`, `riemann_middle`,
+                        `riemann_trapezoid` or `gausslegendre`.
+                        Default: `gausslegendre` if no method is provided.
+            internal_batch_size (int, optional): Divides total #steps * #examples
+                        data points into chunks of size internal_batch_size,
+                        which are computed (forward / backward passes)
+                        sequentially.
+                        For DataParallel models, each batch is split among the
+                        available devices, so evaluations on each available
+                        device contain internal_batch_size / num_devices examples.
+                        If internal_batch_size is None, then all evaluations are
+                        processed in one batch.
+                        Default: None
+            return_convergence_delta (bool, optional): Indicates whether to return
+                        convergence delta or not. If `return_convergence_delta`
+                        is set to True convergence delta will be returned in
+                        a tuple following attributions.
+                        Default: False
+            attribute_to_layer_input (bool, optional): Indicates whether to
+                        compute the attribution with respect to the layer input
+                        or output. If `attribute_to_layer_input` is set to True
+                        then the attributions will be computed with respect to
+                        layer input, otherwise it will be computed with respect
+                        to layer output.
+                        Note that currently it is assumed that either the input
+                        or the output of internal layer, depending on whether we
+                        attribute to the input or output, is a single tensor.
+                        Support for multiple tensors will be added later.
+                        Default: False
+            Returns:
+                **attributions** or 2-element tuple of **attributions**, **delta**:
+                - **attributions** (*tensor* or tuple of *tensors*):
+                        Integrated gradients with respect to `layer`'s inputs or
+                        outputs. Attributions will always be the same size and
+                        dimensionality as the input or output of the given layer,
+                        depending on whether we attribute to the inputs or outputs
+                        of the layer which is decided by the input flag
+                        `attribute_to_layer_input`.
+                - **delta** (*tensor*, returned if return_convergence_delta=True):
+                        The difference between the total approximated and true
+                        integrated gradients. This is computed using the property
+                        that the total sum of forward_func(inputs) -
+                        forward_func(baselines) must equal the total sum of the
+                        integrated gradient.
+                        Delta is calculated per example, meaning that the number of
+                        elements in returned delta tensor is equal to the number of
+                        of examples in inputs.
+
+            Examples::
+
+                >>> # ImageClassifier takes a single input tensor of images Nx3x32x32,
+                >>> # and returns an Nx10 tensor of class probabilities.
+                >>> # It contains an attribute conv1, which is an instance of nn.conv2d,
+                >>> # and the output of this layer has dimensions Nx12x32x32.
+                >>> net = ImageClassifier()
+                >>> lig = LayerIntegratedGradients(net, net.conv1)
+                >>> input = torch.randn(2, 3, 32, 32, requires_grad=True)
+                >>> # Computes layer integrated gradients for class 3.
+                >>> # attribution size matches layer output, Nx12x32x32
+                >>> attribution = lig.attribute(input, target=3)
+    """
         inps, baselines = _format_input_baseline(inputs, baselines)
         _validate_input(inps, baselines, n_steps, method)
 

--- a/captum/attr/_core/layer/layer_integrated_gradients.py
+++ b/captum/attr/_core/layer/layer_integrated_gradients.py
@@ -22,7 +22,7 @@ class LayerIntegratedGradients(LayerAttribution, IntegratedGradients):
     r"""
     Integrated Gradients is an axiomatic model interpretability algorithms that
     assigns an importance score to each input feature by approximating the
-    integral of gradients of model output with respect to the inputs
+    integral of gradients of the model output with respect to the inputs
     along the path (straight line) from given baselines / references to inputs.
 
     In this case since we apply integrated gradients to the layer, the input
@@ -75,14 +75,14 @@ class LayerIntegratedGradients(LayerAttribution, IntegratedGradients):
         attribute_to_layer_input=False,
     ):
     r"""
-        This method attributes the output of the model with given target index
-        (in case it is provided, otherwise it assumes that output is a
-        scalar) to layer inputs or outputs of the model, depending on whether
+        This method attributes the output of the model with given target index,
+        in case it is provided, otherwise it assumes that output is a
+        scalar, to layer inputs or outputs of the model, depending on whether
         `attribute_to_layer_input` is set to True or False, using the approach
         described above.
 
-        In addition to that is also returns (if `return_convergence_delta` is
-        set to True) integral approximation delta based on the completeness
+        In addition to that is also returns, if `return_convergence_delta` is
+        set to True, integral approximation delta based on the completeness
         property of integrated gradients.
 
         Args:

--- a/captum/attr/_core/layer/layer_integrated_gradients.py
+++ b/captum/attr/_core/layer/layer_integrated_gradients.py
@@ -33,7 +33,7 @@ class LayerIntegratedGradients(LayerAttribution, IntegratedGradients):
     To approximate the integral we can choose to use either a variant of
     Riemann sum or Gauss-Legendre quadrature rule.
 
-    More details regarding the integrated gradient method can be found in the
+    More details regarding the integrated gradients method can be found in the
     original paper:
     https://arxiv.org/abs/1703.01365
 

--- a/captum/attr/_core/layer/layer_integrated_gradients.py
+++ b/captum/attr/_core/layer/layer_integrated_gradients.py
@@ -75,9 +75,9 @@ class LayerIntegratedGradients(LayerAttribution, IntegratedGradients):
         attribute_to_layer_input=False,
     ):
     r"""
-        This method attributes the output of the model with given target index,
-        in case it is provided, otherwise it assumes that output is a
-        scalar, to layer inputs or outputs of the model, depending on whether
+        This method attributes the output of the model with given target index
+        (in case it is provided, otherwise it assumes that output is a
+        scalar) to layer inputs or outputs of the model, depending on whether
         `attribute_to_layer_input` is set to True or False, using the approach
         described above.
 


### PR DESCRIPTION
1. Adds documentation for Layer Integrated Gradients
2. Refactors Integrated Gradients - Moves algorithm description directly under the definition of the class
3. Fixes formatting for IG documentation - r"""  is now more consistent with other docs in IG