### PR TITLE
Fix to allow insights assets to be packaged in python wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -150,9 +150,9 @@ if __name__ == "__main__":
             (
                 "share/jupyter/nbextensions/jupyter-captum-insights",
                 [
-                    "captum/insights/frontend/widget/static/extension.js",
-                    "captum/insights/frontend/widget/static/index.js",
-                    "captum/insights/frontend/widget/static/index.js.map",
+                    "captum/insights/widget/static/extension.js",
+                    "captum/insights/widget/static/index.js",
+                    "captum/insights/widget/static/index.js.map",
                 ],
             ),
             (


### PR DESCRIPTION
Summary: The path I use to generate Captum Insights assets changed during development, but I never updated `setup.py` to reflect this. This PR corrects that problem.


