### PR TITLE
Fixing add args type in docs

### DIFF
--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -180,7 +180,7 @@ class DeepLift(GradientAttribution):
                             target for the corresponding example.
 
                         Default: None
-            additional_forward_args (tuple, optional): If the forward function
+            additional_forward_args (any, optional): If the forward function
                         requires additional arguments other than the inputs for
                         which attributions should not be computed, this argument
                         can be provided. It must be either a single additional
@@ -568,7 +568,7 @@ class DeepLiftShap(DeepLift):
                             target for the corresponding example.
 
                         Default: None
-            additional_forward_args (tuple, optional): If the forward function
+            additional_forward_args (any, optional): If the forward function
                         requires additional arguments other than the inputs for
                         which attributions should not be computed, this argument
                         can be provided. It must be either a single additional

--- a/captum/attr/_core/feature_ablation.py
+++ b/captum/attr/_core/feature_ablation.py
@@ -109,7 +109,7 @@ class FeatureAblation(PerturbationAttribution):
                                 target for the corresponding example.
 
                             Default: None
-                additional_forward_args (tuple, optional): If the forward function
+                additional_forward_args (any, optional): If the forward function
                             requires additional arguments other than the inputs for
                             which attributions should not be computed, this argument
                             can be provided. It must be either a single additional

--- a/captum/attr/_core/gradient_shap.py
+++ b/captum/attr/_core/gradient_shap.py
@@ -149,7 +149,7 @@ class GradientShap(GradientAttribution):
                             target for the corresponding example.
 
                         Default: None
-            additional_forward_args (tuple, optional): If the forward function
+            additional_forward_args (any, optional): If the forward function
                         requires additional arguments other than the inputs for
                         which attributions should not be computed, this argument
                         can be provided. It can contain a tuple of ND tensors or

--- a/captum/attr/_core/guided_backprop_deconvnet.py
+++ b/captum/attr/_core/guided_backprop_deconvnet.py
@@ -139,7 +139,7 @@ class GuidedBackprop(ModifiedReluGradientAttribution):
                             target for the corresponding example.
 
                         Default: None
-            additional_forward_args (tuple, optional): If the forward function
+            additional_forward_args (any, optional): If the forward function
                         requires additional arguments other than the inputs for
                         which attributions should not be computed, this argument
                         can be provided. It must be either a single additional
@@ -238,7 +238,7 @@ class Deconvolution(ModifiedReluGradientAttribution):
                             target for the corresponding example.
 
                         Default: None
-            additional_forward_args (tuple, optional): If the forward function
+            additional_forward_args (any, optional): If the forward function
                         requires additional arguments other than the inputs for
                         which attributions should not be computed, this argument
                         can be provided. It must be either a single additional

--- a/captum/attr/_core/guided_grad_cam.py
+++ b/captum/attr/_core/guided_grad_cam.py
@@ -100,7 +100,7 @@ class GuidedGradCam(GradientAttribution):
                                 target for the corresponding example.
 
                             Default: None
-                additional_forward_args (tuple, optional): If the forward function
+                additional_forward_args (any, optional): If the forward function
                             requires additional arguments other than the inputs for
                             which attributions should not be computed, this argument
                             can be provided. It must be either a single additional

--- a/captum/attr/_core/input_x_gradient.py
+++ b/captum/attr/_core/input_x_gradient.py
@@ -56,7 +56,7 @@ class InputXGradient(GradientAttribution):
                             target for the corresponding example.
 
                         Default: None
-            additional_forward_args (tuple, optional): If the forward function
+            additional_forward_args (any, optional): If the forward function
                         requires additional arguments other than the inputs for
                         which attributions should not be computed, this argument
                         can be provided. It must be either a single additional

--- a/captum/attr/_core/integrated_gradients.py
+++ b/captum/attr/_core/integrated_gradients.py
@@ -132,7 +132,7 @@ class IntegratedGradients(GradientAttribution):
                             target for the corresponding example.
 
                         Default: None
-            additional_forward_args (tuple, optional): If the forward function
+            additional_forward_args (any, optional): If the forward function
                         requires additional arguments other than the inputs for
                         which attributions should not be computed, this argument
                         can be provided. It must be either a single additional

--- a/captum/attr/_core/layer/grad_cam.py
+++ b/captum/attr/_core/layer/grad_cam.py
@@ -110,7 +110,7 @@ class LayerGradCam(LayerAttribution, GradientAttribution):
                                 target for the corresponding example.
 
                             Default: None
-                additional_forward_args (tuple, optional): If the forward function
+                additional_forward_args (any, optional): If the forward function
                             requires additional arguments other than the inputs for
                             which attributions should not be computed, this argument
                             can be provided. It must be either a single additional

--- a/captum/attr/_core/layer/internal_influence.py
+++ b/captum/attr/_core/layer/internal_influence.py
@@ -122,7 +122,7 @@ class InternalInfluence(LayerAttribution, GradientAttribution):
                                 target for the corresponding example.
 
                             Default: None
-                additional_forward_args (tuple, optional): If the forward function
+                additional_forward_args (any, optional): If the forward function
                             requires additional arguments other than the inputs for
                             which attributions should not be computed, this argument
                             can be provided. It must be either a single additional

--- a/captum/attr/_core/layer/layer_activation.py
+++ b/captum/attr/_core/layer/layer_activation.py
@@ -55,7 +55,7 @@ class LayerActivation(LayerAttribution):
                             that for all given input tensors, dimension 0 corresponds
                             to the number of examples, and if multiple input tensors
                             are provided, the examples must be aligned appropriately.
-                additional_forward_args (tuple, optional): If the forward function
+                additional_forward_args (any, optional): If the forward function
                             requires additional arguments other than the inputs for
                             which attributions should not be computed, this argument
                             can be provided. It must be either a single additional

--- a/captum/attr/_core/layer/layer_conductance.py
+++ b/captum/attr/_core/layer/layer_conductance.py
@@ -128,7 +128,7 @@ class LayerConductance(LayerAttribution, GradientAttribution):
                                 target for the corresponding example.
 
                             Default: None
-                additional_forward_args (tuple, optional): If the forward function
+                additional_forward_args (any, optional): If the forward function
                             requires additional arguments other than the inputs for
                             which attributions should not be computed, this argument
                             can be provided. It must be either a single additional

--- a/captum/attr/_core/layer/layer_deep_lift.py
+++ b/captum/attr/_core/layer/layer_deep_lift.py
@@ -146,7 +146,7 @@ class LayerDeepLift(LayerAttribution, DeepLift):
                             #output_dims - 1 elements. Each tuple is applied as the
                             target for the corresponding example.
                         Default: None
-            additional_forward_args (tuple, optional): If the forward function
+            additional_forward_args (any, optional): If the forward function
                         requires additional arguments other than the inputs for
                         which attributions should not be computed, this argument
                         can be provided. It must be either a single additional
@@ -397,7 +397,7 @@ class LayerDeepLiftShap(LayerDeepLift, DeepLiftShap):
                             target for the corresponding example.
 
                         Default: None
-            additional_forward_args (tuple, optional): If the forward function
+            additional_forward_args (any, optional): If the forward function
                         requires additional arguments other than the inputs for
                         which attributions should not be computed, this argument
                         can be provided. It must be either a single additional

--- a/captum/attr/_core/layer/layer_feature_ablation.py
+++ b/captum/attr/_core/layer/layer_feature_ablation.py
@@ -107,7 +107,7 @@ class LayerFeatureAblation(LayerAttribution, PerturbationAttribution):
                                 target for the corresponding example.
 
                             Default: None
-                additional_forward_args (tuple, optional): If the forward function
+                additional_forward_args (any, optional): If the forward function
                             requires additional arguments other than the inputs for
                             which attributions should not be computed, this argument
                             can be provided. It must be either a single additional

--- a/captum/attr/_core/layer/layer_gradient_shap.py
+++ b/captum/attr/_core/layer/layer_gradient_shap.py
@@ -168,7 +168,7 @@ class LayerGradientShap(LayerAttribution, GradientShap):
                             target for the corresponding example.
 
                         Default: None
-            additional_forward_args (tuple, optional): If the forward function
+            additional_forward_args (any, optional): If the forward function
                         requires additional arguments other than the inputs for
                         which attributions should not be computed, this argument
                         can be provided. It can contain a tuple of ND tensors or

--- a/captum/attr/_core/layer/layer_gradient_x_activation.py
+++ b/captum/attr/_core/layer/layer_gradient_x_activation.py
@@ -80,7 +80,7 @@ class LayerGradientXActivation(LayerAttribution, GradientAttribution):
                                 target for the corresponding example.
 
                             Default: None
-                additional_forward_args (tuple, optional): If the forward function
+                additional_forward_args (any, optional): If the forward function
                             requires additional arguments other than the inputs for
                             which attributions should not be computed, this argument
                             can be provided. It must be either a single additional

--- a/captum/attr/_core/layer/layer_integrated_gradients.py
+++ b/captum/attr/_core/layer/layer_integrated_gradients.py
@@ -146,7 +146,7 @@ class LayerIntegratedGradients(LayerAttribution, IntegratedGradients):
                             target for the corresponding example.
 
                         Default: None
-            additional_forward_args (tuple, optional): If the forward function
+            additional_forward_args (any, optional): If the forward function
                         requires additional arguments other than the inputs for
                         which attributions should not be computed, this argument
                         can be provided. It must be either a single additional

--- a/captum/attr/_core/neuron/neuron_conductance.py
+++ b/captum/attr/_core/neuron/neuron_conductance.py
@@ -135,7 +135,7 @@ class NeuronConductance(NeuronAttribution, GradientAttribution):
                                 target for the corresponding example.
 
                             Default: None
-                additional_forward_args (tuple, optional): If the forward function
+                additional_forward_args (any, optional): If the forward function
                             requires additional arguments other than the inputs for
                             which attributions should not be computed, this argument
                             can be provided. It must be either a single additional

--- a/captum/attr/_core/neuron/neuron_deep_lift.py
+++ b/captum/attr/_core/neuron/neuron_deep_lift.py
@@ -106,7 +106,7 @@ class NeuronDeepLift(NeuronAttribution, GradientAttribution):
                         use zero scalar corresponding to each input tensor.
 
                         Default: None
-            additional_forward_args (tuple, optional): If the forward function
+            additional_forward_args (any, optional): If the forward function
                         requires additional arguments other than the inputs for
                         which attributions should not be computed, this argument
                         can be provided. It must be either a single additional
@@ -274,7 +274,7 @@ class NeuronDeepLiftShap(NeuronAttribution, GradientAttribution):
                         use zero scalar corresponding to each input tensor.
 
                         Default: None
-            additional_forward_args (tuple, optional): If the forward function
+            additional_forward_args (any, optional): If the forward function
                         requires additional arguments other than the inputs for
                         which attributions should not be computed, this argument
                         can be provided. It must be either a single additional

--- a/captum/attr/_core/neuron/neuron_feature_ablation.py
+++ b/captum/attr/_core/neuron/neuron_feature_ablation.py
@@ -92,7 +92,7 @@ class NeuronFeatureAblation(NeuronAttribution, PerturbationAttribution):
                             In the cases when `baselines` is not provided, we internally
                             use zero scalar corresponding to each input tensor.
                             Default: None
-                additional_forward_args (tuple, optional): If the forward function
+                additional_forward_args (any, optional): If the forward function
                             requires additional arguments other than the inputs for
                             which attributions should not be computed, this argument
                             can be provided. It must be either a single additional

--- a/captum/attr/_core/neuron/neuron_gradient.py
+++ b/captum/attr/_core/neuron/neuron_gradient.py
@@ -65,7 +65,7 @@ class NeuronGradient(NeuronAttribution, GradientAttribution):
                               dimension 0 corresponds to number of examples).
                               An integer may be provided instead of a tuple of
                               length 1.
-                additional_forward_args (tuple, optional): If the forward function
+                additional_forward_args (any, optional): If the forward function
                             requires additional arguments other than the inputs for
                             which attributions should not be computed, this argument
                             can be provided. It must be either a single additional

--- a/captum/attr/_core/neuron/neuron_gradient_shap.py
+++ b/captum/attr/_core/neuron/neuron_gradient_shap.py
@@ -138,7 +138,7 @@ class NeuronGradientShap(NeuronAttribution, GradientAttribution):
                         corresponds to the input with the same index in the inputs
                         tuple.
                         Default: 0.0
-            additional_forward_args (tuple, optional): If the forward function
+            additional_forward_args (any, optional): If the forward function
                         requires additional arguments other than the inputs for
                         which attributions should not be computed, this argument
                         can be provided. It can contain a tuple of ND tensors or

--- a/captum/attr/_core/neuron/neuron_guided_backprop_deconvnet.py
+++ b/captum/attr/_core/neuron/neuron_guided_backprop_deconvnet.py
@@ -71,7 +71,7 @@ class NeuronDeconvolution(NeuronAttribution, GradientAttribution):
                           dimension 0 corresponds to number of examples).
                           An integer may be provided instead of a tuple of
                           length 1.
-            additional_forward_args (tuple, optional): If the forward function
+            additional_forward_args (any, optional): If the forward function
                         requires additional arguments other than the inputs for
                         which attributions should not be computed, this argument
                         can be provided. It must be either a single additional
@@ -190,7 +190,7 @@ class NeuronGuidedBackprop(NeuronAttribution, GradientAttribution):
                           dimension 0 corresponds to number of examples).
                           An integer may be provided instead of a tuple of
                           length 1.
-            additional_forward_args (tuple, optional): If the forward function
+            additional_forward_args (any, optional): If the forward function
                         requires additional arguments other than the inputs for
                         which attributions should not be computed, this argument
                         can be provided. It must be either a single additional

--- a/captum/attr/_core/neuron/neuron_integrated_gradients.py
+++ b/captum/attr/_core/neuron/neuron_integrated_gradients.py
@@ -98,7 +98,7 @@ class NeuronIntegratedGradients(NeuronAttribution, GradientAttribution):
                             use zero scalar corresponding to each input tensor.
 
                             Default: None
-                additional_forward_args (tuple, optional): If the forward function
+                additional_forward_args (any, optional): If the forward function
                             requires additional arguments other than the inputs for
                             which attributions should not be computed, this argument
                             can be provided. It must be either a single additional

--- a/captum/attr/_core/occlusion.py
+++ b/captum/attr/_core/occlusion.py
@@ -137,7 +137,7 @@ class Occlusion(FeatureAblation):
                                 target for the corresponding example.
 
                             Default: None
-                additional_forward_args (tuple, optional): If the forward function
+                additional_forward_args (any, optional): If the forward function
                             requires additional arguments other than the inputs for
                             which attributions should not be computed, this argument
                             can be provided. It must be either a single additional

--- a/captum/attr/_core/saliency.py
+++ b/captum/attr/_core/saliency.py
@@ -66,7 +66,7 @@ class Saliency(GradientAttribution):
                             to True, otherwise returns the (signed) gradients if
                             False.
                             Defalut: True
-                additional_forward_args (tuple, optional): If the forward function
+                additional_forward_args (any, optional): If the forward function
                             requires additional arguments other than the inputs for
                             which attributions should not be computed, this argument
                             can be provided. It must be either a single additional

--- a/captum/attr/_utils/attribution.py
+++ b/captum/attr/_utils/attribution.py
@@ -198,7 +198,7 @@ class GradientAttribution(Attribution):
                                 target for the corresponding example.
 
                             Default: None
-                additional_forward_args (tuple, optional): If the forward function
+                additional_forward_args (any, optional): If the forward function
                             requires additional arguments other than the inputs for
                             which attributions should not be computed, this argument
                             can be provided. It must be either a single additional


### PR DESCRIPTION
Fixes additional_forward_args type from tuple to any in docs, since it doesn't necessarily need to be a tuple.