### PR TITLE
Support debugging mode in CaptumInsights widget

### DIFF
--- a/captum/attr/_utils/attribution.py
+++ b/captum/attr/_utils/attribution.py
@@ -5,13 +5,13 @@ import torch
 import torch.nn.functional as F
 
 from .common import (
-    _run_forward,
+    _format_additional_forward_args,
     _format_input_baseline,
     _format_tensor_into_tuples,
-    _format_additional_forward_args,
+    _run_forward,
+    _tensorize_baseline,
     _validate_input,
     _validate_target,
-    _tensorize_baseline,
 )
 from .gradient import compute_gradients
 
@@ -110,6 +110,25 @@ class Attribution:
         """
         raise NotImplementedError(
             "Deriving sub-class should implement" " compute_convergence_delta method"
+        )
+
+    @classmethod
+    def get_name(cls):
+        r"""
+        Create readable class name by inserting a space before any capital
+        characters besides the very first.
+
+        Returns:
+            str: a readable class name
+        Example:
+            for a class called IntegratedGradients, we return the string
+            'Integrated Gradients'
+        """
+        return "".join(
+            [
+                char if char.islower() or idx == 0 else " " + char
+                for idx, char in enumerate(cls.__name__)
+            ]
         )
 
 

--- a/captum/insights/api.py
+++ b/captum/insights/api.py
@@ -196,12 +196,14 @@ class AttributionVisualizer(object):
             count=4,
         )
 
-    def render(self):
+    def render(self, debug=True):
         from IPython.display import display
         from captum.insights.widget import CaptumInsights
 
         widget = CaptumInsights(visualizer=self)
         display(widget)
+        if debug:
+            display(widget.out)
 
     def serve(self, blocking=False, debug=False, port=None):
         from captum.insights.server import start_server

--- a/captum/insights/config.py
+++ b/captum/insights/config.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+from typing import List, NamedTuple, Optional, Tuple
+
+from captum.attr import (
+    Deconvolution,
+    DeepLift,
+    GuidedBackprop,
+    InputXGradient,
+    IntegratedGradients,
+    Saliency,
+)
+from captum.attr._utils.approximation_methods import SUPPORTED_METHODS
+
+
+class NumberConfig(NamedTuple):
+    value: int = 1
+    limit: Tuple[Optional[int], Optional[int]] = (None, None)
+    type: str = "number"
+
+
+class StrEnumConfig(NamedTuple):
+    value: str
+    limit: List[str]
+    type: str = "enum"
+
+
+SUPPORTED_ATTRIBUTION_METHODS = [
+    Deconvolution,
+    DeepLift,
+    GuidedBackprop,
+    InputXGradient,
+    IntegratedGradients,
+    Saliency,
+]
+
+ATTRIBUTION_NAMES_TO_METHODS = {
+    cls.get_name(): cls for cls in SUPPORTED_ATTRIBUTION_METHODS
+}
+
+ATTRIBUTION_METHOD_CONFIG = {
+    IntegratedGradients.get_name(): {
+        "n_steps": NumberConfig(value=25, limit=(2, None)),
+        "method": StrEnumConfig(limit=SUPPORTED_METHODS, value="gausslegendre"),
+    }
+}

--- a/captum/insights/frontend/src/WebApp.js
+++ b/captum/insights/frontend/src/WebApp.js
@@ -6,7 +6,11 @@ class WebApp extends React.Component {
     super(props);
     this.state = {
       data: [],
-      config: [],
+      config: {
+        classes: [],
+        methods: [],
+        method_arguments: {}
+      },
       loading: false
     };
     this._fetchInit();

--- a/captum/insights/frontend/widget/src/Widget.js
+++ b/captum/insights/frontend/widget/src/Widget.js
@@ -9,7 +9,11 @@ class Widget extends React.Component {
     super(props);
     this.state = {
       data: [],
-      config: [],
+      config: {
+        classes: [],
+        methods: [],
+        method_arguments: {}
+      },
       loading: false,
       callback: null
     };
@@ -42,7 +46,9 @@ class Widget extends React.Component {
   }
 
   _fetchInit = () => {
-    this.setState({ config: this.backbone.model.get("classes") });
+    this.setState({
+      config: this.backbone.model.get("insights_config")
+    });
   };
 
   fetchData = filterConfig => {

--- a/captum/insights/server.py
+++ b/captum/insights/server.py
@@ -9,6 +9,7 @@ from typing import Optional
 from flask import Flask, jsonify, render_template, request
 from torch import Tensor
 
+
 app = Flask(
     __name__, static_folder="frontend/build/static", template_folder="frontend/build"
 )
@@ -53,7 +54,7 @@ def fetch():
 
 @app.route("/init")
 def init():
-    return jsonify(visualizer.classes)
+    return jsonify(visualizer.get_insights_config())
 
 
 @app.route("/")

--- a/captum/insights/widget/widget.py
+++ b/captum/insights/widget/widget.py
@@ -27,17 +27,24 @@ class CaptumInsights(widgets.DOMWidget):
     def __init__(self, **kwargs):
         super(CaptumInsights, self).__init__(**kwargs)
         self.insights_config = self.visualizer.get_insights_config()
+        self.out = widgets.Output()
+        with self.out:
+            print("Captum Insights widget created.")
 
     @observe("config")
     def _fetch_data(self, change):
-        if self.config:
+        if not self.config:
+            return
+        with self.out:
             self.visualizer._update_config(self.config)
             self.output = namedtuple_to_dict(self.visualizer.visualize())
             self.config = dict()
 
     @observe("label_details")
     def _fetch_attribution(self, change):
-        if self.label_details:
+        if not self.label_details:
+            return
+        with self.out:
             self.attribution = namedtuple_to_dict(
                 self.visualizer._calculate_attribution_from_cache(
                     self.label_details["instance"], self.label_details["labelIndex"]

--- a/captum/insights/widget/widget.py
+++ b/captum/insights/widget/widget.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import ipywidgets as widgets
 from captum.insights import AttributionVisualizer
 from captum.insights.server import namedtuple_to_dict
@@ -16,17 +17,16 @@ class CaptumInsights(widgets.DOMWidget):
     _model_module_version = Unicode("^0.1.0").tag(sync=True)
 
     visualizer = Instance(klass=AttributionVisualizer)
-    classes = List(trait=Unicode).tag(sync=True)
 
+    insights_config = Dict().tag(sync=True)
     label_details = Dict().tag(sync=True)
     attribution = Dict().tag(sync=True)
-
     config = Dict().tag(sync=True)
     output = List().tag(sync=True)
 
     def __init__(self, **kwargs):
         super(CaptumInsights, self).__init__(**kwargs)
-        self.classes = self.visualizer.classes
+        self.insights_config = self.visualizer.get_insights_config()
 
     @observe("config")
     def _fetch_data(self, change):

--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -38,7 +38,7 @@ fi
 
 # install other deps
 conda install -y numpy sphinx pytest flake8 ipywidgets ipython
-conda install -y -c conda-forge black matplotlib pytest-cov sphinx-autodoc-typehints mypy
+conda install -y -c conda-forge black matplotlib pytest-cov sphinx-autodoc-typehints mypy flask
 
 # build insights and install captum
 # TODO: remove CI=false when we want React warnings treated as errors

--- a/tests/insights/test_contribution.py
+++ b/tests/insights/test_contribution.py
@@ -160,7 +160,7 @@ class Test(BaseTest):
             dataset=to_iter(data_loader),
             score_func=None,
         )
-        visualizer._config = FilterConfig(steps=2)
+        visualizer._config = FilterConfig(attribution_arguments={"n_steps": 2})
 
         outputs = visualizer.visualize()
 
@@ -203,7 +203,7 @@ class Test(BaseTest):
             dataset=to_iter(data_loader),
             score_func=None,
         )
-        visualizer._config = FilterConfig(steps=2)
+        visualizer._config = FilterConfig(attribution_arguments={"n_steps": 2})
 
         outputs = visualizer.visualize()
 


### PR DESCRIPTION
Summary: This diff makes it simple for users to enable debug mode in the CaptumInsights widget. I've modified the `AttributionVisualizer` to have a `debug` flag in the `render` function. When `debug` is enabled, any output from stdout is redirected to be displayed below the widget.

Reviewed By: edward-io

Differential Revision: D19319091

