### PR TITLE
Type Improvements and Initial Neuron Method Typing

### DIFF
--- a/captum/attr/_core/integrated_gradients.py
+++ b/captum/attr/_core/integrated_gradients.py
@@ -17,7 +17,7 @@ from .._utils.common import (
     _expand_target,
 )
 from .._utils.attribution import GradientAttribution
-from .._utils.typing import TensorOrTuple
+from .._utils.typing import TensorOrTupleOfTensors
 
 
 class IntegratedGradients(GradientAttribution):
@@ -53,7 +53,7 @@ class IntegratedGradients(GradientAttribution):
     @typing.overload
     def attribute(
         self,
-        inputs: TensorOrTuple,
+        inputs: TensorOrTupleOfTensors,
         baselines: Optional[
             Union[Tensor, int, float, Tuple[Union[Tensor, int, float], ...]]
         ] = None,
@@ -64,13 +64,13 @@ class IntegratedGradients(GradientAttribution):
         n_steps: int = 50,
         method: str = "gausslegendre",
         internal_batch_size: Optional[int] = None,
-    ) -> TensorOrTuple:
+    ) -> TensorOrTupleOfTensors:
         ...
 
     @typing.overload
     def attribute(
         self,
-        inputs: TensorOrTuple,
+        inputs: TensorOrTupleOfTensors,
         baselines: Optional[
             Union[Tensor, int, float, Tuple[Union[Tensor, int, float], ...]]
         ] = None,
@@ -82,7 +82,7 @@ class IntegratedGradients(GradientAttribution):
         method: str = "gausslegendre",
         internal_batch_size: Optional[int] = None,
         return_convergence_delta: bool = False,
-    ) -> Union[TensorOrTuple, Tuple[TensorOrTuple, Tensor]]:
+    ) -> Union[TensorOrTupleOfTensors, Tuple[TensorOrTupleOfTensors, Tensor]]:
         ...
 
     def attribute(

--- a/captum/attr/_core/integrated_gradients.py
+++ b/captum/attr/_core/integrated_gradients.py
@@ -17,6 +17,7 @@ from .._utils.common import (
     _expand_target,
 )
 from .._utils.attribution import GradientAttribution
+from .._utils.typing import TensorOrTuple
 
 
 class IntegratedGradients(GradientAttribution):
@@ -52,7 +53,7 @@ class IntegratedGradients(GradientAttribution):
     @typing.overload
     def attribute(
         self,
-        inputs: Tensor,
+        inputs: TensorOrTuple,
         baselines: Optional[
             Union[Tensor, int, float, Tuple[Union[Tensor, int, float], ...]]
         ] = None,
@@ -63,29 +64,13 @@ class IntegratedGradients(GradientAttribution):
         n_steps: int = 50,
         method: str = "gausslegendre",
         internal_batch_size: Optional[int] = None,
-    ) -> Tensor:
+    ) -> TensorOrTuple:
         ...
 
     @typing.overload
     def attribute(
         self,
-        inputs: Tuple[Tensor, ...],
-        baselines: Optional[
-            Union[Tensor, int, float, Tuple[Union[Tensor, int, float], ...]]
-        ] = None,
-        target: Optional[
-            Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
-        ] = None,
-        additional_forward_args: Any = None,
-        n_steps: int = 50,
-        method: str = "gausslegendre",
-        internal_batch_size: Optional[int] = None,
-    ) -> Tuple[Tensor, ...]:
-        ...
-
-    def attribute(
-        self,
-        inputs: Union[Tensor, Tuple[Tensor, ...]],
+        inputs: TensorOrTuple,
         baselines: Optional[
             Union[Tensor, int, float, Tuple[Union[Tensor, int, float], ...]]
         ] = None,
@@ -97,9 +82,20 @@ class IntegratedGradients(GradientAttribution):
         method: str = "gausslegendre",
         internal_batch_size: Optional[int] = None,
         return_convergence_delta: bool = False,
-    ) -> Union[
-        Tensor, Tuple[Tensor, ...], Tuple[Union[Tensor, Tuple[Tensor, ...]], Tensor]
-    ]:
+    ) -> Union[TensorOrTuple, Tuple[TensorOrTuple, Tensor]]:
+        ...
+
+    def attribute(
+        self,
+        inputs,
+        baselines=None,
+        target=None,
+        additional_forward_args=None,
+        n_steps=50,
+        method="gausslegendre",
+        internal_batch_size=None,
+        return_convergence_delta=False,
+    ) -> Union[TensorOrTuple, Tuple[TensorOrTuple, Tensor]]:
         r"""
         This method attributes the output of the model with given target index
         (in case it is provided, otherwise it assumes that output is a

--- a/captum/attr/_core/integrated_gradients.py
+++ b/captum/attr/_core/integrated_gradients.py
@@ -45,6 +45,10 @@ class IntegratedGradients(GradientAttribution):
         """
         GradientAttribution.__init__(self, forward_func)
 
+    # The following overloaded method signatures correspond to the case where
+    # return_convergence_delta is not provided, then only attributions are returned.
+    # When a single Tensor is provided, a single Tensor is returned, and when
+    # a tuple of tensors is provided, a tuple is returned.
     @typing.overload
     def attribute(
         self,

--- a/captum/attr/_core/integrated_gradients.py
+++ b/captum/attr/_core/integrated_gradients.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import typing
 from typing import Callable, List, Optional, Tuple, Union, Any
 
 import torch
@@ -43,6 +44,40 @@ class IntegratedGradients(GradientAttribution):
                           modification of it
         """
         GradientAttribution.__init__(self, forward_func)
+
+    @typing.overload
+    def attribute(
+        self,
+        inputs: Tensor,
+        baselines: Optional[
+            Union[Tensor, int, float, Tuple[Union[Tensor, int, float], ...]]
+        ] = None,
+        target: Optional[
+            Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
+        ] = None,
+        additional_forward_args: Any = None,
+        n_steps: int = 50,
+        method: str = "gausslegendre",
+        internal_batch_size: Optional[int] = None,
+    ) -> Tensor:
+        ...
+
+    @typing.overload
+    def attribute(
+        self,
+        inputs: Tuple[Tensor, ...],
+        baselines: Optional[
+            Union[Tensor, int, float, Tuple[Union[Tensor, int, float], ...]]
+        ] = None,
+        target: Optional[
+            Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
+        ] = None,
+        additional_forward_args: Any = None,
+        n_steps: int = 50,
+        method: str = "gausslegendre",
+        internal_batch_size: Optional[int] = None,
+    ) -> Tuple[Tensor, ...]:
+        ...
 
     def attribute(
         self,

--- a/captum/attr/_core/integrated_gradients.py
+++ b/captum/attr/_core/integrated_gradients.py
@@ -50,6 +50,12 @@ class IntegratedGradients(GradientAttribution):
     # return_convergence_delta is not provided, then only attributions are returned,
     # and when return_convergence_delta is provided, the return type is either
     # just the attributions or a tuple with both attributions and deltas.
+    # Note that this doesn't explicitly type the case where return_convergence_delta
+    # is passed with the value False, the return type when return_convergence_delta is
+    # given is Union[TensorOrTupleOfTensors, Tuple[TensorOrTupleOfTensors, Tensor]].
+    # Supporting separate return types for True and False requires using the Literal
+    # type functionality, which is only available in Python 3.8. We plan to support
+    # this in the future.
     @typing.overload
     def attribute(
         self,

--- a/captum/attr/_core/integrated_gradients.py
+++ b/captum/attr/_core/integrated_gradients.py
@@ -47,9 +47,9 @@ class IntegratedGradients(GradientAttribution):
         GradientAttribution.__init__(self, forward_func)
 
     # The following overloaded method signatures correspond to the case where
-    # return_convergence_delta is not provided, then only attributions are returned.
-    # When a single Tensor is provided, a single Tensor is returned, and when
-    # a tuple of tensors is provided, a tuple is returned.
+    # return_convergence_delta is not provided, then only attributions are returned,
+    # and when return_convergence_delta is provided, the return type is either
+    # just the attributions or a tuple with both attributions and deltas.
     @typing.overload
     def attribute(
         self,
@@ -95,7 +95,7 @@ class IntegratedGradients(GradientAttribution):
         method="gausslegendre",
         internal_batch_size=None,
         return_convergence_delta=False,
-    ) -> Union[TensorOrTuple, Tuple[TensorOrTuple, Tensor]]:
+    ):
         r"""
         This method attributes the output of the model with given target index
         (in case it is provided, otherwise it assumes that output is a

--- a/captum/attr/_core/layer/layer_activation.py
+++ b/captum/attr/_core/layer/layer_activation.py
@@ -41,7 +41,7 @@ class LayerActivation(LayerAttribution):
         inputs: Union[Tensor, Tuple[Tensor, ...]],
         additional_forward_args: Any = None,
         attribute_to_layer_input: bool = False,
-    ) -> Tensor:
+    ) -> Union[Tensor, Tuple[Tensor]]:
         r"""
             Computes activation of selected layer for given input.
 

--- a/captum/attr/_core/neuron/neuron_gradient_shap.py
+++ b/captum/attr/_core/neuron/neuron_gradient_shap.py
@@ -6,7 +6,7 @@ from torch.nn import Module
 from ..gradient_shap import GradientShap
 from ..._utils.attribution import NeuronAttribution, GradientAttribution
 from ..._utils.gradient import construct_neuron_grad_fn
-from .._utils.typing import TensorOrTuple
+from ..._utils.typing import TensorOrTuple
 
 
 class NeuronGradientShap(NeuronAttribution, GradientAttribution):

--- a/captum/attr/_core/neuron/neuron_gradient_shap.py
+++ b/captum/attr/_core/neuron/neuron_gradient_shap.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+from typing import Callable, List, Optional, Tuple, Union, Any
+from torch import Tensor
+from torch.nn import Module
 
 from ..gradient_shap import GradientShap
 from ..._utils.attribution import NeuronAttribution, GradientAttribution
@@ -6,7 +9,12 @@ from ..._utils.gradient import construct_neuron_grad_fn
 
 
 class NeuronGradientShap(NeuronAttribution, GradientAttribution):
-    def __init__(self, forward_func, layer, device_ids=None):
+    def __init__(
+        self,
+        forward_func: Callable,
+        layer: Module,
+        device_ids: Optional[List[int]] = None,
+    ) -> None:
         r"""
         Args:
 
@@ -31,14 +39,16 @@ class NeuronGradientShap(NeuronAttribution, GradientAttribution):
 
     def attribute(
         self,
-        inputs,
-        neuron_index,
-        baselines=None,
-        n_samples=5,
-        stdevs=0.0,
-        additional_forward_args=None,
-        attribute_to_neuron_input=False,
-    ):
+        inputs: Union[Tensor, Tuple[Tensor, ...]],
+        neuron_index: Union[int, Tuple],
+        baselines: Optional[
+            Union[Tensor, int, float, Callable, Tuple[Union[Tensor, int, float], ...]]
+        ] = None,
+        n_samples: int = 5,
+        stdevs: float = 0.0,
+        additional_forward_args: Any = None,
+        attribute_to_neuron_input: bool = False,
+    ) -> Union[Tensor, Tuple[Tensor, ...]]:
         r"""
         Implements gradient SHAP for a neuron in a hidden layer based on the
         implementation from SHAP's primary author. For reference, please, view:

--- a/captum/attr/_core/neuron/neuron_gradient_shap.py
+++ b/captum/attr/_core/neuron/neuron_gradient_shap.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import typing
 from typing import Callable, List, Optional, Tuple, Union, Any
 from torch import Tensor
 from torch.nn import Module
@@ -37,12 +38,60 @@ class NeuronGradientShap(NeuronAttribution, GradientAttribution):
         NeuronAttribution.__init__(self, forward_func, layer, device_ids)
         GradientAttribution.__init__(self, forward_func)
 
+    @typing.overload
+    def attribute(
+        self,
+        inputs: Tensor,
+        neuron_index: Union[int, Tuple[int, ...]],
+        baselines: Optional[
+            Union[
+                Tensor,
+                int,
+                float,
+                Callable[..., Tensor],
+                Tuple[Union[Tensor, int, float], ...],
+            ]
+        ] = None,
+        n_samples: int = 5,
+        stdevs: float = 0.0,
+        additional_forward_args: Any = None,
+        attribute_to_neuron_input: bool = False,
+    ) -> Tensor:
+        ...
+
+    @typing.overload
+    def attribute(
+        self,
+        inputs: Tuple[Tensor, ...],
+        neuron_index: Union[int, Tuple[int, ...]],
+        baselines: Optional[
+            Union[
+                Tensor,
+                int,
+                float,
+                Callable[..., Tensor],
+                Tuple[Union[Tensor, int, float], ...],
+            ]
+        ] = None,
+        n_samples: int = 5,
+        stdevs: float = 0.0,
+        additional_forward_args: Any = None,
+        attribute_to_neuron_input: bool = False,
+    ) -> Tuple[Tensor, ...]:
+        ...
+
     def attribute(
         self,
         inputs: Union[Tensor, Tuple[Tensor, ...]],
-        neuron_index: Union[int, Tuple],
+        neuron_index: Union[int, Tuple[int, ...]],
         baselines: Optional[
-            Union[Tensor, int, float, Callable, Tuple[Union[Tensor, int, float], ...]]
+            Union[
+                Tensor,
+                int,
+                float,
+                Callable[..., Tensor],
+                Tuple[Union[Tensor, int, float], ...],
+            ]
         ] = None,
         n_samples: int = 5,
         stdevs: float = 0.0,

--- a/captum/attr/_core/neuron/neuron_gradient_shap.py
+++ b/captum/attr/_core/neuron/neuron_gradient_shap.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import typing
 from typing import Callable, List, Optional, Tuple, Union, Any
 from torch import Tensor
 from torch.nn import Module
@@ -7,6 +6,7 @@ from torch.nn import Module
 from ..gradient_shap import GradientShap
 from ..._utils.attribution import NeuronAttribution, GradientAttribution
 from ..._utils.gradient import construct_neuron_grad_fn
+from .._utils.typing import TensorOrTuple
 
 
 class NeuronGradientShap(NeuronAttribution, GradientAttribution):
@@ -38,10 +38,9 @@ class NeuronGradientShap(NeuronAttribution, GradientAttribution):
         NeuronAttribution.__init__(self, forward_func, layer, device_ids)
         GradientAttribution.__init__(self, forward_func)
 
-    @typing.overload
     def attribute(
         self,
-        inputs: Tensor,
+        inputs: TensorOrTuple,
         neuron_index: Union[int, Tuple[int, ...]],
         baselines: Optional[
             Union[
@@ -56,48 +55,7 @@ class NeuronGradientShap(NeuronAttribution, GradientAttribution):
         stdevs: float = 0.0,
         additional_forward_args: Any = None,
         attribute_to_neuron_input: bool = False,
-    ) -> Tensor:
-        ...
-
-    @typing.overload
-    def attribute(
-        self,
-        inputs: Tuple[Tensor, ...],
-        neuron_index: Union[int, Tuple[int, ...]],
-        baselines: Optional[
-            Union[
-                Tensor,
-                int,
-                float,
-                Callable[..., Tensor],
-                Tuple[Union[Tensor, int, float], ...],
-            ]
-        ] = None,
-        n_samples: int = 5,
-        stdevs: float = 0.0,
-        additional_forward_args: Any = None,
-        attribute_to_neuron_input: bool = False,
-    ) -> Tuple[Tensor, ...]:
-        ...
-
-    def attribute(
-        self,
-        inputs: Union[Tensor, Tuple[Tensor, ...]],
-        neuron_index: Union[int, Tuple[int, ...]],
-        baselines: Optional[
-            Union[
-                Tensor,
-                int,
-                float,
-                Callable[..., Tensor],
-                Tuple[Union[Tensor, int, float], ...],
-            ]
-        ] = None,
-        n_samples: int = 5,
-        stdevs: float = 0.0,
-        additional_forward_args: Any = None,
-        attribute_to_neuron_input: bool = False,
-    ) -> Union[Tensor, Tuple[Tensor, ...]]:
+    ) -> TensorOrTuple:
         r"""
         Implements gradient SHAP for a neuron in a hidden layer based on the
         implementation from SHAP's primary author. For reference, please, view:

--- a/captum/attr/_core/neuron/neuron_gradient_shap.py
+++ b/captum/attr/_core/neuron/neuron_gradient_shap.py
@@ -6,7 +6,7 @@ from torch.nn import Module
 from ..gradient_shap import GradientShap
 from ..._utils.attribution import NeuronAttribution, GradientAttribution
 from ..._utils.gradient import construct_neuron_grad_fn
-from ..._utils.typing import TensorOrTuple
+from ..._utils.typing import TensorOrTupleOfTensors
 
 
 class NeuronGradientShap(NeuronAttribution, GradientAttribution):
@@ -40,7 +40,7 @@ class NeuronGradientShap(NeuronAttribution, GradientAttribution):
 
     def attribute(
         self,
-        inputs: TensorOrTuple,
+        inputs: TensorOrTupleOfTensors,
         neuron_index: Union[int, Tuple[int, ...]],
         baselines: Optional[
             Union[
@@ -55,7 +55,7 @@ class NeuronGradientShap(NeuronAttribution, GradientAttribution):
         stdevs: float = 0.0,
         additional_forward_args: Any = None,
         attribute_to_neuron_input: bool = False,
-    ) -> TensorOrTuple:
+    ) -> TensorOrTupleOfTensors:
         r"""
         Implements gradient SHAP for a neuron in a hidden layer based on the
         implementation from SHAP's primary author. For reference, please, view:

--- a/captum/attr/_core/neuron/neuron_integrated_gradients.py
+++ b/captum/attr/_core/neuron/neuron_integrated_gradients.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-import typing
 from typing import Callable, List, Optional, Tuple, Union, Any
 from torch import Tensor
 from torch.nn import Module
 
 from ..._utils.attribution import NeuronAttribution, GradientAttribution
 from ..._utils.gradient import construct_neuron_grad_fn
+from .._utils.typing import TensorOrTuple
 
 from ..integrated_gradients import IntegratedGradients
 
@@ -40,10 +40,9 @@ class NeuronIntegratedGradients(NeuronAttribution, GradientAttribution):
         NeuronAttribution.__init__(self, forward_func, layer, device_ids)
         GradientAttribution.__init__(self, forward_func)
 
-    @typing.overload
     def attribute(
         self,
-        inputs: Tensor,
+        inputs: TensorOrTuple,
         neuron_index: Union[int, Tuple[int, ...]],
         baselines: Optional[Union[Tensor, Tuple[Tensor, ...]]] = None,
         additional_forward_args: Any = None,
@@ -51,34 +50,7 @@ class NeuronIntegratedGradients(NeuronAttribution, GradientAttribution):
         method: str = "gausslegendre",
         internal_batch_size: Optional[int] = None,
         attribute_to_neuron_input: bool = False,
-    ) -> Tensor:
-        ...
-
-    @typing.overload
-    def attribute(
-        self,
-        inputs: Tuple[Tensor, ...],
-        neuron_index: Union[int, Tuple[int, ...]],
-        baselines: Optional[Union[Tensor, Tuple[Tensor, ...]]] = None,
-        additional_forward_args: Any = None,
-        n_steps: int = 50,
-        method: str = "gausslegendre",
-        internal_batch_size: Optional[int] = None,
-        attribute_to_neuron_input: bool = False,
-    ) -> Tuple[Tensor, ...]:
-        ...
-
-    def attribute(
-        self,
-        inputs: Union[Tensor, Tuple[Tensor, ...]],
-        neuron_index: Union[int, Tuple[int, ...]],
-        baselines: Optional[Union[Tensor, Tuple[Tensor, ...]]] = None,
-        additional_forward_args: Any = None,
-        n_steps: int = 50,
-        method: str = "gausslegendre",
-        internal_batch_size: Optional[int] = None,
-        attribute_to_neuron_input: bool = False,
-    ) -> Union[Tensor, Tuple[Tensor, ...]]:
+    ) -> TensorOrTuple:
         r"""
             Approximates the integral of gradients for a particular neuron
             along the path from a baseline input to the given input.

--- a/captum/attr/_core/neuron/neuron_integrated_gradients.py
+++ b/captum/attr/_core/neuron/neuron_integrated_gradients.py
@@ -5,7 +5,7 @@ from torch.nn import Module
 
 from ..._utils.attribution import NeuronAttribution, GradientAttribution
 from ..._utils.gradient import construct_neuron_grad_fn
-from .._utils.typing import TensorOrTuple
+from ..._utils.typing import TensorOrTuple
 
 from ..integrated_gradients import IntegratedGradients
 

--- a/captum/attr/_core/neuron/neuron_integrated_gradients.py
+++ b/captum/attr/_core/neuron/neuron_integrated_gradients.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+import typing
+from typing import Callable, List, Optional, Tuple, Union, Any
+from torch import Tensor
+from torch.nn import Module
+
 from ..._utils.attribution import NeuronAttribution, GradientAttribution
 from ..._utils.gradient import construct_neuron_grad_fn
 
@@ -6,7 +11,12 @@ from ..integrated_gradients import IntegratedGradients
 
 
 class NeuronIntegratedGradients(NeuronAttribution, GradientAttribution):
-    def __init__(self, forward_func, layer, device_ids=None):
+    def __init__(
+        self,
+        forward_func: Callable,
+        layer: Module,
+        device_ids: Optional[List[int]] = None,
+    ):
         r"""
         Args:
 
@@ -30,17 +40,45 @@ class NeuronIntegratedGradients(NeuronAttribution, GradientAttribution):
         NeuronAttribution.__init__(self, forward_func, layer, device_ids)
         GradientAttribution.__init__(self, forward_func)
 
+    @typing.overload
     def attribute(
         self,
-        inputs,
-        neuron_index,
-        baselines=None,
-        additional_forward_args=None,
-        n_steps=50,
-        method="gausslegendre",
-        internal_batch_size=None,
-        attribute_to_neuron_input=False,
-    ):
+        inputs: Tensor,
+        neuron_index: Union[int, Tuple[int, ...]],
+        baselines: Optional[Union[Tensor, Tuple[Tensor, ...]]] = None,
+        additional_forward_args: Any = None,
+        n_steps: int = 50,
+        method: str = "gausslegendre",
+        internal_batch_size: Optional[int] = None,
+        attribute_to_neuron_input: bool = False,
+    ) -> Tensor:
+        ...
+
+    @typing.overload
+    def attribute(
+        self,
+        inputs: Tuple[Tensor, ...],
+        neuron_index: Union[int, Tuple[int, ...]],
+        baselines: Optional[Union[Tensor, Tuple[Tensor, ...]]] = None,
+        additional_forward_args: Any = None,
+        n_steps: int = 50,
+        method: str = "gausslegendre",
+        internal_batch_size: Optional[int] = None,
+        attribute_to_neuron_input: bool = False,
+    ) -> Tuple[Tensor, ...]:
+        ...
+
+    def attribute(
+        self,
+        inputs: Union[Tensor, Tuple[Tensor, ...]],
+        neuron_index: Union[int, Tuple[int, ...]],
+        baselines: Optional[Union[Tensor, Tuple[Tensor, ...]]] = None,
+        additional_forward_args: Any = None,
+        n_steps: int = 50,
+        method: str = "gausslegendre",
+        internal_batch_size: Optional[int] = None,
+        attribute_to_neuron_input: bool = False,
+    ) -> Union[Tensor, Tuple[Tensor, ...]]:
         r"""
             Approximates the integral of gradients for a particular neuron
             along the path from a baseline input to the given input.

--- a/captum/attr/_core/neuron/neuron_integrated_gradients.py
+++ b/captum/attr/_core/neuron/neuron_integrated_gradients.py
@@ -5,7 +5,7 @@ from torch.nn import Module
 
 from ..._utils.attribution import NeuronAttribution, GradientAttribution
 from ..._utils.gradient import construct_neuron_grad_fn
-from ..._utils.typing import TensorOrTuple
+from ..._utils.typing import TensorOrTupleOfTensors
 
 from ..integrated_gradients import IntegratedGradients
 
@@ -42,7 +42,7 @@ class NeuronIntegratedGradients(NeuronAttribution, GradientAttribution):
 
     def attribute(
         self,
-        inputs: TensorOrTuple,
+        inputs: TensorOrTupleOfTensors,
         neuron_index: Union[int, Tuple[int, ...]],
         baselines: Optional[Union[Tensor, Tuple[Tensor, ...]]] = None,
         additional_forward_args: Any = None,
@@ -50,7 +50,7 @@ class NeuronIntegratedGradients(NeuronAttribution, GradientAttribution):
         method: str = "gausslegendre",
         internal_batch_size: Optional[int] = None,
         attribute_to_neuron_input: bool = False,
-    ) -> TensorOrTuple:
+    ) -> TensorOrTupleOfTensors:
         r"""
             Approximates the integral of gradients for a particular neuron
             along the path from a baseline input to the given input.

--- a/captum/attr/_utils/attribution.py
+++ b/captum/attr/_utils/attribution.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from typing import Callable
+
 import torch
 import torch.nn.functional as F
 
@@ -29,36 +31,35 @@ class Attribution:
         """
         self.forward_func = forward_func
 
-    def attribute(self, inputs):
-        r"""
-        This method computes and returns the attribution values for each input tensor.
-        Deriving classes are responsible for implementing its logic accordingly.
+    attribute: Callable
+    r"""
+    This method computes and returns the attribution values for each input tensor.
+    Deriving classes are responsible for implementing its logic accordingly.
 
-        Specific attribution algorithms that extend this class take relevant
-        additional arguments.
+    Specific attribution algorithms that extend this class take relevant
+    arguments.
 
-        Args:
+    Args:
 
-            inputs (tensor or tuple of tensors):  Input for which attribution
-                        is computed. It can be provided as a single tensor or
-                        a tuple of multiple tensors. If multiple input tensors
-                        are provided, the batch sizes must be aligned accross all
-                        tensors.
+        inputs (tensor or tuple of tensors):  Input for which attribution
+                    is computed. It can be provided as a single tensor or
+                    a tuple of multiple tensors. If multiple input tensors
+                    are provided, the batch sizes must be aligned accross all
+                    tensors.
 
 
-        Returns:
+    Returns:
 
-            *tensor* or tuple of *tensors* of **attributions**:
-            - **attributions** (*tensor* or tuple of *tensors*):
-                        Attribution values for each
-                        input tensor. The `attributions` have the same shape and
-                        dimensionality as the inputs.
-                        If a single tensor is provided as inputs, a single tensor
-                        is returned. If a tuple is provided for inputs, a tuple of
-                        corresponding sized tensors is returned.
+        *tensor* or tuple of *tensors* of **attributions**:
+        - **attributions** (*tensor* or tuple of *tensors*):
+                    Attribution values for each
+                    input tensor. The `attributions` have the same shape and
+                    dimensionality as the inputs.
+                    If a single tensor is provided as inputs, a single tensor
+                    is returned. If a tuple is provided for inputs, a tuple of
+                    corresponding sized tensors is returned.
 
-        """
-        raise NotImplementedError("Deriving class should implement attribute method")
+    """
 
     def has_convergence_delta(self):
         r"""
@@ -119,7 +120,7 @@ class GradientAttribution(Attribution):
     that we want to interpret or the model itself.
     """
 
-    def __init__(self, forward_func):
+    def __init__(self, forward_func: Callable):
         r"""
         Args:
 
@@ -394,11 +395,14 @@ class NeuronAttribution(InternalAttribution):
         """
         InternalAttribution.__init__(self, forward_func, layer, device_ids)
 
-    def attribute(self, inputs, neuron_index, **kwargs):
+    def attribute(self, inputs, neuron_index):
         r"""
         This method computes and returns the neuron attribution values for each
         input tensor. Deriving classes are responsible for implementing
         its logic accordingly.
+
+        Specific attribution algorithms that extend this class take relevant
+        arguments.
 
         Args:
 

--- a/captum/attr/_utils/attribution.py
+++ b/captum/attr/_utils/attribution.py
@@ -120,7 +120,7 @@ class GradientAttribution(Attribution):
     that we want to interpret or the model itself.
     """
 
-    def __init__(self, forward_func: Callable):
+    def __init__(self, forward_func):
         r"""
         Args:
 

--- a/captum/attr/_utils/typing.py
+++ b/captum/attr/_utils/typing.py
@@ -3,4 +3,4 @@
 from typing import Tuple, TypeVar
 from torch import Tensor
 
-TensorOrTuple = TypeVar("TensorOrTuple", Tensor, Tuple[Tensor, ...])
+TensorOrTupleOfTensors = TypeVar("TensorOrTupleOfTensors", Tensor, Tuple[Tensor, ...])

--- a/captum/attr/_utils/typing.py
+++ b/captum/attr/_utils/typing.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+from typing import Tuple, TypeVar
+from torch import Tensor
+
+TensorOrTuple = TypeVar("TensorOrTuple", Tensor, Tuple[Tensor, ...])

--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -40,7 +40,7 @@ export TERM=xterm
 sudo pip install --upgrade pip
 
 # install captum with dev deps
-sudo pip install --no-cache-dir --force-reinstall -e .[dev]
+sudo pip install -vvv -e .[dev]
 sudo BUILD_INSIGHTS=1 python setup.py develop
 
 # install other frameworks if asked for and make sure this is before pytorch

--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -50,7 +50,7 @@ fi
 
 # install pytorch nightly if asked for
 if [[ $PYTORCH_NIGHTLY == true ]]; then
-  sudo pip install torch_nightly -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+  sudo pip install torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 fi
 
 # install deployment bits if asked for

--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -40,7 +40,7 @@ export TERM=xterm
 sudo pip install --upgrade pip
 
 # install captum with dev deps
-sudo pip install -vvv -e .[dev]
+sudo pip install -e .[dev]
 sudo BUILD_INSIGHTS=1 python setup.py develop
 
 # install other frameworks if asked for and make sure this is before pytorch
@@ -51,6 +51,8 @@ fi
 # install pytorch nightly if asked for
 if [[ $PYTORCH_NIGHTLY == true ]]; then
   sudo pip install --upgrade --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+else
+  sudo pip install --upgrade torch
 fi
 
 # install deployment bits if asked for

--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -50,7 +50,7 @@ fi
 
 # install pytorch nightly if asked for
 if [[ $PYTORCH_NIGHTLY == true ]]; then
-  sudo pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+  sudo pip install --upgrade --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 fi
 
 # install deployment bits if asked for

--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -50,7 +50,7 @@ fi
 
 # install pytorch nightly if asked for
 if [[ $PYTORCH_NIGHTLY == true ]]; then
-  sudo pip install torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+  sudo pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 fi
 
 # install deployment bits if asked for

--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -40,7 +40,7 @@ export TERM=xterm
 sudo pip install --upgrade pip
 
 # install captum with dev deps
-sudo pip install -e .[dev]
+sudo pip install --upgrade -e .[dev]
 sudo BUILD_INSIGHTS=1 python setup.py develop
 
 # install other frameworks if asked for and make sure this is before pytorch

--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -40,7 +40,7 @@ export TERM=xterm
 sudo pip install --upgrade pip
 
 # install captum with dev deps
-sudo pip install --upgrade -e .[dev]
+sudo pip install --no-cache-dir --force-reinstall -e .[dev]
 sudo BUILD_INSIGHTS=1 python setup.py develop
 
 # install other frameworks if asked for and make sure this is before pytorch

--- a/scripts/run_mypy.sh
+++ b/scripts/run_mypy.sh
@@ -5,5 +5,5 @@ set -e
 # hints.
 
 # TODO: Fix type issues with insights and add mypy checks here.
-mypy -p captum.attr --ignore-missing-imports
-mypy -p tests --ignore-missing-imports
+mypy -p captum.attr --ignore-missing-imports --allow-redefinition
+mypy -p tests --ignore-missing-imports --allow-redefinition

--- a/tests/attr/neuron/test_neuron_gradient_shap.py
+++ b/tests/attr/neuron/test_neuron_gradient_shap.py
@@ -63,7 +63,7 @@ class Test(BaseTest):
             baselines = baselines(inputs)
 
         attrs_ig = []
-        for baseline in baselines.__iter__():
+        for baseline in baselines:
             attrs_ig.append(
                 nig.attribute(inputs, neuron_ind, baselines=baseline.unsqueeze(0))
             )

--- a/tests/attr/neuron/test_neuron_gradient_shap.py
+++ b/tests/attr/neuron/test_neuron_gradient_shap.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
+from typing import Callable, Union
+
 import torch
+from torch import Tensor
+from torch.nn import Module
 
 from ..helpers.utils import BaseTest
 
@@ -14,7 +18,7 @@ from captum.attr._core.neuron.neuron_integrated_gradients import (
 
 
 class Test(BaseTest):
-    def test_basic_multilayer(self):
+    def test_basic_multilayer(self) -> None:
         model = BasicModel_MultiLayer(inplace=True)
         model.eval()
 
@@ -23,8 +27,8 @@ class Test(BaseTest):
 
         self._assert_attributions(model, model.linear1, inputs, baselines, 0)
 
-    def test_classification(self):
-        def custom_baseline_fn(inputs):
+    def test_classification(self) -> None:
+        def custom_baseline_fn(inputs: Tensor) -> Tensor:
             num_in = inputs.shape[1]
             return torch.arange(0.0, num_in * 5.0).reshape(5, num_in)
 
@@ -41,8 +45,14 @@ class Test(BaseTest):
         self._assert_attributions(model, model.relu1, inputs, baselines, 1, n_samples)
 
     def _assert_attributions(
-        self, model, layer, inputs, baselines, neuron_ind, n_samples=5
-    ):
+        self,
+        model: Module,
+        layer: Module,
+        inputs: Tensor,
+        baselines: Union[Tensor, Callable[..., Tensor]],
+        neuron_ind: Union[int, tuple],
+        n_samples: int = 5,
+    ) -> None:
         ngs = NeuronGradientShap(model, layer)
         nig = NeuronIntegratedGradients(model, layer)
         attrs_gs = ngs.attribute(
@@ -53,9 +63,9 @@ class Test(BaseTest):
             baselines = baselines(inputs)
 
         attrs_ig = []
-        for baseline in baselines:
+        for baseline in baselines.__iter__():
             attrs_ig.append(
                 nig.attribute(inputs, neuron_ind, baselines=baseline.unsqueeze(0))
             )
-        attrs_ig = torch.stack(attrs_ig, axis=0).mean(axis=0)
-        assertTensorAlmostEqual(self, attrs_gs, attrs_ig, 0.5)
+        combined_attrs_ig = torch.stack(attrs_ig, dim=0).mean(dim=0)
+        assertTensorAlmostEqual(self, attrs_gs, combined_attrs_ig, 0.5)


### PR DESCRIPTION
This PR makes improvements to type hints, particularly adding overload signatures to methods such as IG, simplifying the output types for specific input types (e.g. tensor -> tensor). This is necessary for dependencies to properly identify the returned type rather than considering a variety of type outputs.

We also remove the base attribute method, which was causing issues due to violating Liskov substitutability, and replaced it with a type hint for the attribute.

Finally, type hints were added for neuron methods, particularly neuron Gradient Shap (along with tests) and neuron integrated gradients.