### PR TITLE
Adding Type Hints to Captum: saliency.py/test_salientcy.py

### DIFF
--- a/captum/attr/_core/saliency.py
+++ b/captum/attr/_core/saliency.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python3
 
-import torch
+from typing import Any, Callable, List, Optional, Tuple, Union
 
-from .._utils.common import _format_attributions, _format_input
+import torch
+from captum.attr._utils.typing import TensorOrTupleOfTensors
+from torch import Tensor
+
 from .._utils.attribution import GradientAttribution
+from .._utils.common import _format_attributions, _format_input
 from .._utils.gradient import apply_gradient_requirements, undo_gradient_requirements
 
 
 class Saliency(GradientAttribution):
-    def __init__(self, forward_func):
+    def __init__(self, forward_func: Callable) -> None:
         r"""
         Args:
 
@@ -17,7 +21,15 @@ class Saliency(GradientAttribution):
         """
         GradientAttribution.__init__(self, forward_func)
 
-    def attribute(self, inputs, target=None, abs=True, additional_forward_args=None):
+    def attribute(
+        self,
+        inputs: TensorOrTupleOfTensors,
+        target: Optional[
+            Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
+        ] = None,
+        abs: Optional[bool] = True,
+        additional_forward_args: Any = None,
+    ) -> TensorOrTupleOfTensors:
         r""""
         A baseline approach for computing input attribution. It returns
         the gradients with respect to inputs. If `abs` is set to True, which is

--- a/captum/attr/_core/saliency.py
+++ b/captum/attr/_core/saliency.py
@@ -3,8 +3,8 @@
 from typing import Any, Callable, List, Optional, Tuple, Union
 
 import torch
-from captum.attr._utils.typing import TensorOrTupleOfTensors
 from torch import Tensor
+from captum.attr._utils.typing import TensorOrTupleOfTensors
 
 from .._utils.attribution import GradientAttribution
 from .._utils.common import _format_attributions, _format_input

--- a/captum/attr/_core/saliency.py
+++ b/captum/attr/_core/saliency.py
@@ -27,7 +27,7 @@ class Saliency(GradientAttribution):
         target: Optional[
             Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
         ] = None,
-        abs: Optional[bool] = True,
+        abs: bool = True,
         additional_forward_args: Any = None,
     ) -> TensorOrTupleOfTensors:
         r""""

--- a/captum/attr/_utils/gradient.py
+++ b/captum/attr/_utils/gradient.py
@@ -1,10 +1,15 @@
 #!/usr/bin/env python3
 import threading
-import torch
 import warnings
+from typing import Any, Optional, Tuple
 
-from .common import _run_forward, _verify_select_column
+import torch
+from torch import Tensor
+from torch.nn import Module
+from captum.attr._utils.typing import TensorOrTupleOfTensors
+
 from .batching import _reduce_list, _sort_key_list
+from .common import _run_forward, _verify_select_column
 
 
 def apply_gradient_requirements(inputs):
@@ -62,8 +67,11 @@ def undo_gradient_requirements(inputs, grad_required):
 
 
 def compute_gradients(
-    forward_fn, inputs, target_ind=None, additional_forward_args=None
-):
+    forward_fn: Module,
+    inputs: TensorOrTupleOfTensors,
+    target_ind: Optional[TensorOrTupleOfTensors] = None,
+    additional_forward_args: Any = None,
+) -> Tuple[Tensor, ...]:
     r"""
         Computes gradients of the output with respect to inputs for an
         arbitrary forward function.
@@ -410,7 +418,7 @@ def compute_layer_gradients_and_eval(
 
 
 def construct_neuron_grad_fn(
-    layer, neuron_index, device_ids=None, attribute_to_neuron_input=False,
+    layer, neuron_index, device_ids=None, attribute_to_neuron_input=False
 ):
     def grad_fn(forward_fn, inputs, target_ind=None, additional_forward_args=None):
         _, grads, _ = _forward_layer_eval_with_neuron_grads(

--- a/captum/attr/_utils/gradient.py
+++ b/captum/attr/_utils/gradient.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import threading
 import warnings
-from typing import Any, Optional, Tuple
+from typing import Any, List, Optional, Tuple, Union
 
 import torch
 from torch import Tensor
@@ -69,7 +69,9 @@ def undo_gradient_requirements(inputs, grad_required):
 def compute_gradients(
     forward_fn: Module,
     inputs: TensorOrTupleOfTensors,
-    target_ind: Optional[TensorOrTupleOfTensors] = None,
+    target_ind: Optional[
+        Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
+    ] = None,
     additional_forward_args: Any = None,
 ) -> Tuple[Tensor, ...]:
     r"""

--- a/tests/attr/test_saliency.py
+++ b/tests/attr/test_saliency.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
 
 from typing import Any, Tuple, cast
-import torch
-from torch import Tensor
-from torch.nn import Module
 
 import torch
 from torch import Tensor
@@ -12,7 +9,6 @@ from captum.attr._core.noise_tunnel import NoiseTunnel
 from captum.attr._core.saliency import Saliency
 from captum.attr._utils.gradient import compute_gradients
 from captum.attr._utils.typing import TensorOrTupleOfTensors
-
 
 from .helpers.basic_models import BasicModel, BasicModel5_MultiArgs
 from .helpers.classification_models import SoftmaxModel

--- a/tests/attr/test_saliency.py
+++ b/tests/attr/test_saliency.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 from typing import Any, Tuple, cast
 
 import torch

--- a/tests/attr/test_saliency.py
+++ b/tests/attr/test_saliency.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from typing import Any, Optional, Tuple, cast
+from typing import Any, Tuple, cast
 
 import torch
 from captum.attr._core.noise_tunnel import NoiseTunnel

--- a/tests/attr/test_saliency.py
+++ b/tests/attr/test_saliency.py
@@ -1,24 +1,28 @@
 #!/usr/bin/env python3
 
-import torch
+from typing import Any, Optional, Tuple
 
-from captum.attr._core.saliency import Saliency
+import torch
 from captum.attr._core.noise_tunnel import NoiseTunnel
+from captum.attr._core.saliency import Saliency
 from captum.attr._utils.gradient import compute_gradients
+from captum.attr._utils.typing import TensorOrTupleOfTensors
+from torch import Tensor
+from torch.nn import Module
 
 from .helpers.basic_models import BasicModel, BasicModel5_MultiArgs
 from .helpers.classification_models import SoftmaxModel
-from .helpers.utils import assertArraysAlmostEqual, BaseTest
+from .helpers.utils import BaseTest, assertArraysAlmostEqual
 
 
-def _get_basic_config():
+def _get_basic_config() -> Tuple[Module, Tensor, Tensor, Any]:
     input = torch.tensor([1.0, 2.0, 3.0, 0.0, -1.0, 7.0], requires_grad=True)
     # manually percomputed gradients
     grads = torch.tensor([-0.0, -0.0, -0.0, 1.0, 1.0, -0.0])
     return BasicModel(), input, grads, None
 
 
-def _get_multiargs_basic_config():
+def _get_multiargs_basic_config() -> Tuple[Module, Tuple[Tensor, ...], Any, Any]:
     model = BasicModel5_MultiArgs()
     additional_forward_args = ([2, 3], 1)
     inputs = (
@@ -32,36 +36,41 @@ def _get_multiargs_basic_config():
 
 
 class Test(BaseTest):
-    def test_saliency_test_basic_vanilla(self):
+    def test_saliency_test_basic_vanilla(self) -> None:
         self._saliency_base_assert(*_get_basic_config())
 
-    def test_saliency_test_basic_smoothgrad(self):
+    def test_saliency_test_basic_smoothgrad(self) -> None:
         self._saliency_base_assert(*_get_basic_config(), nt_type="smoothgrad")
 
-    def test_saliency_test_basic_vargrad(self):
+    def test_saliency_test_basic_vargrad(self) -> None:
         self._saliency_base_assert(*_get_basic_config(), nt_type="vargrad")
 
-    def test_saliency_test_basic_multi_variable_vanilla(self):
+    def test_saliency_test_basic_multi_variable_vanilla(self) -> None:
         self._saliency_base_assert(*_get_multiargs_basic_config())
 
-    def test_saliency_test_basic_multi_variable_smoothgrad(self):
+    def test_saliency_test_basic_multi_variable_smoothgrad(self) -> None:
         self._saliency_base_assert(*_get_multiargs_basic_config(), nt_type="smoothgrad")
 
-    def test_saliency_test_basic_multi_vargrad(self):
+    def test_saliency_test_basic_multi_vargrad(self) -> None:
         self._saliency_base_assert(*_get_multiargs_basic_config(), nt_type="vargrad")
 
-    def test_saliency_classification_vanilla(self):
+    def test_saliency_classification_vanilla(self) -> None:
         self._saliency_classification_assert()
 
-    def test_saliency_classification_smoothgrad(self):
+    def test_saliency_classification_smoothgrad(self) -> None:
         self._saliency_classification_assert(nt_type="smoothgrad")
 
-    def test_saliency_classification_vargrad(self):
+    def test_saliency_classification_vargrad(self) -> None:
         self._saliency_classification_assert(nt_type="vargrad")
 
     def _saliency_base_assert(
-        self, model, inputs, expected, additional_forward_args=None, nt_type="vanilla"
-    ):
+        self,
+        model: Module,
+        inputs: TensorOrTupleOfTensors,
+        expected: TensorOrTupleOfTensors,
+        additional_forward_args: Any = None,
+        nt_type: str = "vanilla",
+    ) -> None:
         saliency = Saliency(model)
         if nt_type == "vanilla":
             attributions = saliency.attribute(
@@ -76,19 +85,13 @@ class Test(BaseTest):
                 stdevs=0.0000002,
                 additional_forward_args=additional_forward_args,
             )
-        if isinstance(attributions, tuple):
-            for input, attribution, expected_attr in zip(
-                inputs, attributions, expected
-            ):
-                if nt_type == "vanilla":
-                    self._assert_attribution(attribution, expected_attr)
-                self.assertEqual(input.shape, attribution.shape)
-        else:
-            if nt_type == "vanilla":
-                self._assert_attribution(attributions, expected)
-            self.assertEqual(inputs.shape, attributions.shape)
 
-    def _assert_attribution(self, attribution, expected):
+        for input, attribution, expected_attr in zip(inputs, attributions, expected):
+            if nt_type == "vanilla":
+                self._assert_attribution(attribution, expected_attr)
+            self.assertEqual(input.shape, attribution.shape)
+
+    def _assert_attribution(self, attribution: Tensor, expected: Tensor) -> None:
         expected = torch.abs(expected)
         assertArraysAlmostEqual(
             expected.detach().numpy().flatten().tolist(),
@@ -96,7 +99,7 @@ class Test(BaseTest):
             delta=0.5,
         )
 
-    def _saliency_classification_assert(self, nt_type="vanilla"):
+    def _saliency_classification_assert(self, nt_type: str = "vanilla") -> None:
         num_in = 5
         input = torch.tensor([[0.0, 1.0, 2.0, 3.0, 4.0]], requires_grad=True)
         target = torch.tensor(5)
@@ -109,11 +112,12 @@ class Test(BaseTest):
 
             output = model(input)[:, target]
             output.backward()
-            expected = torch.abs(input.grad)
-            self.assertEqual(
-                expected.detach().numpy().tolist(),
-                attributions.detach().numpy().tolist(),
-            )
+            if input.grad:
+                expected = torch.abs(input.grad)
+                self.assertEqual(
+                    expected.detach().numpy().tolist(),
+                    attributions.detach().numpy().tolist(),
+                )
         else:
             nt = NoiseTunnel(saliency)
             attributions = nt.attribute(

--- a/tests/attr/test_saliency.py
+++ b/tests/attr/test_saliency.py
@@ -3,12 +3,13 @@
 from typing import Any, Tuple, cast
 
 import torch
+from torch import Tensor
+from torch.nn import Module
 from captum.attr._core.noise_tunnel import NoiseTunnel
 from captum.attr._core.saliency import Saliency
 from captum.attr._utils.gradient import compute_gradients
 from captum.attr._utils.typing import TensorOrTupleOfTensors
-from torch import Tensor
-from torch.nn import Module
+
 
 from .helpers.basic_models import BasicModel, BasicModel5_MultiArgs
 from .helpers.classification_models import SoftmaxModel
@@ -31,11 +32,8 @@ def _get_multiargs_basic_config() -> Tuple[
         torch.tensor([[1.5, 2.0, 34.3], [3.4, 1.2, 2.0]], requires_grad=True),
         torch.tensor([[3.0, 3.5, 23.2], [2.3, 1.2, 0.3]], requires_grad=True),
     )
-    grads = cast(
-        Tuple[Tensor, ...],
-        compute_gradients(
-            model, inputs, additional_forward_args=additional_forward_args
-        ),
+    grads = compute_gradients(
+        model, inputs, additional_forward_args=additional_forward_args
     )
     return model, inputs, grads, additional_forward_args
 


### PR DESCRIPTION
This PR adds Type Hints to Captum: saliency.py and its test test_saliency.py.