### PR TITLE
Add mypy type hints for captum/attr/_core/neuron/neuron_guided_backprop_deconvnet.py

### DIFF
--- a/captum/attr/_core/neuron/neuron_guided_backprop_deconvnet.py
+++ b/captum/attr/_core/neuron/neuron_guided_backprop_deconvnet.py
@@ -1,11 +1,22 @@
 #!/usr/bin/env python3
+from typing import Any
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Union
+
+import torch.nn as nn
+from torch import Tensor
+
 from ..._utils.attribution import NeuronAttribution, GradientAttribution
 from ..._utils.gradient import construct_neuron_grad_fn
 from ..guided_backprop_deconvnet import GuidedBackprop, Deconvolution
 
 
 class NeuronDeconvolution(NeuronAttribution, GradientAttribution):
-    def __init__(self, model, layer, device_ids=None):
+    def __init__(
+        self, model: nn.Module, layer: nn.Module, device_ids: Optional[List] = None
+    ) -> None:
         r"""
         Args:
 
@@ -31,11 +42,11 @@ class NeuronDeconvolution(NeuronAttribution, GradientAttribution):
 
     def attribute(
         self,
-        inputs,
-        neuron_index,
-        additional_forward_args=None,
-        attribute_to_neuron_input=False,
-    ):
+        inputs: Union[Tensor, Tuple[Tensor]],
+        neuron_index: Union[int, Tuple[int]],
+        additional_forward_args: Optional[Any] = None,
+        attribute_to_neuron_input: Optional[bool] = False,
+    ) -> Union[Tensor, Tuple[Tensor]]:
         r""""
         Computes attribution of the given neuron using deconvolution.
         Deconvolution computes the gradient of the target output with
@@ -130,7 +141,9 @@ class NeuronDeconvolution(NeuronAttribution, GradientAttribution):
 
 
 class NeuronGuidedBackprop(NeuronAttribution, GradientAttribution):
-    def __init__(self, model, layer, device_ids=None):
+    def __init__(
+        self, model: nn.Module, layer: nn.Module, device_ids: Optional[List[int]] = None
+    ) -> None:
         r"""
         Args:
 
@@ -153,11 +166,11 @@ class NeuronGuidedBackprop(NeuronAttribution, GradientAttribution):
 
     def attribute(
         self,
-        inputs,
-        neuron_index,
-        additional_forward_args=None,
-        attribute_to_neuron_input=False,
-    ):
+        inputs: Union[Tensor, Tuple[Tensor]],
+        neuron_index: Union[int, Tuple[int]],
+        additional_forward_args: Optional[Any] = None,
+        attribute_to_neuron_input: Optional[bool] = False,
+    ) -> Union[Tensor, Tuple[Tensor]]:
         r""""
         Computes attribution of the given neuron using guided backpropagation.
         Guided backpropagation computes the gradient of the target neuron

--- a/captum/attr/_core/neuron/neuron_guided_backprop_deconvnet.py
+++ b/captum/attr/_core/neuron/neuron_guided_backprop_deconvnet.py
@@ -11,7 +11,7 @@ from ..guided_backprop_deconvnet import GuidedBackprop, Deconvolution
 
 class NeuronDeconvolution(NeuronAttribution, GradientAttribution):
     def __init__(
-        self, model: Module, layer: Module, device_ids: Optional[List] = None
+        self, model: Module, layer: Module, device_ids: Optional[List[int]] = None
     ) -> None:
         r"""
         Args:

--- a/captum/attr/_core/neuron/neuron_guided_backprop_deconvnet.py
+++ b/captum/attr/_core/neuron/neuron_guided_backprop_deconvnet.py
@@ -1,27 +1,23 @@
 #!/usr/bin/env python3
-from typing import Any
-from typing import List
-from typing import Optional
-from typing import Tuple
-from typing import Union
+from typing import Any, List, Optional, Tuple, Union
 
-import torch.nn as nn
-from torch import Tensor
+from torch.nn import Module
 
 from ..._utils.attribution import NeuronAttribution, GradientAttribution
 from ..._utils.gradient import construct_neuron_grad_fn
+from ..._utils.typing import TensorOrTupleOfTensors
 from ..guided_backprop_deconvnet import GuidedBackprop, Deconvolution
 
 
 class NeuronDeconvolution(NeuronAttribution, GradientAttribution):
     def __init__(
-        self, model: nn.Module, layer: nn.Module, device_ids: Optional[List] = None
+        self, model: Module, layer: Module, device_ids: Optional[List] = None
     ) -> None:
         r"""
         Args:
 
-            model (nn.Module):  The reference to PyTorch model instance.
-            layer (torch.nn.Module): Layer for which attributions are computed.
+            model (Module):  The reference to PyTorch model instance.
+            layer (Module): Layer for which attributions are computed.
                           Output size of attribute matches this layer's input or
                           output dimensions, depending on whether we attribute to
                           the inputs or outputs of the layer, corresponding to
@@ -42,11 +38,11 @@ class NeuronDeconvolution(NeuronAttribution, GradientAttribution):
 
     def attribute(
         self,
-        inputs: Union[Tensor, Tuple[Tensor]],
-        neuron_index: Union[int, Tuple[int]],
-        additional_forward_args: Optional[Any] = None,
-        attribute_to_neuron_input: Optional[bool] = False,
-    ) -> Union[Tensor, Tuple[Tensor]]:
+        inputs: TensorOrTupleOfTensors,
+        neuron_index: Union[int, Tuple[int, ...]],
+        additional_forward_args: Any = None,
+        attribute_to_neuron_input: bool = False,
+    ) -> TensorOrTupleOfTensors:
         r""""
         Computes attribution of the given neuron using deconvolution.
         Deconvolution computes the gradient of the target output with
@@ -142,13 +138,13 @@ class NeuronDeconvolution(NeuronAttribution, GradientAttribution):
 
 class NeuronGuidedBackprop(NeuronAttribution, GradientAttribution):
     def __init__(
-        self, model: nn.Module, layer: nn.Module, device_ids: Optional[List[int]] = None
+        self, model: Module, layer: Module, device_ids: Optional[List[int]] = None
     ) -> None:
         r"""
         Args:
 
-            model (nn.Module):  The reference to PyTorch model instance.
-            layer (torch.nn.Module): Layer for which neuron attributions are computed.
+            model (Module):  The reference to PyTorch model instance.
+            layer (Module): Layer for which neuron attributions are computed.
                           Attributions for a particular neuron in the output of
                           this layer are computed using the argument neuron_index
                           in the attribute method.
@@ -166,11 +162,11 @@ class NeuronGuidedBackprop(NeuronAttribution, GradientAttribution):
 
     def attribute(
         self,
-        inputs: Union[Tensor, Tuple[Tensor]],
-        neuron_index: Union[int, Tuple[int]],
-        additional_forward_args: Optional[Any] = None,
-        attribute_to_neuron_input: Optional[bool] = False,
-    ) -> Union[Tensor, Tuple[Tensor]]:
+        inputs: TensorOrTupleOfTensors,
+        neuron_index: Union[int, Tuple[int, ...]],
+        additional_forward_args: Any = None,
+        attribute_to_neuron_input: bool = False,
+    ) -> TensorOrTupleOfTensors:
         r""""
         Computes attribution of the given neuron using guided backpropagation.
         Guided backpropagation computes the gradient of the target neuron


### PR DESCRIPTION
This is to add type hints in the file mentioned in the summary

The following tests have been run:
```
python -m unittest -v tests.attr.test_guided_backprop 
python -m unittest -v tests.attr.test_data_parallel
./scripts/run_mypy.sh
```