### PR TITLE
Added typed hints for layer_conductance.py and test_layer_conductance.py

### DIFF
--- a/captum/attr/_core/layer/layer_conductance.py
+++ b/captum/attr/_core/layer/layer_conductance.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 import torch
+from torch import Tensor
+from torch.nn import Module
+from typing import Any, Callable, List, Optional, Tuple, Union
 from ..._utils.approximation_methods import approximation_parameters
 from ..._utils.attribution import LayerAttribution, GradientAttribution
 from ..._utils.batching import _batched_operator
@@ -16,7 +19,12 @@ from ..._utils.gradient import compute_layer_gradients_and_eval
 
 
 class LayerConductance(LayerAttribution, GradientAttribution):
-    def __init__(self, forward_func, layer, device_ids=None):
+    def __init__(
+        self,
+        forward_func: Callable,
+        layer: Module,
+        device_ids: Optional[List[int]] = None,
+    ) -> None:
         r"""
         Args:
 
@@ -37,21 +45,28 @@ class LayerConductance(LayerAttribution, GradientAttribution):
         LayerAttribution.__init__(self, forward_func, layer, device_ids)
         GradientAttribution.__init__(self, forward_func)
 
-    def has_convergence_delta(self):
+    def has_convergence_delta(self) -> bool:
         return True
 
     def attribute(
         self,
-        inputs,
-        baselines=None,
-        target=None,
-        additional_forward_args=None,
-        n_steps=50,
-        method="gausslegendre",
-        internal_batch_size=None,
-        return_convergence_delta=False,
-        attribute_to_layer_input=False,
-    ):
+        inputs: Union[Tensor, Tuple[Tensor, ...]],
+        baselines: Optional[
+            Union[int, float, Tensor, Tuple[Union[int, float, Tensor], ...]]
+        ] = None,
+        target: Optional[
+            Union[int, Tuple[int, ...], Tensor, List[Tuple[int, ...]]]
+        ] = None,
+        additional_forward_args: Any = None,
+        n_steps: int = 50,
+        method: str = "gausslegendre",
+        internal_batch_size: Optional[int] = None,
+        return_convergence_delta: bool = False,
+        attribute_to_layer_input: bool = False,
+    ) -> Union[
+        Union[Tensor, Tuple[Tensor, ...]],
+        Tuple[Union[Tensor, Tuple[Tensor, ...]], Tensor],
+    ]:
         r"""
             Computes conductance with respect to the given layer. The
             returned output is in the shape of the layer's output, showing the total

--- a/tests/attr/layer/test_layer_conductance.py
+++ b/tests/attr/layer/test_layer_conductance.py
@@ -3,6 +3,9 @@
 import unittest
 
 import torch
+from torch import Tensor
+from torch.nn import Module
+from typing import cast, Any, List, Optional, Tuple, Union
 from captum.attr._core.layer.layer_conductance import LayerConductance
 
 from ..helpers.basic_models import (
@@ -19,12 +22,12 @@ from ..helpers.utils import (
 
 
 class Test(BaseTest):
-    def test_simple_input_conductance(self):
+    def test_simple_input_conductance(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         self._conductance_test_assert(net, net.linear0, inp, [[0.0, 390.0, 0.0]])
 
-    def test_simple_input_multi_conductance(self):
+    def test_simple_input_multi_conductance(self) -> None:
         net = BasicModel_MultiLayer(multi_input_module=True)
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         self._conductance_test_assert(
@@ -34,31 +37,31 @@ class Test(BaseTest):
             ([[90.0, 100.0, 100.0, 100.0]], [[90.0, 100.0, 100.0, 100.0]]),
         )
 
-    def test_simple_input_with_scalar_baseline_conductance(self):
+    def test_simple_input_with_scalar_baseline_conductance(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         self._conductance_test_assert(
             net, net.linear0, inp, [[0.0, 390.0, 0.0]], baselines=0.0
         )
 
-    def test_simple_linear_conductance(self):
+    def test_simple_linear_conductance(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
         self._conductance_test_assert(
             net, net.linear1, inp, [[90.0, 100.0, 100.0, 100.0]]
         )
 
-    def test_simple_relu_conductance(self):
+    def test_simple_relu_conductance(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         self._conductance_test_assert(net, net.relu, inp, [[90.0, 100.0, 100.0, 100.0]])
 
-    def test_simple_output_conductance(self):
+    def test_simple_output_conductance(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
         self._conductance_test_assert(net, net.linear2, inp, [[390.0, 0.0]])
 
-    def test_simple_multi_input_linear2_conductance(self):
+    def test_simple_multi_input_linear2_conductance(self) -> None:
         net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 10.0, 0.0]])
         inp2 = torch.tensor([[0.0, 10.0, 0.0]])
@@ -71,7 +74,7 @@ class Test(BaseTest):
             additional_args=(4,),
         )
 
-    def test_simple_multi_input_relu_conductance(self):
+    def test_simple_multi_input_relu_conductance(self) -> None:
         net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 10.0, 1.0]])
         inp2 = torch.tensor([[0.0, 4.0, 5.0]])
@@ -84,7 +87,7 @@ class Test(BaseTest):
             additional_args=(inp3, 5),
         )
 
-    def test_simple_multi_input_relu_conductance_batch(self):
+    def test_simple_multi_input_relu_conductance_batch(self) -> None:
         net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 10.0, 1.0], [0.0, 0.0, 10.0]])
         inp2 = torch.tensor([[0.0, 4.0, 5.0], [0.0, 0.0, 10.0]])
@@ -97,32 +100,32 @@ class Test(BaseTest):
             additional_args=(inp3, 5),
         )
 
-    def test_matching_conv1_conductance(self):
+    def test_matching_conv1_conductance(self) -> None:
         net = BasicModel_ConvNet()
         inp = 100 * torch.randn(1, 1, 10, 10, requires_grad=True)
         self._conductance_reference_test_assert(net, net.conv1, inp)
 
-    def test_matching_pool1_conductance(self):
+    def test_matching_pool1_conductance(self) -> None:
         net = BasicModel_ConvNet()
         inp = 100 * torch.randn(1, 1, 10, 10)
         self._conductance_reference_test_assert(net, net.pool1, inp)
 
-    def test_matching_conv2_conductance(self):
+    def test_matching_conv2_conductance(self) -> None:
         net = BasicModel_ConvNet()
         inp = 100 * torch.randn(1, 1, 10, 10, requires_grad=True)
         self._conductance_reference_test_assert(net, net.conv2, inp)
 
-    def test_matching_pool2_conductance(self):
+    def test_matching_pool2_conductance(self) -> None:
         net = BasicModel_ConvNet()
         inp = 100 * torch.randn(1, 1, 10, 10)
         self._conductance_reference_test_assert(net, net.pool2, inp)
 
-    def test_matching_conv_multi_input_conductance(self):
+    def test_matching_conv_multi_input_conductance(self) -> None:
         net = BasicModel_ConvNet()
         inp = 100 * torch.randn(4, 1, 10, 10, requires_grad=True)
         self._conductance_reference_test_assert(net, net.relu3, inp)
 
-    def test_matching_conv_with_baseline_conductance(self):
+    def test_matching_conv_with_baseline_conductance(self) -> None:
         net = BasicModel_ConvNet()
         inp = 100 * torch.randn(3, 1, 10, 10)
         baseline = 100 * torch.randn(3, 1, 10, 10, requires_grad=True)
@@ -130,13 +133,15 @@ class Test(BaseTest):
 
     def _conductance_test_assert(
         self,
-        model,
-        target_layer,
-        test_input,
-        expected_conductance,
-        baselines=None,
-        additional_args=None,
-    ):
+        model: Module,
+        target_layer: Module,
+        test_input: Union[Tensor, Tuple[Tensor, ...]],
+        expected_conductance: Union[List[List[float]], Tuple[List[List[float]], ...]],
+        baselines: Optional[
+            Union[int, float, Tensor, Tuple[Union[int, float, Tensor], ...]]
+        ] = None,
+        additional_args: Any = None,
+    ) -> None:
         cond = LayerConductance(model, target_layer)
         for internal_batch_size in (None, 1, 20):
             attributions, delta = cond.attribute(
@@ -161,8 +166,12 @@ class Test(BaseTest):
             )
 
     def _conductance_reference_test_assert(
-        self, model, target_layer, test_input, test_baseline=None
-    ):
+        self,
+        model: Module,
+        target_layer: Module,
+        test_input: Tensor,
+        test_baseline: Optional[Tensor] = None,
+    ) -> None:
         layer_output = None
 
         def forward_hook(module, inp, out):
@@ -171,17 +180,21 @@ class Test(BaseTest):
 
         hook = target_layer.register_forward_hook(forward_hook)
         final_output = model(test_input)
+        layer_output = cast(Tensor, layer_output)
         hook.remove()
         target_index = torch.argmax(torch.sum(final_output, 0))
         cond = LayerConductance(model, target_layer)
         cond_ref = ConductanceReference(model, target_layer)
-        attributions, delta = cond.attribute(
-            test_input,
-            baselines=test_baseline,
-            target=target_index,
-            n_steps=300,
-            method="gausslegendre",
-            return_convergence_delta=True,
+        attributions, delta = cast(
+            Tuple[Tensor, Tensor],
+            cond.attribute(
+                test_input,
+                baselines=test_baseline,
+                target=target_index,
+                n_steps=300,
+                method="gausslegendre",
+                return_convergence_delta=True,
+            ),
         )
         delta_condition = all(abs(delta.numpy().flatten()) < 0.005)
         self.assertTrue(
@@ -210,14 +223,17 @@ class Test(BaseTest):
         # Test if batching is working correctly for inputs with multiple examples
         if test_input.shape[0] > 1:
             for i in range(test_input.shape[0]):
-                single_attributions = cond.attribute(
-                    test_input[i : i + 1],
-                    baselines=test_baseline[i : i + 1]
-                    if test_baseline is not None
-                    else None,
-                    target=target_index,
-                    n_steps=300,
-                    method="gausslegendre",
+                single_attributions = cast(
+                    Tensor,
+                    cond.attribute(
+                        test_input[i : i + 1],
+                        baselines=test_baseline[i : i + 1]
+                        if test_baseline is not None
+                        else None,
+                        target=target_index,
+                        n_steps=300,
+                        method="gausslegendre",
+                    ),
                 )
                 # Verify that attributions when passing example independently
                 # matches corresponding attribution of batched input.

--- a/tests/attr/layer/test_layer_integrated_gradients.py
+++ b/tests/attr/layer/test_layer_integrated_gradients.py
@@ -77,7 +77,7 @@ class Test(BaseTest):
     def _assert_compare_with_layer_conductance(
         self, model: Module, input: Tensor, attribute_to_layer_input: bool = False
     ):
-        lc = LayerConductance(model, model.linear2)
+        lc = LayerConductance(model, cast(Module, model.linear2))
         # For large number of steps layer conductance and layer integrated gradients
         # become very close
         attribution, delta = lc.attribute(


### PR DESCRIPTION
Formatted code using 
`black .`

Checked for PEP8 compliance using
`flake8 .`

Static types checked using 
`./scripts/run_mypy.py`

```
Success: no issues found in 44 source files
Success: no issues found in 48 source files
```

Unit tests:
`python -m unittest -v tests.attr.layer.test_layer_conductance`

```
test_matching_conv1_conductance (tests.attr.layer.test_layer_conductance.Test) ... ok
test_matching_conv2_conductance (tests.attr.layer.test_layer_conductance.Test) ... ok
test_matching_conv_multi_input_conductance (tests.attr.layer.test_layer_conductance.Test) ... ok
test_matching_conv_with_baseline_conductance (tests.attr.layer.test_layer_conductance.Test) ... /home/rkrajpal/local/captum/captum/attr/_utils/gradient.py:30: UserWarning: Input Tensor 0 did not already require gradients, required_grads has been set automatically.
  warnings.warn(
ok
test_matching_pool1_conductance (tests.attr.layer.test_layer_conductance.Test) ... ok
test_matching_pool2_conductance (tests.attr.layer.test_layer_conductance.Test) ... ok
test_simple_input_conductance (tests.attr.layer.test_layer_conductance.Test) ... ok
test_simple_input_multi_conductance (tests.attr.layer.test_layer_conductance.Test) ... ok
test_simple_input_with_scalar_baseline_conductance (tests.attr.layer.test_layer_conductance.Test) ... ok
test_simple_linear_conductance (tests.attr.layer.test_layer_conductance.Test) ... ok
test_simple_multi_input_linear2_conductance (tests.attr.layer.test_layer_conductance.Test) ... ok
test_simple_multi_input_relu_conductance (tests.attr.layer.test_layer_conductance.Test) ... ok
test_simple_multi_input_relu_conductance_batch (tests.attr.layer.test_layer_conductance.Test) ... ok
test_simple_output_conductance (tests.attr.layer.test_layer_conductance.Test) ... ok
test_simple_relu_conductance (tests.attr.layer.test_layer_conductance.Test) ... ok

----------------------------------------------------------------------
Ran 15 tests in 15.382s

OK
```