### PR TITLE
Fixing LayerGradientShap Type Hints

### DIFF
--- a/captum/attr/_core/gradient_shap.py
+++ b/captum/attr/_core/gradient_shap.py
@@ -314,7 +314,7 @@ class InputBaselineXGradient(GradientAttribution):
         )
 
         input_baseline_scaled = tuple(
-            self._scale_input(input, baseline, rand_coefficient)
+            _scale_input(input, baseline, rand_coefficient)
             for input, baseline in zip(inputs, baselines)
         )
         grads = self.gradient_func(
@@ -343,21 +343,19 @@ class InputBaselineXGradient(GradientAttribution):
     def has_convergence_delta(self) -> bool:
         return True
 
-    def _scale_input(
-        self,
-        input: Tensor,
-        baseline: Union[Tensor, int, float],
-        rand_coefficient: Tensor,
-    ) -> Tensor:
-        # batch size
-        bsz = input.shape[0]
-        inp_shape_wo_bsz = input.shape[1:]
-        inp_shape = (bsz,) + tuple([1] * len(inp_shape_wo_bsz))
 
-        # expand and reshape the indices
-        rand_coefficient = rand_coefficient.view(inp_shape).requires_grad_()
+def _scale_input(
+    input: Tensor, baseline: Union[Tensor, int, float], rand_coefficient: Tensor,
+) -> Tensor:
+    # batch size
+    bsz = input.shape[0]
+    inp_shape_wo_bsz = input.shape[1:]
+    inp_shape = (bsz,) + tuple([1] * len(inp_shape_wo_bsz))
 
-        input_baseline_scaled = (
-            rand_coefficient * input + (torch.tensor(1) - rand_coefficient) * baseline
-        )
-        return input_baseline_scaled
+    # expand and reshape the indices
+    rand_coefficient = rand_coefficient.view(inp_shape).requires_grad_()
+
+    input_baseline_scaled = (
+        rand_coefficient * input + (torch.tensor(1) - rand_coefficient) * baseline
+    )
+    return input_baseline_scaled

--- a/tests/attr/neuron/test_neuron_conductance.py
+++ b/tests/attr/neuron/test_neuron_conductance.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import unittest
-from typing import List, Optional, Tuple, Union, Any
+from typing import List, Optional, Tuple, Union, Any, cast
 import torch
 from torch import Tensor
 from torch.nn import Module
@@ -155,12 +155,15 @@ class Test(BaseTest):
         ] = None,
     ):
         layer_cond = LayerConductance(model, target_layer)
-        attributions = layer_cond.attribute(
-            test_input,
-            baselines=test_baseline,
-            target=0,
-            n_steps=500,
-            method="gausslegendre",
+        attributions = cast(
+            Tensor,
+            layer_cond.attribute(
+                test_input,
+                baselines=test_baseline,
+                target=0,
+                n_steps=500,
+                method="gausslegendre",
+            ),
         )
         neuron_cond = NeuronConductance(model, target_layer)
         for i in range(attributions.shape[1]):


### PR DESCRIPTION
Fixes for LayerGradientShap type hints which is causing mypy to fail on master. LayerGradientShap previously extended from GradientShap, which has an inconsistent signature; this adjusts the inheritance hierarchy for layer methods to inherit directly from GradientAttribution and just access the necessary methods.