### PR TITLE
Small fixes to Captum Insights example and serve function

### DIFF
--- a/captum/insights/api.py
+++ b/captum/insights/api.py
@@ -180,10 +180,10 @@ class AttributionVisualizer(object):
         widget = CaptumInsights(visualizer=self)
         display(widget)
 
-    def serve(self, blocking=False, debug=False):
+    def serve(self, blocking=False, debug=False, port=None):
         from captum.insights.server import start_server
 
-        start_server(self, blocking=blocking, debug=debug)
+        start_server(self, blocking=blocking, debug=debug, _port=port)
 
     def _get_labels_from_scores(
         self, scores: Tensor, indices: Tensor

--- a/captum/insights/example.py
+++ b/captum/insights/example.py
@@ -92,4 +92,4 @@ if __name__ == "__main__":
         dataset=formatted_data_iter(),
     )
 
-    visualizer.serve()
+    visualizer.serve(debug=True)


### PR DESCRIPTION
Summary: Bring back the port argument. Example should have debug on by default.

Reviewed By: vivekmig

Differential Revision: D19146091

