### PR TITLE
Adding isort

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,13 @@ commands:
           name: "Lint with black"
           command: black --check --diff .
 
+  isort:
+    description: "Check import order with isort"
+    steps:
+      - run:
+          name: "Check import order with isort"
+          command: isort --check-only
+
   mypy_check:
     description: "Static type checking with mypy"
     steps:
@@ -132,6 +139,7 @@ jobs:
           args: "-n -f"
       - lint_flake8
       - lint_black
+      - isort
       - mypy_check
       - unit_tests
       - sphinx
@@ -145,6 +153,7 @@ jobs:
           args: "-f"
       - lint_flake8
       - lint_black
+      - isort
       - mypy_check
       - unit_tests
       - sphinx
@@ -176,6 +185,7 @@ jobs:
           args: "-n"
       - lint_flake8
       - lint_black
+      - isort
       - mypy_check
       - unit_tests
       - sphinx
@@ -200,6 +210,7 @@ jobs:
           args: "-n -f -d"
       - lint_flake8
       - lint_black
+      - isort
       - unit_tests
       - sphinx
       - configure_github_bot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,8 @@ commands:
           name: "Check import order with isort"
           command: |
             isort -v
+            isort captum/insights/example.py --diff --verbose
+            isort captum/attr/_models/pytext.py --diff --verbose
             isort --check-only
 
   mypy_check:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,11 +43,7 @@ commands:
     steps:
       - run:
           name: "Check import order with isort"
-          command: |
-            isort -v
-            isort captum/insights/example.py --diff --verbose
-            isort captum/attr/_models/pytext.py --diff --verbose
-            isort --check-only
+          command: isort --check-only
 
   mypy_check:
     description: "Static type checking with mypy"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,9 @@ commands:
     steps:
       - run:
           name: "Check import order with isort"
-          command: isort --check-only
+          command: |
+            isort -v
+            isort --check-only
 
   mypy_check:
     description: "Static type checking with mypy"

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,6 @@
+[settings]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,4 +4,4 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-known_third_party=pytext,torchvision
+known_third_party=pytext,torchvision,bs4

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,3 +4,4 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
+known_third_party=pytext,torchvision

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ pip using `pip install isort`, and run locally by calling
 ```bash
 isort
 ```
-from the repository root. No additional configuration should be needed.
+from the repository root. Configuration for isort is located in .isort.cfg.
 
 We feel strongly that having a consistent code style is extremely important, so
 CircleCI will fail on your PR if it does not adhere to the black or flake8 formatting style or isort import ordering.

--- a/captum/attr/__init__.py
+++ b/captum/attr/__init__.py
@@ -1,51 +1,51 @@
 #!/usr/bin/env python3
 
-from ._core.integrated_gradients import IntegratedGradients  # noqa
 from ._core.deep_lift import DeepLift, DeepLiftShap  # noqa
-from ._core.input_x_gradient import InputXGradient  # noqa
-from ._core.saliency import Saliency  # noqa
-from ._core.noise_tunnel import NoiseTunnel  # noqa
-from ._core.gradient_shap import GradientShap  # noqa
-from ._core.guided_backprop_deconvnet import GuidedBackprop, Deconvolution  # noqa
-from ._core.guided_grad_cam import GuidedGradCam  # noqa
 from ._core.feature_ablation import FeatureAblation  # noqa
 from ._core.feature_permutation import FeaturePermutation  # noqa
-from ._core.occlusion import Occlusion  # noqa
-from ._core.shapley_value import ShapleyValueSampling, ShapleyValues  # noqa
-from ._core.layer.layer_conductance import LayerConductance  # noqa
-from ._core.layer.layer_gradient_x_activation import LayerGradientXActivation  # noqa
-from ._core.layer.layer_activation import LayerActivation  # noqa
-from ._core.layer.internal_influence import InternalInfluence  # noqa
+from ._core.gradient_shap import GradientShap  # noqa
+from ._core.guided_backprop_deconvnet import Deconvolution  # noqa
+from ._core.guided_backprop_deconvnet import GuidedBackprop
+from ._core.guided_grad_cam import GuidedGradCam  # noqa
+from ._core.input_x_gradient import InputXGradient  # noqa
+from ._core.integrated_gradients import IntegratedGradients  # noqa
 from ._core.layer.grad_cam import LayerGradCam  # noqa
-from ._core.layer.layer_deep_lift import LayerDeepLift, LayerDeepLiftShap  # noqa
+from ._core.layer.internal_influence import InternalInfluence  # noqa
+from ._core.layer.layer_activation import LayerActivation  # noqa
+from ._core.layer.layer_conductance import LayerConductance  # noqa
+from ._core.layer.layer_deep_lift import LayerDeepLift  # noqa
+from ._core.layer.layer_deep_lift import LayerDeepLiftShap
 from ._core.layer.layer_gradient_shap import LayerGradientShap  # noqa
-from ._core.layer.layer_integrated_gradients import LayerIntegratedGradients  # noqa
-from ._core.neuron.neuron_feature_ablation import NeuronFeatureAblation  # noqa
+from ._core.layer.layer_gradient_x_activation import \
+    LayerGradientXActivation  # noqa
+from ._core.layer.layer_integrated_gradients import \
+    LayerIntegratedGradients  # noqa
 from ._core.neuron.neuron_conductance import NeuronConductance  # noqa
+from ._core.neuron.neuron_deep_lift import NeuronDeepLift  # noqa
+from ._core.neuron.neuron_deep_lift import NeuronDeepLiftShap
+from ._core.neuron.neuron_feature_ablation import NeuronFeatureAblation  # noqa
 from ._core.neuron.neuron_gradient import NeuronGradient  # noqa
-from ._core.neuron.neuron_integrated_gradients import NeuronIntegratedGradients  # noqa
-from ._core.neuron.neuron_deep_lift import NeuronDeepLift, NeuronDeepLiftShap  # noqa
 from ._core.neuron.neuron_gradient_shap import NeuronGradientShap  # noqa
-from ._core.neuron.neuron_guided_backprop_deconvnet import (
-    NeuronDeconvolution,
-    NeuronGuidedBackprop,
-)  # noqa
-
-from ._models.base import (
-    InterpretableEmbeddingBase,
-    TokenReferenceBase,
-    configure_interpretable_embedding_layer,
-    remove_interpretable_embedding_layer,
-)  # noqa
+from ._core.neuron.neuron_guided_backprop_deconvnet import (  # noqa
+    NeuronDeconvolution, NeuronGuidedBackprop)
+from ._core.neuron.neuron_integrated_gradients import \
+    NeuronIntegratedGradients  # noqa
+from ._core.noise_tunnel import NoiseTunnel  # noqa
+from ._core.occlusion import Occlusion  # noqa
+from ._core.saliency import Saliency  # noqa
+from ._core.shapley_value import ShapleyValues, ShapleyValueSampling  # noqa
+from ._models.base import InterpretableEmbeddingBase  # noqa
+from ._models.base import (TokenReferenceBase,
+                           configure_interpretable_embedding_layer,
+                           remove_interpretable_embedding_layer)
+from ._utils import visualization  # noqa
 from ._utils.attribution import Attribution  # noqa
 from ._utils.attribution import GradientAttribution  # noqa
-from ._utils.attribution import PerturbationAttribution  # noqa
 from ._utils.attribution import LayerAttribution  # noqa
 from ._utils.attribution import NeuronAttribution  # noqa
-from ._utils import visualization  # noqa
-from ._utils.summarizer import Summarizer, CommonSummarizer
-from ._utils.stat import Mean, StdDev, MSE, Var, Min, Max, Sum, Count
-
+from ._utils.attribution import PerturbationAttribution  # noqa
+from ._utils.stat import MSE, Count, Max, Mean, Min, StdDev, Sum, Var
+from ._utils.summarizer import CommonSummarizer, Summarizer
 
 __all__ = [
     "Attribution",

--- a/captum/attr/__init__.py
+++ b/captum/attr/__init__.py
@@ -16,10 +16,8 @@ from ._core.layer.layer_conductance import LayerConductance  # noqa
 from ._core.layer.layer_deep_lift import LayerDeepLift  # noqa
 from ._core.layer.layer_deep_lift import LayerDeepLiftShap
 from ._core.layer.layer_gradient_shap import LayerGradientShap  # noqa
-from ._core.layer.layer_gradient_x_activation import \
-    LayerGradientXActivation  # noqa
-from ._core.layer.layer_integrated_gradients import \
-    LayerIntegratedGradients  # noqa
+from ._core.layer.layer_gradient_x_activation import LayerGradientXActivation  # noqa
+from ._core.layer.layer_integrated_gradients import LayerIntegratedGradients  # noqa
 from ._core.neuron.neuron_conductance import NeuronConductance  # noqa
 from ._core.neuron.neuron_deep_lift import NeuronDeepLift  # noqa
 from ._core.neuron.neuron_deep_lift import NeuronDeepLiftShap
@@ -27,17 +25,20 @@ from ._core.neuron.neuron_feature_ablation import NeuronFeatureAblation  # noqa
 from ._core.neuron.neuron_gradient import NeuronGradient  # noqa
 from ._core.neuron.neuron_gradient_shap import NeuronGradientShap  # noqa
 from ._core.neuron.neuron_guided_backprop_deconvnet import (  # noqa
-    NeuronDeconvolution, NeuronGuidedBackprop)
-from ._core.neuron.neuron_integrated_gradients import \
-    NeuronIntegratedGradients  # noqa
+    NeuronDeconvolution,
+    NeuronGuidedBackprop,
+)
+from ._core.neuron.neuron_integrated_gradients import NeuronIntegratedGradients  # noqa
 from ._core.noise_tunnel import NoiseTunnel  # noqa
 from ._core.occlusion import Occlusion  # noqa
 from ._core.saliency import Saliency  # noqa
 from ._core.shapley_value import ShapleyValues, ShapleyValueSampling  # noqa
 from ._models.base import InterpretableEmbeddingBase  # noqa
-from ._models.base import (TokenReferenceBase,
-                           configure_interpretable_embedding_layer,
-                           remove_interpretable_embedding_layer)
+from ._models.base import (
+    TokenReferenceBase,
+    configure_interpretable_embedding_layer,
+    remove_interpretable_embedding_layer,
+)
 from ._utils import visualization  # noqa
 from ._utils.attribution import Attribution  # noqa
 from ._utils.attribution import GradientAttribution  # noqa

--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 import typing
-from typing import Tuple, Union, Any, List, Callable, cast
-
 import warnings
+from typing import Any, Callable, List, Tuple, Union, cast
+
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -10,33 +11,20 @@ from torch import Tensor
 from torch.nn import Module
 from torch.utils.hooks import RemovableHandle
 
-import numpy as np
-
-from .._utils.common import (
-    _is_tuple,
-    _format_input,
-    _format_baseline,
-    _format_callable_baseline,
-    _format_attributions,
-    _format_tensor_into_tuples,
-    _format_additional_forward_args,
-    _run_forward,
-    _validate_input,
-    _expand_target,
-    _expand_additional_forward_args,
-    _tensorize_baseline,
-    _call_custom_attribution_func,
-    _compute_conv_delta_and_format_attrs,
-    ExpansionTypes,
-)
 from .._utils.attribution import GradientAttribution
-from .._utils.gradient import apply_gradient_requirements, undo_gradient_requirements
-from .._utils.typing import (
-    TensorOrTupleOfTensorsGeneric,
-    Literal,
-    TargetType,
-    BaselineType,
-)
+from .._utils.common import (ExpansionTypes, _call_custom_attribution_func,
+                             _compute_conv_delta_and_format_attrs,
+                             _expand_additional_forward_args, _expand_target,
+                             _format_additional_forward_args,
+                             _format_attributions, _format_baseline,
+                             _format_callable_baseline, _format_input,
+                             _format_tensor_into_tuples, _is_tuple,
+                             _run_forward, _tensorize_baseline,
+                             _validate_input)
+from .._utils.gradient import (apply_gradient_requirements,
+                               undo_gradient_requirements)
+from .._utils.typing import (BaselineType, Literal, TargetType,
+                             TensorOrTupleOfTensorsGeneric)
 
 
 # Check if module backward hook can safely be used for the module that produced

--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -12,19 +12,30 @@ from torch.nn import Module
 from torch.utils.hooks import RemovableHandle
 
 from .._utils.attribution import GradientAttribution
-from .._utils.common import (ExpansionTypes, _call_custom_attribution_func,
-                             _compute_conv_delta_and_format_attrs,
-                             _expand_additional_forward_args, _expand_target,
-                             _format_additional_forward_args,
-                             _format_attributions, _format_baseline,
-                             _format_callable_baseline, _format_input,
-                             _format_tensor_into_tuples, _is_tuple,
-                             _run_forward, _tensorize_baseline,
-                             _validate_input)
-from .._utils.gradient import (apply_gradient_requirements,
-                               undo_gradient_requirements)
-from .._utils.typing import (BaselineType, Literal, TargetType,
-                             TensorOrTupleOfTensorsGeneric)
+from .._utils.common import (
+    ExpansionTypes,
+    _call_custom_attribution_func,
+    _compute_conv_delta_and_format_attrs,
+    _expand_additional_forward_args,
+    _expand_target,
+    _format_additional_forward_args,
+    _format_attributions,
+    _format_baseline,
+    _format_callable_baseline,
+    _format_input,
+    _format_tensor_into_tuples,
+    _is_tuple,
+    _run_forward,
+    _tensorize_baseline,
+    _validate_input,
+)
+from .._utils.gradient import apply_gradient_requirements, undo_gradient_requirements
+from .._utils.typing import (
+    BaselineType,
+    Literal,
+    TargetType,
+    TensorOrTupleOfTensorsGeneric,
+)
 
 
 # Check if module backward hook can safely be used for the module that produced

--- a/captum/attr/_core/feature_ablation.py
+++ b/captum/attr/_core/feature_ablation.py
@@ -1,24 +1,18 @@
 #!/usr/bin/env python3
 
-import torch
-
-from torch import Tensor, dtype
-
 from typing import Any, Callable, Tuple, Union, cast
 
-from .._utils.common import (
-    _find_output_mode_and_verify,
-    _format_attributions,
-    _format_input,
-    _format_input_baseline,
-    _is_tuple,
-    _run_forward,
-    _expand_additional_forward_args,
-    _expand_target,
-    _format_additional_forward_args,
-)
+import torch
+from torch import Tensor, dtype
+
 from .._utils.attribution import PerturbationAttribution
-from .._utils.typing import TensorOrTupleOfTensorsGeneric, TargetType, BaselineType
+from .._utils.common import (_expand_additional_forward_args, _expand_target,
+                             _find_output_mode_and_verify,
+                             _format_additional_forward_args,
+                             _format_attributions, _format_input,
+                             _format_input_baseline, _is_tuple, _run_forward)
+from .._utils.typing import (BaselineType, TargetType,
+                             TensorOrTupleOfTensorsGeneric)
 
 
 class FeatureAblation(PerturbationAttribution):

--- a/captum/attr/_core/feature_ablation.py
+++ b/captum/attr/_core/feature_ablation.py
@@ -6,13 +6,18 @@ import torch
 from torch import Tensor, dtype
 
 from .._utils.attribution import PerturbationAttribution
-from .._utils.common import (_expand_additional_forward_args, _expand_target,
-                             _find_output_mode_and_verify,
-                             _format_additional_forward_args,
-                             _format_attributions, _format_input,
-                             _format_input_baseline, _is_tuple, _run_forward)
-from .._utils.typing import (BaselineType, TargetType,
-                             TensorOrTupleOfTensorsGeneric)
+from .._utils.common import (
+    _expand_additional_forward_args,
+    _expand_target,
+    _find_output_mode_and_verify,
+    _format_additional_forward_args,
+    _format_attributions,
+    _format_input,
+    _format_input_baseline,
+    _is_tuple,
+    _run_forward,
+)
+from .._utils.typing import BaselineType, TargetType, TensorOrTupleOfTensorsGeneric
 
 
 class FeatureAblation(PerturbationAttribution):

--- a/captum/attr/_core/feature_permutation.py
+++ b/captum/attr/_core/feature_permutation.py
@@ -4,8 +4,8 @@ from typing import Any, Callable, Tuple, Union
 import torch
 from torch import Tensor
 
-from .feature_ablation import FeatureAblation
 from .._utils.typing import TargetType, TensorOrTupleOfTensorsGeneric
+from .feature_ablation import FeatureAblation
 
 
 def _permute_feature(x: Tensor, feature_mask: Tensor) -> Tensor:

--- a/captum/attr/_core/gradient_shap.py
+++ b/captum/attr/_core/gradient_shap.py
@@ -1,26 +1,17 @@
 #!/usr/bin/env python3
-import torch
+import typing
+from typing import Any, Callable, Tuple, Union
 
 import numpy as np
+import torch
 
 from .._utils.attribution import GradientAttribution
-from .._utils.common import (
-    _is_tuple,
-    _format_input_baseline,
-    _format_callable_baseline,
-    _compute_conv_delta_and_format_attrs,
-)
-
+from .._utils.common import (_compute_conv_delta_and_format_attrs,
+                             _format_callable_baseline, _format_input_baseline,
+                             _is_tuple)
+from .._utils.typing import (BaselineType, Literal, TargetType, Tensor,
+                             TensorOrTupleOfTensorsGeneric)
 from .noise_tunnel import NoiseTunnel
-from typing import Any, Callable, Tuple, Union
-from .._utils.typing import (
-    Tensor,
-    TensorOrTupleOfTensorsGeneric,
-    Literal,
-    TargetType,
-    BaselineType,
-)
-import typing
 
 
 class GradientShap(GradientAttribution):

--- a/captum/attr/_core/gradient_shap.py
+++ b/captum/attr/_core/gradient_shap.py
@@ -6,11 +6,19 @@ import numpy as np
 import torch
 
 from .._utils.attribution import GradientAttribution
-from .._utils.common import (_compute_conv_delta_and_format_attrs,
-                             _format_callable_baseline, _format_input_baseline,
-                             _is_tuple)
-from .._utils.typing import (BaselineType, Literal, TargetType, Tensor,
-                             TensorOrTupleOfTensorsGeneric)
+from .._utils.common import (
+    _compute_conv_delta_and_format_attrs,
+    _format_callable_baseline,
+    _format_input_baseline,
+    _is_tuple,
+)
+from .._utils.typing import (
+    BaselineType,
+    Literal,
+    TargetType,
+    Tensor,
+    TensorOrTupleOfTensorsGeneric,
+)
 from .noise_tunnel import NoiseTunnel
 
 

--- a/captum/attr/_core/guided_backprop_deconvnet.py
+++ b/captum/attr/_core/guided_backprop_deconvnet.py
@@ -10,8 +10,7 @@ from torch.utils.hooks import RemovableHandle
 
 from .._utils.attribution import GradientAttribution
 from .._utils.common import _format_attributions, _format_input, _is_tuple
-from .._utils.gradient import (apply_gradient_requirements,
-                               undo_gradient_requirements)
+from .._utils.gradient import apply_gradient_requirements, undo_gradient_requirements
 from .._utils.typing import TargetType, TensorOrTupleOfTensorsGeneric
 
 

--- a/captum/attr/_core/guided_backprop_deconvnet.py
+++ b/captum/attr/_core/guided_backprop_deconvnet.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python3
 import warnings
+from typing import Any, List, Tuple, Union
+
 import torch
 import torch.nn.functional as F
-from typing import Any, List, Union, Tuple
-
 from torch import Tensor
 from torch.nn import Module
 from torch.utils.hooks import RemovableHandle
 
 from .._utils.attribution import GradientAttribution
-from .._utils.common import _format_input, _format_attributions, _is_tuple
-from .._utils.gradient import apply_gradient_requirements, undo_gradient_requirements
+from .._utils.common import _format_attributions, _format_input, _is_tuple
+from .._utils.gradient import (apply_gradient_requirements,
+                               undo_gradient_requirements)
 from .._utils.typing import TargetType, TensorOrTupleOfTensorsGeneric
 
 

--- a/captum/attr/_core/guided_grad_cam.py
+++ b/captum/attr/_core/guided_grad_cam.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python3
-import torch
 import warnings
+from typing import Any, List, Union
+
+import torch
+from torch import Tensor
+from torch.nn import Module
 
 from .._utils.attribution import GradientAttribution, LayerAttribution
-from .._utils.common import _format_input, _format_attributions, _is_tuple
-
-from .layer.grad_cam import LayerGradCam
-from .guided_backprop_deconvnet import GuidedBackprop
-
-from torch.nn import Module
-from torch import Tensor
-from typing import Any, List, Union
+from .._utils.common import _format_attributions, _format_input, _is_tuple
 from .._utils.typing import TargetType, TensorOrTupleOfTensorsGeneric
+from .guided_backprop_deconvnet import GuidedBackprop
+from .layer.grad_cam import LayerGradCam
 
 
 class GuidedGradCam(GradientAttribution):

--- a/captum/attr/_core/input_x_gradient.py
+++ b/captum/attr/_core/input_x_gradient.py
@@ -3,8 +3,7 @@ from typing import Any, Callable
 
 from .._utils.attribution import GradientAttribution
 from .._utils.common import _format_attributions, _format_input, _is_tuple
-from .._utils.gradient import (apply_gradient_requirements,
-                               undo_gradient_requirements)
+from .._utils.gradient import apply_gradient_requirements, undo_gradient_requirements
 from .._utils.typing import TargetType, TensorOrTupleOfTensorsGeneric
 
 

--- a/captum/attr/_core/input_x_gradient.py
+++ b/captum/attr/_core/input_x_gradient.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 from typing import Any, Callable
 
-from .._utils.common import _format_input, _format_attributions, _is_tuple
 from .._utils.attribution import GradientAttribution
-from .._utils.gradient import apply_gradient_requirements, undo_gradient_requirements
+from .._utils.common import _format_attributions, _format_input, _is_tuple
+from .._utils.gradient import (apply_gradient_requirements,
+                               undo_gradient_requirements)
 from .._utils.typing import TargetType, TensorOrTupleOfTensorsGeneric
 
 

--- a/captum/attr/_core/integrated_gradients.py
+++ b/captum/attr/_core/integrated_gradients.py
@@ -6,24 +6,14 @@ import torch
 from torch import Tensor
 
 from .._utils.approximation_methods import approximation_parameters
-from .._utils.batching import _batched_operator
-from .._utils.common import (
-    _validate_input,
-    _format_additional_forward_args,
-    _format_attributions,
-    _format_input_baseline,
-    _reshape_and_sum,
-    _expand_additional_forward_args,
-    _expand_target,
-    _is_tuple,
-)
 from .._utils.attribution import GradientAttribution
-from .._utils.typing import (
-    TensorOrTupleOfTensorsGeneric,
-    Literal,
-    TargetType,
-    BaselineType,
-)
+from .._utils.batching import _batched_operator
+from .._utils.common import (_expand_additional_forward_args, _expand_target,
+                             _format_additional_forward_args,
+                             _format_attributions, _format_input_baseline,
+                             _is_tuple, _reshape_and_sum, _validate_input)
+from .._utils.typing import (BaselineType, Literal, TargetType,
+                             TensorOrTupleOfTensorsGeneric)
 
 
 class IntegratedGradients(GradientAttribution):

--- a/captum/attr/_core/integrated_gradients.py
+++ b/captum/attr/_core/integrated_gradients.py
@@ -8,12 +8,22 @@ from torch import Tensor
 from .._utils.approximation_methods import approximation_parameters
 from .._utils.attribution import GradientAttribution
 from .._utils.batching import _batched_operator
-from .._utils.common import (_expand_additional_forward_args, _expand_target,
-                             _format_additional_forward_args,
-                             _format_attributions, _format_input_baseline,
-                             _is_tuple, _reshape_and_sum, _validate_input)
-from .._utils.typing import (BaselineType, Literal, TargetType,
-                             TensorOrTupleOfTensorsGeneric)
+from .._utils.common import (
+    _expand_additional_forward_args,
+    _expand_target,
+    _format_additional_forward_args,
+    _format_attributions,
+    _format_input_baseline,
+    _is_tuple,
+    _reshape_and_sum,
+    _validate_input,
+)
+from .._utils.typing import (
+    BaselineType,
+    Literal,
+    TargetType,
+    TensorOrTupleOfTensorsGeneric,
+)
 
 
 class IntegratedGradients(GradientAttribution):

--- a/captum/attr/_core/layer/grad_cam.py
+++ b/captum/attr/_core/layer/grad_cam.py
@@ -1,21 +1,17 @@
 #!/usr/bin/env python3
-from typing import Callable, List, Tuple, Union, Any
+from typing import Any, Callable, List, Tuple, Union
+
 import torch
+import torch.nn.functional as F
 from torch import Tensor
 from torch.nn import Module
-import torch.nn.functional as F
 
-from ..._utils.attribution import LayerAttribution, GradientAttribution
-from ..._utils.common import (
-    _format_input,
-    _format_additional_forward_args,
-    _format_attributions,
-)
-from ..._utils.gradient import (
-    compute_layer_gradients_and_eval,
-    apply_gradient_requirements,
-    undo_gradient_requirements,
-)
+from ..._utils.attribution import GradientAttribution, LayerAttribution
+from ..._utils.common import (_format_additional_forward_args,
+                              _format_attributions, _format_input)
+from ..._utils.gradient import (apply_gradient_requirements,
+                                compute_layer_gradients_and_eval,
+                                undo_gradient_requirements)
 from ..._utils.typing import TargetType
 
 

--- a/captum/attr/_core/layer/grad_cam.py
+++ b/captum/attr/_core/layer/grad_cam.py
@@ -7,11 +7,16 @@ from torch import Tensor
 from torch.nn import Module
 
 from ..._utils.attribution import GradientAttribution, LayerAttribution
-from ..._utils.common import (_format_additional_forward_args,
-                              _format_attributions, _format_input)
-from ..._utils.gradient import (apply_gradient_requirements,
-                                compute_layer_gradients_and_eval,
-                                undo_gradient_requirements)
+from ..._utils.common import (
+    _format_additional_forward_args,
+    _format_attributions,
+    _format_input,
+)
+from ..._utils.gradient import (
+    apply_gradient_requirements,
+    compute_layer_gradients_and_eval,
+    undo_gradient_requirements,
+)
 from ..._utils.typing import TargetType
 
 

--- a/captum/attr/_core/layer/internal_influence.py
+++ b/captum/attr/_core/layer/internal_influence.py
@@ -1,24 +1,19 @@
 #!/usr/bin/env python3
-from typing import Callable, List, Tuple, Union, Any
+from typing import Any, Callable, List, Tuple, Union
 
 import torch
 from torch import Tensor
 from torch.nn import Module
 
 from ..._utils.approximation_methods import approximation_parameters
-from ..._utils.attribution import LayerAttribution, GradientAttribution
+from ..._utils.attribution import GradientAttribution, LayerAttribution
 from ..._utils.batching import _batched_operator
-from ..._utils.common import (
-    _reshape_and_sum,
-    _format_input_baseline,
-    _validate_input,
-    _format_additional_forward_args,
-    _format_attributions,
-    _expand_additional_forward_args,
-    _expand_target,
-)
+from ..._utils.common import (_expand_additional_forward_args, _expand_target,
+                              _format_additional_forward_args,
+                              _format_attributions, _format_input_baseline,
+                              _reshape_and_sum, _validate_input)
 from ..._utils.gradient import compute_layer_gradients_and_eval
-from ..._utils.typing import TargetType, BaselineType
+from ..._utils.typing import BaselineType, TargetType
 
 
 class InternalInfluence(LayerAttribution, GradientAttribution):

--- a/captum/attr/_core/layer/internal_influence.py
+++ b/captum/attr/_core/layer/internal_influence.py
@@ -8,10 +8,15 @@ from torch.nn import Module
 from ..._utils.approximation_methods import approximation_parameters
 from ..._utils.attribution import GradientAttribution, LayerAttribution
 from ..._utils.batching import _batched_operator
-from ..._utils.common import (_expand_additional_forward_args, _expand_target,
-                              _format_additional_forward_args,
-                              _format_attributions, _format_input_baseline,
-                              _reshape_and_sum, _validate_input)
+from ..._utils.common import (
+    _expand_additional_forward_args,
+    _expand_target,
+    _format_additional_forward_args,
+    _format_attributions,
+    _format_input_baseline,
+    _reshape_and_sum,
+    _validate_input,
+)
 from ..._utils.gradient import compute_layer_gradients_and_eval
 from ..._utils.typing import BaselineType, TargetType
 

--- a/captum/attr/_core/layer/layer_activation.py
+++ b/captum/attr/_core/layer/layer_activation.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from typing import Callable, List, Tuple, Union, Any
+from typing import Any, Callable, List, Tuple, Union
 
 import torch
 from torch import Tensor

--- a/captum/attr/_core/layer/layer_conductance.py
+++ b/captum/attr/_core/layer/layer_conductance.py
@@ -1,23 +1,20 @@
 #!/usr/bin/env python3
+import typing
+from typing import Any, Callable, List, Tuple, Union
+
 import torch
 from torch import Tensor
 from torch.nn import Module
-import typing
-from typing import Any, Callable, List, Tuple, Union
+
 from ..._utils.approximation_methods import approximation_parameters
-from ..._utils.attribution import LayerAttribution, GradientAttribution
+from ..._utils.attribution import GradientAttribution, LayerAttribution
 from ..._utils.batching import _batched_operator
-from ..._utils.common import (
-    _reshape_and_sum,
-    _format_input_baseline,
-    _format_additional_forward_args,
-    _format_attributions,
-    _expand_additional_forward_args,
-    _validate_input,
-    _expand_target,
-)
+from ..._utils.common import (_expand_additional_forward_args, _expand_target,
+                              _format_additional_forward_args,
+                              _format_attributions, _format_input_baseline,
+                              _reshape_and_sum, _validate_input)
 from ..._utils.gradient import compute_layer_gradients_and_eval
-from ..._utils.typing import Literal, TargetType, BaselineType
+from ..._utils.typing import BaselineType, Literal, TargetType
 
 
 class LayerConductance(LayerAttribution, GradientAttribution):

--- a/captum/attr/_core/layer/layer_conductance.py
+++ b/captum/attr/_core/layer/layer_conductance.py
@@ -9,10 +9,15 @@ from torch.nn import Module
 from ..._utils.approximation_methods import approximation_parameters
 from ..._utils.attribution import GradientAttribution, LayerAttribution
 from ..._utils.batching import _batched_operator
-from ..._utils.common import (_expand_additional_forward_args, _expand_target,
-                              _format_additional_forward_args,
-                              _format_attributions, _format_input_baseline,
-                              _reshape_and_sum, _validate_input)
+from ..._utils.common import (
+    _expand_additional_forward_args,
+    _expand_target,
+    _format_additional_forward_args,
+    _format_attributions,
+    _format_input_baseline,
+    _reshape_and_sum,
+    _validate_input,
+)
 from ..._utils.gradient import compute_layer_gradients_and_eval
 from ..._utils.typing import BaselineType, Literal, TargetType
 

--- a/captum/attr/_core/layer/layer_deep_lift.py
+++ b/captum/attr/_core/layer/layer_deep_lift.py
@@ -8,18 +8,30 @@ from torch.nn import Module
 
 from ..._core.deep_lift import DeepLift, DeepLiftShap
 from ..._utils.attribution import LayerAttribution
-from ..._utils.common import (ExpansionTypes, _call_custom_attribution_func,
-                              _compute_conv_delta_and_format_attrs,
-                              _expand_additional_forward_args, _expand_target,
-                              _format_additional_forward_args,
-                              _format_baseline, _format_callable_baseline,
-                              _format_input, _tensorize_baseline,
-                              _validate_input)
-from ..._utils.gradient import (apply_gradient_requirements,
-                                compute_layer_gradients_and_eval,
-                                undo_gradient_requirements)
-from ..._utils.typing import (BaselineType, Literal, TargetType,
-                              TensorOrTupleOfTensorsGeneric)
+from ..._utils.common import (
+    ExpansionTypes,
+    _call_custom_attribution_func,
+    _compute_conv_delta_and_format_attrs,
+    _expand_additional_forward_args,
+    _expand_target,
+    _format_additional_forward_args,
+    _format_baseline,
+    _format_callable_baseline,
+    _format_input,
+    _tensorize_baseline,
+    _validate_input,
+)
+from ..._utils.gradient import (
+    apply_gradient_requirements,
+    compute_layer_gradients_and_eval,
+    undo_gradient_requirements,
+)
+from ..._utils.typing import (
+    BaselineType,
+    Literal,
+    TargetType,
+    TensorOrTupleOfTensorsGeneric,
+)
 
 
 class LayerDeepLift(LayerAttribution, DeepLift):

--- a/captum/attr/_core/layer/layer_deep_lift.py
+++ b/captum/attr/_core/layer/layer_deep_lift.py
@@ -1,45 +1,25 @@
 #!/usr/bin/env python3
 import typing
-from typing import (
-    Tuple,
-    Union,
-    Any,
-    Callable,
-    Sequence,
-    cast,
-)
+from typing import Any, Callable, Sequence, Tuple, Union, cast
 
 import torch
 from torch import Tensor
 from torch.nn import Module
 
-from ..._utils.attribution import LayerAttribution
 from ..._core.deep_lift import DeepLift, DeepLiftShap
-from ..._utils.gradient import (
-    apply_gradient_requirements,
-    undo_gradient_requirements,
-    compute_layer_gradients_and_eval,
-)
-
-from ..._utils.common import (
-    _format_input,
-    _format_baseline,
-    _format_callable_baseline,
-    _format_additional_forward_args,
-    _validate_input,
-    _tensorize_baseline,
-    _call_custom_attribution_func,
-    _compute_conv_delta_and_format_attrs,
-    _expand_additional_forward_args,
-    _expand_target,
-    ExpansionTypes,
-)
-from ..._utils.typing import (
-    TensorOrTupleOfTensorsGeneric,
-    Literal,
-    TargetType,
-    BaselineType,
-)
+from ..._utils.attribution import LayerAttribution
+from ..._utils.common import (ExpansionTypes, _call_custom_attribution_func,
+                              _compute_conv_delta_and_format_attrs,
+                              _expand_additional_forward_args, _expand_target,
+                              _format_additional_forward_args,
+                              _format_baseline, _format_callable_baseline,
+                              _format_input, _tensorize_baseline,
+                              _validate_input)
+from ..._utils.gradient import (apply_gradient_requirements,
+                                compute_layer_gradients_and_eval,
+                                undo_gradient_requirements)
+from ..._utils.typing import (BaselineType, Literal, TargetType,
+                              TensorOrTupleOfTensorsGeneric)
 
 
 class LayerDeepLift(LayerAttribution, DeepLift):

--- a/captum/attr/_core/layer/layer_feature_ablation.py
+++ b/captum/attr/_core/layer/layer_feature_ablation.py
@@ -1,21 +1,17 @@
 #!/usr/bin/env python3
+from typing import Any, Callable, List, Tuple, Union
+
 import torch
-from torch.nn.parallel.scatter_gather import scatter
 from torch import Tensor
 from torch.nn import Module
-
-from typing import Callable, List, Tuple, Union, Any
+from torch.nn.parallel.scatter_gather import scatter
 
 from ..._utils.attribution import LayerAttribution, PerturbationAttribution
-from ..._utils.common import (
-    _format_input,
-    _format_additional_forward_args,
-    _format_attributions,
-    _run_forward,
-    _extract_device,
-)
+from ..._utils.common import (_extract_device, _format_additional_forward_args,
+                              _format_attributions, _format_input,
+                              _run_forward)
 from ..._utils.gradient import _forward_layer_eval
-from ..._utils.typing import TargetType, BaselineType
+from ..._utils.typing import BaselineType, TargetType
 from ..feature_ablation import FeatureAblation
 
 

--- a/captum/attr/_core/layer/layer_feature_ablation.py
+++ b/captum/attr/_core/layer/layer_feature_ablation.py
@@ -7,9 +7,13 @@ from torch.nn import Module
 from torch.nn.parallel.scatter_gather import scatter
 
 from ..._utils.attribution import LayerAttribution, PerturbationAttribution
-from ..._utils.common import (_extract_device, _format_additional_forward_args,
-                              _format_attributions, _format_input,
-                              _run_forward)
+from ..._utils.common import (
+    _extract_device,
+    _format_additional_forward_args,
+    _format_attributions,
+    _format_input,
+    _run_forward,
+)
 from ..._utils.gradient import _forward_layer_eval
 from ..._utils.typing import BaselineType, TargetType
 from ..feature_ablation import FeatureAblation

--- a/captum/attr/_core/layer/layer_gradient_shap.py
+++ b/captum/attr/_core/layer/layer_gradient_shap.py
@@ -1,29 +1,21 @@
 #!/usr/bin/env python3
 
+import typing
+from typing import Any, Callable, List, Tuple, Union
+
+import numpy as np
 import torch
 from torch import Tensor
 from torch.nn import Module
 
-import typing
-from typing import Callable, List, Tuple, Union, Any
-
-import numpy as np
-
-from ..._utils.attribution import LayerAttribution, GradientAttribution
-from ..._utils.gradient import compute_layer_gradients_and_eval, _forward_layer_eval
-
+from ..._utils.attribution import GradientAttribution, LayerAttribution
+from ..._utils.common import (_compute_conv_delta_and_format_attrs,
+                              _format_callable_baseline,
+                              _format_input_baseline)
+from ..._utils.gradient import (_forward_layer_eval,
+                                compute_layer_gradients_and_eval)
+from ..._utils.typing import Literal, TargetType, TensorOrTupleOfTensorsGeneric
 from ..gradient_shap import _scale_input
-from ..._utils.common import (
-    _format_input_baseline,
-    _format_callable_baseline,
-    _compute_conv_delta_and_format_attrs,
-)
-from ..._utils.typing import (
-    TensorOrTupleOfTensorsGeneric,
-    Literal,
-    TargetType,
-)
-
 from ..noise_tunnel import NoiseTunnel
 
 

--- a/captum/attr/_core/layer/layer_gradient_shap.py
+++ b/captum/attr/_core/layer/layer_gradient_shap.py
@@ -9,11 +9,12 @@ from torch import Tensor
 from torch.nn import Module
 
 from ..._utils.attribution import GradientAttribution, LayerAttribution
-from ..._utils.common import (_compute_conv_delta_and_format_attrs,
-                              _format_callable_baseline,
-                              _format_input_baseline)
-from ..._utils.gradient import (_forward_layer_eval,
-                                compute_layer_gradients_and_eval)
+from ..._utils.common import (
+    _compute_conv_delta_and_format_attrs,
+    _format_callable_baseline,
+    _format_input_baseline,
+)
+from ..._utils.gradient import _forward_layer_eval, compute_layer_gradients_and_eval
 from ..._utils.typing import Literal, TargetType, TensorOrTupleOfTensorsGeneric
 from ..gradient_shap import _scale_input
 from ..noise_tunnel import NoiseTunnel

--- a/captum/attr/_core/layer/layer_gradient_x_activation.py
+++ b/captum/attr/_core/layer/layer_gradient_x_activation.py
@@ -5,16 +5,11 @@ from torch import Tensor
 from torch.nn import Module
 
 from ..._utils.attribution import GradientAttribution, LayerAttribution
-from ..._utils.common import (
-    _format_additional_forward_args,
-    _format_attributions,
-    _format_input,
-)
-from ..._utils.gradient import (
-    apply_gradient_requirements,
-    compute_layer_gradients_and_eval,
-    undo_gradient_requirements,
-)
+from ..._utils.common import (_format_additional_forward_args,
+                              _format_attributions, _format_input)
+from ..._utils.gradient import (apply_gradient_requirements,
+                                compute_layer_gradients_and_eval,
+                                undo_gradient_requirements)
 from ..._utils.typing import TargetType
 
 

--- a/captum/attr/_core/layer/layer_gradient_x_activation.py
+++ b/captum/attr/_core/layer/layer_gradient_x_activation.py
@@ -5,11 +5,16 @@ from torch import Tensor
 from torch.nn import Module
 
 from ..._utils.attribution import GradientAttribution, LayerAttribution
-from ..._utils.common import (_format_additional_forward_args,
-                              _format_attributions, _format_input)
-from ..._utils.gradient import (apply_gradient_requirements,
-                                compute_layer_gradients_and_eval,
-                                undo_gradient_requirements)
+from ..._utils.common import (
+    _format_additional_forward_args,
+    _format_attributions,
+    _format_input,
+)
+from ..._utils.gradient import (
+    apply_gradient_requirements,
+    compute_layer_gradients_and_eval,
+    undo_gradient_requirements,
+)
 from ..._utils.typing import TargetType
 
 

--- a/captum/attr/_core/layer/layer_integrated_gradients.py
+++ b/captum/attr/_core/layer/layer_integrated_gradients.py
@@ -8,13 +8,15 @@ from torch.nn import Module
 from torch.nn.parallel.scatter_gather import scatter
 
 from captum.attr._core.integrated_gradients import IntegratedGradients
-from captum.attr._utils.attribution import (GradientAttribution,
-                                            LayerAttribution)
-from captum.attr._utils.common import (_extract_device,
-                                       _format_additional_forward_args,
-                                       _format_attributions,
-                                       _format_input_baseline,
-                                       _tensorize_baseline, _validate_input)
+from captum.attr._utils.attribution import GradientAttribution, LayerAttribution
+from captum.attr._utils.common import (
+    _extract_device,
+    _format_additional_forward_args,
+    _format_attributions,
+    _format_input_baseline,
+    _tensorize_baseline,
+    _validate_input,
+)
 from captum.attr._utils.gradient import _forward_layer_eval, _run_forward
 from captum.attr._utils.typing import BaselineType, Literal, TargetType
 

--- a/captum/attr/_core/layer/layer_integrated_gradients.py
+++ b/captum/attr/_core/layer/layer_integrated_gradients.py
@@ -1,27 +1,22 @@
 #!/usr/bin/env python3
 import typing
-from typing import Callable, List, Tuple, Union, Any
+from typing import Any, Callable, List, Tuple, Union
+
 import torch
 from torch import Tensor
-
 from torch.nn import Module
 from torch.nn.parallel.scatter_gather import scatter
 
-from captum.attr._utils.common import (
-    _tensorize_baseline,
-    _validate_input,
-    _format_additional_forward_args,
-    _format_attributions,
-    _format_input_baseline,
-    _extract_device,
-)
-
-from captum.attr._utils.gradient import _forward_layer_eval
-
-from captum.attr._utils.attribution import LayerAttribution, GradientAttribution
 from captum.attr._core.integrated_gradients import IntegratedGradients
-from captum.attr._utils.gradient import _run_forward
-from captum.attr._utils.typing import Literal, TargetType, BaselineType
+from captum.attr._utils.attribution import (GradientAttribution,
+                                            LayerAttribution)
+from captum.attr._utils.common import (_extract_device,
+                                       _format_additional_forward_args,
+                                       _format_attributions,
+                                       _format_input_baseline,
+                                       _tensorize_baseline, _validate_input)
+from captum.attr._utils.gradient import _forward_layer_eval, _run_forward
+from captum.attr._utils.typing import BaselineType, Literal, TargetType
 
 
 class LayerIntegratedGradients(LayerAttribution, GradientAttribution):

--- a/captum/attr/_core/neuron/neuron_conductance.py
+++ b/captum/attr/_core/neuron/neuron_conductance.py
@@ -1,23 +1,20 @@
 #!/usr/bin/env python3
+from typing import Any, Callable, List, Tuple, Union
+
 import torch
-from typing import Callable, List, Tuple, Union, Any
 from torch.nn import Module
+
 from ..._utils.approximation_methods import approximation_parameters
-from ..._utils.attribution import NeuronAttribution, GradientAttribution
+from ..._utils.attribution import GradientAttribution, NeuronAttribution
 from ..._utils.batching import _batched_operator
-from ..._utils.common import (
-    _is_tuple,
-    _reshape_and_sum,
-    _format_input_baseline,
-    _format_additional_forward_args,
-    _validate_input,
-    _format_attributions,
-    _expand_additional_forward_args,
-    _expand_target,
-    _verify_select_column,
-)
+from ..._utils.common import (_expand_additional_forward_args, _expand_target,
+                              _format_additional_forward_args,
+                              _format_attributions, _format_input_baseline,
+                              _is_tuple, _reshape_and_sum, _validate_input,
+                              _verify_select_column)
 from ..._utils.gradient import compute_layer_gradients_and_eval
-from ..._utils.typing import TensorOrTupleOfTensorsGeneric, TargetType, BaselineType
+from ..._utils.typing import (BaselineType, TargetType,
+                              TensorOrTupleOfTensorsGeneric)
 
 
 class NeuronConductance(NeuronAttribution, GradientAttribution):

--- a/captum/attr/_core/neuron/neuron_conductance.py
+++ b/captum/attr/_core/neuron/neuron_conductance.py
@@ -7,14 +7,19 @@ from torch.nn import Module
 from ..._utils.approximation_methods import approximation_parameters
 from ..._utils.attribution import GradientAttribution, NeuronAttribution
 from ..._utils.batching import _batched_operator
-from ..._utils.common import (_expand_additional_forward_args, _expand_target,
-                              _format_additional_forward_args,
-                              _format_attributions, _format_input_baseline,
-                              _is_tuple, _reshape_and_sum, _validate_input,
-                              _verify_select_column)
+from ..._utils.common import (
+    _expand_additional_forward_args,
+    _expand_target,
+    _format_additional_forward_args,
+    _format_attributions,
+    _format_input_baseline,
+    _is_tuple,
+    _reshape_and_sum,
+    _validate_input,
+    _verify_select_column,
+)
 from ..._utils.gradient import compute_layer_gradients_and_eval
-from ..._utils.typing import (BaselineType, TargetType,
-                              TensorOrTupleOfTensorsGeneric)
+from ..._utils.typing import BaselineType, TargetType, TensorOrTupleOfTensorsGeneric
 
 
 class NeuronConductance(NeuronAttribution, GradientAttribution):

--- a/captum/attr/_core/neuron/neuron_deep_lift.py
+++ b/captum/attr/_core/neuron/neuron_deep_lift.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
-from ..._utils.attribution import NeuronAttribution, GradientAttribution
-from ..._utils.gradient import construct_neuron_grad_fn
+from typing import Any, Callable, Tuple, Union, cast
 
-from ..deep_lift import DeepLift, DeepLiftShap
-
-from typing import Callable, Tuple, Union, Any, cast
 from torch import Tensor
 from torch.nn import Module
-from ..._utils.typing import TensorOrTupleOfTensorsGeneric, BaselineType
+
+from ..._utils.attribution import GradientAttribution, NeuronAttribution
+from ..._utils.gradient import construct_neuron_grad_fn
+from ..._utils.typing import BaselineType, TensorOrTupleOfTensorsGeneric
+from ..deep_lift import DeepLift, DeepLiftShap
 
 
 class NeuronDeepLift(NeuronAttribution, GradientAttribution):

--- a/captum/attr/_core/neuron/neuron_feature_ablation.py
+++ b/captum/attr/_core/neuron/neuron_feature_ablation.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python3
+from typing import Any, Callable, List, Tuple, Union
+
 import torch
 from torch.nn import Module
-from typing import Callable, List, Tuple, Union, Any
-
 
 from ..._utils.attribution import NeuronAttribution, PerturbationAttribution
 from ..._utils.common import _verify_select_column
 from ..._utils.gradient import _forward_layer_eval
-from ..._utils.typing import TensorOrTupleOfTensorsGeneric, BaselineType
-
+from ..._utils.typing import BaselineType, TensorOrTupleOfTensorsGeneric
 from ..feature_ablation import FeatureAblation
 
 

--- a/captum/attr/_core/neuron/neuron_gradient.py
+++ b/captum/attr/_core/neuron/neuron_gradient.py
@@ -1,19 +1,14 @@
 #!/usr/bin/env python3
-from torch.nn import Module
-from typing import Callable, List, Tuple, Union, Any
+from typing import Any, Callable, List, Tuple, Union
 
-from ..._utils.attribution import NeuronAttribution, GradientAttribution
-from ..._utils.common import (
-    _is_tuple,
-    _format_input,
-    _format_additional_forward_args,
-    _format_attributions,
-)
-from ..._utils.gradient import (
-    apply_gradient_requirements,
-    undo_gradient_requirements,
-    _forward_layer_eval_with_neuron_grads,
-)
+from torch.nn import Module
+
+from ..._utils.attribution import GradientAttribution, NeuronAttribution
+from ..._utils.common import (_format_additional_forward_args,
+                              _format_attributions, _format_input, _is_tuple)
+from ..._utils.gradient import (_forward_layer_eval_with_neuron_grads,
+                                apply_gradient_requirements,
+                                undo_gradient_requirements)
 from ..._utils.typing import TensorOrTupleOfTensorsGeneric
 
 

--- a/captum/attr/_core/neuron/neuron_gradient.py
+++ b/captum/attr/_core/neuron/neuron_gradient.py
@@ -4,11 +4,17 @@ from typing import Any, Callable, List, Tuple, Union
 from torch.nn import Module
 
 from ..._utils.attribution import GradientAttribution, NeuronAttribution
-from ..._utils.common import (_format_additional_forward_args,
-                              _format_attributions, _format_input, _is_tuple)
-from ..._utils.gradient import (_forward_layer_eval_with_neuron_grads,
-                                apply_gradient_requirements,
-                                undo_gradient_requirements)
+from ..._utils.common import (
+    _format_additional_forward_args,
+    _format_attributions,
+    _format_input,
+    _is_tuple,
+)
+from ..._utils.gradient import (
+    _forward_layer_eval_with_neuron_grads,
+    apply_gradient_requirements,
+    undo_gradient_requirements,
+)
 from ..._utils.typing import TensorOrTupleOfTensorsGeneric
 
 

--- a/captum/attr/_core/neuron/neuron_gradient_shap.py
+++ b/captum/attr/_core/neuron/neuron_gradient_shap.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-from typing import Callable, List, Tuple, Union, Any
+from typing import Any, Callable, List, Tuple, Union
+
 from torch.nn import Module
 
-from ..gradient_shap import GradientShap
-from ..._utils.attribution import NeuronAttribution, GradientAttribution
+from ..._utils.attribution import GradientAttribution, NeuronAttribution
 from ..._utils.gradient import construct_neuron_grad_fn
 from ..._utils.typing import TensorOrTupleOfTensorsGeneric
+from ..gradient_shap import GradientShap
 
 
 class NeuronGradientShap(NeuronAttribution, GradientAttribution):

--- a/captum/attr/_core/neuron/neuron_guided_backprop_deconvnet.py
+++ b/captum/attr/_core/neuron/neuron_guided_backprop_deconvnet.py
@@ -3,10 +3,10 @@ from typing import Any, List, Tuple, Union
 
 from torch.nn import Module
 
-from ..._utils.attribution import NeuronAttribution, GradientAttribution
+from ..._utils.attribution import GradientAttribution, NeuronAttribution
 from ..._utils.gradient import construct_neuron_grad_fn
 from ..._utils.typing import TensorOrTupleOfTensorsGeneric
-from ..guided_backprop_deconvnet import GuidedBackprop, Deconvolution
+from ..guided_backprop_deconvnet import Deconvolution, GuidedBackprop
 
 
 class NeuronDeconvolution(NeuronAttribution, GradientAttribution):

--- a/captum/attr/_core/neuron/neuron_integrated_gradients.py
+++ b/captum/attr/_core/neuron/neuron_integrated_gradients.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-from typing import Callable, List, Tuple, Union, Any
+from typing import Any, Callable, List, Tuple, Union
+
 from torch import Tensor
 from torch.nn import Module
 
-from ..._utils.attribution import NeuronAttribution, GradientAttribution
+from ..._utils.attribution import GradientAttribution, NeuronAttribution
 from ..._utils.gradient import construct_neuron_grad_fn
 from ..._utils.typing import TensorOrTupleOfTensorsGeneric
-
 from ..integrated_gradients import IntegratedGradients
 
 

--- a/captum/attr/_core/noise_tunnel.py
+++ b/captum/attr/_core/noise_tunnel.py
@@ -7,12 +7,19 @@ import torch
 from torch import Tensor
 
 from .._utils.attribution import Attribution
-from .._utils.common import (ExpansionTypes, _expand_additional_forward_args,
-                             _expand_target, _format_additional_forward_args,
-                             _format_attributions, _format_baseline,
-                             _format_input, _format_tensor_into_tuples,
-                             _is_tuple, _validate_input,
-                             _validate_noise_tunnel_type)
+from .._utils.common import (
+    ExpansionTypes,
+    _expand_additional_forward_args,
+    _expand_target,
+    _format_additional_forward_args,
+    _format_attributions,
+    _format_baseline,
+    _format_input,
+    _format_tensor_into_tuples,
+    _is_tuple,
+    _validate_input,
+    _validate_noise_tunnel_type,
+)
 
 
 class NoiseTunnelType(Enum):

--- a/captum/attr/_core/noise_tunnel.py
+++ b/captum/attr/_core/noise_tunnel.py
@@ -1,26 +1,18 @@
 #!/usr/bin/env python3
-from typing import Tuple, Union, Any
+from enum import Enum
+from typing import Any, Tuple, Union
 
+import numpy as np
 import torch
 from torch import Tensor
 
-import numpy as np
-from enum import Enum
-
 from .._utils.attribution import Attribution
-from .._utils.common import (
-    _is_tuple,
-    _validate_noise_tunnel_type,
-    _validate_input,
-    _format_baseline,
-    _format_input,
-    _format_attributions,
-    _format_additional_forward_args,
-    _format_tensor_into_tuples,
-    _expand_additional_forward_args,
-    _expand_target,
-    ExpansionTypes,
-)
+from .._utils.common import (ExpansionTypes, _expand_additional_forward_args,
+                             _expand_target, _format_additional_forward_args,
+                             _format_attributions, _format_baseline,
+                             _format_input, _format_tensor_into_tuples,
+                             _is_tuple, _validate_input,
+                             _validate_noise_tunnel_type)
 
 
 class NoiseTunnelType(Enum):

--- a/captum/attr/_core/occlusion.py
+++ b/captum/attr/_core/occlusion.py
@@ -1,17 +1,14 @@
 #!/usr/bin/env python3
 from typing import Any, Callable, Tuple, Union
 
+import numpy as np
 import torch
 from torch import Tensor
-import numpy as np
 
-from .._utils.common import (
-    _format_input,
-    _format_and_verify_strides,
-    _format_and_verify_sliding_window_shapes,
-)
-from .._utils.typing import TensorOrTupleOfTensorsGeneric, TargetType, BaselineType
-
+from .._utils.common import (_format_and_verify_sliding_window_shapes,
+                             _format_and_verify_strides, _format_input)
+from .._utils.typing import (BaselineType, TargetType,
+                             TensorOrTupleOfTensorsGeneric)
 from .feature_ablation import FeatureAblation
 
 

--- a/captum/attr/_core/occlusion.py
+++ b/captum/attr/_core/occlusion.py
@@ -5,10 +5,12 @@ import numpy as np
 import torch
 from torch import Tensor
 
-from .._utils.common import (_format_and_verify_sliding_window_shapes,
-                             _format_and_verify_strides, _format_input)
-from .._utils.typing import (BaselineType, TargetType,
-                             TensorOrTupleOfTensorsGeneric)
+from .._utils.common import (
+    _format_and_verify_sliding_window_shapes,
+    _format_and_verify_strides,
+    _format_input,
+)
+from .._utils.typing import BaselineType, TargetType, TensorOrTupleOfTensorsGeneric
 from .feature_ablation import FeatureAblation
 
 

--- a/captum/attr/_core/saliency.py
+++ b/captum/attr/_core/saliency.py
@@ -3,11 +3,13 @@
 from typing import Any, Callable
 
 import torch
+
 from captum.attr._utils.typing import TensorOrTupleOfTensorsGeneric
 
 from .._utils.attribution import GradientAttribution
 from .._utils.common import _format_attributions, _format_input, _is_tuple
-from .._utils.gradient import apply_gradient_requirements, undo_gradient_requirements
+from .._utils.gradient import (apply_gradient_requirements,
+                               undo_gradient_requirements)
 from .._utils.typing import TargetType
 
 

--- a/captum/attr/_core/saliency.py
+++ b/captum/attr/_core/saliency.py
@@ -8,8 +8,7 @@ from captum.attr._utils.typing import TensorOrTupleOfTensorsGeneric
 
 from .._utils.attribution import GradientAttribution
 from .._utils.common import _format_attributions, _format_input, _is_tuple
-from .._utils.gradient import (apply_gradient_requirements,
-                               undo_gradient_requirements)
+from .._utils.gradient import apply_gradient_requirements, undo_gradient_requirements
 from .._utils.typing import TargetType
 
 

--- a/captum/attr/_core/shapley_value.py
+++ b/captum/attr/_core/shapley_value.py
@@ -1,26 +1,21 @@
 #!/usr/bin/env python3
 
-import warnings
-from typing import Any, Callable, Tuple, Union, Iterable, Sequence
-
 import itertools
+import warnings
+from typing import Any, Callable, Iterable, Sequence, Tuple, Union
+
 import torch
 from torch import Tensor
 
-from .._utils.common import (
-    _find_output_mode_and_verify,
-    _format_attributions,
-    _format_input,
-    _format_input_baseline,
-    _is_tuple,
-    _run_forward,
-    _expand_additional_forward_args,
-    _expand_target,
-    _format_additional_forward_args,
-    _tensorize_baseline,
-)
 from .._utils.attribution import PerturbationAttribution
-from .._utils.typing import TensorOrTupleOfTensorsGeneric, TargetType, BaselineType
+from .._utils.common import (_expand_additional_forward_args, _expand_target,
+                             _find_output_mode_and_verify,
+                             _format_additional_forward_args,
+                             _format_attributions, _format_input,
+                             _format_input_baseline, _is_tuple, _run_forward,
+                             _tensorize_baseline)
+from .._utils.typing import (BaselineType, TargetType,
+                             TensorOrTupleOfTensorsGeneric)
 
 
 def _all_perm_generator(num_features: int, num_samples: int) -> Iterable[Sequence[int]]:

--- a/captum/attr/_core/shapley_value.py
+++ b/captum/attr/_core/shapley_value.py
@@ -8,14 +8,19 @@ import torch
 from torch import Tensor
 
 from .._utils.attribution import PerturbationAttribution
-from .._utils.common import (_expand_additional_forward_args, _expand_target,
-                             _find_output_mode_and_verify,
-                             _format_additional_forward_args,
-                             _format_attributions, _format_input,
-                             _format_input_baseline, _is_tuple, _run_forward,
-                             _tensorize_baseline)
-from .._utils.typing import (BaselineType, TargetType,
-                             TensorOrTupleOfTensorsGeneric)
+from .._utils.common import (
+    _expand_additional_forward_args,
+    _expand_target,
+    _find_output_mode_and_verify,
+    _format_additional_forward_args,
+    _format_attributions,
+    _format_input,
+    _format_input_baseline,
+    _is_tuple,
+    _run_forward,
+    _tensorize_baseline,
+)
+from .._utils.typing import BaselineType, TargetType, TensorOrTupleOfTensorsGeneric
 
 
 def _all_perm_generator(num_features: int, num_samples: int) -> Iterable[Sequence[int]]:

--- a/captum/attr/_models/base.py
+++ b/captum/attr/_models/base.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 
-import torch
-
 import warnings
-
 from functools import reduce
+
+import torch
 from torch.nn import Module
 
 

--- a/captum/attr/_models/pytext.py
+++ b/captum/attr/_models/pytext.py
@@ -3,9 +3,9 @@ from collections import defaultdict
 
 import torch
 
-from pytext.models.model import EmbeddingList, EmbeddingBase
-from pytext.models.embeddings.word_embedding import WordEmbedding
 from pytext.models.embeddings.dict_embedding import DictEmbedding
+from pytext.models.embeddings.word_embedding import WordEmbedding
+from pytext.models.model import EmbeddingBase, EmbeddingList
 
 
 class PyTextInterpretableEmbedding(EmbeddingBase):

--- a/captum/attr/_models/pytext.py
+++ b/captum/attr/_models/pytext.py
@@ -2,7 +2,6 @@
 from collections import defaultdict
 
 import torch
-
 from pytext.models.embeddings.dict_embedding import DictEmbedding
 from pytext.models.embeddings.word_embedding import WordEmbedding
 from pytext.models.model import EmbeddingBase, EmbeddingList

--- a/captum/attr/_utils/approximation_methods.py
+++ b/captum/attr/_utils/approximation_methods.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
-from typing import List, Callable, Tuple
-import numpy as np
 from enum import Enum
+from typing import Callable, List, Tuple
+
+import numpy as np
 
 
 class Riemann(Enum):

--- a/captum/attr/_utils/attribution.py
+++ b/captum/attr/_utils/attribution.py
@@ -6,9 +6,15 @@ import torch.nn.functional as F
 from torch import Tensor
 from torch.nn import Module
 
-from .common import (_format_additional_forward_args, _format_input_baseline,
-                     _format_tensor_into_tuples, _run_forward,
-                     _tensorize_baseline, _validate_input, _validate_target)
+from .common import (
+    _format_additional_forward_args,
+    _format_input_baseline,
+    _format_tensor_into_tuples,
+    _run_forward,
+    _tensorize_baseline,
+    _validate_input,
+    _validate_target,
+)
 from .gradient import compute_gradients
 from .typing import TargetType
 

--- a/captum/attr/_utils/attribution.py
+++ b/captum/attr/_utils/attribution.py
@@ -1,23 +1,16 @@
 #!/usr/bin/env python3
-from typing import Callable, Union, Tuple, Any, Type, List, cast
+from typing import Any, Callable, List, Tuple, Type, Union, cast
 
 import torch
 import torch.nn.functional as F
-
-from .common import (
-    _format_additional_forward_args,
-    _format_input_baseline,
-    _format_tensor_into_tuples,
-    _run_forward,
-    _tensorize_baseline,
-    _validate_input,
-    _validate_target,
-)
-from .gradient import compute_gradients
-from .typing import TargetType
-
 from torch import Tensor
 from torch.nn import Module
+
+from .common import (_format_additional_forward_args, _format_input_baseline,
+                     _format_tensor_into_tuples, _run_forward,
+                     _tensorize_baseline, _validate_input, _validate_target)
+from .gradient import compute_gradients
+from .typing import TargetType
 
 
 class Attribution:

--- a/captum/attr/_utils/batching.py
+++ b/captum/attr/_utils/batching.py
@@ -6,8 +6,11 @@ import torch
 from torch import Tensor, device
 
 from .common import _format_additional_forward_args, _format_input
-from .typing import (TargetType, TensorOrTupleOfTensorsGeneric,
-                     TupleOrTensorOrBoolGeneric)
+from .typing import (
+    TargetType,
+    TensorOrTupleOfTensorsGeneric,
+    TupleOrTensorOrBoolGeneric,
+)
 
 
 @typing.overload

--- a/captum/attr/_utils/batching.py
+++ b/captum/attr/_utils/batching.py
@@ -1,16 +1,13 @@
 #!/usr/bin/env python3
 import typing
-from typing import Any, Callable, List, Tuple, Union, Iterator, Dict
+from typing import Any, Callable, Dict, Iterator, List, Tuple, Union
 
 import torch
 from torch import Tensor, device
 
-from .common import _format_input, _format_additional_forward_args
-from .typing import (
-    TensorOrTupleOfTensorsGeneric,
-    TupleOrTensorOrBoolGeneric,
-    TargetType,
-)
+from .common import _format_additional_forward_args, _format_input
+from .typing import (TargetType, TensorOrTupleOfTensorsGeneric,
+                     TupleOrTensorOrBoolGeneric)
 
 
 @typing.overload

--- a/captum/attr/_utils/common.py
+++ b/captum/attr/_utils/common.py
@@ -1,25 +1,17 @@
 #!/usr/bin/env python3
 import typing
-from typing import (
-    Tuple,
-    Union,
-    overload,
-    List,
-    Any,
-    TYPE_CHECKING,
-    Callable,
-    cast,
-)
+from enum import Enum
+from inspect import signature
+from typing import (TYPE_CHECKING, Any, Callable, List, Tuple, Union, cast,
+                    overload)
 
 import torch
 from torch import Tensor, device
 from torch.nn import Module
 
-from enum import Enum
-from inspect import signature
-
 from .approximation_methods import SUPPORTED_METHODS
-from .typing import TensorOrTupleOfTensorsGeneric, Literal, TargetType, BaselineType
+from .typing import (BaselineType, Literal, TargetType,
+                     TensorOrTupleOfTensorsGeneric)
 
 if TYPE_CHECKING:
     from .attribution import GradientAttribution

--- a/captum/attr/_utils/common.py
+++ b/captum/attr/_utils/common.py
@@ -2,16 +2,14 @@
 import typing
 from enum import Enum
 from inspect import signature
-from typing import (TYPE_CHECKING, Any, Callable, List, Tuple, Union, cast,
-                    overload)
+from typing import TYPE_CHECKING, Any, Callable, List, Tuple, Union, cast, overload
 
 import torch
 from torch import Tensor, device
 from torch.nn import Module
 
 from .approximation_methods import SUPPORTED_METHODS
-from .typing import (BaselineType, Literal, TargetType,
-                     TensorOrTupleOfTensorsGeneric)
+from .typing import BaselineType, Literal, TargetType, TensorOrTupleOfTensorsGeneric
 
 if TYPE_CHECKING:
     from .attribution import GradientAttribution

--- a/captum/attr/_utils/gradient.py
+++ b/captum/attr/_utils/gradient.py
@@ -1,23 +1,16 @@
 #!/usr/bin/env python3
 import threading
-import warnings
 import typing
-from typing import (
-    Any,
-    List,
-    Tuple,
-    Union,
-    Callable,
-    Dict,
-    cast,
-)
+import warnings
+from typing import Any, Callable, Dict, List, Tuple, Union, cast
 
 import torch
 from torch import Tensor, device
 from torch.nn import Module
-from .typing import Literal, TargetType, TensorOrTupleOfTensorsGeneric
+
 from .batching import _reduce_list, _sort_key_list
 from .common import _run_forward, _verify_select_column
+from .typing import Literal, TargetType, TensorOrTupleOfTensorsGeneric
 
 
 def apply_gradient_requirements(inputs: Tuple[Tensor, ...]) -> List[bool]:

--- a/captum/attr/_utils/typing.py
+++ b/captum/attr/_utils/typing.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
-from typing import Tuple, TypeVar, TYPE_CHECKING, Union, List
+from typing import TYPE_CHECKING, List, Tuple, TypeVar, Union
+
 from torch import Tensor
 
 if TYPE_CHECKING:

--- a/captum/attr/_utils/visualization.py
+++ b/captum/attr/_utils/visualization.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python3
-from typing import Iterable, Union, Tuple, Any, List
-
-from enum import Enum
-import numpy as np
-from numpy import ndarray
 import warnings
+from enum import Enum
+from typing import Any, Iterable, List, Tuple, Union
 
+import numpy as np
 from matplotlib import pyplot as plt
-from matplotlib.pyplot import figure, axis
-from matplotlib.figure import Figure
 from matplotlib.colors import LinearSegmentedColormap
+from matplotlib.figure import Figure
+from matplotlib.pyplot import axis, figure
 from mpl_toolkits.axes_grid1 import make_axes_locatable
+from numpy import ndarray
 
 try:
     from IPython.core.display import display, HTML

--- a/captum/insights/api.py
+++ b/captum/insights/api.py
@@ -504,15 +504,19 @@ class AttributionVisualizer(object):
 
         # Type ignore for issue with passing union to function taking generic
         # https://github.com/python/mypy/issues/1533
-        for inputs, additional_args, label in _batched_generator(  # type: ignore
+        for (
+            inputs,
+            additional_forward_args,
+            label,
+        ) in _batched_generator(  # type: ignore
             inputs=batch_data.inputs,
             additional_forward_args=batch_data.additional_args,
             target_ind=batch_data.labels,
             internal_batch_size=1,  # should be 1 until we have batch label support
         ):
-            output = self._calculate_vis_output(inputs, additional_args, label)
+            output = self._calculate_vis_output(inputs, additional_forward_args, label)
             if output is not None:
-                cache = SampleCache(inputs, additional_args, label)
+                cache = SampleCache(inputs, additional_forward_args, label)
                 vis_outputs.append((output, cache))
 
         return vis_outputs

--- a/captum/insights/api.py
+++ b/captum/insights/api.py
@@ -502,15 +502,17 @@ class AttributionVisualizer(object):
         batch_data = next(self._dataset_iter)
         vis_outputs = []
 
-        for inputs, additional_forward_args, label in _batched_generator(
+        # Type ignore for issue with passing union to function taking generic
+        # https://github.com/python/mypy/issues/1533
+        for inputs, additional_args, label in _batched_generator(  # type: ignore
             inputs=batch_data.inputs,
             additional_forward_args=batch_data.additional_args,
             target_ind=batch_data.labels,
             internal_batch_size=1,  # should be 1 until we have batch label support
         ):
-            output = self._calculate_vis_output(inputs, additional_forward_args, label)
+            output = self._calculate_vis_output(inputs, additional_args, label)
             if output is not None:
-                cache = SampleCache(inputs, additional_forward_args, label)
+                cache = SampleCache(inputs, additional_args, label)
                 vis_outputs.append((output, cache))
 
         return vis_outputs

--- a/captum/insights/api.py
+++ b/captum/insights/api.py
@@ -1,18 +1,8 @@
 #!/usr/bin/env python3
 import inspect
 from collections import namedtuple
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    List,
-    NamedTuple,
-    Optional,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import (Any, Callable, Dict, Iterable, List, NamedTuple, Optional,
+                    Tuple, Union, cast)
 
 import torch
 from torch import Tensor
@@ -21,10 +11,8 @@ from torch.nn import Module
 from captum.attr import IntegratedGradients
 from captum.attr._utils.batching import _batched_generator
 from captum.attr._utils.common import _run_forward, safe_div
-from captum.insights.config import (
-    ATTRIBUTION_METHOD_CONFIG,
-    ATTRIBUTION_NAMES_TO_METHODS,
-)
+from captum.insights.config import (ATTRIBUTION_METHOD_CONFIG,
+                                    ATTRIBUTION_NAMES_TO_METHODS)
 from captum.insights.features import BaseFeature
 from captum.insights.server import namedtuple_to_dict
 

--- a/captum/insights/api.py
+++ b/captum/insights/api.py
@@ -1,8 +1,18 @@
 #!/usr/bin/env python3
 import inspect
 from collections import namedtuple
-from typing import (Any, Callable, Dict, Iterable, List, NamedTuple, Optional,
-                    Tuple, Union, cast)
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
 
 import torch
 from torch import Tensor
@@ -11,8 +21,10 @@ from torch.nn import Module
 from captum.attr import IntegratedGradients
 from captum.attr._utils.batching import _batched_generator
 from captum.attr._utils.common import _run_forward, safe_div
-from captum.insights.config import (ATTRIBUTION_METHOD_CONFIG,
-                                    ATTRIBUTION_NAMES_TO_METHODS)
+from captum.insights.config import (
+    ATTRIBUTION_METHOD_CONFIG,
+    ATTRIBUTION_NAMES_TO_METHODS,
+)
 from captum.insights.features import BaseFeature
 from captum.insights.server import namedtuple_to_dict
 

--- a/captum/insights/config.py
+++ b/captum/insights/config.py
@@ -1,14 +1,8 @@
 #!/usr/bin/env python3
 from typing import List, NamedTuple, Optional, Tuple
 
-from captum.attr import (
-    Deconvolution,
-    DeepLift,
-    GuidedBackprop,
-    InputXGradient,
-    IntegratedGradients,
-    Saliency,
-)
+from captum.attr import (Deconvolution, DeepLift, GuidedBackprop,
+                         InputXGradient, IntegratedGradients, Saliency)
 from captum.attr._utils.approximation_methods import SUPPORTED_METHODS
 
 

--- a/captum/insights/config.py
+++ b/captum/insights/config.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python3
 from typing import List, NamedTuple, Optional, Tuple
 
-from captum.attr import (Deconvolution, DeepLift, GuidedBackprop,
-                         InputXGradient, IntegratedGradients, Saliency)
+from captum.attr import (
+    Deconvolution,
+    DeepLift,
+    GuidedBackprop,
+    InputXGradient,
+    IntegratedGradients,
+    Saliency,
+)
 from captum.attr._utils.approximation_methods import SUPPORTED_METHODS
 
 

--- a/captum/insights/widget/widget.py
+++ b/captum/insights/widget/widget.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 import ipywidgets as widgets
+from traitlets import Dict, Instance, List, Unicode, observe
+
 from captum.insights import AttributionVisualizer
 from captum.insights.server import namedtuple_to_dict
-from traitlets import Dict, Instance, List, Unicode, observe
 
 
 @widgets.register

--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -38,7 +38,7 @@ fi
 
 # install other deps
 conda install -y numpy sphinx pytest flake8 ipywidgets ipython
-conda install -y -c conda-forge black matplotlib pytest-cov sphinx-autodoc-typehints mypy flask
+conda install -y -c conda-forge black matplotlib pytest-cov sphinx-autodoc-typehints mypy flask isort
 
 # build insights and install captum
 # TODO: remove CI=false when we want React warnings treated as errors

--- a/scripts/parse_sphinx.py
+++ b/scripts/parse_sphinx.py
@@ -5,7 +5,6 @@ import os
 
 from bs4 import BeautifulSoup
 
-
 js_scripts = """
 <script type="text/javascript" id="documentation_options" data-url_root="./"
   src="/js/documentation_options.js"></script>

--- a/scripts/parse_tutorials.py
+++ b/scripts/parse_tutorials.py
@@ -5,9 +5,9 @@ import json
 import os
 
 import nbformat
-from bs4 import BeautifulSoup
 from nbconvert import HTMLExporter, ScriptExporter
 
+from bs4 import BeautifulSoup
 
 TEMPLATE = """const CWD = process.cwd();
 

--- a/scripts/parse_tutorials.py
+++ b/scripts/parse_tutorials.py
@@ -5,9 +5,8 @@ import json
 import os
 
 import nbformat
-from nbconvert import HTMLExporter, ScriptExporter
-
 from bs4 import BeautifulSoup
+from nbconvert import HTMLExporter, ScriptExporter
 
 TEMPLATE = """const CWD = process.cwd();
 

--- a/scripts/update_versions_html.py
+++ b/scripts/update_versions_html.py
@@ -5,7 +5,6 @@ import json
 
 from bs4 import BeautifulSoup
 
-
 BASE_URL = "/"
 
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ import sys
 
 from setuptools import find_packages, setup
 
-
 REQUIRED_MAJOR = 3
 REQUIRED_MINOR = 6
 

--- a/tests/attr/helpers/conductance_reference.py
+++ b/tests/attr/helpers/conductance_reference.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
 import numpy as np
 import torch
+
 from captum.attr._utils.approximation_methods import approximation_parameters
 from captum.attr._utils.attribution import LayerAttribution
 from captum.attr._utils.common import _reshape_and_sum
-from captum.attr._utils.gradient import (
-    apply_gradient_requirements,
-    undo_gradient_requirements,
-)
+from captum.attr._utils.gradient import (apply_gradient_requirements,
+                                         undo_gradient_requirements)
 
 
 """

--- a/tests/attr/helpers/conductance_reference.py
+++ b/tests/attr/helpers/conductance_reference.py
@@ -5,8 +5,10 @@ import torch
 from captum.attr._utils.approximation_methods import approximation_parameters
 from captum.attr._utils.attribution import LayerAttribution
 from captum.attr._utils.common import _reshape_and_sum
-from captum.attr._utils.gradient import (apply_gradient_requirements,
-                                         undo_gradient_requirements)
+from captum.attr._utils.gradient import (
+    apply_gradient_requirements,
+    undo_gradient_requirements,
+)
 
 
 """

--- a/tests/attr/layer/test_grad_cam.py
+++ b/tests/attr/layer/test_grad_cam.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python3
 
 import unittest
-from typing import List, Tuple, Union, Any
+from typing import Any, List, Tuple, Union
 
 import torch
 from torch import Tensor
 from torch.nn import Module
+
 from captum.attr._core.layer.grad_cam import LayerGradCam
 
-from ..helpers.basic_models import BasicModel_MultiLayer, BasicModel_ConvNet_One_Conv
-from ..helpers.utils import assertTensorTuplesAlmostEqual, BaseTest
+from ..helpers.basic_models import (BasicModel_ConvNet_One_Conv,
+                                    BasicModel_MultiLayer)
+from ..helpers.utils import BaseTest, assertTensorTuplesAlmostEqual
 
 
 class Test(BaseTest):

--- a/tests/attr/layer/test_grad_cam.py
+++ b/tests/attr/layer/test_grad_cam.py
@@ -9,8 +9,7 @@ from torch.nn import Module
 
 from captum.attr._core.layer.grad_cam import LayerGradCam
 
-from ..helpers.basic_models import (BasicModel_ConvNet_One_Conv,
-                                    BasicModel_MultiLayer)
+from ..helpers.basic_models import BasicModel_ConvNet_One_Conv, BasicModel_MultiLayer
 from ..helpers.utils import BaseTest, assertTensorTuplesAlmostEqual
 
 

--- a/tests/attr/layer/test_internal_influence.py
+++ b/tests/attr/layer/test_internal_influence.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
-from typing import Union, Tuple, List, Any
-
 import unittest
+from typing import Any, List, Tuple, Union
 
 import torch
 from torch import Tensor
@@ -10,11 +9,9 @@ from torch.nn import Module
 from captum.attr._core.layer.internal_influence import InternalInfluence
 from captum.attr._utils.typing import BaselineType
 
-from ..helpers.basic_models import (
-    BasicModel_MultiLayer,
-    BasicModel_MultiLayer_MultiInput,
-)
-from ..helpers.utils import assertTensorTuplesAlmostEqual, BaseTest
+from ..helpers.basic_models import (BasicModel_MultiLayer,
+                                    BasicModel_MultiLayer_MultiInput)
+from ..helpers.utils import BaseTest, assertTensorTuplesAlmostEqual
 
 
 class Test(BaseTest):

--- a/tests/attr/layer/test_internal_influence.py
+++ b/tests/attr/layer/test_internal_influence.py
@@ -9,8 +9,10 @@ from torch.nn import Module
 from captum.attr._core.layer.internal_influence import InternalInfluence
 from captum.attr._utils.typing import BaselineType
 
-from ..helpers.basic_models import (BasicModel_MultiLayer,
-                                    BasicModel_MultiLayer_MultiInput)
+from ..helpers.basic_models import (
+    BasicModel_MultiLayer,
+    BasicModel_MultiLayer_MultiInput,
+)
 from ..helpers.utils import BaseTest, assertTensorTuplesAlmostEqual
 
 

--- a/tests/attr/layer/test_layer_ablation.py
+++ b/tests/attr/layer/test_layer_ablation.py
@@ -10,9 +10,11 @@ from torch.nn import Module
 from captum.attr._core.layer.layer_feature_ablation import LayerFeatureAblation
 from captum.attr._utils.typing import BaselineType
 
-from ..helpers.basic_models import (BasicModel_ConvNet_One_Conv,
-                                    BasicModel_MultiLayer,
-                                    BasicModel_MultiLayer_MultiInput)
+from ..helpers.basic_models import (
+    BasicModel_ConvNet_One_Conv,
+    BasicModel_MultiLayer,
+    BasicModel_MultiLayer_MultiInput,
+)
 from ..helpers.utils import BaseTest, assertTensorTuplesAlmostEqual
 
 

--- a/tests/attr/layer/test_layer_ablation.py
+++ b/tests/attr/layer/test_layer_ablation.py
@@ -1,20 +1,19 @@
 #!/usr/bin/env python3
 
 import unittest
-from typing import List, Tuple, Union, Any
+from typing import Any, List, Tuple, Union
 
 import torch
 from torch import Tensor
 from torch.nn import Module
+
 from captum.attr._core.layer.layer_feature_ablation import LayerFeatureAblation
 from captum.attr._utils.typing import BaselineType
 
-from ..helpers.basic_models import (
-    BasicModel_ConvNet_One_Conv,
-    BasicModel_MultiLayer,
-    BasicModel_MultiLayer_MultiInput,
-)
-from ..helpers.utils import assertTensorTuplesAlmostEqual, BaseTest
+from ..helpers.basic_models import (BasicModel_ConvNet_One_Conv,
+                                    BasicModel_MultiLayer,
+                                    BasicModel_MultiLayer_MultiInput)
+from ..helpers.utils import BaseTest, assertTensorTuplesAlmostEqual
 
 
 class Test(BaseTest):

--- a/tests/attr/layer/test_layer_activation.py
+++ b/tests/attr/layer/test_layer_activation.py
@@ -10,10 +10,15 @@ from torch.nn import Module
 
 from captum.attr._core.layer.layer_activation import LayerActivation
 
-from ..helpers.basic_models import (BasicModel_MultiLayer,
-                                    BasicModel_MultiLayer_MultiInput)
-from ..helpers.utils import (BaseTest, assertTensorAlmostEqual,
-                             assertTensorTuplesAlmostEqual)
+from ..helpers.basic_models import (
+    BasicModel_MultiLayer,
+    BasicModel_MultiLayer_MultiInput,
+)
+from ..helpers.utils import (
+    BaseTest,
+    assertTensorAlmostEqual,
+    assertTensorTuplesAlmostEqual,
+)
 
 
 class Test(BaseTest):

--- a/tests/attr/layer/test_layer_activation.py
+++ b/tests/attr/layer/test_layer_activation.py
@@ -1,24 +1,19 @@
 #!/usr/bin/env python3
 
 import unittest
-from typing import List, Tuple, Union, Any
+from typing import Any, List, Tuple, Union
 
 import torch
+import torch.nn as nn
 from torch import Tensor
 from torch.nn import Module
-import torch.nn as nn
 
 from captum.attr._core.layer.layer_activation import LayerActivation
 
-from ..helpers.basic_models import (
-    BasicModel_MultiLayer,
-    BasicModel_MultiLayer_MultiInput,
-)
-from ..helpers.utils import (
-    BaseTest,
-    assertTensorTuplesAlmostEqual,
-    assertTensorAlmostEqual,
-)
+from ..helpers.basic_models import (BasicModel_MultiLayer,
+                                    BasicModel_MultiLayer_MultiInput)
+from ..helpers.utils import (BaseTest, assertTensorAlmostEqual,
+                             assertTensorTuplesAlmostEqual)
 
 
 class Test(BaseTest):

--- a/tests/attr/layer/test_layer_conductance.py
+++ b/tests/attr/layer/test_layer_conductance.py
@@ -10,11 +10,17 @@ from torch.nn import Module
 from captum.attr._core.layer.layer_conductance import LayerConductance
 from captum.attr._utils.typing import BaselineType
 
-from ..helpers.basic_models import (BasicModel_ConvNet, BasicModel_MultiLayer,
-                                    BasicModel_MultiLayer_MultiInput)
+from ..helpers.basic_models import (
+    BasicModel_ConvNet,
+    BasicModel_MultiLayer,
+    BasicModel_MultiLayer_MultiInput,
+)
 from ..helpers.conductance_reference import ConductanceReference
-from ..helpers.utils import (BaseTest, assertArraysAlmostEqual,
-                             assertTensorTuplesAlmostEqual)
+from ..helpers.utils import (
+    BaseTest,
+    assertArraysAlmostEqual,
+    assertTensorTuplesAlmostEqual,
+)
 
 
 class Test(BaseTest):

--- a/tests/attr/layer/test_layer_conductance.py
+++ b/tests/attr/layer/test_layer_conductance.py
@@ -1,24 +1,20 @@
 #!/usr/bin/env python3
 
 import unittest
+from typing import Any, List, Tuple, Union, cast
 
 import torch
 from torch import Tensor
 from torch.nn import Module
-from typing import cast, Any, List, Tuple, Union
+
 from captum.attr._core.layer.layer_conductance import LayerConductance
 from captum.attr._utils.typing import BaselineType
-from ..helpers.basic_models import (
-    BasicModel_ConvNet,
-    BasicModel_MultiLayer,
-    BasicModel_MultiLayer_MultiInput,
-)
+
+from ..helpers.basic_models import (BasicModel_ConvNet, BasicModel_MultiLayer,
+                                    BasicModel_MultiLayer_MultiInput)
 from ..helpers.conductance_reference import ConductanceReference
-from ..helpers.utils import (
-    assertArraysAlmostEqual,
-    assertTensorTuplesAlmostEqual,
-    BaseTest,
-)
+from ..helpers.utils import (BaseTest, assertArraysAlmostEqual,
+                             assertTensorTuplesAlmostEqual)
 
 
 class Test(BaseTest):

--- a/tests/attr/layer/test_layer_deeplift_basic.py
+++ b/tests/attr/layer/test_layer_deeplift_basic.py
@@ -2,24 +2,20 @@
 
 from __future__ import print_function
 
+from typing import List, Tuple, Union, cast
+
 import torch
 from torch import Tensor
-from typing import Tuple, Union, List, cast
 
-from ..helpers.utils import (
-    BaseTest,
-    assertTensorAlmostEqual,
-    assertTensorTuplesAlmostEqual,
-    assertArraysAlmostEqual,
-    assert_delta,
-)
-from ..helpers.basic_models import (
-    ReLULinearDeepLiftModel,
-    BasicModel_MultiLayer,
-    LinearMaxPoolLinearModel,
-)
+from captum.attr._core.layer.layer_deep_lift import (LayerDeepLift,
+                                                     LayerDeepLiftShap)
 
-from captum.attr._core.layer.layer_deep_lift import LayerDeepLift, LayerDeepLiftShap
+from ..helpers.basic_models import (BasicModel_MultiLayer,
+                                    LinearMaxPoolLinearModel,
+                                    ReLULinearDeepLiftModel)
+from ..helpers.utils import (BaseTest, assert_delta, assertArraysAlmostEqual,
+                             assertTensorAlmostEqual,
+                             assertTensorTuplesAlmostEqual)
 
 
 class TestDeepLift(BaseTest):

--- a/tests/attr/layer/test_layer_deeplift_basic.py
+++ b/tests/attr/layer/test_layer_deeplift_basic.py
@@ -7,15 +7,20 @@ from typing import List, Tuple, Union, cast
 import torch
 from torch import Tensor
 
-from captum.attr._core.layer.layer_deep_lift import (LayerDeepLift,
-                                                     LayerDeepLiftShap)
+from captum.attr._core.layer.layer_deep_lift import LayerDeepLift, LayerDeepLiftShap
 
-from ..helpers.basic_models import (BasicModel_MultiLayer,
-                                    LinearMaxPoolLinearModel,
-                                    ReLULinearDeepLiftModel)
-from ..helpers.utils import (BaseTest, assert_delta, assertArraysAlmostEqual,
-                             assertTensorAlmostEqual,
-                             assertTensorTuplesAlmostEqual)
+from ..helpers.basic_models import (
+    BasicModel_MultiLayer,
+    LinearMaxPoolLinearModel,
+    ReLULinearDeepLiftModel,
+)
+from ..helpers.utils import (
+    BaseTest,
+    assert_delta,
+    assertArraysAlmostEqual,
+    assertTensorAlmostEqual,
+    assertTensorTuplesAlmostEqual,
+)
 
 
 class TestDeepLift(BaseTest):

--- a/tests/attr/layer/test_layer_gradient_shap.py
+++ b/tests/attr/layer/test_layer_gradient_shap.py
@@ -1,23 +1,19 @@
 #!/usr/bin/env python3
+from typing import Any, Callable, List, Tuple, Union
+
 import torch
 from torch import Tensor
 from torch.nn import Module
 
-from typing import Union, Tuple, List, Any, Callable
-
-from ..helpers.utils import BaseTest
-
-from ..helpers.utils import assertTensorTuplesAlmostEqual, assertTensorAlmostEqual
-from ..helpers.classification_models import SoftmaxModel
-from ..helpers.basic_models import (
-    BasicModel_MultiLayer,
-    BasicModel_MultiLayer_MultiInput,
-)
-
 from captum.attr._core.gradient_shap import GradientShap
 from captum.attr._core.layer.layer_gradient_shap import LayerGradientShap
-from captum.attr._utils.typing import TensorOrTupleOfTensorsGeneric, TargetType
+from captum.attr._utils.typing import TargetType, TensorOrTupleOfTensorsGeneric
 
+from ..helpers.basic_models import (BasicModel_MultiLayer,
+                                    BasicModel_MultiLayer_MultiInput)
+from ..helpers.classification_models import SoftmaxModel
+from ..helpers.utils import (BaseTest, assertTensorAlmostEqual,
+                             assertTensorTuplesAlmostEqual)
 from ..test_gradient_shap import _assert_attribution_delta
 
 

--- a/tests/attr/layer/test_layer_gradient_shap.py
+++ b/tests/attr/layer/test_layer_gradient_shap.py
@@ -9,11 +9,16 @@ from captum.attr._core.gradient_shap import GradientShap
 from captum.attr._core.layer.layer_gradient_shap import LayerGradientShap
 from captum.attr._utils.typing import TargetType, TensorOrTupleOfTensorsGeneric
 
-from ..helpers.basic_models import (BasicModel_MultiLayer,
-                                    BasicModel_MultiLayer_MultiInput)
+from ..helpers.basic_models import (
+    BasicModel_MultiLayer,
+    BasicModel_MultiLayer_MultiInput,
+)
 from ..helpers.classification_models import SoftmaxModel
-from ..helpers.utils import (BaseTest, assertTensorAlmostEqual,
-                             assertTensorTuplesAlmostEqual)
+from ..helpers.utils import (
+    BaseTest,
+    assertTensorAlmostEqual,
+    assertTensorTuplesAlmostEqual,
+)
 from ..test_gradient_shap import _assert_attribution_delta
 
 

--- a/tests/attr/layer/test_layer_gradient_x_activation.py
+++ b/tests/attr/layer/test_layer_gradient_x_activation.py
@@ -6,11 +6,12 @@ import torch
 from torch import Tensor
 from torch.nn import Module
 
-from captum.attr._core.layer.layer_gradient_x_activation import \
-    LayerGradientXActivation
+from captum.attr._core.layer.layer_gradient_x_activation import LayerGradientXActivation
 
-from ..helpers.basic_models import (BasicModel_MultiLayer,
-                                    BasicModel_MultiLayer_MultiInput)
+from ..helpers.basic_models import (
+    BasicModel_MultiLayer,
+    BasicModel_MultiLayer_MultiInput,
+)
 from ..helpers.utils import BaseTest, assertTensorTuplesAlmostEqual
 
 

--- a/tests/attr/layer/test_layer_gradient_x_activation.py
+++ b/tests/attr/layer/test_layer_gradient_x_activation.py
@@ -6,12 +6,11 @@ import torch
 from torch import Tensor
 from torch.nn import Module
 
-from captum.attr._core.layer.layer_gradient_x_activation import LayerGradientXActivation
+from captum.attr._core.layer.layer_gradient_x_activation import \
+    LayerGradientXActivation
 
-from ..helpers.basic_models import (
-    BasicModel_MultiLayer,
-    BasicModel_MultiLayer_MultiInput,
-)
+from ..helpers.basic_models import (BasicModel_MultiLayer,
+                                    BasicModel_MultiLayer_MultiInput)
 from ..helpers.utils import BaseTest, assertTensorTuplesAlmostEqual
 
 

--- a/tests/attr/layer/test_layer_integrated_gradients.py
+++ b/tests/attr/layer/test_layer_integrated_gradients.py
@@ -1,27 +1,21 @@
 #!/usr/bin/env python3
 
-from typing import List, Tuple, Union, Any, cast
+from typing import Any, List, Tuple, Union, cast
 
 import torch
 from torch import Tensor
 from torch.nn import Module
 
-from ..helpers.utils import assertArraysAlmostEqual, assertTensorTuplesAlmostEqual
-
-from captum.attr._models.base import (
-    configure_interpretable_embedding_layer,
-    remove_interpretable_embedding_layer,
-)
-
 from captum.attr._core.integrated_gradients import IntegratedGradients
-from captum.attr._core.layer.layer_integrated_gradients import LayerIntegratedGradients
 from captum.attr._core.layer.layer_conductance import LayerConductance
+from captum.attr._core.layer.layer_integrated_gradients import \
+    LayerIntegratedGradients
+from captum.attr._models.base import (configure_interpretable_embedding_layer,
+                                      remove_interpretable_embedding_layer)
 
-from ..helpers.utils import BaseTest
-from ..helpers.basic_models import (
-    BasicEmbeddingModel,
-    BasicModel_MultiLayer,
-)
+from ..helpers.basic_models import BasicEmbeddingModel, BasicModel_MultiLayer
+from ..helpers.utils import (BaseTest, assertArraysAlmostEqual,
+                             assertTensorTuplesAlmostEqual)
 
 
 class Test(BaseTest):

--- a/tests/attr/layer/test_layer_integrated_gradients.py
+++ b/tests/attr/layer/test_layer_integrated_gradients.py
@@ -8,14 +8,18 @@ from torch.nn import Module
 
 from captum.attr._core.integrated_gradients import IntegratedGradients
 from captum.attr._core.layer.layer_conductance import LayerConductance
-from captum.attr._core.layer.layer_integrated_gradients import \
-    LayerIntegratedGradients
-from captum.attr._models.base import (configure_interpretable_embedding_layer,
-                                      remove_interpretable_embedding_layer)
+from captum.attr._core.layer.layer_integrated_gradients import LayerIntegratedGradients
+from captum.attr._models.base import (
+    configure_interpretable_embedding_layer,
+    remove_interpretable_embedding_layer,
+)
 
 from ..helpers.basic_models import BasicEmbeddingModel, BasicModel_MultiLayer
-from ..helpers.utils import (BaseTest, assertArraysAlmostEqual,
-                             assertTensorTuplesAlmostEqual)
+from ..helpers.utils import (
+    BaseTest,
+    assertArraysAlmostEqual,
+    assertTensorTuplesAlmostEqual,
+)
 
 
 class Test(BaseTest):

--- a/tests/attr/models/test_base.py
+++ b/tests/attr/models/test_base.py
@@ -2,20 +2,17 @@
 
 from __future__ import print_function
 
-import torch
 import unittest
 
+import torch
 from torch.nn import Embedding
 
-from ..helpers.utils import assertArraysAlmostEqual
-
-from captum.attr._models.base import (
-    configure_interpretable_embedding_layer,
-    remove_interpretable_embedding_layer,
-    InterpretableEmbeddingBase,
-)
+from captum.attr._models.base import (InterpretableEmbeddingBase,
+                                      configure_interpretable_embedding_layer,
+                                      remove_interpretable_embedding_layer)
 
 from ..helpers.basic_models import BasicEmbeddingModel, TextModule
+from ..helpers.utils import assertArraysAlmostEqual
 
 
 class Test(unittest.TestCase):

--- a/tests/attr/models/test_base.py
+++ b/tests/attr/models/test_base.py
@@ -7,9 +7,11 @@ import unittest
 import torch
 from torch.nn import Embedding
 
-from captum.attr._models.base import (InterpretableEmbeddingBase,
-                                      configure_interpretable_embedding_layer,
-                                      remove_interpretable_embedding_layer)
+from captum.attr._models.base import (
+    InterpretableEmbeddingBase,
+    configure_interpretable_embedding_layer,
+    remove_interpretable_embedding_layer,
+)
 
 from ..helpers.basic_models import BasicEmbeddingModel, TextModule
 from ..helpers.utils import assertArraysAlmostEqual

--- a/tests/attr/models/test_pytext.py
+++ b/tests/attr/models/test_pytext.py
@@ -3,8 +3,8 @@
 from __future__ import print_function
 
 import os
-import unittest
 import tempfile
+import unittest
 
 import torch
 

--- a/tests/attr/neuron/test_neuron_ablation.py
+++ b/tests/attr/neuron/test_neuron_ablation.py
@@ -7,14 +7,14 @@ import torch
 from torch import Tensor
 from torch.nn import Module
 
-from captum.attr._core.neuron.neuron_feature_ablation import \
-    NeuronFeatureAblation
-from captum.attr._utils.typing import (BaselineType,
-                                       TensorOrTupleOfTensorsGeneric)
+from captum.attr._core.neuron.neuron_feature_ablation import NeuronFeatureAblation
+from captum.attr._utils.typing import BaselineType, TensorOrTupleOfTensorsGeneric
 
-from ..helpers.basic_models import (BasicModel_ConvNet_One_Conv,
-                                    BasicModel_MultiLayer,
-                                    BasicModel_MultiLayer_MultiInput)
+from ..helpers.basic_models import (
+    BasicModel_ConvNet_One_Conv,
+    BasicModel_MultiLayer,
+    BasicModel_MultiLayer_MultiInput,
+)
 from ..helpers.utils import BaseTest, assertTensorAlmostEqual
 
 

--- a/tests/attr/neuron/test_neuron_ablation.py
+++ b/tests/attr/neuron/test_neuron_ablation.py
@@ -1,21 +1,21 @@
 #!/usr/bin/env python3
 
 import unittest
+from typing import Any, List, Tuple, Union
 
 import torch
 from torch import Tensor
 from torch.nn import Module
 
-from captum.attr._utils.typing import TensorOrTupleOfTensorsGeneric, BaselineType
-from captum.attr._core.neuron.neuron_feature_ablation import NeuronFeatureAblation
-from typing import Tuple, Union, Any, List
+from captum.attr._core.neuron.neuron_feature_ablation import \
+    NeuronFeatureAblation
+from captum.attr._utils.typing import (BaselineType,
+                                       TensorOrTupleOfTensorsGeneric)
 
-from ..helpers.basic_models import (
-    BasicModel_ConvNet_One_Conv,
-    BasicModel_MultiLayer,
-    BasicModel_MultiLayer_MultiInput,
-)
-from ..helpers.utils import assertTensorAlmostEqual, BaseTest
+from ..helpers.basic_models import (BasicModel_ConvNet_One_Conv,
+                                    BasicModel_MultiLayer,
+                                    BasicModel_MultiLayer_MultiInput)
+from ..helpers.utils import BaseTest, assertTensorAlmostEqual
 
 
 class Test(BaseTest):

--- a/tests/attr/neuron/test_neuron_conductance.py
+++ b/tests/attr/neuron/test_neuron_conductance.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python3
 
 import unittest
-from typing import List, Tuple, Union, Any, cast
+from typing import Any, List, Tuple, Union, cast
+
 import torch
 from torch import Tensor
 from torch.nn import Module
+
 from captum.attr._core.layer.layer_conductance import LayerConductance
 from captum.attr._core.neuron.neuron_conductance import NeuronConductance
+from captum.attr._utils.typing import (BaselineType,
+                                       TensorOrTupleOfTensorsGeneric)
 
-from ..helpers.basic_models import (
-    BasicModel_ConvNet,
-    BasicModel_MultiLayer,
-    BasicModel_MultiLayer_MultiInput,
-)
-from ..helpers.utils import assertArraysAlmostEqual, BaseTest
-from captum.attr._utils.typing import TensorOrTupleOfTensorsGeneric, BaselineType
+from ..helpers.basic_models import (BasicModel_ConvNet, BasicModel_MultiLayer,
+                                    BasicModel_MultiLayer_MultiInput)
+from ..helpers.utils import BaseTest, assertArraysAlmostEqual
 
 
 class Test(BaseTest):

--- a/tests/attr/neuron/test_neuron_conductance.py
+++ b/tests/attr/neuron/test_neuron_conductance.py
@@ -9,11 +9,13 @@ from torch.nn import Module
 
 from captum.attr._core.layer.layer_conductance import LayerConductance
 from captum.attr._core.neuron.neuron_conductance import NeuronConductance
-from captum.attr._utils.typing import (BaselineType,
-                                       TensorOrTupleOfTensorsGeneric)
+from captum.attr._utils.typing import BaselineType, TensorOrTupleOfTensorsGeneric
 
-from ..helpers.basic_models import (BasicModel_ConvNet, BasicModel_MultiLayer,
-                                    BasicModel_MultiLayer_MultiInput)
+from ..helpers.basic_models import (
+    BasicModel_ConvNet,
+    BasicModel_MultiLayer,
+    BasicModel_MultiLayer_MultiInput,
+)
 from ..helpers.utils import BaseTest, assertArraysAlmostEqual
 
 

--- a/tests/attr/neuron/test_neuron_deeplift_basic.py
+++ b/tests/attr/neuron/test_neuron_deeplift_basic.py
@@ -7,15 +7,15 @@ from typing import Tuple, Union
 import torch
 from torch import Tensor
 
-from captum.attr._core.neuron.neuron_deep_lift import (NeuronDeepLift,
-                                                       NeuronDeepLiftShap)
+from captum.attr._core.neuron.neuron_deep_lift import NeuronDeepLift, NeuronDeepLiftShap
 from captum.attr._utils.typing import TensorOrTupleOfTensorsGeneric
 
 from ..helpers.basic_models import ReLULinearDeepLiftModel
 from ..helpers.utils import BaseTest, assertTensorAlmostEqual
 from ..layer.test_layer_deeplift_basic import (
     _create_inps_and_base_for_deeplift_neuron_layer_testing,
-    _create_inps_and_base_for_deepliftshap_neuron_layer_testing)
+    _create_inps_and_base_for_deepliftshap_neuron_layer_testing,
+)
 
 
 class Test(BaseTest):

--- a/tests/attr/neuron/test_neuron_deeplift_basic.py
+++ b/tests/attr/neuron/test_neuron_deeplift_basic.py
@@ -2,20 +2,20 @@
 
 from __future__ import print_function
 
+from typing import Tuple, Union
+
 import torch
+from torch import Tensor
 
-from ..helpers.utils import BaseTest, assertTensorAlmostEqual
+from captum.attr._core.neuron.neuron_deep_lift import (NeuronDeepLift,
+                                                       NeuronDeepLiftShap)
+from captum.attr._utils.typing import TensorOrTupleOfTensorsGeneric
+
 from ..helpers.basic_models import ReLULinearDeepLiftModel
-
-from captum.attr._core.neuron.neuron_deep_lift import NeuronDeepLift, NeuronDeepLiftShap
+from ..helpers.utils import BaseTest, assertTensorAlmostEqual
 from ..layer.test_layer_deeplift_basic import (
     _create_inps_and_base_for_deeplift_neuron_layer_testing,
-    _create_inps_and_base_for_deepliftshap_neuron_layer_testing,
-)
-
-from typing import Tuple, Union
-from torch import Tensor
-from captum.attr._utils.typing import TensorOrTupleOfTensorsGeneric
+    _create_inps_and_base_for_deepliftshap_neuron_layer_testing)
 
 
 class Test(BaseTest):

--- a/tests/attr/neuron/test_neuron_gradient.py
+++ b/tests/attr/neuron/test_neuron_gradient.py
@@ -12,10 +12,16 @@ from captum.attr._core.saliency import Saliency
 from captum.attr._utils.gradient import _forward_layer_eval
 from captum.attr._utils.typing import TensorOrTupleOfTensorsGeneric
 
-from ..helpers.basic_models import (BasicModel_ConvNet, BasicModel_MultiLayer,
-                                    BasicModel_MultiLayer_MultiInput)
-from ..helpers.utils import (BaseTest, assertArraysAlmostEqual,
-                             assertTensorTuplesAlmostEqual)
+from ..helpers.basic_models import (
+    BasicModel_ConvNet,
+    BasicModel_MultiLayer,
+    BasicModel_MultiLayer_MultiInput,
+)
+from ..helpers.utils import (
+    BaseTest,
+    assertArraysAlmostEqual,
+    assertTensorTuplesAlmostEqual,
+)
 
 
 class Test(BaseTest):

--- a/tests/attr/neuron/test_neuron_gradient.py
+++ b/tests/attr/neuron/test_neuron_gradient.py
@@ -1,26 +1,21 @@
 #!/usr/bin/env python3
 
-from torch.nn import Module
-from torch import Tensor
-from typing import Any, List, Tuple, Union, cast
 import unittest
+from typing import Any, List, Tuple, Union, cast
 
 import torch
-from captum.attr._core.saliency import Saliency
+from torch import Tensor
+from torch.nn import Module
+
 from captum.attr._core.neuron.neuron_gradient import NeuronGradient
+from captum.attr._core.saliency import Saliency
 from captum.attr._utils.gradient import _forward_layer_eval
 from captum.attr._utils.typing import TensorOrTupleOfTensorsGeneric
 
-from ..helpers.basic_models import (
-    BasicModel_ConvNet,
-    BasicModel_MultiLayer,
-    BasicModel_MultiLayer_MultiInput,
-)
-from ..helpers.utils import (
-    assertArraysAlmostEqual,
-    assertTensorTuplesAlmostEqual,
-    BaseTest,
-)
+from ..helpers.basic_models import (BasicModel_ConvNet, BasicModel_MultiLayer,
+                                    BasicModel_MultiLayer_MultiInput)
+from ..helpers.utils import (BaseTest, assertArraysAlmostEqual,
+                             assertTensorTuplesAlmostEqual)
 
 
 class Test(BaseTest):

--- a/tests/attr/neuron/test_neuron_gradient_shap.py
+++ b/tests/attr/neuron/test_neuron_gradient_shap.py
@@ -6,8 +6,9 @@ from torch import Tensor
 from torch.nn import Module
 
 from captum.attr._core.neuron.neuron_gradient_shap import NeuronGradientShap
-from captum.attr._core.neuron.neuron_integrated_gradients import \
-    NeuronIntegratedGradients
+from captum.attr._core.neuron.neuron_integrated_gradients import (
+    NeuronIntegratedGradients,
+)
 
 from ..helpers.basic_models import BasicModel_MultiLayer
 from ..helpers.classification_models import SoftmaxModel

--- a/tests/attr/neuron/test_neuron_gradient_shap.py
+++ b/tests/attr/neuron/test_neuron_gradient_shap.py
@@ -5,16 +5,13 @@ import torch
 from torch import Tensor
 from torch.nn import Module
 
-from ..helpers.utils import BaseTest
-
-from ..helpers.utils import assertTensorAlmostEqual
-from ..helpers.classification_models import SoftmaxModel
-from ..helpers.basic_models import BasicModel_MultiLayer
-
 from captum.attr._core.neuron.neuron_gradient_shap import NeuronGradientShap
-from captum.attr._core.neuron.neuron_integrated_gradients import (
-    NeuronIntegratedGradients,
-)
+from captum.attr._core.neuron.neuron_integrated_gradients import \
+    NeuronIntegratedGradients
+
+from ..helpers.basic_models import BasicModel_MultiLayer
+from ..helpers.classification_models import SoftmaxModel
+from ..helpers.utils import BaseTest, assertTensorAlmostEqual
 
 
 class Test(BaseTest):

--- a/tests/attr/neuron/test_neuron_integrated_gradients.py
+++ b/tests/attr/neuron/test_neuron_integrated_gradients.py
@@ -8,14 +8,21 @@ from torch import Tensor
 from torch.nn import Module
 
 from captum.attr._core.integrated_gradients import IntegratedGradients
-from captum.attr._core.neuron.neuron_integrated_gradients import \
-    NeuronIntegratedGradients
+from captum.attr._core.neuron.neuron_integrated_gradients import (
+    NeuronIntegratedGradients,
+)
 from captum.attr._utils.typing import TensorOrTupleOfTensorsGeneric
 
-from ..helpers.basic_models import (BasicModel_ConvNet, BasicModel_MultiLayer,
-                                    BasicModel_MultiLayer_MultiInput)
-from ..helpers.utils import (BaseTest, assertArraysAlmostEqual,
-                             assertTensorTuplesAlmostEqual)
+from ..helpers.basic_models import (
+    BasicModel_ConvNet,
+    BasicModel_MultiLayer,
+    BasicModel_MultiLayer_MultiInput,
+)
+from ..helpers.utils import (
+    BaseTest,
+    assertArraysAlmostEqual,
+    assertTensorTuplesAlmostEqual,
+)
 
 
 class Test(BaseTest):

--- a/tests/attr/neuron/test_neuron_integrated_gradients.py
+++ b/tests/attr/neuron/test_neuron_integrated_gradients.py
@@ -1,29 +1,21 @@
 #!/usr/bin/env python3
 
 import unittest
-from typing import List, Tuple, Union, Any
+from typing import Any, List, Tuple, Union
 
 import torch
 from torch import Tensor
 from torch.nn import Module
 
 from captum.attr._core.integrated_gradients import IntegratedGradients
-from captum.attr._core.neuron.neuron_integrated_gradients import (
-    NeuronIntegratedGradients,
-)
-
+from captum.attr._core.neuron.neuron_integrated_gradients import \
+    NeuronIntegratedGradients
 from captum.attr._utils.typing import TensorOrTupleOfTensorsGeneric
 
-from ..helpers.basic_models import (
-    BasicModel_ConvNet,
-    BasicModel_MultiLayer,
-    BasicModel_MultiLayer_MultiInput,
-)
-from ..helpers.utils import (
-    assertArraysAlmostEqual,
-    assertTensorTuplesAlmostEqual,
-    BaseTest,
-)
+from ..helpers.basic_models import (BasicModel_ConvNet, BasicModel_MultiLayer,
+                                    BasicModel_MultiLayer_MultiInput)
+from ..helpers.utils import (BaseTest, assertArraysAlmostEqual,
+                             assertTensorTuplesAlmostEqual)
 
 
 class Test(BaseTest):

--- a/tests/attr/test_approximation_methods.py
+++ b/tests/attr/test_approximation_methods.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from captum.attr._utils.approximation_methods import riemann_builders, Riemann
+from captum.attr._utils.approximation_methods import Riemann, riemann_builders
 
 from .helpers.utils import assertArraysAlmostEqual
 

--- a/tests/attr/test_common.py
+++ b/tests/attr/test_common.py
@@ -1,16 +1,14 @@
 #!/usr/bin/env python3
 
+from typing import List, Tuple, cast
+
 import torch
-from typing import cast, List, Tuple
 
-from captum.attr._utils.common import (
-    _validate_input,
-    _validate_noise_tunnel_type,
-    _select_targets,
-)
 from captum.attr._core.noise_tunnel import SUPPORTED_NOISE_TUNNEL_TYPES
+from captum.attr._utils.common import (_select_targets, _validate_input,
+                                       _validate_noise_tunnel_type)
 
-from .helpers.utils import assertTensorAlmostEqual, BaseTest
+from .helpers.utils import BaseTest, assertTensorAlmostEqual
 
 
 class Test(BaseTest):

--- a/tests/attr/test_common.py
+++ b/tests/attr/test_common.py
@@ -5,8 +5,11 @@ from typing import List, Tuple, cast
 import torch
 
 from captum.attr._core.noise_tunnel import SUPPORTED_NOISE_TUNNEL_TYPES
-from captum.attr._utils.common import (_select_targets, _validate_input,
-                                       _validate_noise_tunnel_type)
+from captum.attr._utils.common import (
+    _select_targets,
+    _validate_input,
+    _validate_noise_tunnel_type,
+)
 
 from .helpers.utils import BaseTest, assertTensorAlmostEqual
 

--- a/tests/attr/test_data_parallel.py
+++ b/tests/attr/test_data_parallel.py
@@ -4,41 +4,38 @@ import unittest
 
 import torch
 
-from captum.attr._core.feature_ablation import FeatureAblation
 from captum.attr._core.deep_lift import DeepLift
+from captum.attr._core.feature_ablation import FeatureAblation
 from captum.attr._core.gradient_shap import GradientShap
-from captum.attr._core.occlusion import Occlusion
-from captum.attr._core.shapley_value import ShapleyValueSampling, ShapleyValues
-
 from captum.attr._core.layer.grad_cam import LayerGradCam
 from captum.attr._core.layer.internal_influence import InternalInfluence
 from captum.attr._core.layer.layer_activation import LayerActivation
 from captum.attr._core.layer.layer_conductance import LayerConductance
-from captum.attr._core.layer.layer_gradient_x_activation import LayerGradientXActivation
-from captum.attr._core.layer.layer_deep_lift import LayerDeepLift, LayerDeepLiftShap
-from captum.attr._core.layer.layer_gradient_shap import LayerGradientShap
-from captum.attr._core.layer.layer_integrated_gradients import LayerIntegratedGradients
+from captum.attr._core.layer.layer_deep_lift import (LayerDeepLift,
+                                                     LayerDeepLiftShap)
 from captum.attr._core.layer.layer_feature_ablation import LayerFeatureAblation
-
+from captum.attr._core.layer.layer_gradient_shap import LayerGradientShap
+from captum.attr._core.layer.layer_gradient_x_activation import \
+    LayerGradientXActivation
+from captum.attr._core.layer.layer_integrated_gradients import \
+    LayerIntegratedGradients
 from captum.attr._core.neuron.neuron_conductance import NeuronConductance
+from captum.attr._core.neuron.neuron_deep_lift import (NeuronDeepLift,
+                                                       NeuronDeepLiftShap)
+from captum.attr._core.neuron.neuron_feature_ablation import \
+    NeuronFeatureAblation
 from captum.attr._core.neuron.neuron_gradient import NeuronGradient
-from captum.attr._core.neuron.neuron_integrated_gradients import (
-    NeuronIntegratedGradients,
-)
-from captum.attr._core.neuron.neuron_guided_backprop_deconvnet import (
-    NeuronDeconvolution,
-    NeuronGuidedBackprop,
-)
-from captum.attr._core.neuron.neuron_deep_lift import NeuronDeepLift, NeuronDeepLiftShap
 from captum.attr._core.neuron.neuron_gradient_shap import NeuronGradientShap
-from captum.attr._core.neuron.neuron_feature_ablation import NeuronFeatureAblation
+from captum.attr._core.neuron.neuron_guided_backprop_deconvnet import (
+    NeuronDeconvolution, NeuronGuidedBackprop)
+from captum.attr._core.neuron.neuron_integrated_gradients import \
+    NeuronIntegratedGradients
+from captum.attr._core.occlusion import Occlusion
+from captum.attr._core.shapley_value import ShapleyValues, ShapleyValueSampling
 
-from .helpers.basic_models import (
-    BasicModel_MultiLayer,
-    BasicModel_MultiLayer_MultiInput,
-    BasicModel_ConvNet,
-    ReLULinearDeepLiftModel,
-)
+from .helpers.basic_models import (BasicModel_ConvNet, BasicModel_MultiLayer,
+                                   BasicModel_MultiLayer_MultiInput,
+                                   ReLULinearDeepLiftModel)
 from .helpers.utils import BaseGPUTest
 
 

--- a/tests/attr/test_data_parallel.py
+++ b/tests/attr/test_data_parallel.py
@@ -11,31 +11,32 @@ from captum.attr._core.layer.grad_cam import LayerGradCam
 from captum.attr._core.layer.internal_influence import InternalInfluence
 from captum.attr._core.layer.layer_activation import LayerActivation
 from captum.attr._core.layer.layer_conductance import LayerConductance
-from captum.attr._core.layer.layer_deep_lift import (LayerDeepLift,
-                                                     LayerDeepLiftShap)
+from captum.attr._core.layer.layer_deep_lift import LayerDeepLift, LayerDeepLiftShap
 from captum.attr._core.layer.layer_feature_ablation import LayerFeatureAblation
 from captum.attr._core.layer.layer_gradient_shap import LayerGradientShap
-from captum.attr._core.layer.layer_gradient_x_activation import \
-    LayerGradientXActivation
-from captum.attr._core.layer.layer_integrated_gradients import \
-    LayerIntegratedGradients
+from captum.attr._core.layer.layer_gradient_x_activation import LayerGradientXActivation
+from captum.attr._core.layer.layer_integrated_gradients import LayerIntegratedGradients
 from captum.attr._core.neuron.neuron_conductance import NeuronConductance
-from captum.attr._core.neuron.neuron_deep_lift import (NeuronDeepLift,
-                                                       NeuronDeepLiftShap)
-from captum.attr._core.neuron.neuron_feature_ablation import \
-    NeuronFeatureAblation
+from captum.attr._core.neuron.neuron_deep_lift import NeuronDeepLift, NeuronDeepLiftShap
+from captum.attr._core.neuron.neuron_feature_ablation import NeuronFeatureAblation
 from captum.attr._core.neuron.neuron_gradient import NeuronGradient
 from captum.attr._core.neuron.neuron_gradient_shap import NeuronGradientShap
 from captum.attr._core.neuron.neuron_guided_backprop_deconvnet import (
-    NeuronDeconvolution, NeuronGuidedBackprop)
-from captum.attr._core.neuron.neuron_integrated_gradients import \
-    NeuronIntegratedGradients
+    NeuronDeconvolution,
+    NeuronGuidedBackprop,
+)
+from captum.attr._core.neuron.neuron_integrated_gradients import (
+    NeuronIntegratedGradients,
+)
 from captum.attr._core.occlusion import Occlusion
 from captum.attr._core.shapley_value import ShapleyValues, ShapleyValueSampling
 
-from .helpers.basic_models import (BasicModel_ConvNet, BasicModel_MultiLayer,
-                                   BasicModel_MultiLayer_MultiInput,
-                                   ReLULinearDeepLiftModel)
+from .helpers.basic_models import (
+    BasicModel_ConvNet,
+    BasicModel_MultiLayer,
+    BasicModel_MultiLayer_MultiInput,
+    ReLULinearDeepLiftModel,
+)
 from .helpers.utils import BaseGPUTest
 
 

--- a/tests/attr/test_deconvolution.py
+++ b/tests/attr/test_deconvolution.py
@@ -3,18 +3,18 @@
 from __future__ import print_function
 
 import unittest
+from typing import Any, List, Tuple, Union
 
 import torch
-from captum.attr._core.guided_backprop_deconvnet import Deconvolution
-from captum.attr._core.neuron.neuron_guided_backprop_deconvnet import (
-    NeuronDeconvolution,
-)
-
-from typing import Any, Tuple, Union, List
 from torch.nn import Module
-from .helpers.basic_models import BasicModel_ConvNet_One_Conv
-from .helpers.utils import assertTensorAlmostEqual, BaseTest
+
+from captum.attr._core.guided_backprop_deconvnet import Deconvolution
+from captum.attr._core.neuron.neuron_guided_backprop_deconvnet import \
+    NeuronDeconvolution
 from captum.attr._utils.typing import TensorOrTupleOfTensorsGeneric
+
+from .helpers.basic_models import BasicModel_ConvNet_One_Conv
+from .helpers.utils import BaseTest, assertTensorAlmostEqual
 
 
 class Test(BaseTest):

--- a/tests/attr/test_deconvolution.py
+++ b/tests/attr/test_deconvolution.py
@@ -9,8 +9,9 @@ import torch
 from torch.nn import Module
 
 from captum.attr._core.guided_backprop_deconvnet import Deconvolution
-from captum.attr._core.neuron.neuron_guided_backprop_deconvnet import \
-    NeuronDeconvolution
+from captum.attr._core.neuron.neuron_guided_backprop_deconvnet import (
+    NeuronDeconvolution,
+)
 from captum.attr._utils.typing import TensorOrTupleOfTensorsGeneric
 
 from .helpers.basic_models import BasicModel_ConvNet_One_Conv

--- a/tests/attr/test_deeplift_basic.py
+++ b/tests/attr/test_deeplift_basic.py
@@ -1,29 +1,22 @@
 #!/usr/bin/env python3
 
-from typing import Tuple, List, Union, Callable
+from inspect import signature
+from typing import Callable, List, Tuple, Union
 
 import torch
 from torch import Tensor
 from torch.nn import Module
 
-from inspect import signature
-
 from captum.attr._core.deep_lift import DeepLift, DeepLiftShap
 from captum.attr._core.integrated_gradients import IntegratedGradients
 
-from .helpers.utils import (
-    assertAttributionComparision,
-    assertArraysAlmostEqual,
-    assertTensorAlmostEqual,
-    BaseTest,
-)
-from .helpers.basic_models import (
-    ReLUDeepLiftModel,
-    TanhDeepLiftModel,
-    BasicModelWithReusableModules,
-    LinearMaxPoolLinearModel,
-)
-from .helpers.basic_models import ReLULinearDeepLiftModel, Conv1dDeepLiftModel
+from .helpers.basic_models import (BasicModelWithReusableModules,
+                                   Conv1dDeepLiftModel,
+                                   LinearMaxPoolLinearModel, ReLUDeepLiftModel,
+                                   ReLULinearDeepLiftModel, TanhDeepLiftModel)
+from .helpers.utils import (BaseTest, assertArraysAlmostEqual,
+                            assertAttributionComparision,
+                            assertTensorAlmostEqual)
 
 
 class Test(BaseTest):

--- a/tests/attr/test_deeplift_basic.py
+++ b/tests/attr/test_deeplift_basic.py
@@ -10,13 +10,20 @@ from torch.nn import Module
 from captum.attr._core.deep_lift import DeepLift, DeepLiftShap
 from captum.attr._core.integrated_gradients import IntegratedGradients
 
-from .helpers.basic_models import (BasicModelWithReusableModules,
-                                   Conv1dDeepLiftModel,
-                                   LinearMaxPoolLinearModel, ReLUDeepLiftModel,
-                                   ReLULinearDeepLiftModel, TanhDeepLiftModel)
-from .helpers.utils import (BaseTest, assertArraysAlmostEqual,
-                            assertAttributionComparision,
-                            assertTensorAlmostEqual)
+from .helpers.basic_models import (
+    BasicModelWithReusableModules,
+    Conv1dDeepLiftModel,
+    LinearMaxPoolLinearModel,
+    ReLUDeepLiftModel,
+    ReLULinearDeepLiftModel,
+    TanhDeepLiftModel,
+)
+from .helpers.utils import (
+    BaseTest,
+    assertArraysAlmostEqual,
+    assertAttributionComparision,
+    assertTensorAlmostEqual,
+)
 
 
 class Test(BaseTest):

--- a/tests/attr/test_deeplift_classification.py
+++ b/tests/attr/test_deeplift_classification.py
@@ -10,11 +10,12 @@ from captum.attr._core.deep_lift import DeepLift, DeepLiftShap
 from captum.attr._core.integrated_gradients import IntegratedGradients
 from captum.attr._utils.typing import TargetType
 
-from .helpers.basic_models import (BasicModel_ConvNet,
-                                   BasicModel_ConvNet_MaxPool1d,
-                                   BasicModel_ConvNet_MaxPool3d)
-from .helpers.classification_models import (SigmoidDeepLiftModel,
-                                            SoftmaxDeepLiftModel)
+from .helpers.basic_models import (
+    BasicModel_ConvNet,
+    BasicModel_ConvNet_MaxPool1d,
+    BasicModel_ConvNet_MaxPool3d,
+)
+from .helpers.classification_models import SigmoidDeepLiftModel, SoftmaxDeepLiftModel
 from .helpers.utils import BaseTest, assertAttributionComparision
 
 

--- a/tests/attr/test_deeplift_classification.py
+++ b/tests/attr/test_deeplift_classification.py
@@ -10,12 +10,12 @@ from captum.attr._core.deep_lift import DeepLift, DeepLiftShap
 from captum.attr._core.integrated_gradients import IntegratedGradients
 from captum.attr._utils.typing import TargetType
 
-from .helpers.utils import assertAttributionComparision, BaseTest
-from .helpers.classification_models import SigmoidDeepLiftModel
-from .helpers.classification_models import SoftmaxDeepLiftModel
-from .helpers.basic_models import BasicModel_ConvNet
-from .helpers.basic_models import BasicModel_ConvNet_MaxPool1d
-from .helpers.basic_models import BasicModel_ConvNet_MaxPool3d
+from .helpers.basic_models import (BasicModel_ConvNet,
+                                   BasicModel_ConvNet_MaxPool1d,
+                                   BasicModel_ConvNet_MaxPool3d)
+from .helpers.classification_models import (SigmoidDeepLiftModel,
+                                            SoftmaxDeepLiftModel)
+from .helpers.utils import BaseTest, assertAttributionComparision
 
 
 class Test(BaseTest):

--- a/tests/attr/test_feature_ablation.py
+++ b/tests/attr/test_feature_ablation.py
@@ -1,25 +1,20 @@
 #!/usr/bin/env python3
 
 import unittest
+from typing import Any, Callable, List, Tuple, Union
 
 import torch
 from torch import Tensor
-from captum.attr._core.feature_ablation import FeatureAblation
-from typing import List, Tuple, Union, Any, Callable
 
-from .helpers.basic_models import (
-    BasicModel,
-    BasicModelWithSparseInputs,
-    BasicModel_ConvNet_One_Conv,
-    BasicModel_MultiLayer,
-    BasicModel_MultiLayer_MultiInput,
-)
-from .helpers.utils import assertTensorAlmostEqual, BaseTest
-from captum.attr._utils.typing import (
-    TensorOrTupleOfTensorsGeneric,
-    TargetType,
-    BaselineType,
-)
+from captum.attr._core.feature_ablation import FeatureAblation
+from captum.attr._utils.typing import (BaselineType, TargetType,
+                                       TensorOrTupleOfTensorsGeneric)
+
+from .helpers.basic_models import (BasicModel, BasicModel_ConvNet_One_Conv,
+                                   BasicModel_MultiLayer,
+                                   BasicModel_MultiLayer_MultiInput,
+                                   BasicModelWithSparseInputs)
+from .helpers.utils import BaseTest, assertTensorAlmostEqual
 
 
 class Test(BaseTest):

--- a/tests/attr/test_feature_ablation.py
+++ b/tests/attr/test_feature_ablation.py
@@ -7,13 +7,19 @@ import torch
 from torch import Tensor
 
 from captum.attr._core.feature_ablation import FeatureAblation
-from captum.attr._utils.typing import (BaselineType, TargetType,
-                                       TensorOrTupleOfTensorsGeneric)
+from captum.attr._utils.typing import (
+    BaselineType,
+    TargetType,
+    TensorOrTupleOfTensorsGeneric,
+)
 
-from .helpers.basic_models import (BasicModel, BasicModel_ConvNet_One_Conv,
-                                   BasicModel_MultiLayer,
-                                   BasicModel_MultiLayer_MultiInput,
-                                   BasicModelWithSparseInputs)
+from .helpers.basic_models import (
+    BasicModel,
+    BasicModel_ConvNet_One_Conv,
+    BasicModel_MultiLayer,
+    BasicModel_MultiLayer_MultiInput,
+    BasicModelWithSparseInputs,
+)
 from .helpers.utils import BaseTest, assertTensorAlmostEqual
 
 

--- a/tests/attr/test_feature_permutation.py
+++ b/tests/attr/test_feature_permutation.py
@@ -4,12 +4,10 @@ from typing import List, Tuple
 import torch
 from torch import Tensor
 
-from captum.attr._core.feature_permutation import (FeaturePermutation,
-                                                   _permute_feature)
+from captum.attr._core.feature_permutation import FeaturePermutation, _permute_feature
 
 from .helpers.basic_models import BasicModelWithSparseInputs
-from .helpers.utils import (BaseTest, assertArraysAlmostEqual,
-                            assertTensorAlmostEqual)
+from .helpers.utils import BaseTest, assertArraysAlmostEqual, assertTensorAlmostEqual
 
 
 class Test(BaseTest):

--- a/tests/attr/test_feature_permutation.py
+++ b/tests/attr/test_feature_permutation.py
@@ -3,13 +3,13 @@ from typing import List, Tuple
 
 import torch
 from torch import Tensor
-from captum.attr._core.feature_permutation import (
-    FeaturePermutation,
-    _permute_feature,
-)
+
+from captum.attr._core.feature_permutation import (FeaturePermutation,
+                                                   _permute_feature)
 
 from .helpers.basic_models import BasicModelWithSparseInputs
-from .helpers.utils import BaseTest, assertArraysAlmostEqual, assertTensorAlmostEqual
+from .helpers.utils import (BaseTest, assertArraysAlmostEqual,
+                            assertTensorAlmostEqual)
 
 
 class Test(BaseTest):

--- a/tests/attr/test_gradient.py
+++ b/tests/attr/test_gradient.py
@@ -5,19 +5,14 @@ from typing import cast
 import torch
 from torch import Tensor
 
-from captum.attr._utils.gradient import (
-    compute_gradients,
-    compute_layer_gradients_and_eval,
-    apply_gradient_requirements,
-    undo_gradient_requirements,
-)
+from captum.attr._utils.gradient import (apply_gradient_requirements,
+                                         compute_gradients,
+                                         compute_layer_gradients_and_eval,
+                                         undo_gradient_requirements)
 
-from .helpers.utils import assertArraysAlmostEqual, BaseTest
-from .helpers.basic_models import (
-    BasicModel,
-    BasicModel6_MultiTensor,
-    BasicModel_MultiLayer,
-)
+from .helpers.basic_models import (BasicModel, BasicModel6_MultiTensor,
+                                   BasicModel_MultiLayer)
+from .helpers.utils import BaseTest, assertArraysAlmostEqual
 
 
 class Test(BaseTest):

--- a/tests/attr/test_gradient.py
+++ b/tests/attr/test_gradient.py
@@ -5,13 +5,18 @@ from typing import cast
 import torch
 from torch import Tensor
 
-from captum.attr._utils.gradient import (apply_gradient_requirements,
-                                         compute_gradients,
-                                         compute_layer_gradients_and_eval,
-                                         undo_gradient_requirements)
+from captum.attr._utils.gradient import (
+    apply_gradient_requirements,
+    compute_gradients,
+    compute_layer_gradients_and_eval,
+    undo_gradient_requirements,
+)
 
-from .helpers.basic_models import (BasicModel, BasicModel6_MultiTensor,
-                                   BasicModel_MultiLayer)
+from .helpers.basic_models import (
+    BasicModel,
+    BasicModel6_MultiTensor,
+    BasicModel_MultiLayer,
+)
 from .helpers.utils import BaseTest, assertArraysAlmostEqual
 
 

--- a/tests/attr/test_gradient_shap.py
+++ b/tests/attr/test_gradient_shap.py
@@ -1,16 +1,19 @@
 #!/usr/bin/env python3
 
-import torch
-import numpy as np
+from typing import Tuple, Union, cast
 
-from .helpers.utils import assertArraysAlmostEqual, assertTensorAlmostEqual, BaseTest
-from .helpers.classification_models import SoftmaxModel
-from .helpers.basic_models import BasicModel2, BasicLinearModel
+import numpy as np
+import torch
+from numpy import ndarray
+
 from captum.attr._core.gradient_shap import GradientShap
 from captum.attr._core.integrated_gradients import IntegratedGradients
-from typing import Union, Tuple, cast
 from captum.attr._utils.typing import Tensor
-from numpy import ndarray
+
+from .helpers.basic_models import BasicLinearModel, BasicModel2
+from .helpers.classification_models import SoftmaxModel
+from .helpers.utils import (BaseTest, assertArraysAlmostEqual,
+                            assertTensorAlmostEqual)
 
 
 class Test(BaseTest):

--- a/tests/attr/test_gradient_shap.py
+++ b/tests/attr/test_gradient_shap.py
@@ -12,8 +12,7 @@ from captum.attr._utils.typing import Tensor
 
 from .helpers.basic_models import BasicLinearModel, BasicModel2
 from .helpers.classification_models import SoftmaxModel
-from .helpers.utils import (BaseTest, assertArraysAlmostEqual,
-                            assertTensorAlmostEqual)
+from .helpers.utils import BaseTest, assertArraysAlmostEqual, assertTensorAlmostEqual
 
 
 class Test(BaseTest):

--- a/tests/attr/test_guided_backprop.py
+++ b/tests/attr/test_guided_backprop.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
 
 import unittest
+from typing import Any, List, Tuple, Union
 
 import torch
+from torch.nn import Module
+
 from captum.attr._core.guided_backprop_deconvnet import GuidedBackprop
-from captum.attr._core.neuron.neuron_guided_backprop_deconvnet import (
-    NeuronGuidedBackprop,
-)
+from captum.attr._core.neuron.neuron_guided_backprop_deconvnet import \
+    NeuronGuidedBackprop
+from captum.attr._utils.typing import TensorOrTupleOfTensorsGeneric
 
 from .helpers.basic_models import BasicModel_ConvNet_One_Conv
-from .helpers.utils import assertTensorAlmostEqual, BaseTest
-from typing import Any, Tuple, Union, List
-from torch.nn import Module
-from captum.attr._utils.typing import TensorOrTupleOfTensorsGeneric
+from .helpers.utils import BaseTest, assertTensorAlmostEqual
 
 
 class Test(BaseTest):

--- a/tests/attr/test_guided_backprop.py
+++ b/tests/attr/test_guided_backprop.py
@@ -7,8 +7,9 @@ import torch
 from torch.nn import Module
 
 from captum.attr._core.guided_backprop_deconvnet import GuidedBackprop
-from captum.attr._core.neuron.neuron_guided_backprop_deconvnet import \
-    NeuronGuidedBackprop
+from captum.attr._core.neuron.neuron_guided_backprop_deconvnet import (
+    NeuronGuidedBackprop,
+)
 from captum.attr._utils.typing import TensorOrTupleOfTensorsGeneric
 
 from .helpers.basic_models import BasicModel_ConvNet_One_Conv

--- a/tests/attr/test_guided_grad_cam.py
+++ b/tests/attr/test_guided_grad_cam.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
 
 import unittest
+from typing import Any
 
 import torch
+from torch.nn import Module
+
 from captum.attr._core.guided_grad_cam import GuidedGradCam
+from captum.attr._utils.typing import TensorOrTupleOfTensorsGeneric
 
 from .helpers.basic_models import BasicModel_ConvNet_One_Conv
-from .helpers.utils import assertTensorAlmostEqual, BaseTest
-
-from torch.nn import Module
-from typing import Any
-from captum.attr._utils.typing import TensorOrTupleOfTensorsGeneric
+from .helpers.utils import BaseTest, assertTensorAlmostEqual
 
 
 class Test(BaseTest):

--- a/tests/attr/test_input_x_gradient.py
+++ b/tests/attr/test_input_x_gradient.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from typing import Any
+
 import torch
 from torch import Tensor
 from torch.nn import Module
@@ -9,7 +10,7 @@ from captum.attr._core.noise_tunnel import NoiseTunnel
 from captum.attr._utils.typing import TensorOrTupleOfTensorsGeneric
 
 from .helpers.classification_models import SoftmaxModel
-from .helpers.utils import assertArraysAlmostEqual, BaseTest
+from .helpers.utils import BaseTest, assertArraysAlmostEqual
 from .test_saliency import _get_basic_config, _get_multiargs_basic_config
 
 

--- a/tests/attr/test_integrated_gradients_basic.py
+++ b/tests/attr/test_integrated_gradients_basic.py
@@ -1,29 +1,24 @@
 #!/usr/bin/env python3
 
-from captum.attr._core.integrated_gradients import IntegratedGradients
-from captum.attr._core.noise_tunnel import NoiseTunnel
-from captum.attr._utils.common import _zeros, _tensorize_baseline
-from captum.attr._utils.typing import (
-    Tensor,
-    TensorOrTupleOfTensorsGeneric,
-    BaselineType,
-)
-
-from .helpers.basic_models import (
-    BasicModel,
-    BasicModel2,
-    BasicModel3,
-    BasicModel4_MultiArgs,
-    BasicModel5_MultiArgs,
-    BasicModel6_MultiTensor,
-    BasicModel_MultiLayer,
-)
-from .helpers.utils import assertArraysAlmostEqual, assertTensorAlmostEqual, BaseTest
-
 import unittest
+from typing import Any, Tuple, Union, cast
+
 import torch
 from torch.nn import Module
-from typing import Any, cast, Tuple, Union
+
+from captum.attr._core.integrated_gradients import IntegratedGradients
+from captum.attr._core.noise_tunnel import NoiseTunnel
+from captum.attr._utils.common import _tensorize_baseline, _zeros
+from captum.attr._utils.typing import (BaselineType, Tensor,
+                                       TensorOrTupleOfTensorsGeneric)
+
+from .helpers.basic_models import (BasicModel, BasicModel2, BasicModel3,
+                                   BasicModel4_MultiArgs,
+                                   BasicModel5_MultiArgs,
+                                   BasicModel6_MultiTensor,
+                                   BasicModel_MultiLayer)
+from .helpers.utils import (BaseTest, assertArraysAlmostEqual,
+                            assertTensorAlmostEqual)
 
 
 class Test(BaseTest):

--- a/tests/attr/test_integrated_gradients_basic.py
+++ b/tests/attr/test_integrated_gradients_basic.py
@@ -9,16 +9,22 @@ from torch.nn import Module
 from captum.attr._core.integrated_gradients import IntegratedGradients
 from captum.attr._core.noise_tunnel import NoiseTunnel
 from captum.attr._utils.common import _tensorize_baseline, _zeros
-from captum.attr._utils.typing import (BaselineType, Tensor,
-                                       TensorOrTupleOfTensorsGeneric)
+from captum.attr._utils.typing import (
+    BaselineType,
+    Tensor,
+    TensorOrTupleOfTensorsGeneric,
+)
 
-from .helpers.basic_models import (BasicModel, BasicModel2, BasicModel3,
-                                   BasicModel4_MultiArgs,
-                                   BasicModel5_MultiArgs,
-                                   BasicModel6_MultiTensor,
-                                   BasicModel_MultiLayer)
-from .helpers.utils import (BaseTest, assertArraysAlmostEqual,
-                            assertTensorAlmostEqual)
+from .helpers.basic_models import (
+    BasicModel,
+    BasicModel2,
+    BasicModel3,
+    BasicModel4_MultiArgs,
+    BasicModel5_MultiArgs,
+    BasicModel6_MultiTensor,
+    BasicModel_MultiLayer,
+)
+from .helpers.utils import BaseTest, assertArraysAlmostEqual, assertTensorAlmostEqual
 
 
 class Test(BaseTest):

--- a/tests/attr/test_integrated_gradients_classification.py
+++ b/tests/attr/test_integrated_gradients_classification.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python3
 
-import torch
 import unittest
 
+import torch
 from torch.nn import Module
 
 from captum.attr._core.integrated_gradients import IntegratedGradients
 from captum.attr._core.noise_tunnel import NoiseTunnel
-from captum.attr._utils.typing import Tensor, BaselineType
+from captum.attr._utils.typing import BaselineType, Tensor
 
-from .helpers.utils import BaseTest
 from .helpers.classification_models import SigmoidModel, SoftmaxModel
-from .helpers.utils import assertTensorAlmostEqual
+from .helpers.utils import BaseTest, assertTensorAlmostEqual
 
 
 class Test(BaseTest):

--- a/tests/attr/test_occlusion.py
+++ b/tests/attr/test_occlusion.py
@@ -1,24 +1,18 @@
 #!/usr/bin/env python3
-from typing import Callable, Union, Tuple, List, Any
 import unittest
+from typing import Any, Callable, List, Tuple, Union
 
 import torch
 from torch import Tensor
 
 from captum.attr._core.occlusion import Occlusion
-from captum.attr._utils.typing import (
-    TensorOrTupleOfTensorsGeneric,
-    TargetType,
-    BaselineType,
-)
+from captum.attr._utils.typing import (BaselineType, TargetType,
+                                       TensorOrTupleOfTensorsGeneric)
 
-from .helpers.basic_models import (
-    BasicModel3,
-    BasicModel_ConvNet_One_Conv,
-    BasicModel_MultiLayer,
-    BasicModel_MultiLayer_MultiInput,
-)
-from .helpers.utils import assertTensorAlmostEqual, BaseTest
+from .helpers.basic_models import (BasicModel3, BasicModel_ConvNet_One_Conv,
+                                   BasicModel_MultiLayer,
+                                   BasicModel_MultiLayer_MultiInput)
+from .helpers.utils import BaseTest, assertTensorAlmostEqual
 
 
 class Test(BaseTest):

--- a/tests/attr/test_occlusion.py
+++ b/tests/attr/test_occlusion.py
@@ -6,12 +6,18 @@ import torch
 from torch import Tensor
 
 from captum.attr._core.occlusion import Occlusion
-from captum.attr._utils.typing import (BaselineType, TargetType,
-                                       TensorOrTupleOfTensorsGeneric)
+from captum.attr._utils.typing import (
+    BaselineType,
+    TargetType,
+    TensorOrTupleOfTensorsGeneric,
+)
 
-from .helpers.basic_models import (BasicModel3, BasicModel_ConvNet_One_Conv,
-                                   BasicModel_MultiLayer,
-                                   BasicModel_MultiLayer_MultiInput)
+from .helpers.basic_models import (
+    BasicModel3,
+    BasicModel_ConvNet_One_Conv,
+    BasicModel_MultiLayer,
+    BasicModel_MultiLayer_MultiInput,
+)
 from .helpers.utils import BaseTest, assertTensorAlmostEqual
 
 

--- a/tests/attr/test_saliency.py
+++ b/tests/attr/test_saliency.py
@@ -4,6 +4,7 @@ from typing import Any, Tuple, cast
 import torch
 from torch import Tensor
 from torch.nn import Module
+
 from captum.attr._core.noise_tunnel import NoiseTunnel
 from captum.attr._core.saliency import Saliency
 from captum.attr._utils.gradient import compute_gradients

--- a/tests/attr/test_shapley.py
+++ b/tests/attr/test_shapley.py
@@ -6,11 +6,12 @@ from typing import Any, Callable, Tuple, Union
 import torch
 
 from captum.attr._core.shapley_value import ShapleyValues, ShapleyValueSampling
-from captum.attr._utils.typing import (BaselineType,
-                                       TensorOrTupleOfTensorsGeneric)
+from captum.attr._utils.typing import BaselineType, TensorOrTupleOfTensorsGeneric
 
-from .helpers.basic_models import (BasicModel_MultiLayer,
-                                   BasicModel_MultiLayer_MultiInput)
+from .helpers.basic_models import (
+    BasicModel_MultiLayer,
+    BasicModel_MultiLayer_MultiInput,
+)
 from .helpers.utils import BaseTest, assertTensorTuplesAlmostEqual
 
 

--- a/tests/attr/test_shapley.py
+++ b/tests/attr/test_shapley.py
@@ -1,19 +1,17 @@
 #!/usr/bin/env python3
 
-from typing import Any, Callable, Tuple, Union
-
 import unittest
+from typing import Any, Callable, Tuple, Union
 
 import torch
 
-from captum.attr._core.shapley_value import ShapleyValueSampling, ShapleyValues
-from captum.attr._utils.typing import TensorOrTupleOfTensorsGeneric, BaselineType
+from captum.attr._core.shapley_value import ShapleyValues, ShapleyValueSampling
+from captum.attr._utils.typing import (BaselineType,
+                                       TensorOrTupleOfTensorsGeneric)
 
-from .helpers.basic_models import (
-    BasicModel_MultiLayer,
-    BasicModel_MultiLayer_MultiInput,
-)
-from .helpers.utils import assertTensorTuplesAlmostEqual, BaseTest
+from .helpers.basic_models import (BasicModel_MultiLayer,
+                                   BasicModel_MultiLayer_MultiInput)
+from .helpers.utils import BaseTest, assertTensorTuplesAlmostEqual
 
 
 class Test(BaseTest):

--- a/tests/attr/test_stat.py
+++ b/tests/attr/test_stat.py
@@ -6,8 +6,7 @@ import torch
 
 from captum.attr import MSE, Max, Mean, Min, StdDev, Sum, Summarizer, Var
 
-from .helpers.utils import (BaseTest, assertArraysAlmostEqual,
-                            assertTensorAlmostEqual)
+from .helpers.utils import BaseTest, assertArraysAlmostEqual, assertTensorAlmostEqual
 
 
 def get_values(n=100, lo=None, hi=None, integers=False):

--- a/tests/attr/test_stat.py
+++ b/tests/attr/test_stat.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
-import numpy as np
-import torch
 import random
 
-from captum.attr import Mean, Var, StdDev, Min, Max, Sum, MSE, Summarizer
-from .helpers.utils import BaseTest, assertTensorAlmostEqual, assertArraysAlmostEqual
+import numpy as np
+import torch
+
+from captum.attr import MSE, Max, Mean, Min, StdDev, Sum, Summarizer, Var
+
+from .helpers.utils import (BaseTest, assertArraysAlmostEqual,
+                            assertTensorAlmostEqual)
 
 
 def get_values(n=100, lo=None, hi=None, integers=False):

--- a/tests/attr/test_summarizer.py
+++ b/tests/attr/test_summarizer.py
@@ -2,6 +2,7 @@
 import torch
 
 from captum.attr import CommonSummarizer
+
 from .helpers.utils import BaseTest
 
 

--- a/tests/attr/test_targets.py
+++ b/tests/attr/test_targets.py
@@ -3,24 +3,26 @@
 import unittest
 
 import torch
-from captum.attr._core.integrated_gradients import IntegratedGradients
-from captum.attr._core.saliency import Saliency
-from captum.attr._core.input_x_gradient import InputXGradient
-from captum.attr._core.deep_lift import DeepLift, DeepLiftShap
-from captum.attr._core.gradient_shap import GradientShap
-from captum.attr._core.noise_tunnel import NoiseTunnel
-from captum.attr._core.feature_ablation import FeatureAblation
-from captum.attr._core.occlusion import Occlusion
-from captum.attr._core.shapley_value import ShapleyValueSampling
 
+from captum.attr._core.deep_lift import DeepLift, DeepLiftShap
+from captum.attr._core.feature_ablation import FeatureAblation
+from captum.attr._core.gradient_shap import GradientShap
+from captum.attr._core.input_x_gradient import InputXGradient
+from captum.attr._core.integrated_gradients import IntegratedGradients
 from captum.attr._core.layer.internal_influence import InternalInfluence
 from captum.attr._core.layer.layer_conductance import LayerConductance
-from captum.attr._core.layer.layer_integrated_gradients import LayerIntegratedGradients
-from captum.attr._core.layer.layer_gradient_x_activation import LayerGradientXActivation
+from captum.attr._core.layer.layer_deep_lift import (LayerDeepLift,
+                                                     LayerDeepLiftShap)
 from captum.attr._core.layer.layer_feature_ablation import LayerFeatureAblation
-from captum.attr._core.layer.layer_deep_lift import LayerDeepLift, LayerDeepLiftShap
-
+from captum.attr._core.layer.layer_gradient_x_activation import \
+    LayerGradientXActivation
+from captum.attr._core.layer.layer_integrated_gradients import \
+    LayerIntegratedGradients
 from captum.attr._core.neuron.neuron_conductance import NeuronConductance
+from captum.attr._core.noise_tunnel import NoiseTunnel
+from captum.attr._core.occlusion import Occlusion
+from captum.attr._core.saliency import Saliency
+from captum.attr._core.shapley_value import ShapleyValueSampling
 
 from .helpers.basic_models import BasicModel_MultiLayer
 from .helpers.utils import BaseTest, assertTensorAlmostEqual

--- a/tests/attr/test_targets.py
+++ b/tests/attr/test_targets.py
@@ -11,13 +11,10 @@ from captum.attr._core.input_x_gradient import InputXGradient
 from captum.attr._core.integrated_gradients import IntegratedGradients
 from captum.attr._core.layer.internal_influence import InternalInfluence
 from captum.attr._core.layer.layer_conductance import LayerConductance
-from captum.attr._core.layer.layer_deep_lift import (LayerDeepLift,
-                                                     LayerDeepLiftShap)
+from captum.attr._core.layer.layer_deep_lift import LayerDeepLift, LayerDeepLiftShap
 from captum.attr._core.layer.layer_feature_ablation import LayerFeatureAblation
-from captum.attr._core.layer.layer_gradient_x_activation import \
-    LayerGradientXActivation
-from captum.attr._core.layer.layer_integrated_gradients import \
-    LayerIntegratedGradients
+from captum.attr._core.layer.layer_gradient_x_activation import LayerGradientXActivation
+from captum.attr._core.layer.layer_integrated_gradients import LayerIntegratedGradients
 from captum.attr._core.neuron.neuron_conductance import NeuronConductance
 from captum.attr._core.noise_tunnel import NoiseTunnel
 from captum.attr._core.occlusion import Occlusion

--- a/tests/attr/test_utils_batching.py
+++ b/tests/attr/test_utils_batching.py
@@ -2,13 +2,9 @@
 
 import torch
 
-from captum.attr._utils.batching import (
-    _tuple_splice_range,
-    _reduce_list,
-    _sort_key_list,
-    _batched_operator,
-    _batched_generator,
-)
+from captum.attr._utils.batching import (_batched_generator, _batched_operator,
+                                         _reduce_list, _sort_key_list,
+                                         _tuple_splice_range)
 
 from .helpers.utils import BaseTest, assertTensorAlmostEqual
 

--- a/tests/attr/test_utils_batching.py
+++ b/tests/attr/test_utils_batching.py
@@ -2,9 +2,13 @@
 
 import torch
 
-from captum.attr._utils.batching import (_batched_generator, _batched_operator,
-                                         _reduce_list, _sort_key_list,
-                                         _tuple_splice_range)
+from captum.attr._utils.batching import (
+    _batched_generator,
+    _batched_operator,
+    _reduce_list,
+    _sort_key_list,
+    _tuple_splice_range,
+)
 
 from .helpers.utils import BaseTest, assertTensorAlmostEqual
 

--- a/tests/insights/test_contribution.py
+++ b/tests/insights/test_contribution.py
@@ -5,6 +5,7 @@ from typing import Callable, List, Union
 
 import torch
 import torch.nn as nn
+
 from captum.insights import AttributionVisualizer, Batch, FilterConfig
 from captum.insights.features import BaseFeature, FeatureOutput, ImageFeature
 from tests.attr.helpers.utils import BaseTest


### PR DESCRIPTION
This applies isort to alphabetize import ordering. We also add an isort check to CircleCI to ensure that import ordering is maintained in future PRs. This required adding an isort config that is compatible with black, which was found here: https://github.com/psf/black

This also adds a type: ignore for an issue caused by merging Insights type fixes with type hints for common.
