### PR TITLE
Adding CircleCI Configs for PyTorch 1.2 and 1.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,6 +225,10 @@ workflows:
           filters: *exclude_ghpages_fbconfig
       - lint_test_py37_conda:
           filters: *exclude_ghpages_fbconfig
+      - test_py36_pip_torch_1_2:
+          filters: *exclude_ghpages_fbconfig
+      - test_py36_pip_torch_1_3:
+          filters: *exclude_ghpages_fbconfig
       - test_cuda_multi_gpu:
           filters: *exclude_ghpages_fbconfig
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,24 @@ jobs:
       - unit_tests
       - sphinx
 
+  test_py36_pip_torch_1_3:
+    docker:
+      - image: circleci/python:3.6.8
+    steps:
+      - checkout
+      - pip_install:
+          args: "-f -v 1.3"
+      - unit_tests
+
+  test_py36_pip_torch_1_2:
+    docker:
+      - image: circleci/python:3.6.8
+    steps:
+      - checkout
+      - pip_install:
+          args: "-f -v 1.2"
+      - unit_tests
+
   lint_test_py37_conda:
     docker:
       - image: continuumio/miniconda3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,6 @@ jobs:
           args: "-n -f"
       - lint_flake8
       - lint_black
-      - mypy_check
       - unit_tests
       - sphinx
 
@@ -145,7 +144,6 @@ jobs:
           args: "-f"
       - lint_flake8
       - lint_black
-      - mypy_check
       - unit_tests
       - sphinx
 
@@ -176,7 +174,6 @@ jobs:
           args: "-n"
       - lint_flake8
       - lint_black
-      - mypy_check
       - unit_tests
       - sphinx
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,6 +132,7 @@ jobs:
           args: "-n -f"
       - lint_flake8
       - lint_black
+      - mypy_check
       - unit_tests
       - sphinx
 
@@ -144,6 +145,7 @@ jobs:
           args: "-f"
       - lint_flake8
       - lint_black
+      - mypy_check
       - unit_tests
       - sphinx
 
@@ -174,6 +176,7 @@ jobs:
           args: "-n"
       - lint_flake8
       - lint_black
+      - mypy_check
       - unit_tests
       - sphinx
 

--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -30,7 +30,7 @@ fi
 
 if [[ $PYTORCH_NIGHTLY == true ]]; then
   # install CPU version for much smaller download
-  conda install -y -c pytorch pytorch-nightly-cpu
+  conda install -y pytorch cpuonly -c pytorch-nightly
 else
  # install CPU version for much smaller download
  conda install -y -c pytorch pytorch-cpu

--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -4,13 +4,15 @@ set -e
 
 PYTORCH_NIGHTLY=false
 DEPLOY=false
+CHOSEN_TORCH_VERSION=-1
 
-while getopts 'ndf' flag; do
+while getopts 'ndfv:' flag; do
   case "${flag}" in
     n) PYTORCH_NIGHTLY=true ;;
     d) DEPLOY=true ;;
     f) FRAMEWORKS=true ;;
-    *) echo "usage: $0 [-n] [-d] [-f]" >&2
+    v) CHOSEN_TORCH_VERSION=${OPTARG};;
+    *) echo "usage: $0 [-n] [-d] [-f] [-v]" >&2
        exit 1 ;;
     esac
   done
@@ -50,7 +52,13 @@ fi
 
 # install pytorch nightly if asked for
 if [[ $PYTORCH_NIGHTLY == true ]]; then
-  sudo pip install torch_nightly -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+  sudo pip install --upgrade --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+else
+  if [[ $CHOSEN_TORCH_VERSION == -1 ]]; then
+    sudo pip install --upgrade torch
+  else
+    sudo pip install torch==$CHOSEN_TORCH_VERSION
+  end
 fi
 
 # install deployment bits if asked for

--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -12,7 +12,7 @@ while getopts 'ndfv:' flag; do
     d) DEPLOY=true ;;
     f) FRAMEWORKS=true ;;
     v) CHOSEN_TORCH_VERSION=${OPTARG};;
-    *) echo "usage: $0 [-n] [-d] [-f] [-v]" >&2
+    *) echo "usage: $0 [-n] [-d] [-f] [-v version]" >&2
        exit 1 ;;
     esac
   done

--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -54,6 +54,7 @@ fi
 if [[ $PYTORCH_NIGHTLY == true ]]; then
   sudo pip install --upgrade --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 else
+  # If no version specified, upgrade to latest release.
   if [[ $CHOSEN_TORCH_VERSION == -1 ]]; then
     sudo pip install --upgrade torch
   else

--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -58,7 +58,7 @@ else
     sudo pip install --upgrade torch
   else
     sudo pip install torch==$CHOSEN_TORCH_VERSION
-  end
+  fi
 fi
 
 # install deployment bits if asked for

--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -54,16 +54,12 @@ fi
 if [[ $PYTORCH_NIGHTLY == true ]]; then
   sudo pip install --upgrade --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 else
-<<<<<<< HEAD
   # If no version specified, upgrade to latest release.
   if [[ $CHOSEN_TORCH_VERSION == -1 ]]; then
     sudo pip install --upgrade torch
   else
     sudo pip install torch==$CHOSEN_TORCH_VERSION
   fi
-=======
-  sudo pip install --upgrade torch
->>>>>>> c26c9745f45c00b80ada973cf398ea83977f144c
 fi
 
 # install deployment bits if asked for

--- a/tests/attr/layer/test_layer_activation.py
+++ b/tests/attr/layer/test_layer_activation.py
@@ -23,7 +23,7 @@ from ..helpers.utils import (
 
 class Test(BaseTest):
     def test_simple_input_activation(self) -> None:
-        print("PYTORCH VERSION", torch.__version__)
+        self.assertEqual(0, torch.__version__)
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
         self._layer_activation_test_assert(net, net.linear0, inp, [0.0, 100.0, 0.0])

--- a/tests/attr/layer/test_layer_activation.py
+++ b/tests/attr/layer/test_layer_activation.py
@@ -23,6 +23,7 @@ from ..helpers.utils import (
 
 class Test(BaseTest):
     def test_simple_input_activation(self) -> None:
+        print("PYTORCH VERSION", torch.__version__)
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
         self._layer_activation_test_assert(net, net.linear0, inp, [0.0, 100.0, 0.0])

--- a/tests/attr/layer/test_layer_activation.py
+++ b/tests/attr/layer/test_layer_activation.py
@@ -23,7 +23,6 @@ from ..helpers.utils import (
 
 class Test(BaseTest):
     def test_simple_input_activation(self) -> None:
-        self.assertEqual(0, torch.__version__)
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
         self._layer_activation_test_assert(net, net.linear0, inp, [0.0, 100.0, 0.0])


### PR DESCRIPTION
This PR adds test configurations on CircleCI for PyTorch 1.2 and 1.3, which we still support, and updates the existing Conda and PIP tests for torch nightly to use the latest nightly builds. 