### PR TITLE
Remove running mypy on PyTorch Nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,6 @@ jobs:
       - lint_flake8
       - lint_black
       - isort
-      - mypy_check
       - unit_tests
       - sphinx
 
@@ -186,7 +185,6 @@ jobs:
       - lint_flake8
       - lint_black
       - isort
-      - mypy_check
       - unit_tests
       - sphinx
 


### PR DESCRIPTION
Removes mypy checks from nightly PyTorch tests and only runs mypy with latest PyTorch release build.