### PR TITLE
Sparse Updates for Permutation Importance

### DIFF
--- a/tests/attr/helpers/basic_models.py
+++ b/tests/attr/helpers/basic_models.py
@@ -139,6 +139,19 @@ class BasicModelWithReusableModules(nn.Module):
         return self.relu(self.lin2(self.relu(self.lin1(inputs))))
 
 
+class BasicModelWithSparseInputs(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.lin1 = nn.Linear(3, 1)
+        self.lin1.weight = nn.Parameter(torch.tensor([[3.0, 1.0, 2.0]]))
+        self.lin1.bias = nn.Parameter(torch.zeros(1))
+
+    def forward(self, inputs, sparse_list):
+        return (
+            self.lin1(inputs) + (sparse_list[0] if torch.numel(sparse_list) > 0 else 0)
+        ).sum()
+
+
 class TanhDeepLiftModel(nn.Module):
     r"""
         Same as the ReLUDeepLiftModel, but with activations

--- a/tests/attr/test_feature_ablation.py
+++ b/tests/attr/test_feature_ablation.py
@@ -7,6 +7,7 @@ from captum.attr._core.feature_ablation import FeatureAblation
 
 from .helpers.basic_models import (
     BasicModel,
+    BasicModelWithSparseInputs,
     BasicModel_ConvNet_One_Conv,
     BasicModel_MultiLayer,
     BasicModel_MultiLayer_MultiInput,
@@ -203,6 +204,23 @@ class Test(BaseTest):
         ablation = FeatureAblation(lambda inp: torch.sum(net(inp)).item())
         with self.assertRaises(AssertionError):
             _ = ablation.attribute(inp, ablations_per_eval=2)
+
+    def test_empty_sparse_features(self):
+        model = BasicModelWithSparseInputs()
+        inp1 = torch.tensor([[1.0, -2.0, 3.0], [2.0, -1.0, 3.0]])
+        inp2 = torch.tensor([])
+        self._ablation_test_assert(
+            model, (inp1, inp2), ([[9.0, -3.0, 12.0]], [[]],), target=None,
+        )
+
+    def test_sparse_features(self):
+        model = BasicModelWithSparseInputs()
+        inp1 = torch.tensor([[1.0, -2.0, 3.0], [2.0, -1.0, 3.0]])
+        # Length of sparse index list may not match # of examples
+        inp2 = torch.tensor([1, 7, 2, 4, 5, 3, 6])
+        self._ablation_test_assert(
+            model, (inp1, inp2), ([[9.0, -3.0, 12.0]], [[2.0]],), target=None,
+        )
 
     def test_single_ablation_batch_scalar_float(self):
         net = BasicModel_MultiLayer()


### PR DESCRIPTION
This PR adds support for sparse 1D tensors (which may not match the number of examples) and empty tensors (which will have empty attributions) to both feature ablation and permutation feature importance with corresponding test cases.

Differential Revision: D19539757

