### PR TITLE
add Insights API docs

### DIFF
--- a/captum/insights/api.py
+++ b/captum/insights/api.py
@@ -3,13 +3,13 @@ from collections import namedtuple
 from typing import Callable, Iterable, List, NamedTuple, Optional, Tuple, Union
 
 import torch
+from torch import Tensor
+from torch.nn import Module
+
 from captum.attr import IntegratedGradients
 from captum.attr._utils.batching import _batched_generator
 from captum.attr._utils.common import _run_forward, safe_div
 from captum.insights.features import BaseFeature
-from torch import Tensor
-from torch.nn import Module
-
 
 OutputScore = namedtuple("OutputScore", "score index label")
 VisualizationOutput = namedtuple(
@@ -56,7 +56,7 @@ class Batch:
                         argument of a Tensor or arbitrary (non-tuple) type or a
                         tuple containing multiple additional arguments including
                         tensors or any arbitrary python types. These arguments
-                        are provided to forward_func in order following the
+                        are provided to ``forward_func`` in order following the
                         arguments in inputs.
                         For a tensor, the first dimension of the tensor must
                         correspond to the number of examples.

--- a/captum/insights/example.py
+++ b/captum/insights/example.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 import os
 
-from captum.insights import AttributionVisualizer, Batch
-from captum.insights.features import ImageFeature
-
 import torch
 import torch.nn as nn
 import torchvision
 import torchvision.transforms as transforms
+
+from captum.insights import AttributionVisualizer, Batch
+from captum.insights.features import ImageFeature
 
 
 def get_classes():

--- a/sphinx/source/index.rst
+++ b/sphinx/source/index.rst
@@ -18,6 +18,12 @@ Captum API Reference
    utilities
    base_classes
 
+.. toctree::
+   :maxdepth: 2
+   :caption: Insights API Reference
+
+   insights
+
 
 Indices and Tables
 ==================

--- a/sphinx/source/insights.rst
+++ b/sphinx/source/insights.rst
@@ -1,0 +1,34 @@
+Insights
+============
+
+Batch
+^^^^^
+
+.. autoclass:: captum.insights.api.Batch
+    :members:
+
+AttributionVisualizer
+^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: captum.insights.api.AttributionVisualizer
+    :members:
+
+
+Features
+========
+
+BaseFeature
+^^^^^^^^^^^
+.. autoclass:: captum.insights.features.BaseFeature
+    :members:
+
+GeneralFeature
+^^^^^^^^^^^^^^
+.. autoclass:: captum.insights.features.GeneralFeature
+
+TextFeature
+^^^^^^^^^^^
+.. autoclass:: captum.insights.features.TextFeature
+
+ImageFeature
+^^^^^^^^^^^^
+.. autoclass:: captum.insights.features.ImageFeature


### PR DESCRIPTION
Add documentation for `insights/features.py` and add it to the main Captum API docs page.

test plan:

Build docs (`./scripts/build_docs.sh`) and verify that they show up correctly on http://localhost:3000/api/.