### PR TITLE
Add type hints to layer_integrated_gradients.py

### DIFF
--- a/captum/attr/_core/layer/layer_integrated_gradients.py
+++ b/captum/attr/_core/layer/layer_integrated_gradients.py
@@ -274,7 +274,9 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
         def gradient_func(
             forward_fn: Callable,
             inputs: Union[Tensor, Tuple[Tensor, ...]],
-            target_ind: int = None,
+            target_ind: Optional[
+                Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
+            ] = None,
             additional_forward_args: Any = None,
         ) -> Tuple[Tensor, ...]:
             if self.device_ids is None:
@@ -282,9 +284,9 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
             else:
                 # scatter method does not have a precise enough return type in its
                 # stub, so suppress the type warning.
-                scattered_inputs = scatter(
+                scattered_inputs = scatter(  # type:ignore
                     inputs, target_gpus=self.device_ids
-                )  # type:ignore
+                )
 
             scattered_inputs_dict = {
                 scattered_input[0].device: scattered_input

--- a/captum/attr/_core/layer/layer_integrated_gradients.py
+++ b/captum/attr/_core/layer/layer_integrated_gradients.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
+from typing import Callable, List, Optional, Tuple, Union, Any
 import torch
+from torch import Tensor
 
 from torch.nn.parallel.scatter_gather import scatter
 
@@ -40,7 +42,12 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
 
     """
 
-    def __init__(self, forward_func, layer, device_ids=None):
+    def __init__(
+        self,
+        forward_func: Callable,
+        layer: torch.nn.Module,
+        device_ids: Optional[List[int]] = None,
+    ) -> None:
         r"""
         Args:
             forward_func (callable):  The forward function of the model or any
@@ -64,16 +71,22 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
 
     def attribute(
         self,
-        inputs,
-        baselines=None,
-        target=None,
-        additional_forward_args=None,
-        n_steps=50,
-        method="gausslegendre",
-        internal_batch_size=None,
-        return_convergence_delta=False,
-        attribute_to_layer_input=False,
-    ):
+        inputs: Union[Tensor, Tuple[Tensor, ...]],
+        baselines: Optional[
+            Union[Tensor, int, float, Tuple[Union[Tensor, int, float], ...]]
+        ] = None,
+        target: Optional[
+            Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
+        ] = None,
+        additional_forward_args: Any = None,
+        n_steps: int = 50,
+        method: str = "gausslegendre",
+        internal_batch_size: Optional[int] = None,
+        return_convergence_delta: Optional[bool] = False,
+        attribute_to_layer_input: Optional[bool] = False,
+    ) -> Union[
+        Tensor, Tuple[Tensor, ...], Tuple[Union[Tensor, Tuple[Tensor, ...]], Tensor]
+    ]:
         r"""
         This method attributes the output of the model with given target index
         (in case it is provided, otherwise it assumes that output is a
@@ -326,5 +339,5 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
             return _format_attributions(is_layer_tuple, attributions), delta
         return _format_attributions(is_layer_tuple, attributions)
 
-    def has_convergence_delta(self):
+    def has_convergence_delta(self) -> bool:
         return True

--- a/captum/attr/_core/layer/layer_integrated_gradients.py
+++ b/captum/attr/_core/layer/layer_integrated_gradients.py
@@ -82,8 +82,8 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
         n_steps: int = 50,
         method: str = "gausslegendre",
         internal_batch_size: Optional[int] = None,
-        return_convergence_delta: Optional[bool] = False,
-        attribute_to_layer_input: Optional[bool] = False,
+        return_convergence_delta: bool = False,
+        attribute_to_layer_input: bool = False,
     ) -> Union[
         Tensor, Tuple[Tensor, ...], Tuple[Union[Tensor, Tuple[Tensor, ...]], Tensor]
     ]:
@@ -271,8 +271,12 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
 
         # inputs -> these inputs are scaled
         def gradient_func(
-            forward_fn, inputs, target_ind=None, additional_forward_args=None
+            forward_fn: Callable,
+            inputs: Union[Tensor, Tuple[Tensor,...]],
+            target_ind: int = None,
+            additional_forward_args: Any = None
         ):
+            scattered_inputs: Union[Tuple[Union[Tensor, Tuple[Tensor, ...]]], Union[Tuple[Tensor, ...], List[Tuple[Any, ...]]]]
             if self.device_ids is None:
                 scattered_inputs = (inputs,)
             else:

--- a/tests/attr/layer/test_layer_integrated_gradients.py
+++ b/tests/attr/layer/test_layer_integrated_gradients.py
@@ -37,8 +37,7 @@ class Test(BaseTest):
         )
 
     def test_compare_with_emb_patching_batch(self) -> None:
-        input1 = torch.tensor([[2, 5, 0, 1], [3,
-         1, 1, 0]])
+        input1 = torch.tensor([[2, 5, 0, 1], [3, 1, 1, 0]])
         baseline1 = torch.tensor([[0, 0, 0, 0]])
         # these ones will be use as an additional forward args
         input2 = torch.tensor([[0, 2, 4, 1], [2, 3, 5, 7]])
@@ -76,10 +75,7 @@ class Test(BaseTest):
         )
 
     def _assert_compare_with_layer_conductance(
-        self,
-        model: Module,
-        input: Tensor,
-        attribute_to_layer_input: bool = False
+        self, model: Module, input: Tensor, attribute_to_layer_input: bool = False
     ):
         lc = LayerConductance(model, model.linear2)
         # For large number of steps layer conductance and layer integrated gradients
@@ -103,10 +99,8 @@ class Test(BaseTest):
         assertArraysAlmostEqual(delta, delta2, 0.05)
 
     def _assert_compare_with_emb_patching(
-        self,
-        input: Tensor,
-        baseline: Tensor,
-        additional_args:Tuple[Tensor, ...]):
+        self, input: Tensor, baseline: Tensor, additional_args: Tuple[Tensor, ...]
+    ):
         model = BasicEmbeddingModel(nested_second_embedding=True)
         lig = LayerIntegratedGradients(model, model.embedding1)
 

--- a/tests/attr/layer/test_layer_integrated_gradients.py
+++ b/tests/attr/layer/test_layer_integrated_gradients.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from typing import List, Tuple, Union, Any
+from typing import List, Tuple, Union, Any, cast
 
 import torch
 from torch import Tensor
@@ -37,7 +37,8 @@ class Test(BaseTest):
         )
 
     def test_compare_with_emb_patching_batch(self) -> None:
-        input1 = torch.tensor([[2, 5, 0, 1], [3, 1, 1, 0]])
+        input1 = torch.tensor([[2, 5, 0, 1], [3,
+         1, 1, 0]])
         baseline1 = torch.tensor([[0, 0, 0, 0]])
         # these ones will be use as an additional forward args
         input2 = torch.tensor([[0, 2, 4, 1], [2, 3, 5, 7]])
@@ -75,7 +76,10 @@ class Test(BaseTest):
         )
 
     def _assert_compare_with_layer_conductance(
-        self, model, input, attribute_to_layer_input=False
+        self,
+        model: Module,
+        input: Tensor,
+        attribute_to_layer_input: bool = False
     ):
         lc = LayerConductance(model, model.linear2)
         # For large number of steps layer conductance and layer integrated gradients
@@ -87,7 +91,7 @@ class Test(BaseTest):
             return_convergence_delta=True,
             attribute_to_layer_input=attribute_to_layer_input,
         )
-        lig = LayerIntegratedGradients(model, model.linear2)
+        lig = LayerIntegratedGradients(model, cast(Module, model.linear2))
         attributions2, delta2 = lig.attribute(
             input,
             target=0,
@@ -98,10 +102,11 @@ class Test(BaseTest):
         assertArraysAlmostEqual(attribution, attributions2, 0.01)
         assertArraysAlmostEqual(delta, delta2, 0.05)
 
-    def _assert_compare_with_emb_patching(self,
-        input,
-        baseline,
-        additional_args):
+    def _assert_compare_with_emb_patching(
+        self,
+        input: Tensor,
+        baseline: Tensor,
+        additional_args:Tuple[Tensor, ...]):
         model = BasicEmbeddingModel(nested_second_embedding=True)
         lig = LayerIntegratedGradients(model, model.embedding1)
 

--- a/tests/attr/layer/test_layer_integrated_gradients.py
+++ b/tests/attr/layer/test_layer_integrated_gradients.py
@@ -98,7 +98,10 @@ class Test(BaseTest):
         assertArraysAlmostEqual(attribution, attributions2, 0.01)
         assertArraysAlmostEqual(delta, delta2, 0.05)
 
-    def _assert_compare_with_emb_patching(self, input, baseline, additional_args):
+    def _assert_compare_with_emb_patching(self,
+        input,
+        baseline,
+        additional_args):
         model = BasicEmbeddingModel(nested_second_embedding=True)
         lig = LayerIntegratedGradients(model, model.embedding1)
 
@@ -134,7 +137,7 @@ class Test(BaseTest):
         model: Module,
         target_layer: Module,
         test_input: Union[Tensor, Tuple[Tensor, ...]],
-        expected_ig: Tuple[List[List[float]], List[List[float]]],
+        expected_ig: Tuple[List[List[float]], ...],
         additional_input: Any = None,
     ):
         layer_ig = LayerIntegratedGradients(model, target_layer)

--- a/tests/attr/layer/test_layer_integrated_gradients.py
+++ b/tests/attr/layer/test_layer_integrated_gradients.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 
+from typing import List, Tuple, Union, Any
+
 import torch
+from torch import Tensor
+from torch.nn import Module
 
 from ..helpers.utils import assertArraysAlmostEqual, assertTensorTuplesAlmostEqual
 
@@ -21,7 +25,7 @@ from ..helpers.basic_models import (
 
 
 class Test(BaseTest):
-    def test_compare_with_emb_patching(self):
+    def test_compare_with_emb_patching(self) -> None:
         input1 = torch.tensor([[2, 5, 0, 1]])
         baseline1 = torch.tensor([[0, 0, 0, 0]])
         # these ones will be use as an additional forward args
@@ -32,7 +36,7 @@ class Test(BaseTest):
             input1, baseline1, additional_args=(input2, input3)
         )
 
-    def test_compare_with_emb_patching_batch(self):
+    def test_compare_with_emb_patching_batch(self) -> None:
         input1 = torch.tensor([[2, 5, 0, 1], [3, 1, 1, 0]])
         baseline1 = torch.tensor([[0, 0, 0, 0]])
         # these ones will be use as an additional forward args
@@ -43,12 +47,12 @@ class Test(BaseTest):
             input1, baseline1, additional_args=(input2, input3)
         )
 
-    def test_compare_with_layer_conductance_attr_to_outputs(self):
+    def test_compare_with_layer_conductance_attr_to_outputs(self) -> None:
         model = BasicModel_MultiLayer()
         input = torch.tensor([[50.0, 50.0, 50.0]], requires_grad=True)
         self._assert_compare_with_layer_conductance(model, input)
 
-    def test_compare_with_layer_conductance_attr_to_inputs(self):
+    def test_compare_with_layer_conductance_attr_to_inputs(self) -> None:
         # Note that Layer Conductance and Layer Integrated Gradients (IG) aren't
         # exactly the same. Layer IG computes partial derivative of the output
         # with respect to the layer and sums along the straight line. While Layer
@@ -60,7 +64,7 @@ class Test(BaseTest):
         input = torch.tensor([[50.0, 50.0, 50.0]], requires_grad=True)
         self._assert_compare_with_layer_conductance(model, input, True)
 
-    def test_multiple_tensors_compare_with_expected(self):
+    def test_multiple_tensors_compare_with_expected(self) -> None:
         net = BasicModel_MultiLayer(multi_input_module=True)
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         self._assert_compare_with_expected(
@@ -126,7 +130,12 @@ class Test(BaseTest):
         assertArraysAlmostEqual(delta, delta_with_ig)
 
     def _assert_compare_with_expected(
-        self, model, target_layer, test_input, expected_ig, additional_input=None,
+        self,
+        model: Module,
+        target_layer: Module,
+        test_input: Union[Tensor, Tuple[Tensor, ...]],
+        expected_ig: Tuple[List[List[float]], List[List[float]]],
+        additional_input: Any = None,
     ):
         layer_ig = LayerIntegratedGradients(model, target_layer)
         attributions = layer_ig.attribute(


### PR DESCRIPTION
See also: https://github.com/pytorch/captum/pull/184

Tests:

captum] black .
reformatted /data/users/quinton/captum/captum/attr/_core/layer/layer_integrated_gradients.py
All done! ✨ 🍰 ✨
1 file reformatted, 105 files left unchanged.
captum] flake8 .
captum] ./scripts/run_mypy.sh
Success: no issues found in 43 source files
Success: no issues found in 48 source files

This is my first contribution to PyTorch, so I want to confirm that my dev process and initial attempt are sound.  More methods can be typehinted in this or followup PR's (similar to #184 above).
