### PR TITLE
Adding type hints to deep_lift.py

### DIFF
--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -376,7 +376,9 @@ class DeepLift(GradientAttribution):
         self, module: Module, inputs: TensorOrTupleOfTensors
     ) -> None:
         inputs = _format_tensor_into_tuples(inputs)
-        module.input_ref = tuple(input.clone().detach() for input in inputs)  # type: ignore
+        module.input_ref = tuple(  # type: ignore
+            input.clone().detach() for input in inputs
+        )
 
     def _forward_pre_hook(self, module: Module, inputs: TensorOrTupleOfTensors) -> None:
         """
@@ -494,7 +496,7 @@ class DeepLift(GradientAttribution):
         # adds forward hook to leaf nodes that are non-linear
         forward_handle = module.register_forward_hook(self._forward_hook)
         pre_forward_handle = module.register_forward_pre_hook(self._forward_pre_hook)
-        backward_handle = module.register_backward_hook(self._backward_hook)  # type: ignore
+        backward_handle = module.register_backward_hook(self._backward_hook)
         self.forward_handles.append(forward_handle)
         self.forward_handles.append(pre_forward_handle)
         self.backward_handles.append(backward_handle)

--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -832,7 +832,9 @@ class DeepLiftShap(DeepLift):
             input_additional_args,
         )
 
-    def _compute_mean_across_baselines(self, inp_bsz, base_bsz, attribution):
+    def _compute_mean_across_baselines(
+        self, inp_bsz: int, base_bsz: int, attribution: Tensor
+    ) -> Tensor:
         # Average for multiple references
         attr_shape = (inp_bsz, base_bsz)
         if len(attribution.shape) > 1:

--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -7,6 +7,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
+from torch.nn import Module
+from torch.utils.hooks import RemovableHandle
 
 import numpy as np
 
@@ -60,7 +62,7 @@ def _check_valid_module(inputs_grad_fn, outputs) -> bool:
 
 
 class DeepLift(GradientAttribution):
-    def __init__(self, model: nn.Module) -> None:
+    def __init__(self, model: Module) -> None:
         r"""
         Args:
 
@@ -68,15 +70,15 @@ class DeepLift(GradientAttribution):
         """
         GradientAttribution.__init__(self, model)
         self.model = model
-        self.forward_handles: List[Any] = []
-        self.backward_handles: List[Any] = []
+        self.forward_handles: List[RemovableHandle] = []
+        self.backward_handles: List[RemovableHandle] = []
 
     @typing.overload
     def attribute(
         self,
         inputs: TensorOrTupleOfTensors,
         baselines: Optional[
-            Union[Tensor, int, float, Tuple[Union[Tensor, int, float], ...]]
+            Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
         ] = None,
         target: Optional[
             Union[
@@ -347,23 +349,36 @@ class DeepLift(GradientAttribution):
         )
 
     def _construct_forward_func(
-        self, forward_func, inputs, target=None, additional_forward_args=None
-    ):
+        self,
+        forward_func: Callable,
+        inputs: TensorOrTupleOfTensors,
+        target: Optional[
+            Union[
+                int,
+                Tensor,
+                List[Union[int, Tensor, Tuple[Union[int, Tensor], ...]]],
+                Tuple[Union[int, Tensor], ...],
+            ]
+        ] = None,
+        additional_forward_args: Any = None,
+    ) -> Callable:
         def forward_fn():
             return _run_forward(forward_func, inputs, target, additional_forward_args)
 
         if hasattr(forward_func, "device_ids"):
-            forward_fn.device_ids = forward_func.device_ids
+            forward_fn.device_ids = forward_func.device_ids  # type: ignore
         return forward_fn
 
-    def _is_non_linear(self, module: nn.Module) -> bool:
+    def _is_non_linear(self, module: Module) -> bool:
         return type(module) in SUPPORTED_NON_LINEAR.keys()
 
-    def _forward_pre_hook_ref(self, module: Any, inputs: TensorOrTupleOfTensors) -> None:
+    def _forward_pre_hook_ref(
+        self, module: Module, inputs: TensorOrTupleOfTensors
+    ) -> None:
         inputs = _format_tensor_into_tuples(inputs)
-        module.input_ref = tuple(input.clone().detach() for input in inputs)
+        module.input_ref = tuple(input.clone().detach() for input in inputs)  # type: ignore
 
-    def _forward_pre_hook(self, module, inputs):
+    def _forward_pre_hook(self, module: Module, inputs: TensorOrTupleOfTensors) -> None:
         """
         For the modules that perform in-place operations such as ReLUs, we cannot
         use inputs from forward hooks. This is because in that case inputs
@@ -372,7 +387,7 @@ class DeepLift(GradientAttribution):
         """
         inputs = _format_tensor_into_tuples(inputs)
         module.input = inputs[0].clone().detach()
-        module.input_grad_fns = inputs[0].grad_fn
+        module.input_grad_fns = inputs[0].grad_fn  # type: ignore
 
         def tensor_backward_hook(grad):
             if module.saved_grad is None:
@@ -392,7 +407,12 @@ class DeepLift(GradientAttribution):
         handle = inputs[0].register_hook(tensor_backward_hook)
         module.input_hook = handle
 
-    def _forward_hook(self, module, inputs, outputs):
+    def _forward_hook(
+        self,
+        module: Module,
+        inputs: TensorOrTupleOfTensors,
+        outputs: TensorOrTupleOfTensors,
+    ) -> None:
         r"""
         we need forward hook to access and detach the inputs and
         outputs of a neuron
@@ -407,17 +427,23 @@ class DeepLift(GradientAttribution):
                     module
                 )
             )
-            module.is_invalid = True
-            module.saved_grad = None
-            self.forward_handles.append(module.input_hook)
+            module.is_invalid = True  # type: ignore
+            module.saved_grad = None  # type: ignore
+            self.forward_handles.append(cast(RemovableHandle, module.input_hook))
         else:
-            module.is_invalid = False
+            module.is_invalid = False  # type: ignore
             # removing the hook if there is no failure case
-            module.input_hook.remove()
+            cast(RemovableHandle, module.input_hook).remove()
         del module.input_hook
         del module.input_grad_fns
 
-    def _backward_hook(self, module, grad_input, grad_output, eps=1e-10):
+    def _backward_hook(
+        self,
+        module: Module,
+        grad_input: TensorOrTupleOfTensors,
+        grad_output: TensorOrTupleOfTensors,
+        eps: float = 1e-10,
+    ):
         r"""
          `grad_input` is the gradient of the neuron with respect to its input
          `grad_output` is the gradient of the neuron with respect to its output
@@ -449,26 +475,26 @@ class DeepLift(GradientAttribution):
 
         return multipliers
 
-    def satisfies_attribute_criteria(self, module: nn.Module) -> bool:
+    def satisfies_attribute_criteria(self, module: Module) -> bool:
         return hasattr(module, "input") and hasattr(module, "output")
 
-    def _can_register_hook(self, module) -> bool:
+    def _can_register_hook(self, module: Module) -> bool:
         # TODO find a better way of checking if a module is a container or not
         module_fullname = str(type(module))
-        has_already_hooks = len(module._backward_hooks) > 0
+        has_already_hooks = len(module._backward_hooks) > 0  # type: ignore
         return not (
             "nn.modules.container" in module_fullname
             or has_already_hooks
             or not self._is_non_linear(module)
         )
 
-    def _register_hooks(self, module: nn.Module) -> None:
+    def _register_hooks(self, module: Module) -> None:
         if not self._can_register_hook(module):
             return
         # adds forward hook to leaf nodes that are non-linear
         forward_handle = module.register_forward_hook(self._forward_hook)
         pre_forward_handle = module.register_forward_pre_hook(self._forward_pre_hook)
-        backward_handle = module.register_backward_hook(self._backward_hook)
+        backward_handle = module.register_backward_hook(self._backward_hook)  # type: ignore
         self.forward_handles.append(forward_handle)
         self.forward_handles.append(pre_forward_handle)
         self.backward_handles.append(backward_handle)
@@ -479,8 +505,10 @@ class DeepLift(GradientAttribution):
         for backward_handle in self.backward_handles:
             backward_handle.remove()
 
-    def _pre_hook_main_model(self):
-        def pre_hook(module, baseline_inputs_add_args):
+    def _pre_hook_main_model(self) -> RemovableHandle:
+        def pre_hook(
+            module: Module, baseline_inputs_add_args: Tuple[Tensor, ...]
+        ) -> Tuple[Tensor, ...]:
             inputs = baseline_inputs_add_args[0]
             baselines = baseline_inputs_add_args[1]
             additional_args = None
@@ -496,22 +524,61 @@ class DeepLift(GradientAttribution):
             return baseline_input_tsr
 
         if isinstance(self.model, nn.DataParallel):
-            return self.model.module.register_forward_pre_hook(pre_hook)
+            return self.model.module.register_forward_pre_hook(pre_hook)  # type: ignore
         else:
-            return self.model.register_forward_pre_hook(pre_hook)
+            return self.model.register_forward_pre_hook(pre_hook)  # type: ignore
 
     def has_convergence_delta(self) -> bool:
         return True
 
 
 class DeepLiftShap(DeepLift):
-    def __init__(self, model: nn.Module) -> None:
+    def __init__(self, model: Module) -> None:
         r"""
         Args:
 
             model (nn.Module):  The reference to PyTorch model instance.
         """
         DeepLift.__init__(self, model)
+
+    # There's a mismatch between the signatures of DeepLift.attribute and
+    # DeepLiftShap.attribute, so we ignore typing here
+    @typing.overload  # type: ignore
+    def attribute(
+        self,
+        inputs: TensorOrTupleOfTensors,
+        baselines: Union[TensorOrTupleOfTensors, Callable[..., TensorOrTupleOfTensors]],
+        target: Optional[
+            Union[
+                int,
+                Tensor,
+                List[Union[int, Tensor, Tuple[Union[int, Tensor], ...]]],
+                Tuple[Union[int, Tensor], ...],
+            ]
+        ] = None,
+        additional_forward_args: Any = None,
+        custom_attribution_func: Callable[..., Tuple[Tensor, ...]] = None,
+    ) -> TensorOrTupleOfTensors:
+        ...
+
+    @typing.overload
+    def attribute(
+        self,
+        inputs: TensorOrTupleOfTensors,
+        baselines: Union[TensorOrTupleOfTensors, Callable[..., TensorOrTupleOfTensors]],
+        target: Optional[
+            Union[
+                int,
+                Tensor,
+                List[Union[int, Tensor, Tuple[Union[int, Tensor], ...]]],
+                Tuple[Union[int, Tensor], ...],
+            ]
+        ] = None,
+        additional_forward_args: Any = None,
+        return_convergence_delta: bool = False,
+        custom_attribution_func: Callable[..., Tuple[Tensor, ...]] = None,
+    ) -> Union[TensorOrTupleOfTensors, Tuple[TensorOrTupleOfTensors, Tensor]]:
+        ...
 
     def attribute(
         self,
@@ -771,7 +838,14 @@ class DeepLiftShap(DeepLift):
         return torch.mean(attribution.view(attr_shape), axis=1, keepdim=False)
 
 
-def nonlinear(module: nn.Module, inputs: Tensor, outputs: Tensor, grad_input: Tensor, grad_output: Tensor, eps: float=1e-10):
+def nonlinear(
+    module: Module,
+    inputs: Tensor,
+    outputs: Tensor,
+    grad_input: Tensor,
+    grad_output: Tensor,
+    eps: float = 1e-10,
+):
     r"""
     grad_input: (dLoss / dprev_layer_out, dLoss / wij, dLoss / bij)
     grad_output: (dLoss / dlayer_out)
@@ -794,7 +868,14 @@ def nonlinear(module: nn.Module, inputs: Tensor, outputs: Tensor, grad_input: Te
     return new_grad_inp
 
 
-def softmax(module, inputs, outputs, grad_input, grad_output, eps=1e-10):
+def softmax(
+    module: Module,
+    inputs: Tensor,
+    outputs: Tensor,
+    grad_input: Tensor,
+    grad_output: Tensor,
+    eps: float = 1e-10,
+):
     delta_in, delta_out = _compute_diffs(inputs, outputs)
 
     new_grad_inp = list(grad_input)
@@ -809,7 +890,14 @@ def softmax(module, inputs, outputs, grad_input, grad_output, eps=1e-10):
     return new_grad_inp
 
 
-def maxpool1d(module, inputs, outputs, grad_input, grad_output, eps=1e-10):
+def maxpool1d(
+    module: Module,
+    inputs: Tensor,
+    outputs: Tensor,
+    grad_input: Tensor,
+    grad_output: Tensor,
+    eps: float = 1e-10,
+):
     return maxpool(
         module,
         F.max_pool1d,
@@ -822,7 +910,14 @@ def maxpool1d(module, inputs, outputs, grad_input, grad_output, eps=1e-10):
     )
 
 
-def maxpool2d(module, inputs, outputs, grad_input, grad_output, eps=1e-10):
+def maxpool2d(
+    module: Module,
+    inputs: Tensor,
+    outputs: Tensor,
+    grad_input: Tensor,
+    grad_output: Tensor,
+    eps: float = 1e-10,
+):
     return maxpool(
         module,
         F.max_pool2d,
@@ -835,7 +930,9 @@ def maxpool2d(module, inputs, outputs, grad_input, grad_output, eps=1e-10):
     )
 
 
-def maxpool3d(module, inputs, outputs, grad_input, grad_output, eps=1e-10):
+def maxpool3d(
+    module: Module, inputs, outputs, grad_input, grad_output, eps: float = 1e-10
+):
     return maxpool(
         module,
         F.max_pool3d,
@@ -849,7 +946,14 @@ def maxpool3d(module, inputs, outputs, grad_input, grad_output, eps=1e-10):
 
 
 def maxpool(
-    module, pool_func, unpool_func, inputs, outputs, grad_inputs, grad_output, eps=1e-10,
+    module: Module,
+    pool_func: Callable,
+    unpool_func: Callable,
+    inputs,
+    outputs,
+    grad_input,
+    grad_output,
+    eps: float = 1e-10,
 ):
     with torch.no_grad():
         input, input_ref = inputs.chunk(2)

--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -495,9 +495,7 @@ class DeepLift(GradientAttribution):
             backward_handle.remove()
 
     def _pre_hook_main_model(self) -> RemovableHandle:
-        def pre_hook(
-            module: Module, baseline_inputs_add_args: Tuple[Tensor, ...]
-        ) -> Tuple[Tensor, ...]:
+        def pre_hook(module: Module, baseline_inputs_add_args: Tuple) -> Tuple:
             inputs = baseline_inputs_add_args[0]
             baselines = baseline_inputs_add_args[1]
             additional_args = None

--- a/captum/attr/_core/neuron/neuron_deep_lift.py
+++ b/captum/attr/_core/neuron/neuron_deep_lift.py
@@ -211,15 +211,7 @@ class NeuronDeepLiftShap(NeuronAttribution, GradientAttribution):
         self,
         inputs: TensorOrTupleOfTensors,
         neuron_index: Union[int, Tuple[int, ...]],
-        baselines: Optional[
-            Union[
-                int,
-                float,
-                Tensor,
-                Tuple[Union[Tensor, int, float], ...],
-                Callable[..., Union[Tensor, Tuple[Tensor, ...]]],
-            ]
-        ] = None,
+        baselines: Union[TensorOrTupleOfTensors, Callable[..., TensorOrTupleOfTensors]],
         additional_forward_args: Any = None,
         attribute_to_neuron_input: bool = False,
         custom_attribution_func: Optional[Callable[..., Tuple[Tensor, ...]]] = None,

--- a/tests/attr/neuron/test_neuron_deeplift_basic.py
+++ b/tests/attr/neuron/test_neuron_deeplift_basic.py
@@ -122,9 +122,7 @@ class Test(BaseTest):
         self,
         attr_method: Union[NeuronDeepLift, NeuronDeepLiftShap],
         inputs: TensorOrTupleOfTensors,
-        baselines: Optional[
-            Union[Tensor, int, float, Tuple[Union[Tensor, int, float], ...]]
-        ],
+        baselines,
         expected,
     ) -> None:
         def custom_attr_func(

--- a/tests/attr/test_deeplift_basic.py
+++ b/tests/attr/test_deeplift_basic.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
 
+from typing import Tuple, List, Union, Optional, Callable
+
 import torch
+from torch import Tensor
+from torch.nn import Module
 
 from inspect import signature
 
 from captum.attr._core.deep_lift import DeepLift, DeepLiftShap
 from captum.attr._core.integrated_gradients import IntegratedGradients
+
+from captum.attr._utils.typing import TensorOrTupleOfTensors
 
 from .helpers.utils import (
     assertAttributionComparision,
@@ -23,7 +29,7 @@ from .helpers.basic_models import ReLULinearDeepLiftModel, Conv1dDeepLiftModel
 
 
 class Test(BaseTest):
-    def test_relu_deeplift(self):
+    def test_relu_deeplift(self) -> None:
         x1 = torch.tensor([1.0], requires_grad=True)
         x2 = torch.tensor([2.0], requires_grad=True)
 
@@ -36,7 +42,7 @@ class Test(BaseTest):
         model = ReLUDeepLiftModel()
         self._deeplift_assert(model, DeepLift(model), inputs, baselines)
 
-    def test_relu_deeplift_exact_match(self):
+    def test_relu_deeplift_exact_match(self) -> None:
         x1 = torch.tensor([1.0], requires_grad=True)
         x2 = torch.tensor([2.0], requires_grad=True)
 
@@ -54,7 +60,7 @@ class Test(BaseTest):
         self.assertEqual(attributions[1][0], 1.0)
         self.assertEqual(delta[0], 0.0)
 
-    def test_tanh_deeplift(self):
+    def test_tanh_deeplift(self) -> None:
         x1 = torch.tensor([-1.0], requires_grad=True)
         x2 = torch.tensor([-2.0], requires_grad=True)
 
@@ -67,7 +73,7 @@ class Test(BaseTest):
         model = TanhDeepLiftModel()
         self._deeplift_assert(model, DeepLift(model), inputs, baselines)
 
-    def test_relu_deeplift_batch(self):
+    def test_relu_deeplift_batch(self) -> None:
         x1 = torch.tensor([[1.0], [1.0], [1.0], [1.0]], requires_grad=True)
         x2 = torch.tensor([[2.0], [2.0], [2.0], [2.0]], requires_grad=True)
 
@@ -80,7 +86,7 @@ class Test(BaseTest):
         model = ReLUDeepLiftModel()
         self._deeplift_assert(model, DeepLift(model), inputs, baselines)
 
-    def test_relu_linear_deeplift(self):
+    def test_relu_linear_deeplift(self) -> None:
         model = ReLULinearDeepLiftModel(inplace=True)
         x1 = torch.tensor([[-10.0, 1.0, -5.0]], requires_grad=True)
         x2 = torch.tensor([[3.0, 3.0, 1.0]], requires_grad=True)
@@ -91,7 +97,7 @@ class Test(BaseTest):
         # expected = [[[0.0, 0.0]], [[6.0, 2.0]]]
         self._deeplift_assert(model, DeepLift(model), inputs, baselines)
 
-    def test_relu_linear_deeplift_compare_inplace(self):
+    def test_relu_linear_deeplift_compare_inplace(self) -> None:
         model1 = ReLULinearDeepLiftModel(inplace=True)
         x1 = torch.tensor([[-10.0, 1.0, -5.0], [2.0, 3.0, 4.0]], requires_grad=True)
         x2 = torch.tensor([[3.0, 3.0, 1.0], [2.3, 5.0, 4.0]], requires_grad=True)
@@ -103,7 +109,7 @@ class Test(BaseTest):
         assertTensorAlmostEqual(self, attributions1[0], attributions2[0])
         assertTensorAlmostEqual(self, attributions1[1], attributions2[1])
 
-    def test_relu_linear_deepliftshap_compare_inplace(self):
+    def test_relu_linear_deepliftshap_compare_inplace(self) -> None:
         model1 = ReLULinearDeepLiftModel(inplace=True)
         x1 = torch.tensor([[-10.0, 1.0, -5.0], [2.0, 3.0, 4.0]], requires_grad=True)
         x2 = torch.tensor([[3.0, 3.0, 1.0], [2.3, 5.0, 4.0]], requires_grad=True)
@@ -119,7 +125,7 @@ class Test(BaseTest):
         assertTensorAlmostEqual(self, attributions1[0], attributions2[0])
         assertTensorAlmostEqual(self, attributions1[1], attributions2[1])
 
-    def test_relu_linear_deeplift_batch(self):
+    def test_relu_linear_deeplift_batch(self) -> None:
         model = ReLULinearDeepLiftModel(inplace=True)
         x1 = torch.tensor([[-10.0, 1.0, -5.0], [2.0, 3.0, 4.0]], requires_grad=True)
         x2 = torch.tensor([[3.0, 3.0, 1.0], [2.3, 5.0, 4.0]], requires_grad=True)
@@ -129,7 +135,7 @@ class Test(BaseTest):
         # expected = [[[0.0, 0.0]], [[6.0, 2.0]]]
         self._deeplift_assert(model, DeepLift(model), inputs, baselines)
 
-    def test_relu_deeplift_with_hypothetical_contrib_func(self):
+    def test_relu_deeplift_with_hypothetical_contrib_func(self) -> None:
         model = Conv1dDeepLiftModel()
         rand_seq_data = torch.abs(torch.randn(2, 4, 1000))
         rand_seq_ref = torch.abs(torch.randn(2, 4, 1000))
@@ -142,7 +148,7 @@ class Test(BaseTest):
         )
         self.assertEqual(attr.shape, rand_seq_data.shape)
 
-    def test_relu_deepliftshap_batch_4D_input(self):
+    def test_relu_deepliftshap_batch_4D_input(self) -> None:
         x1 = torch.ones(4, 1, 1, 1)
         x2 = torch.tensor([[[[2.0]]]] * 4)
 
@@ -155,7 +161,7 @@ class Test(BaseTest):
         model = ReLUDeepLiftModel()
         self._deeplift_assert(model, DeepLiftShap(model), inputs, baselines)
 
-    def test_relu_deepliftshap_multi_ref(self):
+    def test_relu_deepliftshap_multi_ref(self) -> None:
         x1 = torch.tensor([[1.0]], requires_grad=True)
         x2 = torch.tensor([[2.0]], requires_grad=True)
 
@@ -168,25 +174,27 @@ class Test(BaseTest):
         model = ReLUDeepLiftModel()
         self._deeplift_assert(model, DeepLiftShap(model), inputs, baselines)
 
-    def test_relu_deepliftshap_baselines_as_func(self):
+    def test_relu_deepliftshap_baselines_as_func(self) -> None:
         model = ReLULinearDeepLiftModel(inplace=True)
         x1 = torch.tensor([[-10.0, 1.0, -5.0]])
         x2 = torch.tensor([[3.0, 3.0, 1.0]])
 
-        def gen_baselines():
+        def gen_baselines() -> Tuple[Tensor, ...]:
             b1 = torch.tensor([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
             b2 = torch.tensor([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
             return (b1, b2)
 
-        def gen_baselines_scalar():
+        def gen_baselines_scalar() -> Tuple[float, ...]:
             return (0.0, 0.0001)
 
-        def gen_baselines_with_inputs(inputs):
+        def gen_baselines_with_inputs(
+            inputs: Tuple[Tensor, Tensor]
+        ) -> Tuple[Tensor, ...]:
             b1 = torch.cat([inputs[0], inputs[0] - 10])
             b2 = torch.cat([inputs[1], inputs[1] - 10])
             return (b1, b2)
 
-        def gen_baselines_returns_array():
+        def gen_baselines_returns_array() -> Tuple[List[List[float]], ...]:
             b1 = [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]
             b2 = [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]
             return (b1, b2)
@@ -209,8 +217,12 @@ class Test(BaseTest):
         assertTensorAlmostEqual(self, attributions[0], attributions_with_func[0])
         assertTensorAlmostEqual(self, attributions[1], attributions_with_func[1])
 
-    def test_relu_deepliftshap_with_custom_attr_func(self):
-        def custom_attr_func(multipliers, inputs, baselines):
+    def test_relu_deepliftshap_with_custom_attr_func(self) -> None:
+        def custom_attr_func(
+            multipliers: Tuple[Tensor, ...],
+            inputs: Tuple[Tensor, ...],
+            baselines: Tuple[Union[Tensor, int, float], ...],
+        ) -> Tuple[Tensor, ...]:
             return tuple(multiplier * 0.0 for multiplier in multipliers)
 
         model = ReLULinearDeepLiftModel(inplace=True)
@@ -228,7 +240,7 @@ class Test(BaseTest):
         assertTensorAlmostEqual(self, attr_w_func[0], [[0.0, 0.0, 0.0]], 0.0)
         assertTensorAlmostEqual(self, attr_w_func[1], [[0.0, 0.0, 0.0]], 0.0)
 
-    def test_relu_deepliftshap_with_hypothetical_contrib_func(self):
+    def test_relu_deepliftshap_with_hypothetical_contrib_func(self) -> None:
         model = Conv1dDeepLiftModel()
         rand_seq_data = torch.abs(torch.randn(2, 4, 1000))
         rand_seq_ref = torch.abs(torch.randn(3, 4, 1000))
@@ -241,14 +253,14 @@ class Test(BaseTest):
         )
         self.assertEqual(attr.shape, rand_seq_data.shape)
 
-    def test_reusable_modules(self):
+    def test_reusable_modules(self) -> None:
         model = BasicModelWithReusableModules()
         input = torch.rand(1, 3)
         dl = DeepLift(model)
         with self.assertRaises(RuntimeError):
             dl.attribute(input, target=0)
 
-    def test_lin_maxpool_lin_classification(self):
+    def test_lin_maxpool_lin_classification(self) -> None:
         inputs = torch.ones(2, 4)
         baselines = torch.tensor([[1, 2, 3, 9], [4, 8, 6, 7]]).float()
 
@@ -263,8 +275,13 @@ class Test(BaseTest):
         assertArraysAlmostEqual(delta.detach().numpy(), expected_delta)
 
     def _deeplift_assert(
-        self, model, attr_method, inputs, baselines, custom_attr_func=None
-    ):
+        self,
+        model: Module,
+        attr_method: Union[DeepLift, DeepLiftShap],
+        inputs: Tuple[Tensor, ...],
+        baselines,  # ?
+        custom_attr_func: Callable[..., Tuple[Tensor, ...]] = None,
+    ) -> None:
         input_bsz = len(inputs[0])
         if callable(baselines):
             baseline_parameters = signature(baselines).parameters

--- a/tests/attr/test_deeplift_basic.py
+++ b/tests/attr/test_deeplift_basic.py
@@ -368,7 +368,7 @@ def _hypothetical_contrib_func(
             hypothetical_input[:, :, i] = 1.0
             hypothetical_input_ref_diff = hypothetical_input - baselines[k]
             sub_attributions[:, :, i] = torch.sum(
-                hypothetical_input_ref_diff * multipliers[k], axis=-1
+                hypothetical_input_ref_diff * multipliers[k], dim=-1
             )
         attributions.append(sub_attributions)
     return tuple(attributions)

--- a/tests/attr/test_deeplift_basic.py
+++ b/tests/attr/test_deeplift_basic.py
@@ -217,7 +217,7 @@ class Test(BaseTest):
         def custom_attr_func(
             multipliers: Tuple[Tensor, ...],
             inputs: Tuple[Tensor, ...],
-            baselines: Tuple[Union[Tensor, int, float], ...],
+            baselines: Tuple[Tensor, ...],
         ) -> Tuple[Tensor, ...]:
             return tuple(multiplier * 0.0 for multiplier in multipliers)
 

--- a/tests/attr/test_deeplift_basic.py
+++ b/tests/attr/test_deeplift_basic.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from typing import Tuple, List, Union, Optional, Callable
+from typing import Tuple, List, Union, Callable
 
 import torch
 from torch import Tensor
@@ -10,8 +10,6 @@ from inspect import signature
 
 from captum.attr._core.deep_lift import DeepLift, DeepLiftShap
 from captum.attr._core.integrated_gradients import IntegratedGradients
-
-from captum.attr._utils.typing import TensorOrTupleOfTensors
 
 from .helpers.utils import (
     assertAttributionComparision,
@@ -187,9 +185,7 @@ class Test(BaseTest):
         def gen_baselines_scalar() -> Tuple[float, ...]:
             return (0.0, 0.0001)
 
-        def gen_baselines_with_inputs(
-            inputs: Tuple[Tensor, Tensor]
-        ) -> Tuple[Tensor, ...]:
+        def gen_baselines_with_inputs(inputs: Tuple[Tensor, ...]) -> Tuple[Tensor, ...]:
             b1 = torch.cat([inputs[0], inputs[0] - 10])
             b2 = torch.cat([inputs[1], inputs[1] - 10])
             return (b1, b2)
@@ -279,7 +275,7 @@ class Test(BaseTest):
         model: Module,
         attr_method: Union[DeepLift, DeepLiftShap],
         inputs: Tuple[Tensor, ...],
-        baselines,  # ?
+        baselines,
         custom_attr_func: Callable[..., Tuple[Tensor, ...]] = None,
     ) -> None:
         input_bsz = len(inputs[0])
@@ -342,7 +338,11 @@ class Test(BaseTest):
                 assertAttributionComparision(self, attributions, attributions_ig)
 
 
-def _hypothetical_contrib_func(multipliers, inputs, baselines):
+def _hypothetical_contrib_func(
+    multipliers: Tuple[Tensor, ...],
+    inputs: Tuple[Tensor, ...],
+    baselines: Tuple[Tensor, ...],
+) -> Tuple[Tensor, ...]:
     r"""
     Implements hypothetical input contributions based on the logic described here:
     https://github.com/kundajelab/deeplift/pull/36/files

--- a/tests/attr/test_deeplift_classification.py
+++ b/tests/attr/test_deeplift_classification.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 
+from typing import Union, Tuple, Optional, List
+
 import torch
+from torch import Tensor
+from torch.nn import Module
 
 from captum.attr._core.deep_lift import DeepLift, DeepLiftShap
 from captum.attr._core.integrated_gradients import IntegratedGradients
@@ -14,7 +18,7 @@ from .helpers.basic_models import BasicModel_ConvNet_MaxPool3d
 
 
 class Test(BaseTest):
-    def test_sigmoid_classification(self):
+    def test_sigmoid_classification(self) -> None:
         num_in = 20
         input = torch.arange(0.0, num_in * 1.0, requires_grad=True).unsqueeze(0)
         baseline = 0 * input
@@ -33,7 +37,7 @@ class Test(BaseTest):
         attributions_ig = ig.attribute(input, baseline, target=target)
         assertAttributionComparision(self, (attributions,), (attributions_ig,))
 
-    def test_softmax_classification_zero_baseline(self):
+    def test_softmax_classification_zero_baseline(self) -> None:
         num_in = 20
         input = torch.arange(0.0, num_in * 1.0, requires_grad=True).unsqueeze(0)
         baselines = 0.0
@@ -43,7 +47,7 @@ class Test(BaseTest):
 
         self.softmax_classification(model, dl, input, baselines, torch.tensor(2))
 
-    def test_softmax_classification_batch_zero_baseline(self):
+    def test_softmax_classification_batch_zero_baseline(self) -> None:
         num_in = 40
         input = torch.arange(0.0, num_in * 3.0, requires_grad=True).reshape(3, num_in)
         baselines = 0
@@ -54,7 +58,7 @@ class Test(BaseTest):
             model, dl, input, baselines, torch.tensor([2, 2, 2])
         )
 
-    def test_softmax_classification_batch_multi_target(self):
+    def test_softmax_classification_batch_multi_target(self) -> None:
         num_in = 40
         inputs = torch.arange(0.0, num_in * 3.0, requires_grad=True).reshape(3, num_in)
         baselines = torch.arange(1.0, num_in + 1).reshape(1, num_in)
@@ -65,7 +69,7 @@ class Test(BaseTest):
             model, dl, inputs, baselines, torch.tensor([2, 2, 2])
         )
 
-    def test_softmax_classification_multi_baseline(self):
+    def test_softmax_classification_multi_baseline(self) -> None:
         num_in = 40
         input = torch.arange(0.0, num_in * 1.0, requires_grad=True).unsqueeze(0)
         baselines = torch.randn(5, 40)
@@ -75,7 +79,7 @@ class Test(BaseTest):
 
         self.softmax_classification(model, dl, input, baselines, torch.tensor(2))
 
-    def test_softmax_classification_batch_multi_baseline(self):
+    def test_softmax_classification_batch_multi_baseline(self) -> None:
         num_in = 40
         input = torch.arange(0.0, num_in * 2.0, requires_grad=True).reshape(2, num_in)
         baselines = torch.randn(5, 40)
@@ -85,7 +89,7 @@ class Test(BaseTest):
 
         self.softmax_classification(model, dl, input, baselines, torch.tensor(2))
 
-    def test_convnet_with_maxpool3d(self):
+    def test_convnet_with_maxpool3d(self) -> None:
         input = 100 * torch.randn(2, 1, 10, 10, 10, requires_grad=True)
         baseline = 20 * torch.randn(2, 1, 10, 10, 10)
 
@@ -94,7 +98,7 @@ class Test(BaseTest):
 
         self.softmax_classification(model, dl, input, baseline, torch.tensor(2))
 
-    def test_convnet_with_maxpool3d_large_baselines(self):
+    def test_convnet_with_maxpool3d_large_baselines(self) -> None:
         input = 100 * torch.randn(2, 1, 10, 10, 10, requires_grad=True)
         baseline = 600 * torch.randn(2, 1, 10, 10, 10)
 
@@ -103,7 +107,7 @@ class Test(BaseTest):
 
         self.softmax_classification(model, dl, input, baseline, torch.tensor(2))
 
-    def test_convnet_with_maxpool2d(self):
+    def test_convnet_with_maxpool2d(self) -> None:
         input = 100 * torch.randn(2, 1, 10, 10, requires_grad=True)
         baseline = 20 * torch.randn(2, 1, 10, 10)
 
@@ -112,7 +116,7 @@ class Test(BaseTest):
 
         self.softmax_classification(model, dl, input, baseline, torch.tensor(2))
 
-    def test_convnet_with_maxpool2d_large_baselines(self):
+    def test_convnet_with_maxpool2d_large_baselines(self) -> None:
         input = 100 * torch.randn(2, 1, 10, 10, requires_grad=True)
         baseline = 500 * torch.randn(2, 1, 10, 10)
 
@@ -121,7 +125,7 @@ class Test(BaseTest):
 
         self.softmax_classification(model, dl, input, baseline, torch.tensor(2))
 
-    def test_convnet_with_maxpool1d(self):
+    def test_convnet_with_maxpool1d(self) -> None:
         input = 100 * torch.randn(2, 1, 10, requires_grad=True)
         baseline = 20 * torch.randn(2, 1, 10)
 
@@ -130,7 +134,7 @@ class Test(BaseTest):
 
         self.softmax_classification(model, dl, input, baseline, torch.tensor(2))
 
-    def test_convnet_with_maxpool1d_large_baselines(self):
+    def test_convnet_with_maxpool1d_large_baselines(self) -> None:
         input = 100 * torch.randn(2, 1, 10, requires_grad=True)
         baseline = 500 * torch.randn(2, 1, 10)
 
@@ -139,7 +143,14 @@ class Test(BaseTest):
 
         self.softmax_classification(model, dl, input, baseline, torch.tensor(2))
 
-    def softmax_classification(self, model, attr_method, input, baselines, target):
+    def softmax_classification(
+        self,
+        model: Module,
+        attr_method: Union[DeepLift, DeepLiftShap],
+        input: Tensor,
+        baselines: Union[Tensor, int, float],
+        target: Optional[Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]],
+    ) -> None:
         # TODO add test cases for multiple different layers
         model.zero_grad()
         attributions, delta = attr_method.attribute(
@@ -155,8 +166,16 @@ class Test(BaseTest):
         self._assert_attributions(model, attributions, input, baselines, delta, target2)
 
     def _assert_attributions(
-        self, model, attributions, inputs, baselines, delta, target=None
-    ):
+        self,
+        model: Module,
+        attributions: Tensor,
+        inputs: Tensor,
+        baselines: Union[Tensor, int, float],
+        delta: Tensor,
+        target: Optional[
+            Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
+        ] = None,
+    ) -> None:
         self.assertEqual(inputs.shape, attributions.shape)
 
         delta_condition = all(abs(delta.numpy().flatten()) < 0.003)

--- a/tests/attr/test_deeplift_classification.py
+++ b/tests/attr/test_deeplift_classification.py
@@ -148,7 +148,7 @@ class Test(BaseTest):
         model: Module,
         attr_method: Union[DeepLift, DeepLiftShap],
         input: Tensor,
-        baselines: Union[Tensor, int, float],
+        baselines,
         target: Optional[Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]],
     ) -> None:
         # TODO add test cases for multiple different layers


### PR DESCRIPTION
Adding type hints to:
```
captum/attr/_core/deep_lift.py
tests/attr/test_deeplift_basic.py
tests/attr/test_deeplift_classification.py
```

I've added a number of type hints so far but I'm running into issues with what's left. The biggest is that whenever I try to add type hints to `DeepLiftShap.attribute`, I get: `error: Signature of "attribute" incompatible with supertype "DeepLift"`. So, just wanted to get some feedback on what I have so far and see if there are any suggestions going forward.
