### PR TITLE
Remove the unnecessary line in the occlusion examp

### DIFF
--- a/tutorials/Resnet_TorchVision_Interpret.ipynb
+++ b/tutorials/Resnet_TorchVision_Interpret.ipynb
@@ -84,8 +84,7 @@
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": [
-     ]
+     "text": []
     }
    ],
    "source": [
@@ -427,7 +426,6 @@
    "source": [
     "occlusion = Occlusion(model)\n",
     "\n",
-    "rand_img_dist = torch.cat([input * 0, input * 1])\n",
     "attributions_occ = occlusion.attribute(input,\n",
     "                                       strides = (3, 50, 50),\n",
     "                                       target=pred_label_idx,\n",
@@ -460,7 +458,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/tutorials/Resnet_TorchVision_Interpret.ipynb
+++ b/tutorials/Resnet_TorchVision_Interpret.ipynb
@@ -84,7 +84,8 @@
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": []
+     "text": [
+     ]
     }
    ],
    "source": [
@@ -458,7 +459,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes pytorch/captum#296 removing the unnecessary line `rand_img_dist = torch.cat([input * 0, input * 1])` in the occlusion example in the tutorial [Model Interpretation for Pretrained ResNet Model](https://captum.ai/tutorials/Resnet_TorchVision_Interpret).