### PR TITLE
Adding Type Hints to Captum: LayerGradientXActivation

### DIFF
--- a/captum/attr/_core/layer/layer_gradient_x_activation.py
+++ b/captum/attr/_core/layer/layer_gradient_x_activation.py
@@ -1,19 +1,29 @@
 #!/usr/bin/env python3
-from ..._utils.attribution import LayerAttribution, GradientAttribution
+from typing import Any, Callable, List, Optional, Tuple, Union
+
+from torch import Tensor
+from torch.nn import Module
+
+from ..._utils.attribution import GradientAttribution, LayerAttribution
 from ..._utils.common import (
-    _format_input,
     _format_additional_forward_args,
     _format_attributions,
+    _format_input,
 )
 from ..._utils.gradient import (
-    compute_layer_gradients_and_eval,
     apply_gradient_requirements,
+    compute_layer_gradients_and_eval,
     undo_gradient_requirements,
 )
 
 
 class LayerGradientXActivation(LayerAttribution, GradientAttribution):
-    def __init__(self, forward_func, layer, device_ids=None):
+    def __init__(
+        self,
+        forward_func: Callable,
+        layer: Module,
+        device_ids: Optional[List[int]] = None,
+    ) -> None:
         r"""
         Args:
 
@@ -36,11 +46,13 @@ class LayerGradientXActivation(LayerAttribution, GradientAttribution):
 
     def attribute(
         self,
-        inputs,
-        target=None,
-        additional_forward_args=None,
-        attribute_to_layer_input=False,
-    ):
+        inputs: Union[Tensor, Tuple[Tensor, ...]],
+        target: Optional[
+            Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
+        ] = None,
+        additional_forward_args: Any = None,
+        attribute_to_layer_input: bool = False,
+    ) -> Union[Tensor, Tuple[Tensor, ...]]:
         r"""
             Computes element-wise product of gradient and activation for selected
             layer on given inputs.

--- a/tests/attr/layer/test_layer_gradient_x_activation.py
+++ b/tests/attr/layer/test_layer_gradient_x_activation.py
@@ -1,31 +1,34 @@
 #!/usr/bin/env python3
-
 import unittest
+from typing import Any, List, Tuple, Union
 
 import torch
+from torch import Tensor
+from torch.nn import Module
+
 from captum.attr._core.layer.layer_gradient_x_activation import LayerGradientXActivation
 
 from ..helpers.basic_models import (
     BasicModel_MultiLayer,
     BasicModel_MultiLayer_MultiInput,
 )
-from ..helpers.utils import assertTensorTuplesAlmostEqual, BaseTest
+from ..helpers.utils import BaseTest, assertTensorTuplesAlmostEqual
 
 
 class Test(BaseTest):
-    def test_simple_input_gradient_activation(self):
+    def test_simple_input_gradient_activation(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
         self._layer_activation_test_assert(net, net.linear0, inp, [0.0, 400.0, 0.0])
 
-    def test_simple_linear_gradient_activation(self):
+    def test_simple_linear_gradient_activation(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         self._layer_activation_test_assert(
             net, net.linear1, inp, [90.0, 101.0, 101.0, 101.0]
         )
 
-    def test_simple_linear_gradient_activation_no_grad(self):
+    def test_simple_linear_gradient_activation_no_grad(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
 
@@ -38,24 +41,24 @@ class Test(BaseTest):
             net, net.linear1, inp, [90.0, 101.0, 101.0, 101.0]
         )
 
-    def test_simple_multi_gradient_activation(self):
+    def test_simple_multi_gradient_activation(self) -> None:
         net = BasicModel_MultiLayer(multi_input_module=True)
         inp = torch.tensor([[3.0, 4.0, 0.0]])
         self._layer_activation_test_assert(
             net, net.relu, inp, ([0.0, 8.0, 8.0, 8.0], [0.0, 8.0, 8.0, 8.0])
         )
 
-    def test_simple_relu_gradient_activation(self):
+    def test_simple_relu_gradient_activation(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[3.0, 4.0, 0.0]], requires_grad=True)
         self._layer_activation_test_assert(net, net.relu, inp, [0.0, 8.0, 8.0, 8.0])
 
-    def test_simple_output_gradient_activation(self):
+    def test_simple_output_gradient_activation(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         self._layer_activation_test_assert(net, net.linear2, inp, [392.0, 0.0])
 
-    def test_simple_gradient_activation_multi_input_linear2(self):
+    def test_simple_gradient_activation_multi_input_linear2(self) -> None:
         net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 10.0, 0.0]])
         inp2 = torch.tensor([[0.0, 10.0, 0.0]])
@@ -64,7 +67,7 @@ class Test(BaseTest):
             net, net.model.linear2, (inp1, inp2, inp3), [392.0, 0.0], (4,)
         )
 
-    def test_simple_gradient_activation_multi_input_relu(self):
+    def test_simple_gradient_activation_multi_input_relu(self) -> None:
         net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 10.0, 1.0]])
         inp2 = torch.tensor([[0.0, 4.0, 5.0]])
@@ -75,12 +78,12 @@ class Test(BaseTest):
 
     def _layer_activation_test_assert(
         self,
-        model,
-        target_layer,
-        test_input,
-        expected_activation,
-        additional_input=None,
-    ):
+        model: Module,
+        target_layer: Module,
+        test_input: Union[Tensor, Tuple[Tensor, ...]],
+        expected_activation: Union[List[float], Tuple[List[float], ...]],
+        additional_input: Any = None,
+    ) -> None:
         layer_act = LayerGradientXActivation(model, target_layer)
         attributions = layer_act.attribute(
             test_input, target=0, additional_forward_args=additional_input


### PR DESCRIPTION
Adding Type Hints to LayerGradientXActivation and corresponding tests.

Test plan:
`./scripts/run_mypy.sh` doesn't produce new warnings.