### PR TITLE
Add type hints to neuron_feature_ablation.py

### DIFF
--- a/captum/attr/_core/neuron/neuron_feature_ablation.py
+++ b/captum/attr/_core/neuron/neuron_feature_ablation.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 import torch
+from torch import Tensor
+from torch.nn import Module
+from typing import Callable, List, Optional, Tuple, Union, Any
+
 
 from ..._utils.attribution import NeuronAttribution, PerturbationAttribution
 from ..._utils.common import _verify_select_column
@@ -9,7 +13,12 @@ from ..feature_ablation import FeatureAblation
 
 
 class NeuronFeatureAblation(NeuronAttribution, PerturbationAttribution):
-    def __init__(self, forward_func, layer, device_ids=None):
+    def __init__(
+        self,
+        forward_func: Callable,
+        layer: Module,
+        device_ids: Optional[List[int]] = None,
+    ) -> None:
         r"""
         Args:
 
@@ -33,13 +42,15 @@ class NeuronFeatureAblation(NeuronAttribution, PerturbationAttribution):
 
     def attribute(
         self,
-        inputs,
-        neuron_index,
-        baselines=None,
-        additional_forward_args=None,
-        feature_mask=None,
-        attribute_to_neuron_input=False,
-        ablations_per_eval=1,
+        inputs: Union[Tensor, Tuple[Tensor, ...]],
+        neuron_index: Union[int, Tuple[int]],
+        baselines: Optional[
+            Union[Tensor, int, float, Tuple[Union[Tensor, int, float], ...]]
+        ] = None,
+        additional_forward_args: Any = None,
+        feature_mask: Union[Tensor, Tuple[Tensor, ...]] = None,
+        attribute_to_neuron_input: bool = False,
+        ablations_per_eval: int = 1,
     ):
         r"""
             A perturbation based approach to computing neuron attribution,
@@ -199,7 +210,7 @@ class NeuronFeatureAblation(NeuronAttribution, PerturbationAttribution):
             >>>                          feature_mask=feature_mask)
         """
 
-        def neuron_forward_func(*args):
+        def neuron_forward_func(*args: str):
             with torch.no_grad():
                 layer_eval, _ = _forward_layer_eval(
                     self.forward_func,
@@ -214,7 +225,7 @@ class NeuronFeatureAblation(NeuronAttribution, PerturbationAttribution):
                 )
                 return _verify_select_column(layer_eval[0], neuron_index)
 
-        ablator = FeatureAblation(neuron_forward_func)
+        ablator: FeatureAblation = FeatureAblation(neuron_forward_func)
 
         return ablator.attribute(
             inputs,

--- a/captum/attr/_core/neuron/neuron_feature_ablation.py
+++ b/captum/attr/_core/neuron/neuron_feature_ablation.py
@@ -8,7 +8,7 @@ from typing import Callable, List, Optional, Tuple, Union, Any
 from ..._utils.attribution import NeuronAttribution, PerturbationAttribution
 from ..._utils.common import _verify_select_column
 from ..._utils.gradient import _forward_layer_eval
-from .._utils.typing import TensorOrTupleOfTensors
+from ..._utils.typing import TensorOrTupleOfTensors
 
 from ..feature_ablation import FeatureAblation
 

--- a/captum/attr/_core/neuron/neuron_feature_ablation.py
+++ b/captum/attr/_core/neuron/neuron_feature_ablation.py
@@ -8,6 +8,7 @@ from typing import Callable, List, Optional, Tuple, Union, Any
 from ..._utils.attribution import NeuronAttribution, PerturbationAttribution
 from ..._utils.common import _verify_select_column
 from ..._utils.gradient import _forward_layer_eval
+from .._utils.typing import TensorOrTupleOfTensors
 
 from ..feature_ablation import FeatureAblation
 
@@ -42,13 +43,13 @@ class NeuronFeatureAblation(NeuronAttribution, PerturbationAttribution):
 
     def attribute(
         self,
-        inputs: Union[Tensor, Tuple[Tensor, ...]],
-        neuron_index: Union[int, Tuple[int]],
+        inputs: TensorOrTupleOfTensors,
+        neuron_index: Union[int, Tuple[int, ...]],
         baselines: Optional[
             Union[Tensor, int, float, Tuple[Union[Tensor, int, float], ...]]
         ] = None,
         additional_forward_args: Any = None,
-        feature_mask: Union[Tensor, Tuple[Tensor, ...]] = None,
+        feature_mask: TensorOrTupleOfTensors = None,
         attribute_to_neuron_input: bool = False,
         ablations_per_eval: int = 1,
     ):
@@ -210,7 +211,7 @@ class NeuronFeatureAblation(NeuronAttribution, PerturbationAttribution):
             >>>                          feature_mask=feature_mask)
         """
 
-        def neuron_forward_func(*args: str):
+        def neuron_forward_func(*args: Any):
             with torch.no_grad():
                 layer_eval, _ = _forward_layer_eval(
                     self.forward_func,
@@ -225,7 +226,7 @@ class NeuronFeatureAblation(NeuronAttribution, PerturbationAttribution):
                 )
                 return _verify_select_column(layer_eval[0], neuron_index)
 
-        ablator: FeatureAblation = FeatureAblation(neuron_forward_func)
+        ablator = FeatureAblation(neuron_forward_func)
 
         return ablator.attribute(
             inputs,

--- a/captum/attr/_core/neuron/neuron_feature_ablation.py
+++ b/captum/attr/_core/neuron/neuron_feature_ablation.py
@@ -49,10 +49,10 @@ class NeuronFeatureAblation(NeuronAttribution, PerturbationAttribution):
             Union[Tensor, int, float, Tuple[Union[Tensor, int, float], ...]]
         ] = None,
         additional_forward_args: Any = None,
-        feature_mask: TensorOrTupleOfTensors = None,
+        feature_mask: Optional[TensorOrTupleOfTensors] = None,
         attribute_to_neuron_input: bool = False,
         ablations_per_eval: int = 1,
-    ):
+    ) -> TensorOrTupleOfTensors:
         r"""
             A perturbation based approach to computing neuron attribution,
             involving replacing each input feature with a given baseline /

--- a/tests/attr/neuron/test_neuron_ablation.py
+++ b/tests/attr/neuron/test_neuron_ablation.py
@@ -14,7 +14,7 @@ from ..helpers.utils import assertTensorAlmostEqual, BaseTest
 
 
 class Test(BaseTest):
-    def test_simple_ablation_with_mask(self):
+    def test_simple_ablation_with_mask(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[20.0, 50.0, 30.0]], requires_grad=True)
         self._ablation_test_assert(
@@ -26,7 +26,7 @@ class Test(BaseTest):
             ablations_per_eval=(1, 2, 3),
         )
 
-    def test_multi_sample_ablation_with_mask(self):
+    def test_multi_sample_ablation_with_mask(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[2.0, 10.0, 3.0], [20.0, 50.0, 30.0]], requires_grad=True)
         mask = torch.tensor([[0, 0, 1], [1, 1, 0]])
@@ -39,7 +39,7 @@ class Test(BaseTest):
             ablations_per_eval=(1, 2, 3),
         )
 
-    def test_multi_input_ablation_with_mask(self):
+    def test_multi_input_ablation_with_mask(self) -> None:
         net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[23.0, 100.0, 0.0], [20.0, 50.0, 30.0]])
         inp2 = torch.tensor([[20.0, 50.0, 30.0], [0.0, 100.0, 0.0]])
@@ -85,7 +85,7 @@ class Test(BaseTest):
             ablations_per_eval=(1, 2, 3),
         )
 
-    def test_multi_input_ablation(self):
+    def test_multi_input_ablation(self) -> None:
         net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[23.0, 100.0, 0.0], [20.0, 50.0, 30.0]])
         inp2 = torch.tensor([[20.0, 50.0, 30.0], [0.0, 100.0, 0.0]])
@@ -123,9 +123,9 @@ class Test(BaseTest):
             ablations_per_eval=(1, 2, 3),
         )
 
-    def test_simple_multi_input_conv(self):
+    def test_simple_multi_input_conv(self) -> None:
         net = BasicModel_ConvNet_One_Conv()
-        inp = torch.arange(16).view(1, 1, 4, 4).type(torch.FloatTensor)
+        inp = torch.arange(16).view(1, 1, 4, 4)
         inp2 = torch.ones((1, 1, 4, 4))
         self._ablation_test_assert(
             net,
@@ -156,9 +156,9 @@ class Test(BaseTest):
             ablations_per_eval=(1, 3, 7, 14),
         )
 
-    def test_simple_multi_input_conv_intermediate(self):
+    def test_simple_multi_input_conv_intermediate(self) -> None:
         net = BasicModel_ConvNet_One_Conv(inplace=True)
-        inp = torch.arange(16).view(1, 1, 4, 4).type(torch.FloatTensor)
+        inp = torch.arange(16).view(1, 1, 4, 4)
         inp2 = torch.ones((1, 1, 4, 4))
         self._ablation_test_assert(
             net,
@@ -214,7 +214,7 @@ class Test(BaseTest):
         baselines=None,
         neuron_index=0,
         attribute_to_neuron_input=False,
-    ):
+    ) -> None:
         for batch_size in ablations_per_eval:
             ablation = NeuronFeatureAblation(model, layer)
             attributions = ablation.attribute(

--- a/tests/attr/neuron/test_neuron_ablation.py
+++ b/tests/attr/neuron/test_neuron_ablation.py
@@ -3,7 +3,12 @@
 import unittest
 
 import torch
+from torch import Tensor
+from torch.nn import Module
+
+from captum.attr._utils.typing import TensorOrTupleOfTensors
 from captum.attr._core.neuron.neuron_feature_ablation import NeuronFeatureAblation
+from typing import Optional, Tuple, Union, Any
 
 from ..helpers.basic_models import (
     BasicModel_ConvNet_One_Conv,
@@ -125,7 +130,7 @@ class Test(BaseTest):
 
     def test_simple_multi_input_conv(self) -> None:
         net = BasicModel_ConvNet_One_Conv()
-        inp = torch.arange(16).view(1, 1, 4, 4)
+        inp = torch.arange(16, dtype=torch.float).view(1, 1, 4, 4)
         inp2 = torch.ones((1, 1, 4, 4))
         self._ablation_test_assert(
             net,
@@ -158,7 +163,7 @@ class Test(BaseTest):
 
     def test_simple_multi_input_conv_intermediate(self) -> None:
         net = BasicModel_ConvNet_One_Conv(inplace=True)
-        inp = torch.arange(16).view(1, 1, 4, 4)
+        inp = torch.arange(16, dtype=torch.float).view(1, 1, 4, 4)
         inp2 = torch.ones((1, 1, 4, 4))
         self._ablation_test_assert(
             net,
@@ -204,16 +209,18 @@ class Test(BaseTest):
 
     def _ablation_test_assert(
         self,
-        model,
-        layer,
-        test_input,
-        expected_ablation,
-        feature_mask=None,
-        additional_input=None,
-        ablations_per_eval=(1,),
-        baselines=None,
-        neuron_index=0,
-        attribute_to_neuron_input=False,
+        model: Module,
+        layer: Module,
+        test_input: TensorOrTupleOfTensors,
+        expected_ablation: Any,
+        feature_mask: Optional[TensorOrTupleOfTensors] = None,
+        additional_input: Any = None,
+        ablations_per_eval: Tuple[int, ...] = (1,),
+        baselines: Optional[
+            Union[Tensor, int, float, Tuple[Union[Tensor, int, float], ...]]
+        ] = None,
+        neuron_index: Union[int, Tuple[int, ...]] = 0,
+        attribute_to_neuron_input: bool = False,
     ) -> None:
         for batch_size in ablations_per_eval:
             ablation = NeuronFeatureAblation(model, layer)

--- a/tests/attr/neuron/test_neuron_ablation.py
+++ b/tests/attr/neuron/test_neuron_ablation.py
@@ -8,7 +8,7 @@ from torch.nn import Module
 
 from captum.attr._utils.typing import TensorOrTupleOfTensors
 from captum.attr._core.neuron.neuron_feature_ablation import NeuronFeatureAblation
-from typing import Optional, Tuple, Union, Any
+from typing import Optional, Tuple, Union, Any, List
 
 from ..helpers.basic_models import (
     BasicModel_ConvNet_One_Conv,
@@ -212,7 +212,12 @@ class Test(BaseTest):
         model: Module,
         layer: Module,
         test_input: TensorOrTupleOfTensors,
-        expected_ablation: Any,
+        expected_ablation: Union[
+            List[float],
+            List[List[float]],
+            Tuple[Tensor, ...],
+            Tuple[List[List[float]], ...],
+        ],
         feature_mask: Optional[TensorOrTupleOfTensors] = None,
         additional_input: Any = None,
         ablations_per_eval: Tuple[int, ...] = (1,),


### PR DESCRIPTION
## What's changed
Add type hints to ```captum/attr/_core/neuron/neuron_feature_ablation.py```

## Test case:
No error from mypy: 
```
Success: no issues found in 44 source files
Success: no issues found in 48 source files
```