### PR TITLE
Fixing Guided GradCAM RST path

### DIFF
--- a/sphinx/source/guided_grad_cam.rst
+++ b/sphinx/source/guided_grad_cam.rst
@@ -1,5 +1,5 @@
 Guided GradCAM
 =========
 
-.. autoclass:: captum.attr.GuidedGradCAM
+.. autoclass:: captum.attr.GuidedGradCam
     :members:


### PR DESCRIPTION
Guided GradCAM was not generating docs appropriately, since the path in the RST file was not cased appropriately.