### PR TITLE
Adding matplotlib to Conda dependencies

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -17,6 +17,7 @@ requirements:
   run:
     - numpy
     - pytorch>=1.2
+    - matplotlib
 
 test:
   imports:


### PR DESCRIPTION
Noticed that matplotlib was included in setup.py and required for pip, but not for conda. Adding matplotlib so both are consistent.