### PR TITLE
Use relative paths for Insights

### DIFF
--- a/captum/insights/api.py
+++ b/captum/insights/api.py
@@ -256,14 +256,14 @@ class AttributionVisualizer(object):
     def serve(self, blocking=False, debug=False, port=None):
         context = _get_context()
         if context == _CONTEXT_COLAB:
-            self._serve_colab(blocking=blocking, debug=debug, port=port)
+            return self._serve_colab(blocking=blocking, debug=debug, port=port)
         else:
-            self._serve(blocking=blocking, debug=debug, port=port)
+            return self._serve(blocking=blocking, debug=debug, port=port)
 
     def _serve(self, blocking=False, debug=False, port=None):
         from captum.insights.server import start_server
 
-        start_server(self, blocking=blocking, debug=debug, _port=port)
+        return start_server(self, blocking=blocking, debug=debug, _port=port)
 
     def _serve_colab(self, blocking=False, debug=False, port=None):
         from IPython.display import display, HTML

--- a/captum/insights/frontend/package.json
+++ b/captum/insights/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "frontend",
   "version": "0.2.0",
   "private": true,
+  "homepage": ".",
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.5.5",
     "babel-loader": "^8.0.6",

--- a/captum/insights/frontend/src/WebApp.js
+++ b/captum/insights/frontend/src/WebApp.js
@@ -17,14 +17,14 @@ class WebApp extends React.Component {
   }
 
   _fetchInit = () => {
-    fetch("/init")
+    fetch("init")
       .then(r => r.json())
       .then(r => this.setState({ config: r }));
   };
 
   fetchData = filter_config => {
     this.setState({ loading: true });
-    fetch("/fetch", {
+    fetch("fetch", {
       method: "POST",
       headers: {
         "Content-Type": "application/json"
@@ -36,7 +36,7 @@ class WebApp extends React.Component {
   };
 
   onTargetClick = (labelIndex, instance, callback) => {
-    fetch("/attribute", {
+    fetch("attribute", {
       method: "POST",
       headers: {
         "Content-Type": "application/json"

--- a/captum/insights/server.py
+++ b/captum/insights/server.py
@@ -91,7 +91,6 @@ def start_server(
             app.logger.disabled = True
 
         port = _port or get_free_tcp_port()
-        print(f"\nFetch data and view Captum Insights at http://localhost:{port}/\n")
         # Start in a new thread to not block notebook execution
         t = threading.Thread(target=run_app, kwargs={"debug": debug})
         t.start()
@@ -99,4 +98,5 @@ def start_server(
         if blocking:
             t.join()
 
+    print(f"\nFetch data and view Captum Insights at http://localhost:{port}/\n")
     return port


### PR DESCRIPTION
This change allows Insights to work with [Jupyter server proxy](https://github.com/jupyterhub/jupyter-server-proxy).

However, Sagemaker is broken due to https://forums.aws.amazon.com/message.jspa?messageID=914445#914445.

