### PR TITLE
Fix issue in gradcam and layer_gradient_x_activation when model is in no_requires_grad mode

### DIFF
--- a/captum/attr/_core/layer/grad_cam.py
+++ b/captum/attr/_core/layer/grad_cam.py
@@ -187,6 +187,8 @@ class LayerGradCam(LayerAttribution, GradientAttribution):
             device_ids=self.device_ids,
             attribute_to_layer_input=attribute_to_layer_input,
         )
+        undo_gradient_requirements(inputs, gradient_mask)
+
         summed_grads = tuple(
             torch.mean(
                 layer_grad,
@@ -200,7 +202,6 @@ class LayerGradCam(LayerAttribution, GradientAttribution):
             torch.sum(summed_grad * layer_eval, dim=1, keepdim=True)
             for summed_grad, layer_eval in zip(summed_grads, layer_evals)
         )
-        undo_gradient_requirements(inputs, gradient_mask)
         if relu_attributions:
             scaled_acts = tuple(F.relu(scaled_act) for scaled_act in scaled_acts)
         return _format_attributions(is_layer_tuple, scaled_acts)

--- a/captum/attr/_core/layer/grad_cam.py
+++ b/captum/attr/_core/layer/grad_cam.py
@@ -8,8 +8,11 @@ from ..._utils.common import (
     _format_additional_forward_args,
     _format_attributions,
 )
-from ..._utils.gradient import compute_layer_gradients_and_eval
-from ..._utils.gradient import apply_gradient_requirements, undo_gradient_requirements
+from ..._utils.gradient import (
+    compute_layer_gradients_and_eval,
+    apply_gradient_requirements,
+    undo_gradient_requirements,
+)
 
 
 class LayerGradCam(LayerAttribution, GradientAttribution):

--- a/captum/attr/_core/layer/grad_cam.py
+++ b/captum/attr/_core/layer/grad_cam.py
@@ -9,6 +9,7 @@ from ..._utils.common import (
     _format_attributions,
 )
 from ..._utils.gradient import compute_layer_gradients_and_eval
+from ..._utils.gradient import apply_gradient_requirements, undo_gradient_requirements
 
 
 class LayerGradCam(LayerAttribution, GradientAttribution):
@@ -174,6 +175,7 @@ class LayerGradCam(LayerAttribution, GradientAttribution):
         additional_forward_args = _format_additional_forward_args(
             additional_forward_args
         )
+        gradient_mask = apply_gradient_requirements(inputs)
         # Returns gradient of output with respect to
         # hidden layer and hidden layer evaluated at each input.
         layer_gradients, layer_evals, is_layer_tuple = compute_layer_gradients_and_eval(
@@ -198,6 +200,7 @@ class LayerGradCam(LayerAttribution, GradientAttribution):
             torch.sum(summed_grad * layer_eval, dim=1, keepdim=True)
             for summed_grad, layer_eval in zip(summed_grads, layer_evals)
         )
+        undo_gradient_requirements(inputs, gradient_mask)
         if relu_attributions:
             scaled_acts = tuple(F.relu(scaled_act) for scaled_act in scaled_acts)
         return _format_attributions(is_layer_tuple, scaled_acts)

--- a/captum/attr/_core/layer/layer_gradient_x_activation.py
+++ b/captum/attr/_core/layer/layer_gradient_x_activation.py
@@ -5,8 +5,11 @@ from ..._utils.common import (
     _format_additional_forward_args,
     _format_attributions,
 )
-from ..._utils.gradient import compute_layer_gradients_and_eval
-from ..._utils.gradient import apply_gradient_requirements, undo_gradient_requirements
+from ..._utils.gradient import (
+    compute_layer_gradients_and_eval,
+    apply_gradient_requirements,
+    undo_gradient_requirements,
+)
 
 
 class LayerGradientXActivation(LayerAttribution, GradientAttribution):

--- a/captum/attr/_core/layer/layer_gradient_x_activation.py
+++ b/captum/attr/_core/layer/layer_gradient_x_activation.py
@@ -6,6 +6,7 @@ from ..._utils.common import (
     _format_attributions,
 )
 from ..._utils.gradient import compute_layer_gradients_and_eval
+from ..._utils.gradient import apply_gradient_requirements, undo_gradient_requirements
 
 
 class LayerGradientXActivation(LayerAttribution, GradientAttribution):
@@ -126,6 +127,7 @@ class LayerGradientXActivation(LayerAttribution, GradientAttribution):
         additional_forward_args = _format_additional_forward_args(
             additional_forward_args
         )
+        gradient_mask = apply_gradient_requirements(inputs)
         # Returns gradient of output with respect to
         # hidden layer and hidden layer evaluated at each input.
         layer_gradients, layer_evals, is_layer_tuple = compute_layer_gradients_and_eval(
@@ -137,6 +139,7 @@ class LayerGradientXActivation(LayerAttribution, GradientAttribution):
             device_ids=self.device_ids,
             attribute_to_layer_input=attribute_to_layer_input,
         )
+        undo_gradient_requirements(inputs, gradient_mask)
         return _format_attributions(
             is_layer_tuple,
             tuple(

--- a/tests/attr/layer/test_grad_cam.py
+++ b/tests/attr/layer/test_grad_cam.py
@@ -28,8 +28,8 @@ class Test(BaseTest):
     def test_simple_input_conv_no_grad(self):
         net = BasicModel_ConvNet_One_Conv()
 
-        # this way we deactivate require_grad. Some models expictly do that
-        # before interpreting the model.
+        # this way we deactivate require_grad. Some models explicitly
+        # do that before interpreting the model.
         for param in net.parameters():
             param.requires_grad = False
 

--- a/tests/attr/layer/test_grad_cam.py
+++ b/tests/attr/layer/test_grad_cam.py
@@ -25,6 +25,17 @@ class Test(BaseTest):
         inp = torch.arange(16).view(1, 1, 4, 4).float()
         self._grad_cam_test_assert(net, net.conv1, inp, [[11.25, 13.5], [20.25, 22.5]])
 
+    def test_simple_input_conv_no_grad(self):
+        net = BasicModel_ConvNet_One_Conv()
+
+        # this way we deactivate require_grad. Some models expictly do that
+        # before interpreting the model.
+        for param in net.parameters():
+            param.requires_grad = False
+
+        inp = torch.arange(16).view(1, 1, 4, 4).float()
+        self._grad_cam_test_assert(net, net.conv1, inp, [[11.25, 13.5], [20.25, 22.5]])
+
     def test_simple_input_conv_relu(self):
         net = BasicModel_ConvNet_One_Conv()
         inp = torch.arange(16).view(1, 1, 4, 4).float()

--- a/tests/attr/layer/test_layer_gradient_x_activation.py
+++ b/tests/attr/layer/test_layer_gradient_x_activation.py
@@ -25,6 +25,18 @@ class Test(BaseTest):
             net, net.linear1, inp, [90.0, 101.0, 101.0, 101.0]
         )
 
+    def test_simple_linear_gradient_activation_no_grad(self):
+        net = BasicModel_MultiLayer()
+        inp = torch.tensor([[0.0, 100.0, 0.0]])
+        # this way we deactivate require_grad. Some models expictly do that
+        # before interpreting the model.
+        for param in net.parameters():
+            param.requires_grad = False
+
+        self._layer_activation_test_assert(
+            net, net.linear1, inp, [90.0, 101.0, 101.0, 101.0]
+        )
+
     def test_simple_multi_gradient_activation(self):
         net = BasicModel_MultiLayer(multi_input_module=True)
         inp = torch.tensor([[3.0, 4.0, 0.0]])

--- a/tests/attr/layer/test_layer_gradient_x_activation.py
+++ b/tests/attr/layer/test_layer_gradient_x_activation.py
@@ -28,8 +28,9 @@ class Test(BaseTest):
     def test_simple_linear_gradient_activation_no_grad(self):
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
-        # this way we deactivate require_grad. Some models expictly do that
-        # before interpreting the model.
+
+        # this way we deactivate require_grad. Some models explicitly
+        # do that before interpreting the model.
         for param in net.parameters():
             param.requires_grad = False
 


### PR DESCRIPTION
As I was playing with gradcam and layer_gradient_x_activation, noticed that if the require_grads is set to False for a model, model developers sometimes do that as an optimization, then those two methods fail. To fix that we need to apply `apply_gradient_requirements and undo_gradient_requirements`...

I created some test cases for those cases.
The grads are sometimes disabled with the following command:
```
        for param in net.parameters():
            param.requires_grad = False
```