### PR TITLE
Adding Type Hints to Captum: LayerGradCam

### DIFF
--- a/captum/attr/_core/layer/grad_cam.py
+++ b/captum/attr/_core/layer/grad_cam.py
@@ -20,11 +20,11 @@ from ..._utils.gradient import (
 
 class LayerGradCam(LayerAttribution, GradientAttribution):
     def __init__(
-            self,
-            forward_func: Callable,
-            layer: Module,
-            device_ids: Optional[List[int]] = None,
-        ) -> None:
+        self,
+        forward_func: Callable,
+        layer: Module,
+        device_ids: Optional[List[int]] = None,
+    ) -> None:
         r"""
         Args
 
@@ -52,7 +52,7 @@ class LayerGradCam(LayerAttribution, GradientAttribution):
         additional_forward_args: Any = None,
         attribute_to_layer_input: bool = False,
         relu_attributions: bool = False,
-    ) -> Union[Tensor, Tuple[Tensor,...]]:
+    ) -> Union[Tensor, Tuple[Tensor, ...]]:
         r"""
             Computes GradCAM attribution for chosen layer. GradCAM is designed for
             convolutional neural networks, and is usually applied to the last

--- a/captum/attr/_core/layer/grad_cam.py
+++ b/captum/attr/_core/layer/grad_cam.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
+from typing import Callable, List, Optional, Tuple, Union, Any
 import torch
+from torch import Tensor
+from torch.nn import Module
 import torch.nn.functional as F
 
 from ..._utils.attribution import LayerAttribution, GradientAttribution
@@ -16,7 +19,12 @@ from ..._utils.gradient import (
 
 
 class LayerGradCam(LayerAttribution, GradientAttribution):
-    def __init__(self, forward_func, layer, device_ids=None):
+    def __init__(
+            self,
+            forward_func: Callable,
+            layer: Module,
+            device_ids: Optional[List[int]] = None,
+        ) -> None:
         r"""
         Args
 
@@ -37,12 +45,14 @@ class LayerGradCam(LayerAttribution, GradientAttribution):
 
     def attribute(
         self,
-        inputs,
-        target=None,
-        additional_forward_args=None,
-        attribute_to_layer_input=False,
-        relu_attributions=False,
-    ):
+        inputs: Union[Tensor, Tuple[Tensor, ...]],
+        target: Optional[
+            Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
+        ] = None,
+        additional_forward_args: Any = None,
+        attribute_to_layer_input: bool = False,
+        relu_attributions: bool = False,
+    ) -> Union[Tensor, Tuple[Tensor,...]]:
         r"""
             Computes GradCAM attribution for chosen layer. GradCAM is designed for
             convolutional neural networks, and is usually applied to the last

--- a/tests/attr/layer/test_grad_cam.py
+++ b/tests/attr/layer/test_grad_cam.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 
 import unittest
+from typing import List, Tuple, Union, Any
 
 import torch
+from torch import Tensor
+from torch.nn import Module
 from captum.attr._core.layer.grad_cam import LayerGradCam
 
 from ..helpers.basic_models import BasicModel_MultiLayer, BasicModel_ConvNet_One_Conv
@@ -10,22 +13,22 @@ from ..helpers.utils import assertTensorTuplesAlmostEqual, BaseTest
 
 
 class Test(BaseTest):
-    def test_simple_input_non_conv(self):
+    def test_simple_input_non_conv(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
         self._grad_cam_test_assert(net, net.linear0, inp, [400.0])
 
-    def test_simple_multi_input_non_conv(self):
+    def test_simple_multi_input_non_conv(self) -> None:
         net = BasicModel_MultiLayer(multi_input_module=True)
         inp = torch.tensor([[0.0, 6.0, 0.0]], requires_grad=True)
         self._grad_cam_test_assert(net, net.relu, inp, ([21.0], [21.0]))
 
-    def test_simple_input_conv(self):
+    def test_simple_input_conv(self) -> None:
         net = BasicModel_ConvNet_One_Conv()
         inp = torch.arange(16).view(1, 1, 4, 4).float()
         self._grad_cam_test_assert(net, net.conv1, inp, [[11.25, 13.5], [20.25, 22.5]])
 
-    def test_simple_input_conv_no_grad(self):
+    def test_simple_input_conv_no_grad(self) -> None:
         net = BasicModel_ConvNet_One_Conv()
 
         # this way we deactivate require_grad. Some models explicitly
@@ -36,12 +39,12 @@ class Test(BaseTest):
         inp = torch.arange(16).view(1, 1, 4, 4).float()
         self._grad_cam_test_assert(net, net.conv1, inp, [[11.25, 13.5], [20.25, 22.5]])
 
-    def test_simple_input_conv_relu(self):
+    def test_simple_input_conv_relu(self) -> None:
         net = BasicModel_ConvNet_One_Conv()
         inp = torch.arange(16).view(1, 1, 4, 4).float()
         self._grad_cam_test_assert(net, net.relu1, inp, [[0.0, 4.0], [28.0, 32.5]])
 
-    def test_simple_input_conv_without_final_relu(self):
+    def test_simple_input_conv_without_final_relu(self) -> None:
         net = BasicModel_ConvNet_One_Conv()
         inp = torch.arange(16).view(1, 1, 4, 4).float()
         inp.requires_grad_()
@@ -51,7 +54,7 @@ class Test(BaseTest):
             net, net.conv1, inp, (0.5625 * inp,), attribute_to_layer_input=True
         )
 
-    def test_simple_input_conv_fc_with_final_relu(self):
+    def test_simple_input_conv_fc_with_final_relu(self) -> None:
         net = BasicModel_ConvNet_One_Conv()
         inp = torch.arange(16).view(1, 1, 4, 4).float()
         inp.requires_grad_()
@@ -68,7 +71,7 @@ class Test(BaseTest):
             relu_attributions=True,
         )
 
-    def test_simple_multi_input_conv(self):
+    def test_simple_multi_input_conv(self) -> None:
         net = BasicModel_ConvNet_One_Conv()
         inp = torch.arange(16).view(1, 1, 4, 4).float()
         inp2 = torch.ones((1, 1, 4, 4))
@@ -78,13 +81,13 @@ class Test(BaseTest):
 
     def _grad_cam_test_assert(
         self,
-        model,
-        target_layer,
-        test_input,
-        expected_activation,
-        additional_input=None,
-        attribute_to_layer_input=False,
-        relu_attributions=False,
+        model: Module,
+        target_layer: Module,
+        test_input: Union[Tensor, Tuple[Tensor, ...]],
+        expected_activation: Union[List[float], Tuple[List[float], List[float]], List[List[float]], Tuple[Tensor,...]],
+        additional_input: Any = None,
+        attribute_to_layer_input: bool = False,
+        relu_attributions: bool = False,
     ):
         layer_gc = LayerGradCam(model, target_layer)
         attributions = layer_gc.attribute(

--- a/tests/attr/layer/test_grad_cam.py
+++ b/tests/attr/layer/test_grad_cam.py
@@ -84,7 +84,9 @@ class Test(BaseTest):
         model: Module,
         target_layer: Module,
         test_input: Union[Tensor, Tuple[Tensor, ...]],
-        expected_activation: Union[List[float], Tuple[List[float], List[float]], List[List[float]], Tuple[Tensor,...]],
+        expected_activation: Union[
+            List[float], Tuple[List[float], ...], List[List[float]], Tuple[Tensor, ...]
+        ],
         additional_input: Any = None,
         attribute_to_layer_input: bool = False,
         relu_attributions: bool = False,


### PR DESCRIPTION
Add type hints to the following files in Captum
captum/attr/_core/layer/grad_cam.py
tests/attr/layer/test_grad_cam.py