### PR TITLE
adding Type Hints to Captum: gradient_shap.py

### DIFF
--- a/captum/attr/_core/gradient_shap.py
+++ b/captum/attr/_core/gradient_shap.py
@@ -304,14 +304,14 @@ class InputBaselineXGradient(GradientAttribution):
 
     def attribute(
         self,
-        inputs: TensorOrTupleOfTensors,
+        inputs: Union[Tensor, Tuple[Tensor, ...]],
         baselines: Union[
             Tensor, int, float, Tuple[Union[Tensor, int, float], ...], None
         ] = None,
         target: Optional[Union[int, Tuple, Tensor, List[Tensor]]] = None,
         additional_forward_args: Any = None,
         return_convergence_delta: bool = False,
-    ) -> TensorOrTupleOfTensors:
+    ) -> Union[Tensor, Tuple[Tensor, ...]]:
         # Keeps track whether original input is a tuple or not before
         # converting it into a tuple.
         is_inputs_tuple = isinstance(inputs, tuple)

--- a/captum/attr/_core/gradient_shap.py
+++ b/captum/attr/_core/gradient_shap.py
@@ -37,7 +37,7 @@ class GradientShap(GradientAttribution):
             Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
         ] = None,
         additional_forward_args: Any = None,
-        return_convergence_delta: Optional[bool] = False,
+        return_convergence_delta: bool = False,
     ) -> Tensor:
         r"""
         This is an overload method which returns a Tensor if input is Tensor.
@@ -56,7 +56,7 @@ class GradientShap(GradientAttribution):
             Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
         ] = None,
         additional_forward_args: Any = None,
-        return_convergence_delta: Optional[bool] = False,
+        return_convergence_delta: bool = False,
     ) -> Tuple[Tensor, ...]:
         r"""
         This is an overload method which returns a 'Tuple of Tensor'
@@ -74,7 +74,7 @@ class GradientShap(GradientAttribution):
             Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
         ] = None,
         additional_forward_args: Any = None,
-        return_convergence_delta: Optional[bool] = False,
+        return_convergence_delta: bool = False,
     ) -> TensorOrTupleOfTensors:
         r"""
         Implements gradient SHAP based on the implementation from SHAP's primary
@@ -276,15 +276,41 @@ class InputBaselineXGradient(GradientAttribution):
         """
         GradientAttribution.__init__(self, forward_func)
 
+    @typing.overload
+    def attribute(
+        self,
+        inputs: Tensor,
+        baselines: Union[
+            Tensor, int, float, Tuple[Union[Tensor, int, float], ...], None
+        ] = None,
+        target: Optional[Union[int, Tuple, Tensor, List[Tensor]]] = None,
+        additional_forward_args: Any = None,
+        return_convergence_delta: bool = False,
+    ) -> Tensor:
+        ...
+
+    @typing.overload
+    def attribute(
+        self,
+        inputs: Tuple[Tensor, ...],
+        baselines: Union[
+            Tensor, int, float, Tuple[Union[Tensor, int, float], ...], None
+        ] = None,
+        target: Optional[Union[int, Tuple, Tensor, List[Tensor]]] = None,
+        additional_forward_args: Any = None,
+        return_convergence_delta: bool = False,
+    ) -> Tuple[Tensor, ...]:
+        ...
+
     def attribute(
         self,
         inputs: TensorOrTupleOfTensors,
         baselines: Union[
             Tensor, int, float, Tuple[Union[Tensor, int, float], ...], None
         ] = None,
-        target: Optional[Union[int, Tuple, Tensor, List[Any]]] = None,
-        additional_forward_args: Optional[Any] = None,
-        return_convergence_delta: Optional[bool] = False,
+        target: Optional[Union[int, Tuple, Tensor, List[Tensor]]] = None,
+        additional_forward_args: Any = None,
+        return_convergence_delta: bool = False,
     ) -> TensorOrTupleOfTensors:
         # Keeps track whether original input is a tuple or not before
         # converting it into a tuple.

--- a/captum/attr/_core/gradient_shap.py
+++ b/captum/attr/_core/gradient_shap.py
@@ -13,6 +13,7 @@ from .._utils.common import (
 from .noise_tunnel import NoiseTunnel
 from typing import Callable, Union, Optional, Tuple, List, Any
 from .._utils.typing import Tensor, TensorOrTupleOfTensors
+import typing
 
 
 class GradientShap(GradientAttribution):
@@ -25,14 +26,54 @@ class GradientShap(GradientAttribution):
         """
         GradientAttribution.__init__(self, forward_func)
 
+    @typing.overload
+    def attribute(
+        self,
+        inputs: Tensor,
+        baselines: Union[Tensor, Callable, Tuple[Tensor, ...]],
+        n_samples: int = 5,
+        stdevs: Union[float, Tuple[float, ...]] = 0.0,
+        target: Optional[
+            Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
+        ] = None,
+        additional_forward_args: Any = None,
+        return_convergence_delta: Optional[bool] = False,
+    ) -> Tensor:
+        r"""
+        This is an overload method which returns a Tensor if input is Tensor.
+        i.e. not a "Tuple of Tensor"
+        """
+        ...
+
+    @typing.overload
+    def attribute(
+        self,
+        inputs: Tuple[Tensor, ...],
+        baselines: Union[Tensor, Callable, Tuple[Tensor, ...]],
+        n_samples: int = 5,
+        stdevs: Union[float, Tuple[float, ...]] = 0.0,
+        target: Optional[
+            Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
+        ] = None,
+        additional_forward_args: Any = None,
+        return_convergence_delta: Optional[bool] = False,
+    ) -> Tuple[Tensor, ...]:
+        r"""
+        This is an overload method which returns a 'Tuple of Tensor'
+        if input is a 'Tuple of Tensor'.
+        """
+        ...
+
     def attribute(
         self,
         inputs: TensorOrTupleOfTensors,
         baselines: Union[Tensor, Callable, Tuple[Tensor, ...]],
-        n_samples: Optional[int] = 5,
-        stdevs: Optional[Union[float, Tuple[float]]] = 0.0,
-        target: Optional[Union[int, Tuple, Tensor, List[Any]]] = None,
-        additional_forward_args: Optional[Any] = None,
+        n_samples: int = 5,
+        stdevs: Union[float, Tuple[float, ...]] = 0.0,
+        target: Optional[
+            Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
+        ] = None,
+        additional_forward_args: Any = None,
         return_convergence_delta: Optional[bool] = False,
     ) -> TensorOrTupleOfTensors:
         r"""

--- a/captum/attr/_core/gradient_shap.py
+++ b/captum/attr/_core/gradient_shap.py
@@ -272,7 +272,9 @@ class InputBaselineXGradient(GradientAttribution):
         baselines: Union[
             Tensor, int, float, Tuple[Union[Tensor, int, float], ...], None
         ] = None,
-        target: Optional[Union[int, Tuple, Tensor, List[Tensor]]] = None,
+        target: Optional[
+            Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
+        ] = None,
         additional_forward_args: Any = None,
     ) -> TensorOrTupleOfTensors:
         ...
@@ -284,7 +286,9 @@ class InputBaselineXGradient(GradientAttribution):
         baselines: Union[
             Tensor, int, float, Tuple[Union[Tensor, int, float], ...], None
         ] = None,
-        target: Optional[Union[int, Tuple, Tensor, List[Tensor]]] = None,
+        target: Optional[
+            Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
+        ] = None,
         additional_forward_args: Any = None,
         return_convergence_delta: bool = False,
     ) -> TensorOrTupleOfTensors:

--- a/captum/attr/_core/gradient_shap.py
+++ b/captum/attr/_core/gradient_shap.py
@@ -30,14 +30,13 @@ class GradientShap(GradientAttribution):
     def attribute(
         self,
         inputs: TensorOrTupleOfTensors,
-        baselines: Union[Tensor, Callable, Tuple[Tensor, ...]],
+        baselines: Union[TensorOrTupleOfTensors, Callable[..., TensorOrTupleOfTensors]],
         n_samples: int = 5,
         stdevs: Union[float, Tuple[float, ...]] = 0.0,
         target: Optional[
             Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
         ] = None,
         additional_forward_args: Any = None,
-        return_convergence_delta: bool = True,
     ) -> TensorOrTupleOfTensors:
         ...
 
@@ -45,20 +44,7 @@ class GradientShap(GradientAttribution):
     def attribute(
         self,
         inputs: TensorOrTupleOfTensors,
-        baselines: Union[Tensor, Callable, Tuple[Tensor, ...]],
-        n_samples: int = 5,
-        stdevs: Union[float, Tuple[float, ...]] = 0.0,
-        target: Optional[
-            Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
-        ] = None,
-        additional_forward_args: Any = None,
-    ) -> Union[TensorOrTupleOfTensors, Tuple[TensorOrTupleOfTensors, Tensor]]:
-        ...
-
-    def attribute(
-        self,
-        inputs: TensorOrTupleOfTensors,
-        baselines: Union[Tensor, Callable, Tuple[Tensor, ...]],
+        baselines: Union[TensorOrTupleOfTensors, Callable[..., TensorOrTupleOfTensors]],
         n_samples: int = 5,
         stdevs: Union[float, Tuple[float, ...]] = 0.0,
         target: Optional[
@@ -66,6 +52,18 @@ class GradientShap(GradientAttribution):
         ] = None,
         additional_forward_args: Any = None,
         return_convergence_delta: bool = False,
+    ) -> Union[TensorOrTupleOfTensors, Tuple[TensorOrTupleOfTensors, Tensor]]:
+        ...
+
+    def attribute(
+        self,
+        inputs,
+        baselines,
+        n_samples=5,
+        stdevs=0.0,
+        target=None,
+        additional_forward_args=None,
+        return_convergence_delta=False,
     ):
         r"""
         Implements gradient SHAP based on the implementation from SHAP's primary
@@ -276,7 +274,6 @@ class InputBaselineXGradient(GradientAttribution):
         ] = None,
         target: Optional[Union[int, Tuple, Tensor, List[Tensor]]] = None,
         additional_forward_args: Any = None,
-        return_convergence_delta: bool = True,
     ) -> TensorOrTupleOfTensors:
         ...
 
@@ -289,19 +286,18 @@ class InputBaselineXGradient(GradientAttribution):
         ] = None,
         target: Optional[Union[int, Tuple, Tensor, List[Tensor]]] = None,
         additional_forward_args: Any = None,
+        return_convergence_delta: bool = False,
     ) -> TensorOrTupleOfTensors:
         ...
 
     def attribute(
         self,
-        inputs: Union[Tensor, Tuple[Tensor, ...]],
-        baselines: Union[
-            Tensor, int, float, Tuple[Union[Tensor, int, float], ...], None
-        ] = None,
-        target: Optional[Union[int, Tuple, Tensor, List[Tensor]]] = None,
-        additional_forward_args: Any = None,
-        return_convergence_delta: bool = False,
-    ) -> Union[Tensor, Tuple[Tensor, ...]]:
+        inputs,
+        baselines=None,
+        target=None,
+        additional_forward_args=None,
+        return_convergence_delta=False,
+    ):
         # Keeps track whether original input is a tuple or not before
         # converting it into a tuple.
         is_inputs_tuple = isinstance(inputs, tuple)

--- a/captum/attr/_core/gradient_shap.py
+++ b/captum/attr/_core/gradient_shap.py
@@ -11,10 +11,12 @@ from .._utils.common import (
 )
 
 from .noise_tunnel import NoiseTunnel
+from typing import Callable, Union, Optional, Tuple, List, Any
+from .._utils.typing import Tensor, TensorOrTupleOfTensors
 
 
 class GradientShap(GradientAttribution):
-    def __init__(self, forward_func):
+    def __init__(self, forward_func: Callable) -> None:
         r"""
         Args:
 
@@ -25,14 +27,14 @@ class GradientShap(GradientAttribution):
 
     def attribute(
         self,
-        inputs,
-        baselines,
-        n_samples=5,
-        stdevs=0.0,
-        target=None,
-        additional_forward_args=None,
-        return_convergence_delta=False,
-    ):
+        inputs: TensorOrTupleOfTensors,
+        baselines: Union[Tensor, Callable, Tuple[Tensor, ...]],
+        n_samples: Optional[int] = 5,
+        stdevs: Optional[Union[float, Tuple[float]]] = 0.0,
+        target: Optional[Union[int, Tuple, Tensor, List[Any]]] = None,
+        additional_forward_args: Optional[Any] = None,
+        return_convergence_delta: Optional[bool] = False,
+    ) -> TensorOrTupleOfTensors:
         r"""
         Implements gradient SHAP based on the implementation from SHAP's primary
         author. For reference, please, view:
@@ -219,12 +221,12 @@ class GradientShap(GradientAttribution):
 
         return attributions
 
-    def has_convergence_delta(self):
+    def has_convergence_delta(self) -> bool:
         return True
 
 
 class InputBaselineXGradient(GradientAttribution):
-    def __init__(self, forward_func):
+    def __init__(self, forward_func: Callable) -> None:
         r"""
         Args:
 
@@ -235,12 +237,14 @@ class InputBaselineXGradient(GradientAttribution):
 
     def attribute(
         self,
-        inputs,
-        baselines=None,
-        target=None,
-        additional_forward_args=None,
-        return_convergence_delta=False,
-    ):
+        inputs: TensorOrTupleOfTensors,
+        baselines: Union[
+            Tensor, int, float, Tuple[Union[Tensor, int, float], ...], None
+        ] = None,
+        target: Optional[Union[int, Tuple, Tensor, List[Any]]] = None,
+        additional_forward_args: Optional[Any] = None,
+        return_convergence_delta: Optional[bool] = False,
+    ) -> TensorOrTupleOfTensors:
         # Keeps track whether original input is a tuple or not before
         # converting it into a tuple.
         is_inputs_tuple = isinstance(inputs, tuple)
@@ -279,10 +283,15 @@ class InputBaselineXGradient(GradientAttribution):
             is_inputs_tuple,
         )
 
-    def has_convergence_delta(self):
+    def has_convergence_delta(self) -> bool:
         return True
 
-    def _scale_input(self, input, baseline, rand_coefficient):
+    def _scale_input(
+        self,
+        input: Tensor,
+        baseline: Union[Tensor, int, float],
+        rand_coefficient: Tensor,
+    ) -> Tensor:
         # batch size
         bsz = input.shape[0]
         inp_shape_wo_bsz = input.shape[1:]
@@ -292,6 +301,6 @@ class InputBaselineXGradient(GradientAttribution):
         rand_coefficient = rand_coefficient.view(inp_shape).requires_grad_()
 
         input_baseline_scaled = (
-            rand_coefficient * input + (1 - rand_coefficient) * baseline
+            rand_coefficient * input + (torch.tensor(1) - rand_coefficient) * baseline
         )
         return input_baseline_scaled

--- a/captum/attr/_core/gradient_shap.py
+++ b/captum/attr/_core/gradient_shap.py
@@ -29,7 +29,7 @@ class GradientShap(GradientAttribution):
     @typing.overload
     def attribute(
         self,
-        inputs: Tensor,
+        inputs: TensorOrTupleOfTensors,
         baselines: Union[Tensor, Callable, Tuple[Tensor, ...]],
         n_samples: int = 5,
         stdevs: Union[float, Tuple[float, ...]] = 0.0,
@@ -37,18 +37,14 @@ class GradientShap(GradientAttribution):
             Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
         ] = None,
         additional_forward_args: Any = None,
-        return_convergence_delta: bool = False,
-    ) -> Tensor:
-        r"""
-        This is an overload method which returns a Tensor if input is Tensor.
-        i.e. not a "Tuple of Tensor"
-        """
+        return_convergence_delta: bool = True,
+    ) -> TensorOrTupleOfTensors:
         ...
 
     @typing.overload
     def attribute(
         self,
-        inputs: Tuple[Tensor, ...],
+        inputs: TensorOrTupleOfTensors,
         baselines: Union[Tensor, Callable, Tuple[Tensor, ...]],
         n_samples: int = 5,
         stdevs: Union[float, Tuple[float, ...]] = 0.0,
@@ -56,12 +52,7 @@ class GradientShap(GradientAttribution):
             Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
         ] = None,
         additional_forward_args: Any = None,
-        return_convergence_delta: bool = False,
-    ) -> Tuple[Tensor, ...]:
-        r"""
-        This is an overload method which returns a 'Tuple of Tensor'
-        if input is a 'Tuple of Tensor'.
-        """
+    ) -> Union[TensorOrTupleOfTensors, Tuple[TensorOrTupleOfTensors, Tensor]]:
         ...
 
     def attribute(
@@ -75,7 +66,7 @@ class GradientShap(GradientAttribution):
         ] = None,
         additional_forward_args: Any = None,
         return_convergence_delta: bool = False,
-    ) -> TensorOrTupleOfTensors:
+    ):
         r"""
         Implements gradient SHAP based on the implementation from SHAP's primary
         author. For reference, please, view:
@@ -279,27 +270,26 @@ class InputBaselineXGradient(GradientAttribution):
     @typing.overload
     def attribute(
         self,
-        inputs: Tensor,
+        inputs: TensorOrTupleOfTensors,
         baselines: Union[
             Tensor, int, float, Tuple[Union[Tensor, int, float], ...], None
         ] = None,
         target: Optional[Union[int, Tuple, Tensor, List[Tensor]]] = None,
         additional_forward_args: Any = None,
-        return_convergence_delta: bool = False,
-    ) -> Tensor:
+        return_convergence_delta: bool = True,
+    ) -> TensorOrTupleOfTensors:
         ...
 
     @typing.overload
     def attribute(
         self,
-        inputs: Tuple[Tensor, ...],
+        inputs: TensorOrTupleOfTensors,
         baselines: Union[
             Tensor, int, float, Tuple[Union[Tensor, int, float], ...], None
         ] = None,
         target: Optional[Union[int, Tuple, Tensor, List[Tensor]]] = None,
         additional_forward_args: Any = None,
-        return_convergence_delta: bool = False,
-    ) -> Tuple[Tensor, ...]:
+    ) -> TensorOrTupleOfTensors:
         ...
 
     def attribute(

--- a/captum/attr/_core/neuron/neuron_gradient_shap.py
+++ b/captum/attr/_core/neuron/neuron_gradient_shap.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 from typing import Callable, List, Optional, Tuple, Union, Any
-from torch import Tensor
 from torch.nn import Module
 
 from ..gradient_shap import GradientShap
@@ -42,7 +41,7 @@ class NeuronGradientShap(NeuronAttribution, GradientAttribution):
         self,
         inputs: TensorOrTupleOfTensors,
         neuron_index: Union[int, Tuple[int, ...]],
-        baselines: Union[Tensor, Callable[..., Tensor], Tuple[Union[Tensor], ...]],
+        baselines: Union[TensorOrTupleOfTensors, Callable[..., TensorOrTupleOfTensors]],
         n_samples: int = 5,
         stdevs: float = 0.0,
         additional_forward_args: Any = None,

--- a/tests/attr/test_gradient_shap.py
+++ b/tests/attr/test_gradient_shap.py
@@ -8,7 +8,7 @@ from .helpers.classification_models import SoftmaxModel
 from .helpers.basic_models import BasicModel2, BasicLinearModel
 from captum.attr._core.gradient_shap import GradientShap
 from captum.attr._core.integrated_gradients import IntegratedGradients
-from typing import Union, Tuple, List, Any
+from typing import Union, Tuple, List
 from captum.attr._utils.typing import Tensor, TensorOrTupleOfTensors
 
 
@@ -177,7 +177,7 @@ class Test(BaseTest):
 
     def _assert_shap_ig_comparision(
         self,
-        attributions1: Union[Tensor, Tuple[Any]],
+        attributions1: Union[Tensor, Tuple[Tensor, ...]],
         attributions2: TensorOrTupleOfTensors,
     ) -> None:
         for attribution1, attribution2 in zip(attributions1, attributions2):
@@ -189,8 +189,8 @@ class Test(BaseTest):
 
 def _assert_attribution_delta(
     test: BaseTest,
-    inputs: Union[Tuple[Tensor], Tuple[Tensor, Tensor]],
-    attributions: Union[Tensor, Tuple[Any]],
+    inputs: Union[Tensor, Tuple[Tensor, ...]],
+    attributions: Union[Tensor, Tuple[Tensor, ...]],
     n_samples: int,
     delta: Tensor,
     is_layer: bool = False,


### PR DESCRIPTION
Summary: added type hints to the following files in Captum:
captum/attr/_core/gradient_shap.py
tests/attr/test_gradient_shap.py

Test Plan:
 black .
All done! ✨ 🍰 ✨                                                                                                                                                                                                                            108 files left unchanged.

flake8 .    -- no errors

UT:
python -m unittest -v tests.attr.test_gradient_shap
test_basic_multi_input (tests.attr.test_gradient_shap.Test) ... ok
test_basic_relu_multi_input (tests.attr.test_gradient_shap.Test) ... ok
test_classification (tests.attr.test_gradient_shap.Test) ... ok
test_classification_baselines_as_function (tests.attr.test_gradient_shap.Test) ... ok

----------------------------------------------------------------------
Ran 4 tests in 3.272s

OK

./scripts/run_mypy.sh
Success: no issues found in 44 source files
Success: no issues found in 48 source files