### PR TITLE
Adding Type Hints to Captum: neuron_conductance.py

### DIFF
--- a/captum/attr/_core/neuron/neuron_conductance.py
+++ b/captum/attr/_core/neuron/neuron_conductance.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 import torch
+from typing import Callable, List, Optional, Tuple, Union, Any
+from torch import Tensor
+from torch.nn import Module
 from ..._utils.approximation_methods import approximation_parameters
 from ..._utils.attribution import NeuronAttribution, GradientAttribution
 from ..._utils.batching import _batched_operator
@@ -14,10 +17,16 @@ from ..._utils.common import (
     _verify_select_column,
 )
 from ..._utils.gradient import compute_layer_gradients_and_eval
+from ..._utils.typing import TensorOrTupleOfTensors
 
 
 class NeuronConductance(NeuronAttribution, GradientAttribution):
-    def __init__(self, forward_func, layer, device_ids=None):
+    def __init__(
+        self,
+        forward_func: Callable,
+        layer: Module,
+        device_ids: Optional[List[int]] = None,
+    ) -> None:
         r"""
         Args:
 
@@ -49,16 +58,20 @@ class NeuronConductance(NeuronAttribution, GradientAttribution):
 
     def attribute(
         self,
-        inputs,
-        neuron_index,
-        baselines=None,
-        target=None,
-        additional_forward_args=None,
-        n_steps=50,
-        method="riemann_trapezoid",
-        internal_batch_size=None,
-        attribute_to_neuron_input=False,
-    ):
+        inputs: TensorOrTupleOfTensors,
+        neuron_index: Union[int, Tuple[int, ...]],
+        baselines: Optional[
+            Union[Tensor, int, float, Tuple[Union[Tensor, int, float], ...]]
+        ] = None,
+        target: Optional[
+            Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
+        ] = None,
+        additional_forward_args: Optional[Any] = None,
+        n_steps: Optional[int] = 50,
+        method: Optional[str] = "riemann_trapezoid",
+        internal_batch_size: Optional[int] = None,
+        attribute_to_neuron_input: Optional[bool] = False,
+    ) -> TensorOrTupleOfTensors:
         r"""
             Computes conductance with respect to particular hidden neuron. The
             returned output is in the shape of the input, showing the attribution

--- a/captum/attr/_core/neuron/neuron_conductance.py
+++ b/captum/attr/_core/neuron/neuron_conductance.py
@@ -66,11 +66,11 @@ class NeuronConductance(NeuronAttribution, GradientAttribution):
         target: Optional[
             Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
         ] = None,
-        additional_forward_args: Optional[Any] = None,
-        n_steps: Optional[int] = 50,
-        method: Optional[str] = "riemann_trapezoid",
+        additional_forward_args: Any = None,
+        n_steps: int = 50,
+        method: str = "riemann_trapezoid",
         internal_batch_size: Optional[int] = None,
-        attribute_to_neuron_input: Optional[bool] = False,
+        attribute_to_neuron_input: bool = False,
     ) -> TensorOrTupleOfTensors:
         r"""
             Computes conductance with respect to particular hidden neuron. The

--- a/tests/attr/neuron/test_neuron_conductance.py
+++ b/tests/attr/neuron/test_neuron_conductance.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import unittest
-from typing import List, Optional, Tuple, Union, Any
+from typing import List, Tuple, Union, Any
 import torch
 from torch.nn import Module
 from captum.attr._core.layer.layer_conductance import LayerConductance
@@ -144,7 +144,7 @@ class Test(BaseTest):
         model: Module,
         target_layer: Module,
         test_input: TensorOrTupleOfTensors,
-        test_baseline: Optional[Any] = None,
+        test_baseline: Any = None,
     ):
         layer_cond = LayerConductance(model, target_layer)
         attributions = layer_cond.attribute(

--- a/tests/attr/neuron/test_neuron_conductance.py
+++ b/tests/attr/neuron/test_neuron_conductance.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
 import unittest
-from typing import List, Optional, Tensor, Tuple, Union, Any
+from typing import List, Optional, Tuple, Union, Any
 import torch
+from torch import Tensor
 from torch.nn import Module
 from captum.attr._core.layer.layer_conductance import LayerConductance
 from captum.attr._core.neuron.neuron_conductance import NeuronConductance

--- a/tests/attr/neuron/test_neuron_conductance.py
+++ b/tests/attr/neuron/test_neuron_conductance.py
@@ -111,7 +111,7 @@ class Test(BaseTest):
         test_input: TensorOrTupleOfTensors,
         test_neuron: Union[int, Tuple[int, ...]],
         expected_input_conductance: Tuple[List[List[float]]],
-        additional_input: Optional[Any] = None,
+        additional_input: Any = None,
     ) -> None:
         for internal_batch_size in (None, 1, 20):
             cond = NeuronConductance(model, target_layer)

--- a/tests/attr/neuron/test_neuron_conductance.py
+++ b/tests/attr/neuron/test_neuron_conductance.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
 import unittest
-
+from typing import List, Optional, Tuple, Union, Any
 import torch
+from torch.nn import Module
 from captum.attr._core.layer.layer_conductance import LayerConductance
 from captum.attr._core.neuron.neuron_conductance import NeuronConductance
 
@@ -12,27 +13,28 @@ from ..helpers.basic_models import (
     BasicModel_MultiLayer_MultiInput,
 )
 from ..helpers.utils import assertArraysAlmostEqual, BaseTest
+from captum.attr._utils.typing import TensorOrTupleOfTensors
 
 
 class Test(BaseTest):
-    def test_simple_conductance_input_linear2(self):
+    def test_simple_conductance_input_linear2(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
         self._conductance_input_test_assert(
             net, net.linear2, inp, (0,), [0.0, 390.0, 0.0]
         )
 
-    def test_simple_conductance_input_linear1(self):
+    def test_simple_conductance_input_linear1(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         self._conductance_input_test_assert(net, net.linear1, inp, 0, [0.0, 90.0, 0.0])
 
-    def test_simple_conductance_input_relu(self):
+    def test_simple_conductance_input_relu(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 70.0, 30.0]], requires_grad=True)
         self._conductance_input_test_assert(net, net.relu, inp, (3,), [0.0, 70.0, 30.0])
 
-    def test_simple_conductance_multi_input_linear2(self):
+    def test_simple_conductance_multi_input_linear2(self) -> None:
         net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 10.0, 0.0]])
         inp2 = torch.tensor([[0.0, 10.0, 0.0]])
@@ -46,7 +48,7 @@ class Test(BaseTest):
             (4,),
         )
 
-    def test_simple_conductance_multi_input_relu(self):
+    def test_simple_conductance_multi_input_relu(self) -> None:
         net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 10.0, 1.0]])
         inp2 = torch.tensor([[0.0, 4.0, 5.0]])
@@ -60,7 +62,7 @@ class Test(BaseTest):
             (inp3, 5),
         )
 
-    def test_simple_conductance_multi_input_batch_relu(self):
+    def test_simple_conductance_multi_input_batch_relu(self) -> None:
         net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 10.0, 1.0], [0.0, 0.0, 10.0]])
         inp2 = torch.tensor([[0.0, 4.0, 5.0], [0.0, 0.0, 10.0]])
@@ -77,7 +79,7 @@ class Test(BaseTest):
             (inp3, 5),
         )
 
-    def test_matching_conv2_multi_input_conductance(self):
+    def test_matching_conv2_multi_input_conductance(self) -> None:
         net = BasicModel_ConvNet()
         inp = 100 * torch.randn(2, 1, 10, 10)
         self._conductance_input_sum_test_assert(net, net.conv2, inp, 0.0)
@@ -85,18 +87,18 @@ class Test(BaseTest):
         # trying different baseline
         self._conductance_input_sum_test_assert(net, net.conv2, inp, 0.000001)
 
-    def test_matching_relu2_multi_input_conductance(self):
+    def test_matching_relu2_multi_input_conductance(self) -> None:
         net = BasicModel_ConvNet()
         inp = 100 * torch.randn(3, 1, 10, 10, requires_grad=True)
         baseline = 20 * torch.randn(3, 1, 10, 10, requires_grad=True)
         self._conductance_input_sum_test_assert(net, net.relu2, inp, baseline)
 
-    def test_matching_relu2_with_scalar_base_multi_input_conductance(self):
+    def test_matching_relu2_with_scalar_base_multi_input_conductance(self) -> None:
         net = BasicModel_ConvNet()
         inp = 100 * torch.randn(3, 1, 10, 10, requires_grad=True)
         self._conductance_input_sum_test_assert(net, net.relu2, inp, 0.0)
 
-    def test_matching_pool2_multi_input_conductance(self):
+    def test_matching_pool2_multi_input_conductance(self) -> None:
         net = BasicModel_ConvNet()
         inp = 100 * torch.randn(1, 1, 10, 10)
         baseline = 20 * torch.randn(1, 1, 10, 10, requires_grad=True)
@@ -104,13 +106,13 @@ class Test(BaseTest):
 
     def _conductance_input_test_assert(
         self,
-        model,
-        target_layer,
-        test_input,
-        test_neuron,
-        expected_input_conductance,
-        additional_input=None,
-    ):
+        model: Module,
+        target_layer: Module,
+        test_input: TensorOrTupleOfTensors,
+        test_neuron: Union[int, Tuple[int, ...]],
+        expected_input_conductance: Tuple[List[List[float]]],
+        additional_input: Optional[Any] = None,
+    ) -> None:
         for internal_batch_size in (None, 1, 20):
             cond = NeuronConductance(model, target_layer)
             attributions = cond.attribute(
@@ -138,7 +140,11 @@ class Test(BaseTest):
                 )
 
     def _conductance_input_sum_test_assert(
-        self, model, target_layer, test_input, test_baseline=None
+        self,
+        model: Module,
+        target_layer: Module,
+        test_input: TensorOrTupleOfTensors,
+        test_baseline: Optional[Any] = None,
     ):
         layer_cond = LayerConductance(model, target_layer)
         attributions = layer_cond.attribute(


### PR DESCRIPTION
**Unit test command:** python -m unittest -v tests.attr.neuron.test_neuron_conductance
**Output:** 
test_matching_conv2_multi_input_conductance (tests.attr.neuron.test_neuron_conductance.Test) ... ok
test_matching_pool2_multi_input_conductance (tests.attr.neuron.test_neuron_conductance.Test) ... ok
test_matching_relu2_multi_input_conductance (tests.attr.neuron.test_neuron_conductance.Test) ... ok
test_matching_relu2_with_scalar_base_multi_input_conductance (tests.attr.neuron.test_neuron_conductance.Test) ... ok
test_simple_conductance_input_linear1 (tests.attr.neuron.test_neuron_conductance.Test) ... ok
test_simple_conductance_input_linear2 (tests.attr.neuron.test_neuron_conductance.Test) ... ok
test_simple_conductance_input_relu (tests.attr.neuron.test_neuron_conductance.Test) ... ok
test_simple_conductance_multi_input_batch_relu (tests.attr.neuron.test_neuron_conductance.Test) ... ok
test_simple_conductance_multi_input_linear2 (tests.attr.neuron.test_neuron_conductance.Test) ... ok
test_simple_conductance_multi_input_relu (tests.attr.neuron.test_neuron_conductance.Test) ... ok

----------------------------------------------------------------------
Ran 10 tests in 8.296s

OK 