### PR TITLE
Incorporate config in frontend

### DIFF
--- a/captum/attr/_utils/attribution.py
+++ b/captum/attr/_utils/attribution.py
@@ -3,13 +3,14 @@ import torch
 import torch.nn.functional as F
 
 from .common import (
-    _run_forward,
+    _format_additional_forward_args,
     _format_input_baseline,
     _format_tensor_into_tuples,
-    _format_additional_forward_args,
+    _run_forward,
+    _tensorize_baseline,
     _validate_input,
     _validate_target,
-    _tensorize_baseline,
+    classproperty,
 )
 from .gradient import compute_gradients
 
@@ -109,6 +110,22 @@ class Attribution:
         """
         raise NotImplementedError(
             "Deriving sub-class should implement" " compute_convergence_delta method"
+        )
+
+    @classproperty
+    def display_name(self):
+        r"""
+        Create readable class name by inserting a space before any capital
+        characters besides the very first.
+
+        Returns:
+            str: a readable class name
+        """
+        return "".join(
+            [
+                char if char.islower() or idx == 0 else " " + char
+                for idx, char in enumerate(self.__name__)
+            ]
         )
 
 

--- a/captum/attr/_utils/common.py
+++ b/captum/attr/_utils/common.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python3
+from enum import Enum
+from inspect import signature
 from typing import Optional, Tuple, Union, overload
 
 import torch
 from torch import Tensor
-
-from enum import Enum
-from inspect import signature
 
 from .approximation_methods import SUPPORTED_METHODS
 
@@ -526,3 +525,11 @@ class MaxList:
                 self.list.insert(i, (value, item))
                 break
         self.list = self.list[: self.size]
+
+
+class classproperty(object):
+    def __init__(self, f):
+        self.f = f
+
+    def __get__(self, obj, owner):
+        return self.f(owner)

--- a/captum/insights/api.py
+++ b/captum/insights/api.py
@@ -1,12 +1,28 @@
 #!/usr/bin/env python3
+import inspect
 from collections import namedtuple
-from typing import Callable, Iterable, List, NamedTuple, Optional, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Tuple,
+    Union,
+)
 
 import torch
 from captum.attr import IntegratedGradients
 from captum.attr._utils.batching import _batched_generator
 from captum.attr._utils.common import _run_forward, safe_div
+from captum.insights.config import (
+    ATTRIBUTION_METHOD_CONFIG,
+    ATTRIBUTION_NAMES_TO_METHODS,
+)
 from captum.insights.features import BaseFeature
+from captum.insights.server import namedtuple_to_dict
 from torch import Tensor
 from torch.nn import Module
 
@@ -20,7 +36,13 @@ SampleCache = namedtuple("SampleCache", "inputs additional_forward_args label")
 
 
 class FilterConfig(NamedTuple):
-    steps: int = 20
+    attribution_method: str = IntegratedGradients.display_name
+    attribution_arguments: Dict[str, Any] = {
+        arg: config.value
+        for arg, config in ATTRIBUTION_METHOD_CONFIG[
+            IntegratedGradients.display_name
+        ].items()
+    }
     prediction: str = "all"
     classes: List[str] = []
     count: int = 4
@@ -128,7 +150,7 @@ class AttributionVisualizer(object):
         self.dataset = dataset
         self.score_func = score_func
         self._outputs = []
-        self._config = FilterConfig(steps=25, prediction="all", classes=[], count=4)
+        self._config = FilterConfig(prediction="all", classes=[], count=4)
         self._use_label_for_attr = use_label_for_attr
 
     def _calculate_attribution_from_cache(
@@ -147,7 +169,9 @@ class AttributionVisualizer(object):
         additional_forward_args: Optional[Tuple[Tensor, ...]],
         label: Optional[Union[Tensor]],
     ) -> Tensor:
-        ig = IntegratedGradients(net)
+        attribution_cls = ATTRIBUTION_NAMES_TO_METHODS[self._config.attribution_method]
+        attribution_method = attribution_cls(net)
+        args = self._config.attribution_arguments
         # TODO support multiple baselines
         baseline = baselines[0] if len(baselines) > 0 else None
         label = (
@@ -155,19 +179,18 @@ class AttributionVisualizer(object):
             if not self._use_label_for_attr or label is None or label.nelement() == 0
             else label
         )
-        attr_ig = ig.attribute(
-            data,
-            baselines=baseline,
-            additional_forward_args=additional_forward_args,
-            target=label,
-            n_steps=self._config.steps,
+        if "baselines" in inspect.signature(attribution_method.attribute).parameters:
+            args["baselines"] = baseline
+        attr = attribution_method.attribute(
+            data, additional_forward_args=additional_forward_args, target=label, **args
         )
 
-        return attr_ig
+        return attr
 
     def _update_config(self, settings):
         self._config = FilterConfig(
-            steps=int(settings["approximation_steps"]),
+            attribution_method=settings["attribution_method"],
+            attribution_arguments=settings["arguments"],
             prediction=settings["prediction"],
             classes=settings["classes"],
             count=4,
@@ -384,3 +407,11 @@ class AttributionVisualizer(object):
             except StopIteration:
                 break
         return [o[0] for o in self._outputs]
+
+    def get_insights_config(self):
+        return {
+            "classes": self.classes,
+            "methods": list(ATTRIBUTION_NAMES_TO_METHODS.keys()),
+            "method_arguments": namedtuple_to_dict(ATTRIBUTION_METHOD_CONFIG),
+            "selected_method": self._config.attribution_method,
+        }

--- a/captum/insights/config.py
+++ b/captum/insights/config.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+from typing import List, NamedTuple, Optional, Tuple
+
+from captum.attr import (
+    Deconvolution,
+    DeepLift,
+    GuidedBackprop,
+    InputXGradient,
+    IntegratedGradients,
+    Saliency,
+)
+from captum.attr._utils.approximation_methods import SUPPORTED_METHODS
+
+
+class NumberConfig(NamedTuple):
+    value: int = 1
+    limit: Tuple[Optional[int], Optional[int]] = (None, None)
+    type: str = "number"
+
+
+class StrEnumConfig(NamedTuple):
+    value: str
+    limit: List[str]
+    type: str = "enum"
+
+
+SUPPORTED_ATTRIBUTION_METHODS = [
+    Deconvolution,
+    DeepLift,
+    GuidedBackprop,
+    InputXGradient,
+    IntegratedGradients,
+    Saliency,
+]
+
+ATTRIBUTION_NAMES_TO_METHODS = {
+    cls.display_name: cls for cls in SUPPORTED_ATTRIBUTION_METHODS
+}
+
+ATTRIBUTION_METHOD_CONFIG = {
+    IntegratedGradients.display_name: {
+        "n_steps": NumberConfig(value=25, limit=(2, None)),
+        "method": StrEnumConfig(limit=SUPPORTED_METHODS, value="gausslegendre"),
+    }
+}

--- a/captum/insights/frontend/src/WebApp.js
+++ b/captum/insights/frontend/src/WebApp.js
@@ -6,7 +6,11 @@ class WebApp extends React.Component {
     super(props);
     this.state = {
       data: [],
-      config: [],
+      config: {
+        classes: [],
+        methods: [],
+        method_arguments: {}
+      },
       loading: false
     };
     this._fetchInit();

--- a/captum/insights/frontend/widget/src/Widget.js
+++ b/captum/insights/frontend/widget/src/Widget.js
@@ -9,7 +9,11 @@ class Widget extends React.Component {
     super(props);
     this.state = {
       data: [],
-      config: [],
+      config: {
+        classes: [],
+        methods: [],
+        method_arguments: {}
+      },
       loading: false,
       callback: null
     };
@@ -42,7 +46,9 @@ class Widget extends React.Component {
   }
 
   _fetchInit = () => {
-    this.setState({ config: this.backbone.model.get("classes") });
+    this.setState({
+      config: this.backbone.model.get("insights_config")
+    });
   };
 
   fetchData = filterConfig => {

--- a/captum/insights/server.py
+++ b/captum/insights/server.py
@@ -9,6 +9,7 @@ from typing import Optional
 from flask import Flask, jsonify, render_template, request
 from torch import Tensor
 
+
 app = Flask(
     __name__, static_folder="frontend/build/static", template_folder="frontend/build"
 )
@@ -53,7 +54,7 @@ def fetch():
 
 @app.route("/init")
 def init():
-    return jsonify(visualizer.classes)
+    return jsonify(visualizer.get_insights_config())
 
 
 @app.route("/")

--- a/captum/insights/widget/widget.py
+++ b/captum/insights/widget/widget.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import ipywidgets as widgets
 from captum.insights import AttributionVisualizer
 from captum.insights.server import namedtuple_to_dict
@@ -16,17 +17,16 @@ class CaptumInsights(widgets.DOMWidget):
     _model_module_version = Unicode("^0.1.0").tag(sync=True)
 
     visualizer = Instance(klass=AttributionVisualizer)
-    classes = List(trait=Unicode).tag(sync=True)
 
+    insights_config = Dict().tag(sync=True)
     label_details = Dict().tag(sync=True)
     attribution = Dict().tag(sync=True)
-
     config = Dict().tag(sync=True)
     output = List().tag(sync=True)
 
     def __init__(self, **kwargs):
         super(CaptumInsights, self).__init__(**kwargs)
-        self.classes = self.visualizer.classes
+        self.insights_config = self.visualizer.get_insights_config()
 
     @observe("config")
     def _fetch_data(self, change):

--- a/tests/insights/test_contribution.py
+++ b/tests/insights/test_contribution.py
@@ -160,7 +160,7 @@ class Test(BaseTest):
             dataset=to_iter(data_loader),
             score_func=None,
         )
-        visualizer._config = FilterConfig(steps=2)
+        visualizer._config = FilterConfig(attribution_arguments={"n_steps": 2})
 
         outputs = visualizer.visualize()
 
@@ -203,7 +203,7 @@ class Test(BaseTest):
             dataset=to_iter(data_loader),
             score_func=None,
         )
-        visualizer._config = FilterConfig(steps=2)
+        visualizer._config = FilterConfig(attribution_arguments={"n_steps": 2})
 
         outputs = visualizer.visualize()
 


### PR DESCRIPTION
Summary:
Modify frontend to use the config information passed from the backend(s).
This means the frontend now
- Displays attribution method options.
- Displays attribution method arguments based on the selected method.
  - Create React components for different argument data types
- Updates and persists arguments even when selected method is changed
- Sends chosen arguments when Fetch button is pressed

Differential Revision: D19254187

