### PR TITLE
Select targets gpu fix

### DIFF
--- a/captum/attr/_utils/common.py
+++ b/captum/attr/_utils/common.py
@@ -450,6 +450,7 @@ def _select_targets(output: Tensor, target: TargetType) -> Tensor:
 
     num_examples = output.shape[0]
     dims = len(output.shape)
+    device = output.device
     if isinstance(target, (int, tuple)):
         return _verify_select_column(output, target)
     elif isinstance(target, torch.Tensor):
@@ -467,7 +468,7 @@ def _select_targets(output: Tensor, target: TargetType) -> Tensor:
         assert len(target) == num_examples, "Target list length does not match output!"
         if isinstance(target[0], int):
             assert dims == 2, "Output must be 2D to select tensor of targets."
-            return torch.gather(output, 1, torch.tensor(target).reshape(len(output), 1))
+            return torch.gather(output, 1, torch.tensor(target, device=device).reshape(len(output), 1))
         elif isinstance(target[0], tuple):
             return torch.stack(
                 [

--- a/captum/attr/_utils/common.py
+++ b/captum/attr/_utils/common.py
@@ -468,7 +468,9 @@ def _select_targets(output: Tensor, target: TargetType) -> Tensor:
         assert len(target) == num_examples, "Target list length does not match output!"
         if isinstance(target[0], int):
             assert dims == 2, "Output must be 2D to select tensor of targets."
-            return torch.gather(output, 1, torch.tensor(target, device=device).reshape(len(output), 1))
+            return torch.gather(
+                output, 1, torch.tensor(target, device=device).reshape(len(output), 1)
+            )
         elif isinstance(target[0], tuple):
             return torch.stack(
                 [

--- a/tests/attr/test_targets.py
+++ b/tests/attr/test_targets.py
@@ -43,7 +43,8 @@ class Test(BaseTest):
     def test_simple_target_ig(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             IntegratedGradients,
             net,
             inputs=inp,
@@ -54,7 +55,8 @@ class Test(BaseTest):
     def test_simple_target_ig_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             IntegratedGradients,
             net,
             inputs=inp,
@@ -65,7 +67,8 @@ class Test(BaseTest):
     def test_simple_target_ig_single_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             IntegratedGradients,
             net,
             inputs=inp,
@@ -77,7 +80,8 @@ class Test(BaseTest):
     def test_multi_target_ig(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             IntegratedGradients,
             net,
             inputs=inp,
@@ -89,19 +93,20 @@ class Test(BaseTest):
     def test_simple_target_saliency(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(Saliency, net, inputs=inp, targets=[0, 1, 1, 0])
+        _target_batch_test_assert(self, Saliency, net, inputs=inp, targets=[0, 1, 1, 0])
 
     def test_simple_target_saliency_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
-            Saliency, net, inputs=inp, targets=torch.tensor([0, 1, 1, 0])
+        _target_batch_test_assert(
+            self, Saliency, net, inputs=inp, targets=torch.tensor([0, 1, 1, 0])
         )
 
     def test_multi_target_saliency(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             Saliency,
             net,
             inputs=inp,
@@ -112,21 +117,22 @@ class Test(BaseTest):
     def test_simple_target_ablation(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
-            FeatureAblation, net, inputs=inp, targets=[0, 1, 1, 0]
+        _target_batch_test_assert(
+            self, FeatureAblation, net, inputs=inp, targets=[0, 1, 1, 0]
         )
 
     def test_simple_target_ablation_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
-            FeatureAblation, net, inputs=inp, targets=torch.tensor([0, 1, 1, 0])
+        _target_batch_test_assert(
+            self, FeatureAblation, net, inputs=inp, targets=torch.tensor([0, 1, 1, 0])
         )
 
     def test_multi_target_ablation(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             FeatureAblation,
             net,
             inputs=inp,
@@ -137,7 +143,8 @@ class Test(BaseTest):
     def test_multi_target_occlusion(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             Occlusion,
             net,
             inputs=inp,
@@ -149,7 +156,8 @@ class Test(BaseTest):
     def test_simple_target_shapley_value_sampling(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             ShapleyValueSampling,
             net,
             inputs=inp,
@@ -161,7 +169,8 @@ class Test(BaseTest):
     def test_simple_target_shapley_value_sampling_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             ShapleyValueSampling,
             net,
             inputs=inp,
@@ -173,7 +182,8 @@ class Test(BaseTest):
     def test_multi_target_shapley_value_sampling(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             ShapleyValueSampling,
             net,
             inputs=inp,
@@ -186,12 +196,13 @@ class Test(BaseTest):
     def test_simple_target_deep_lift(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(DeepLift, net, inputs=inp, targets=[0, 1, 1, 0])
+        _target_batch_test_assert(self, DeepLift, net, inputs=inp, targets=[0, 1, 1, 0])
 
     def test_multi_target_deep_lift(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             DeepLift,
             net,
             inputs=inp,
@@ -202,14 +213,20 @@ class Test(BaseTest):
     def test_simple_target_deep_lift_shap(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
-            DeepLiftShap, net, inputs=inp, baselines=0.5 * inp, targets=[0, 1, 1, 0]
+        _target_batch_test_assert(
+            self,
+            DeepLiftShap,
+            net,
+            inputs=inp,
+            baselines=0.5 * inp,
+            targets=[0, 1, 1, 0],
         )
 
     def test_simple_target_deep_lift_shap_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             DeepLiftShap,
             net,
             inputs=inp,
@@ -220,7 +237,8 @@ class Test(BaseTest):
     def test_simple_target_deep_lift_shap_single_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             DeepLiftShap,
             net,
             inputs=inp,
@@ -232,7 +250,8 @@ class Test(BaseTest):
     def test_multi_target_deep_lift_shap(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             DeepLiftShap,
             net,
             inputs=inp,
@@ -244,7 +263,8 @@ class Test(BaseTest):
     def test_simple_target_gradient_shap(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             GradientShap,
             net,
             inputs=inp,
@@ -258,7 +278,8 @@ class Test(BaseTest):
     def test_simple_target_gradient_shap_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             GradientShap,
             net,
             inputs=inp,
@@ -272,7 +293,8 @@ class Test(BaseTest):
     def test_simple_target_gradient_shap_single_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             GradientShap,
             net,
             inputs=inp,
@@ -287,7 +309,8 @@ class Test(BaseTest):
     def test_multi_target_gradient_shap(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             GradientShap,
             net,
             inputs=inp,
@@ -302,7 +325,8 @@ class Test(BaseTest):
     def test_simple_target_nt(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             NoiseTunnel,
             IntegratedGradients(net),
             inputs=inp,
@@ -314,7 +338,8 @@ class Test(BaseTest):
     def test_simple_target_nt_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             NoiseTunnel,
             IntegratedGradients(net),
             inputs=inp,
@@ -326,7 +351,8 @@ class Test(BaseTest):
     def test_simple_target_nt_single_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             NoiseTunnel,
             IntegratedGradients(net),
             inputs=inp,
@@ -339,7 +365,8 @@ class Test(BaseTest):
     def test_multi_target_nt(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             NoiseTunnel,
             IntegratedGradients(net),
             inputs=inp,
@@ -352,14 +379,15 @@ class Test(BaseTest):
     def test_simple_target_input_x_gradient(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
-            InputXGradient, net, inputs=inp, targets=[0, 1, 1, 0]
+        _target_batch_test_assert(
+            self, InputXGradient, net, inputs=inp, targets=[0, 1, 1, 0]
         )
 
     def test_multi_target_input_x_gradient(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             InputXGradient,
             net,
             inputs=inp,
@@ -370,7 +398,8 @@ class Test(BaseTest):
     def test_simple_target_int_inf(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             InternalInfluence,
             net,
             inputs=inp,
@@ -382,7 +411,8 @@ class Test(BaseTest):
     def test_multi_target_int_inf(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             InternalInfluence,
             net,
             inputs=inp,
@@ -395,7 +425,8 @@ class Test(BaseTest):
     def test_simple_target_layer_cond(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             LayerConductance,
             net,
             inputs=inp,
@@ -407,7 +438,8 @@ class Test(BaseTest):
     def test_simple_target_layer_cond_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             LayerConductance,
             net,
             inputs=inp,
@@ -419,7 +451,8 @@ class Test(BaseTest):
     def test_multi_target_layer_cond(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             LayerConductance,
             net,
             inputs=inp,
@@ -432,15 +465,21 @@ class Test(BaseTest):
     def test_simple_target_layer_deeplift(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
-            LayerDeepLift, net, inputs=inp, target_layer=net.relu, targets=[0, 1, 1, 0],
+        _target_batch_test_assert(
+            self,
+            LayerDeepLift,
+            net,
+            inputs=inp,
+            target_layer=net.relu,
+            targets=[0, 1, 1, 0],
         )
 
     def test_simple_target_layer_deeplift_shap(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         baseline = torch.randn(6, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             LayerDeepLiftShap,
             net,
             inputs=inp,
@@ -452,7 +491,8 @@ class Test(BaseTest):
     def test_simple_target_layer_ig(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             LayerIntegratedGradients,
             net,
             inputs=inp,
@@ -463,7 +503,8 @@ class Test(BaseTest):
     def test_multi_target_layer_ig(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             LayerIntegratedGradients,
             net,
             inputs=inp,
@@ -475,7 +516,8 @@ class Test(BaseTest):
     def test_simple_target_layer_gradient_x_act(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             LayerGradientXActivation,
             net,
             inputs=inp,
@@ -486,7 +528,8 @@ class Test(BaseTest):
     def test_multi_target_layer_gradient_x_act(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             LayerGradientXActivation,
             net,
             inputs=inp,
@@ -498,7 +541,8 @@ class Test(BaseTest):
     def test_simple_target_layer_ablation_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             LayerFeatureAblation,
             net,
             inputs=inp,
@@ -509,7 +553,8 @@ class Test(BaseTest):
     def test_simple_target_neuron_conductance(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             NeuronConductance,
             net,
             inputs=inp,
@@ -522,7 +567,8 @@ class Test(BaseTest):
     def test_simple_target_neuron_conductance_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             NeuronConductance,
             net,
             inputs=inp,
@@ -535,7 +581,8 @@ class Test(BaseTest):
     def test_multi_target_neuron_conductance(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
+            self,
             NeuronConductance,
             net,
             inputs=inp,
@@ -546,136 +593,75 @@ class Test(BaseTest):
             test_batches=True,
         )
 
-    def _target_batch_test_assert(
-        self,
-        algorithm,
-        model,
-        inputs,
-        targets,
-        target_layer=None,
-        test_batches=False,
-        splice_targets=True,
-        delta=0.0001,
-        comp_mode="sum",
-        **kwargs
-    ):
-        if target_layer:
-            attr_method = algorithm(model, target_layer)
-        else:
-            attr_method = algorithm(model)
-
-        batch_sizes = [None]
-        if test_batches:
-            batch_sizes = [None, 2, 4]
-        for batch_size in batch_sizes:
-            if batch_size:
-                attributions_orig = attr_method.attribute(
-                    inputs=inputs,
-                    target=targets,
-                    internal_batch_size=batch_size,
-                    **kwargs
-                )
-            else:
-                attributions_orig = attr_method.attribute(
-                    inputs=inputs, target=targets, **kwargs
-                )
-            for i in range(len(inputs)):
-                single_attr = attr_method.attribute(
-                    inputs=inputs[i : i + 1],
-                    target=targets[i] if splice_targets else targets,
-                    **kwargs
-                )
-                single_attr_target_list = attr_method.attribute(
-                    inputs=inputs[i : i + 1],
-                    target=targets[i : i + 1] if splice_targets else targets,
-                    **kwargs
-                )
-                assertTensorAlmostEqual(
-                    self,
-                    attributions_orig[i : i + 1],
-                    single_attr,
-                    delta=delta,
-                    mode=comp_mode,
-                )
-                assertTensorAlmostEqual(
-                    self,
-                    attributions_orig[i : i + 1],
-                    single_attr_target_list,
-                    delta=delta,
-                    mode=comp_mode,
-                )
-
 
 class GPUTest(BaseGPUTest):
     def test_simple_target_saliency_gpu(self):
         net = BasicModel_MultiLayer().cuda()
         inp = torch.randn(4, 3).cuda()
-        self._target_batch_test_assert(Saliency, net, inputs=inp, targets=[0, 1, 1, 0])
+        _target_batch_test_assert(self, Saliency, net, inputs=inp, targets=[0, 1, 1, 0])
 
     def test_simple_target_saliency_tensor_gpu(self):
         net = BasicModel_MultiLayer().cuda()
         inp = torch.randn(4, 3).cuda()
         target = torch.tensor([0, 1, 1, 0]).cuda()
-        self._target_batch_test_assert(Saliency, net, inputs=inp, targets=target)
+        _target_batch_test_assert(self, Saliency, net, inputs=inp, targets=target)
 
-    def _target_batch_test_assert(
-        self,
-        algorithm,
-        model,
-        inputs,
-        targets,
-        target_layer=None,
-        test_batches=False,
-        splice_targets=True,
-        delta=0.0001,
-        comp_mode="sum",
-        **kwargs
-    ):
-        if target_layer:
-            attr_method = algorithm(model, target_layer)
+
+def _target_batch_test_assert(
+    test,
+    algorithm,
+    model,
+    inputs,
+    targets,
+    target_layer=None,
+    test_batches=False,
+    splice_targets=True,
+    delta=0.0001,
+    comp_mode="sum",
+    **kwargs
+):
+    if target_layer:
+        attr_method = algorithm(model, target_layer)
+    else:
+        attr_method = algorithm(model)
+
+    batch_sizes = [None]
+    if test_batches:
+        batch_sizes = [None, 2, 4]
+    for batch_size in batch_sizes:
+        if batch_size:
+            attributions_orig = attr_method.attribute(
+                inputs=inputs, target=targets, internal_batch_size=batch_size, **kwargs
+            )
         else:
-            attr_method = algorithm(model)
-
-        batch_sizes = [None]
-        if test_batches:
-            batch_sizes = [None, 2, 4]
-        for batch_size in batch_sizes:
-            if batch_size:
-                attributions_orig = attr_method.attribute(
-                    inputs=inputs,
-                    target=targets,
-                    internal_batch_size=batch_size,
-                    **kwargs
-                )
-            else:
-                attributions_orig = attr_method.attribute(
-                    inputs=inputs, target=targets, **kwargs
-                )
-            for i in range(len(inputs)):
-                single_attr = attr_method.attribute(
-                    inputs=inputs[i : i + 1],
-                    target=targets[i] if splice_targets else targets,
-                    **kwargs
-                )
-                single_attr_target_list = attr_method.attribute(
-                    inputs=inputs[i : i + 1],
-                    target=targets[i : i + 1] if splice_targets else targets,
-                    **kwargs
-                )
-                assertTensorAlmostEqual(
-                    self,
-                    attributions_orig[i : i + 1],
-                    single_attr,
-                    delta=delta,
-                    mode=comp_mode,
-                )
-                assertTensorAlmostEqual(
-                    self,
-                    attributions_orig[i : i + 1],
-                    single_attr_target_list,
-                    delta=delta,
-                    mode=comp_mode,
-                )
+            attributions_orig = attr_method.attribute(
+                inputs=inputs, target=targets, **kwargs
+            )
+        for i in range(len(inputs)):
+            single_attr = attr_method.attribute(
+                inputs=inputs[i : i + 1],
+                target=targets[i] if splice_targets else targets,
+                **kwargs
+            )
+            single_attr_target_list = attr_method.attribute(
+                inputs=inputs[i : i + 1],
+                target=targets[i : i + 1] if splice_targets else targets,
+                **kwargs
+            )
+            assertTensorAlmostEqual(
+                test,
+                attributions_orig[i : i + 1],
+                single_attr,
+                delta=delta,
+                mode=comp_mode,
+            )
+            assertTensorAlmostEqual(
+                test,
+                attributions_orig[i : i + 1],
+                single_attr_target_list,
+                delta=delta,
+                mode=comp_mode,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/attr/test_targets.py
+++ b/tests/attr/test_targets.py
@@ -22,7 +22,7 @@ from captum.attr._core.saliency import Saliency
 from captum.attr._core.shapley_value import ShapleyValueSampling
 
 from .helpers.basic_models import BasicModel_MultiLayer
-from .helpers.utils import BaseTest, assertTensorAlmostEqual
+from .helpers.utils import BaseTest, assertTensorAlmostEqual, BaseGPUTest
 
 
 class Test(BaseTest):
@@ -43,7 +43,7 @@ class Test(BaseTest):
     def test_simple_target_ig(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             IntegratedGradients,
             net,
             inputs=inp,
@@ -54,7 +54,7 @@ class Test(BaseTest):
     def test_simple_target_ig_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             IntegratedGradients,
             net,
             inputs=inp,
@@ -65,7 +65,7 @@ class Test(BaseTest):
     def test_simple_target_ig_single_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             IntegratedGradients,
             net,
             inputs=inp,
@@ -77,7 +77,7 @@ class Test(BaseTest):
     def test_multi_target_ig(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             IntegratedGradients,
             net,
             inputs=inp,
@@ -89,19 +89,19 @@ class Test(BaseTest):
     def test_simple_target_saliency(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(Saliency, net, inputs=inp, targets=[0, 1, 1, 0])
+        self._target_batch_test_assert(Saliency, net, inputs=inp, targets=[0, 1, 1, 0])
 
     def test_simple_target_saliency_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             Saliency, net, inputs=inp, targets=torch.tensor([0, 1, 1, 0])
         )
 
     def test_multi_target_saliency(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             Saliency,
             net,
             inputs=inp,
@@ -112,21 +112,21 @@ class Test(BaseTest):
     def test_simple_target_ablation(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             FeatureAblation, net, inputs=inp, targets=[0, 1, 1, 0]
         )
 
     def test_simple_target_ablation_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             FeatureAblation, net, inputs=inp, targets=torch.tensor([0, 1, 1, 0])
         )
 
     def test_multi_target_ablation(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             FeatureAblation,
             net,
             inputs=inp,
@@ -137,7 +137,7 @@ class Test(BaseTest):
     def test_multi_target_occlusion(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             Occlusion,
             net,
             inputs=inp,
@@ -149,7 +149,7 @@ class Test(BaseTest):
     def test_simple_target_shapley_value_sampling(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             ShapleyValueSampling,
             net,
             inputs=inp,
@@ -161,7 +161,7 @@ class Test(BaseTest):
     def test_simple_target_shapley_value_sampling_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             ShapleyValueSampling,
             net,
             inputs=inp,
@@ -173,7 +173,7 @@ class Test(BaseTest):
     def test_multi_target_shapley_value_sampling(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             ShapleyValueSampling,
             net,
             inputs=inp,
@@ -186,12 +186,12 @@ class Test(BaseTest):
     def test_simple_target_deep_lift(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(DeepLift, net, inputs=inp, targets=[0, 1, 1, 0])
+        self._target_batch_test_assert(DeepLift, net, inputs=inp, targets=[0, 1, 1, 0])
 
     def test_multi_target_deep_lift(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             DeepLift,
             net,
             inputs=inp,
@@ -202,14 +202,14 @@ class Test(BaseTest):
     def test_simple_target_deep_lift_shap(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             DeepLiftShap, net, inputs=inp, baselines=0.5 * inp, targets=[0, 1, 1, 0]
         )
 
     def test_simple_target_deep_lift_shap_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             DeepLiftShap,
             net,
             inputs=inp,
@@ -220,7 +220,7 @@ class Test(BaseTest):
     def test_simple_target_deep_lift_shap_single_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             DeepLiftShap,
             net,
             inputs=inp,
@@ -232,7 +232,7 @@ class Test(BaseTest):
     def test_multi_target_deep_lift_shap(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             DeepLiftShap,
             net,
             inputs=inp,
@@ -244,7 +244,7 @@ class Test(BaseTest):
     def test_simple_target_gradient_shap(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             GradientShap,
             net,
             inputs=inp,
@@ -258,7 +258,7 @@ class Test(BaseTest):
     def test_simple_target_gradient_shap_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             GradientShap,
             net,
             inputs=inp,
@@ -272,7 +272,7 @@ class Test(BaseTest):
     def test_simple_target_gradient_shap_single_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             GradientShap,
             net,
             inputs=inp,
@@ -287,7 +287,7 @@ class Test(BaseTest):
     def test_multi_target_gradient_shap(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             GradientShap,
             net,
             inputs=inp,
@@ -302,7 +302,7 @@ class Test(BaseTest):
     def test_simple_target_nt(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             NoiseTunnel,
             IntegratedGradients(net),
             inputs=inp,
@@ -314,7 +314,7 @@ class Test(BaseTest):
     def test_simple_target_nt_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             NoiseTunnel,
             IntegratedGradients(net),
             inputs=inp,
@@ -326,7 +326,7 @@ class Test(BaseTest):
     def test_simple_target_nt_single_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             NoiseTunnel,
             IntegratedGradients(net),
             inputs=inp,
@@ -339,7 +339,7 @@ class Test(BaseTest):
     def test_multi_target_nt(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             NoiseTunnel,
             IntegratedGradients(net),
             inputs=inp,
@@ -352,12 +352,12 @@ class Test(BaseTest):
     def test_simple_target_input_x_gradient(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(InputXGradient, net, inputs=inp, targets=[0, 1, 1, 0])
+        self._target_batch_test_assert(InputXGradient, net, inputs=inp, targets=[0, 1, 1, 0])
 
     def test_multi_target_input_x_gradient(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             InputXGradient,
             net,
             inputs=inp,
@@ -368,7 +368,7 @@ class Test(BaseTest):
     def test_simple_target_int_inf(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             InternalInfluence,
             net,
             inputs=inp,
@@ -380,7 +380,7 @@ class Test(BaseTest):
     def test_multi_target_int_inf(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             InternalInfluence,
             net,
             inputs=inp,
@@ -393,7 +393,7 @@ class Test(BaseTest):
     def test_simple_target_layer_cond(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             LayerConductance,
             net,
             inputs=inp,
@@ -405,7 +405,7 @@ class Test(BaseTest):
     def test_simple_target_layer_cond_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             LayerConductance,
             net,
             inputs=inp,
@@ -417,7 +417,7 @@ class Test(BaseTest):
     def test_multi_target_layer_cond(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             LayerConductance,
             net,
             inputs=inp,
@@ -430,7 +430,7 @@ class Test(BaseTest):
     def test_simple_target_layer_deeplift(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             LayerDeepLift, net, inputs=inp, target_layer=net.relu, targets=[0, 1, 1, 0],
         )
 
@@ -438,7 +438,7 @@ class Test(BaseTest):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         baseline = torch.randn(6, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             LayerDeepLiftShap,
             net,
             inputs=inp,
@@ -450,7 +450,7 @@ class Test(BaseTest):
     def test_simple_target_layer_ig(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             LayerIntegratedGradients,
             net,
             inputs=inp,
@@ -461,7 +461,7 @@ class Test(BaseTest):
     def test_multi_target_layer_ig(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             LayerIntegratedGradients,
             net,
             inputs=inp,
@@ -473,7 +473,7 @@ class Test(BaseTest):
     def test_simple_target_layer_gradient_x_act(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             LayerGradientXActivation,
             net,
             inputs=inp,
@@ -484,7 +484,7 @@ class Test(BaseTest):
     def test_multi_target_layer_gradient_x_act(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             LayerGradientXActivation,
             net,
             inputs=inp,
@@ -496,7 +496,7 @@ class Test(BaseTest):
     def test_simple_target_layer_ablation_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             LayerFeatureAblation,
             net,
             inputs=inp,
@@ -507,7 +507,7 @@ class Test(BaseTest):
     def test_simple_target_neuron_conductance(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             NeuronConductance,
             net,
             inputs=inp,
@@ -520,7 +520,7 @@ class Test(BaseTest):
     def test_simple_target_neuron_conductance_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             NeuronConductance,
             net,
             inputs=inp,
@@ -533,7 +533,7 @@ class Test(BaseTest):
     def test_multi_target_neuron_conductance(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        _target_batch_test_assert(
+        self._target_batch_test_assert(
             NeuronConductance,
             net,
             inputs=inp,
@@ -544,74 +544,130 @@ class Test(BaseTest):
             test_batches=True,
         )
 
+    def _target_batch_test_assert(
+        self,
+        algorithm,
+        model,
+        inputs,
+        targets,
+        target_layer=None,
+        test_batches=False,
+        splice_targets=True,
+        delta=0.0001,
+        comp_mode="sum",
+        **kwargs
+    ):
+        if target_layer:
+            attr_method = algorithm(model, target_layer)
+        else:
+            attr_method = algorithm(model)
+
+        batch_sizes = [None]
+        if test_batches:
+            batch_sizes = [None, 2, 4]
+        for batch_size in batch_sizes:
+            if batch_size:
+                attributions_orig = attr_method.attribute(
+                    inputs=inputs, target=targets, internal_batch_size=batch_size, **kwargs
+                )
+            else:
+                attributions_orig = attr_method.attribute(
+                    inputs=inputs, target=targets, **kwargs
+                )
+            for i in range(len(inputs)):
+                single_attr = attr_method.attribute(
+                    inputs=inputs[i : i + 1],
+                    target=targets[i] if splice_targets else targets,
+                    **kwargs
+                )
+                single_attr_target_list = attr_method.attribute(
+                    inputs=inputs[i : i + 1],
+                    target=targets[i : i + 1] if splice_targets else targets,
+                    **kwargs
+                )
+                assertTensorAlmostEqual(
+                    self,
+                    attributions_orig[i : i + 1],
+                    single_attr,
+                    delta=delta,
+                    mode=comp_mode,
+                )
+                assertTensorAlmostEqual(
+                    self,
+                    attributions_orig[i : i + 1],
+                    single_attr_target_list,
+                    delta=delta,
+                    mode=comp_mode,
+                )
 
 class GPUTest(BaseGPUTest):
     def test_simple_target_saliency_gpu(self):
         net = BasicModel_MultiLayer().cuda()
         inp = torch.randn(4, 3).cuda()
-        _target_batch_test_assert(Saliency, net, inputs=inp, targets=[0, 1, 1, 0])
+        self._target_batch_test_assert(Saliency, net, inputs=inp, targets=[0, 1, 1, 0])
 
     def test_simple_target_saliency_tensor_gpu(self):
         net = BasicModel_MultiLayer().cuda()
         inp = torch.randn(4, 3).cuda()
         target = torch.tensor([0, 1, 1, 0]).cuda()
-        _target_batch_test_assert(Saliency, net, inputs=inp, targets=target)
+        self._target_batch_test_assert(Saliency, net, inputs=inp, targets=target)
 
 
-def _target_batch_test_assert(
-    algorithm,
-    model,
-    inputs,
-    targets,
-    target_layer=None,
-    test_batches=False,
-    splice_targets=True,
-    delta=0.0001,
-    comp_mode="sum",
-    **kwargs
-):
-    if target_layer:
-        attr_method = algorithm(model, target_layer)
-    else:
-        attr_method = algorithm(model)
-
-    batch_sizes = [None]
-    if test_batches:
-        batch_sizes = [None, 2, 4]
-    for batch_size in batch_sizes:
-        if batch_size:
-            attributions_orig = attr_method.attribute(
-                inputs=inputs, target=targets, internal_batch_size=batch_size, **kwargs
-            )
+    def _target_batch_test_assert(
+        self,
+        algorithm,
+        model,
+        inputs,
+        targets,
+        target_layer=None,
+        test_batches=False,
+        splice_targets=True,
+        delta=0.0001,
+        comp_mode="sum",
+        **kwargs
+    ):
+        if target_layer:
+            attr_method = algorithm(model, target_layer)
         else:
-            attributions_orig = attr_method.attribute(
-                inputs=inputs, target=targets, **kwargs
-            )
-        for i in range(len(inputs)):
-            single_attr = attr_method.attribute(
-                inputs=inputs[i : i + 1],
-                target=targets[i] if splice_targets else targets,
-                **kwargs
-            )
-            single_attr_target_list = attr_method.attribute(
-                inputs=inputs[i : i + 1],
-                target=targets[i : i + 1] if splice_targets else targets,
-                **kwargs
-            )
-            assertTensorAlmostEqual(
-                self,
-                attributions_orig[i : i + 1],
-                single_attr,
-                delta=delta,
-                mode=comp_mode,
-            )
-            assertTensorAlmostEqual(
-                self,
-                attributions_orig[i : i + 1],
-                single_attr_target_list,
-                delta=delta,
-                mode=comp_mode,
-            )
+            attr_method = algorithm(model)
+
+        batch_sizes = [None]
+        if test_batches:
+            batch_sizes = [None, 2, 4]
+        for batch_size in batch_sizes:
+            if batch_size:
+                attributions_orig = attr_method.attribute(
+                    inputs=inputs, target=targets, internal_batch_size=batch_size, **kwargs
+                )
+            else:
+                attributions_orig = attr_method.attribute(
+                    inputs=inputs, target=targets, **kwargs
+                )
+            for i in range(len(inputs)):
+                single_attr = attr_method.attribute(
+                    inputs=inputs[i : i + 1],
+                    target=targets[i] if splice_targets else targets,
+                    **kwargs
+                )
+                single_attr_target_list = attr_method.attribute(
+                    inputs=inputs[i : i + 1],
+                    target=targets[i : i + 1] if splice_targets else targets,
+                    **kwargs
+                )
+                assertTensorAlmostEqual(
+                    self,
+                    attributions_orig[i : i + 1],
+                    single_attr,
+                    delta=delta,
+                    mode=comp_mode,
+                )
+                assertTensorAlmostEqual(
+                    self,
+                    attributions_orig[i : i + 1],
+                    single_attr_target_list,
+                    delta=delta,
+                    mode=comp_mode,
+                )
 
 
 if __name__ == "__main__":

--- a/tests/attr/test_targets.py
+++ b/tests/attr/test_targets.py
@@ -43,7 +43,7 @@ class Test(BaseTest):
     def test_simple_target_ig(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             IntegratedGradients,
             net,
             inputs=inp,
@@ -54,7 +54,7 @@ class Test(BaseTest):
     def test_simple_target_ig_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             IntegratedGradients,
             net,
             inputs=inp,
@@ -65,7 +65,7 @@ class Test(BaseTest):
     def test_simple_target_ig_single_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             IntegratedGradients,
             net,
             inputs=inp,
@@ -77,7 +77,7 @@ class Test(BaseTest):
     def test_multi_target_ig(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             IntegratedGradients,
             net,
             inputs=inp,
@@ -89,19 +89,19 @@ class Test(BaseTest):
     def test_simple_target_saliency(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(Saliency, net, inputs=inp, targets=[0, 1, 1, 0])
+        _target_batch_test_assert(Saliency, net, inputs=inp, targets=[0, 1, 1, 0])
 
     def test_simple_target_saliency_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             Saliency, net, inputs=inp, targets=torch.tensor([0, 1, 1, 0])
         )
 
     def test_multi_target_saliency(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             Saliency,
             net,
             inputs=inp,
@@ -112,21 +112,21 @@ class Test(BaseTest):
     def test_simple_target_ablation(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             FeatureAblation, net, inputs=inp, targets=[0, 1, 1, 0]
         )
 
     def test_simple_target_ablation_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             FeatureAblation, net, inputs=inp, targets=torch.tensor([0, 1, 1, 0])
         )
 
     def test_multi_target_ablation(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             FeatureAblation,
             net,
             inputs=inp,
@@ -137,7 +137,7 @@ class Test(BaseTest):
     def test_multi_target_occlusion(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             Occlusion,
             net,
             inputs=inp,
@@ -149,7 +149,7 @@ class Test(BaseTest):
     def test_simple_target_shapley_value_sampling(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             ShapleyValueSampling,
             net,
             inputs=inp,
@@ -161,7 +161,7 @@ class Test(BaseTest):
     def test_simple_target_shapley_value_sampling_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             ShapleyValueSampling,
             net,
             inputs=inp,
@@ -173,7 +173,7 @@ class Test(BaseTest):
     def test_multi_target_shapley_value_sampling(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             ShapleyValueSampling,
             net,
             inputs=inp,
@@ -186,12 +186,12 @@ class Test(BaseTest):
     def test_simple_target_deep_lift(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(DeepLift, net, inputs=inp, targets=[0, 1, 1, 0])
+        _target_batch_test_assert(DeepLift, net, inputs=inp, targets=[0, 1, 1, 0])
 
     def test_multi_target_deep_lift(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             DeepLift,
             net,
             inputs=inp,
@@ -202,14 +202,14 @@ class Test(BaseTest):
     def test_simple_target_deep_lift_shap(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             DeepLiftShap, net, inputs=inp, baselines=0.5 * inp, targets=[0, 1, 1, 0]
         )
 
     def test_simple_target_deep_lift_shap_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             DeepLiftShap,
             net,
             inputs=inp,
@@ -220,7 +220,7 @@ class Test(BaseTest):
     def test_simple_target_deep_lift_shap_single_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             DeepLiftShap,
             net,
             inputs=inp,
@@ -232,7 +232,7 @@ class Test(BaseTest):
     def test_multi_target_deep_lift_shap(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             DeepLiftShap,
             net,
             inputs=inp,
@@ -244,7 +244,7 @@ class Test(BaseTest):
     def test_simple_target_gradient_shap(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             GradientShap,
             net,
             inputs=inp,
@@ -258,7 +258,7 @@ class Test(BaseTest):
     def test_simple_target_gradient_shap_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             GradientShap,
             net,
             inputs=inp,
@@ -272,7 +272,7 @@ class Test(BaseTest):
     def test_simple_target_gradient_shap_single_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             GradientShap,
             net,
             inputs=inp,
@@ -287,7 +287,7 @@ class Test(BaseTest):
     def test_multi_target_gradient_shap(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             GradientShap,
             net,
             inputs=inp,
@@ -302,7 +302,7 @@ class Test(BaseTest):
     def test_simple_target_nt(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             NoiseTunnel,
             IntegratedGradients(net),
             inputs=inp,
@@ -314,7 +314,7 @@ class Test(BaseTest):
     def test_simple_target_nt_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             NoiseTunnel,
             IntegratedGradients(net),
             inputs=inp,
@@ -326,7 +326,7 @@ class Test(BaseTest):
     def test_simple_target_nt_single_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             NoiseTunnel,
             IntegratedGradients(net),
             inputs=inp,
@@ -339,7 +339,7 @@ class Test(BaseTest):
     def test_multi_target_nt(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             NoiseTunnel,
             IntegratedGradients(net),
             inputs=inp,
@@ -352,14 +352,12 @@ class Test(BaseTest):
     def test_simple_target_input_x_gradient(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
-            InputXGradient, net, inputs=inp, targets=[0, 1, 1, 0]
-        )
+        _target_batch_test_assert(InputXGradient, net, inputs=inp, targets=[0, 1, 1, 0])
 
     def test_multi_target_input_x_gradient(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             InputXGradient,
             net,
             inputs=inp,
@@ -370,7 +368,7 @@ class Test(BaseTest):
     def test_simple_target_int_inf(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             InternalInfluence,
             net,
             inputs=inp,
@@ -382,7 +380,7 @@ class Test(BaseTest):
     def test_multi_target_int_inf(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             InternalInfluence,
             net,
             inputs=inp,
@@ -395,7 +393,7 @@ class Test(BaseTest):
     def test_simple_target_layer_cond(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             LayerConductance,
             net,
             inputs=inp,
@@ -407,7 +405,7 @@ class Test(BaseTest):
     def test_simple_target_layer_cond_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             LayerConductance,
             net,
             inputs=inp,
@@ -419,7 +417,7 @@ class Test(BaseTest):
     def test_multi_target_layer_cond(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             LayerConductance,
             net,
             inputs=inp,
@@ -432,7 +430,7 @@ class Test(BaseTest):
     def test_simple_target_layer_deeplift(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             LayerDeepLift, net, inputs=inp, target_layer=net.relu, targets=[0, 1, 1, 0],
         )
 
@@ -440,7 +438,7 @@ class Test(BaseTest):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
         baseline = torch.randn(6, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             LayerDeepLiftShap,
             net,
             inputs=inp,
@@ -452,7 +450,7 @@ class Test(BaseTest):
     def test_simple_target_layer_ig(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             LayerIntegratedGradients,
             net,
             inputs=inp,
@@ -463,7 +461,7 @@ class Test(BaseTest):
     def test_multi_target_layer_ig(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             LayerIntegratedGradients,
             net,
             inputs=inp,
@@ -475,7 +473,7 @@ class Test(BaseTest):
     def test_simple_target_layer_gradient_x_act(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             LayerGradientXActivation,
             net,
             inputs=inp,
@@ -486,7 +484,7 @@ class Test(BaseTest):
     def test_multi_target_layer_gradient_x_act(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             LayerGradientXActivation,
             net,
             inputs=inp,
@@ -498,7 +496,7 @@ class Test(BaseTest):
     def test_simple_target_layer_ablation_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             LayerFeatureAblation,
             net,
             inputs=inp,
@@ -509,7 +507,7 @@ class Test(BaseTest):
     def test_simple_target_neuron_conductance(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             NeuronConductance,
             net,
             inputs=inp,
@@ -522,7 +520,7 @@ class Test(BaseTest):
     def test_simple_target_neuron_conductance_tensor(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             NeuronConductance,
             net,
             inputs=inp,
@@ -535,7 +533,7 @@ class Test(BaseTest):
     def test_multi_target_neuron_conductance(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(
+        _target_batch_test_assert(
             NeuronConductance,
             net,
             inputs=inp,
@@ -546,64 +544,74 @@ class Test(BaseTest):
             test_batches=True,
         )
 
-    def _target_batch_test_assert(
-        self,
-        algorithm,
-        model,
-        inputs,
-        targets,
-        target_layer=None,
-        test_batches=False,
-        splice_targets=True,
-        delta=0.0001,
-        comp_mode="sum",
-        **kwargs
-    ):
-        if target_layer:
-            attr_method = algorithm(model, target_layer)
-        else:
-            attr_method = algorithm(model)
 
-        batch_sizes = [None]
-        if test_batches:
-            batch_sizes = [None, 2, 4]
-        for batch_size in batch_sizes:
-            if batch_size:
-                attributions_orig = attr_method.attribute(
-                    inputs=inputs,
-                    target=targets,
-                    internal_batch_size=batch_size,
-                    **kwargs
-                )
-            else:
-                attributions_orig = attr_method.attribute(
-                    inputs=inputs, target=targets, **kwargs
-                )
-            for i in range(len(inputs)):
-                single_attr = attr_method.attribute(
-                    inputs=inputs[i : i + 1],
-                    target=targets[i] if splice_targets else targets,
-                    **kwargs
-                )
-                single_attr_target_list = attr_method.attribute(
-                    inputs=inputs[i : i + 1],
-                    target=targets[i : i + 1] if splice_targets else targets,
-                    **kwargs
-                )
-                assertTensorAlmostEqual(
-                    self,
-                    attributions_orig[i : i + 1],
-                    single_attr,
-                    delta=delta,
-                    mode=comp_mode,
-                )
-                assertTensorAlmostEqual(
-                    self,
-                    attributions_orig[i : i + 1],
-                    single_attr_target_list,
-                    delta=delta,
-                    mode=comp_mode,
-                )
+class GPUTest(BaseGPUTest):
+    def test_simple_target_saliency_gpu(self):
+        net = BasicModel_MultiLayer().cuda()
+        inp = torch.randn(4, 3).cuda()
+        _target_batch_test_assert(Saliency, net, inputs=inp, targets=[0, 1, 1, 0])
+
+    def test_simple_target_saliency_tensor_gpu(self):
+        net = BasicModel_MultiLayer().cuda()
+        inp = torch.randn(4, 3).cuda()
+        target = torch.tensor([0, 1, 1, 0]).cuda()
+        _target_batch_test_assert(Saliency, net, inputs=inp, targets=target)
+
+
+def _target_batch_test_assert(
+    algorithm,
+    model,
+    inputs,
+    targets,
+    target_layer=None,
+    test_batches=False,
+    splice_targets=True,
+    delta=0.0001,
+    comp_mode="sum",
+    **kwargs
+):
+    if target_layer:
+        attr_method = algorithm(model, target_layer)
+    else:
+        attr_method = algorithm(model)
+
+    batch_sizes = [None]
+    if test_batches:
+        batch_sizes = [None, 2, 4]
+    for batch_size in batch_sizes:
+        if batch_size:
+            attributions_orig = attr_method.attribute(
+                inputs=inputs, target=targets, internal_batch_size=batch_size, **kwargs
+            )
+        else:
+            attributions_orig = attr_method.attribute(
+                inputs=inputs, target=targets, **kwargs
+            )
+        for i in range(len(inputs)):
+            single_attr = attr_method.attribute(
+                inputs=inputs[i : i + 1],
+                target=targets[i] if splice_targets else targets,
+                **kwargs
+            )
+            single_attr_target_list = attr_method.attribute(
+                inputs=inputs[i : i + 1],
+                target=targets[i : i + 1] if splice_targets else targets,
+                **kwargs
+            )
+            assertTensorAlmostEqual(
+                self,
+                attributions_orig[i : i + 1],
+                single_attr,
+                delta=delta,
+                mode=comp_mode,
+            )
+            assertTensorAlmostEqual(
+                self,
+                attributions_orig[i : i + 1],
+                single_attr_target_list,
+                delta=delta,
+                mode=comp_mode,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/attr/test_targets.py
+++ b/tests/attr/test_targets.py
@@ -352,7 +352,9 @@ class Test(BaseTest):
     def test_simple_target_input_x_gradient(self):
         net = BasicModel_MultiLayer()
         inp = torch.randn(4, 3)
-        self._target_batch_test_assert(InputXGradient, net, inputs=inp, targets=[0, 1, 1, 0])
+        self._target_batch_test_assert(
+            InputXGradient, net, inputs=inp, targets=[0, 1, 1, 0]
+        )
 
     def test_multi_target_input_x_gradient(self):
         net = BasicModel_MultiLayer()
@@ -568,7 +570,10 @@ class Test(BaseTest):
         for batch_size in batch_sizes:
             if batch_size:
                 attributions_orig = attr_method.attribute(
-                    inputs=inputs, target=targets, internal_batch_size=batch_size, **kwargs
+                    inputs=inputs,
+                    target=targets,
+                    internal_batch_size=batch_size,
+                    **kwargs
                 )
             else:
                 attributions_orig = attr_method.attribute(
@@ -600,6 +605,7 @@ class Test(BaseTest):
                     mode=comp_mode,
                 )
 
+
 class GPUTest(BaseGPUTest):
     def test_simple_target_saliency_gpu(self):
         net = BasicModel_MultiLayer().cuda()
@@ -611,7 +617,6 @@ class GPUTest(BaseGPUTest):
         inp = torch.randn(4, 3).cuda()
         target = torch.tensor([0, 1, 1, 0]).cuda()
         self._target_batch_test_assert(Saliency, net, inputs=inp, targets=target)
-
 
     def _target_batch_test_assert(
         self,
@@ -637,7 +642,10 @@ class GPUTest(BaseGPUTest):
         for batch_size in batch_sizes:
             if batch_size:
                 attributions_orig = attr_method.attribute(
-                    inputs=inputs, target=targets, internal_batch_size=batch_size, **kwargs
+                    inputs=inputs,
+                    target=targets,
+                    internal_batch_size=batch_size,
+                    **kwargs
                 )
             else:
                 attributions_orig = attr_method.attribute(

--- a/tests/attr/test_targets.py
+++ b/tests/attr/test_targets.py
@@ -22,7 +22,7 @@ from captum.attr._core.saliency import Saliency
 from captum.attr._core.shapley_value import ShapleyValueSampling
 
 from .helpers.basic_models import BasicModel_MultiLayer
-from .helpers.utils import BaseTest, assertTensorAlmostEqual, BaseGPUTest
+from .helpers.utils import BaseGPUTest, BaseTest, assertTensorAlmostEqual
 
 
 class Test(BaseTest):


### PR DESCRIPTION
Hey,
Here is my proposed fix for [#316](https://github.com/pytorch/captum/issues/316).
I've added a test case that uses the BaseGPUTest class and simply runs the saliency target tests again, with everything on the GPU. As I did not fully understand the `_target_batch_test_assert` function and what the requirements for the tests are, I simply copied the function for now. I assume there may be an obvious way to integrate these tests. :)

Another question is:
Do we want to enforce the move if we receive a target tensor, which is not on the right device?
We could print a User Warning similar to automatically setting require gradients as in gradient.py:33.
Or should the user be responsible to move the target tensor to the correct device?

Best regards,
Kai