### PR TITLE
Fix internal batching bug for cases when attribution is called  `with no_grad()` block

### DIFF
--- a/captum/attr/_utils/batching.py
+++ b/captum/attr/_utils/batching.py
@@ -126,8 +126,9 @@ def _batched_generator(
     else:
         for current_total in range(0, num_examples, internal_batch_size):
             with torch.autograd.set_grad_enabled(True):
-               inputs_splice = _tuple_splice_range(inputs, current_total,
-                                            current_total + internal_batch_size)
+                inputs_splice = _tuple_splice_range(
+                    inputs, current_total, current_total + internal_batch_size
+                )
             yield inputs_splice, _tuple_splice_range(
                 additional_forward_args,
                 current_total,

--- a/captum/attr/_utils/batching.py
+++ b/captum/attr/_utils/batching.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import warnings
 import typing
 from typing import Any, Callable, Dict, Iterator, List, Tuple, Union
 
@@ -121,6 +122,13 @@ def _batched_generator(
     inputs = _format_input(inputs)
     additional_forward_args = _format_additional_forward_args(additional_forward_args)
     num_examples = inputs[0].shape[0]
+    # TODO Reconsider this check if _batched_generator is used for non gradient-based
+    # attribution algorithms
+    if not (inputs[0] * 1).requires_grad:
+        warnings.warn(
+            """It looks like that the attribution for gradient methods is calleds in
+            a `torch.no_grad` block or perhaps the inputs has no requires_grad."""
+        )
     if internal_batch_size is None:
         yield inputs, additional_forward_args, target_ind
     else:

--- a/captum/attr/_utils/batching.py
+++ b/captum/attr/_utils/batching.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-import warnings
 import typing
+import warnings
 from typing import Any, Callable, Dict, Iterator, List, Tuple, Union
 
 import torch

--- a/captum/attr/_utils/batching.py
+++ b/captum/attr/_utils/batching.py
@@ -125,9 +125,10 @@ def _batched_generator(
         yield inputs, additional_forward_args, target_ind
     else:
         for current_total in range(0, num_examples, internal_batch_size):
-            yield _tuple_splice_range(
-                inputs, current_total, current_total + internal_batch_size
-            ), _tuple_splice_range(
+            with torch.autograd.set_grad_enabled(True):
+               inputs_splice = _tuple_splice_range(inputs, current_total,
+                                            current_total + internal_batch_size)
+            yield inputs_splice, _tuple_splice_range(
                 additional_forward_args,
                 current_total,
                 current_total + internal_batch_size,

--- a/captum/attr/_utils/batching.py
+++ b/captum/attr/_utils/batching.py
@@ -126,8 +126,8 @@ def _batched_generator(
     # attribution algorithms
     if not (inputs[0] * 1).requires_grad:
         warnings.warn(
-            """It looks like that the attribution for a gradient-based method is called
-            in a `torch.no_grad` block or perhaps the inputs has no requires_grad."""
+            """It looks like that the attribution for a gradient-based method is computed
+            in a `torch.no_grad` block or perhaps the inputs have no requires_grad."""
         )
     if internal_batch_size is None:
         yield inputs, additional_forward_args, target_ind

--- a/captum/attr/_utils/batching.py
+++ b/captum/attr/_utils/batching.py
@@ -126,8 +126,9 @@ def _batched_generator(
     # attribution algorithms
     if not (inputs[0] * 1).requires_grad:
         warnings.warn(
-            """It looks like that the attribution for a gradient-based method is computed
-            in a `torch.no_grad` block or perhaps the inputs have no requires_grad."""
+            """It looks like that the attribution for a gradient-based method is
+            computed in a `torch.no_grad` block or perhaps the inputs have no
+            requires_grad."""
         )
     if internal_batch_size is None:
         yield inputs, additional_forward_args, target_ind

--- a/captum/attr/_utils/batching.py
+++ b/captum/attr/_utils/batching.py
@@ -126,8 +126,8 @@ def _batched_generator(
     # attribution algorithms
     if not (inputs[0] * 1).requires_grad:
         warnings.warn(
-            """It looks like that the attribution for gradient methods is calleds in
-            a `torch.no_grad` block or perhaps the inputs has no requires_grad."""
+            """It looks like that the attribution for a gradient-based method is called
+            in a `torch.no_grad` block or perhaps the inputs has no requires_grad."""
         )
     if internal_batch_size is None:
         yield inputs, additional_forward_args, target_ind


### PR DESCRIPTION
This problem came up as we were using `internal_batch_size` for BERT models.
Autograd was failing to compute the gradients with respect to the inputs (both for IG and layerIG) because grad wasn't enabled for the input slice, this happened because attribute was called in  `with no_grad()` block. Thanks @vivekmig for pointing out to the general issue.


```
inp = torch.rand(3,4)
inp.requires_grad_()
print(inp.requires_grad) # True

with torch.no_grad():
   print((inp*1).requires_grad) # False

```