### PR TITLE
DataParallel DeepLift Fixes

### DIFF
--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -543,20 +543,6 @@ class DeepLift(GradientAttribution):
                 self.model.register_forward_hook(forward_hook),
             ]  # type: ignore
 
-    def _hook_data_parallel_model(self) -> List[RemovableHandle]:
-        if isinstance(self.model, nn.DataParallel):
-
-            def _dp_hook(module, inputs, outputs):
-                return outputs.reshape((outputs.shape[0] // 2, 2) + outputs.shape[1:])
-
-            def _final_hook(module, inputs, outputs):
-                return torch.cat((outputs[:, 0], outputs[:, 1]))
-
-            forward_dp_hook = self.model.module.register_forward_hook(_dp_hook)
-            forward_full_hook = self.model.register_forward_hook(_final_hook)
-            return [forward_dp_hook, forward_full_hook]
-        return []
-
     def has_convergence_delta(self) -> bool:
         return True
 

--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -305,21 +305,20 @@ class DeepLift(GradientAttribution):
 
         baselines = _tensorize_baseline(inputs, baselines)
         main_model_pre_hook = self._pre_hook_main_model()
+        dp_model_hooks = self._hook_data_parallel_model()
 
         self.model.apply(self._register_hooks)
 
         additional_forward_args = _format_additional_forward_args(
             additional_forward_args
         )
-        input_base_additional_args = _expand_additional_forward_args(
-            additional_forward_args, 2, ExpansionTypes.repeat
-        )
+
         expanded_target = _expand_target(
             target, 2, expansion_type=ExpansionTypes.repeat
         )
 
         wrapped_forward_func = self._construct_forward_func(
-            self.model, (inputs, baselines), expanded_target, input_base_additional_args
+            self.model, (inputs, baselines), expanded_target, additional_forward_args
         )
         gradients = self.gradient_func(wrapped_forward_func, inputs)
         if custom_attribution_func is None:
@@ -333,6 +332,9 @@ class DeepLift(GradientAttribution):
             )
         # remove hooks from all activations
         main_model_pre_hook.remove()
+        for hook in dp_model_hooks:
+            hook.remove()
+
         self._remove_hooks()
 
         undo_gradient_requirements(inputs, gradient_mask)
@@ -514,13 +516,33 @@ class DeepLift(GradientAttribution):
                 for input, baseline in zip(inputs, baselines)
             )
             if additional_args is not None:
-                return (*baseline_input_tsr, *additional_args)
+                expanded_additional_args = cast(
+                    Tuple,
+                    _expand_additional_forward_args(
+                        additional_args, 2, ExpansionTypes.repeat
+                    ),
+                )
+                return (*baseline_input_tsr, *expanded_additional_args)
             return baseline_input_tsr
 
         if isinstance(self.model, nn.DataParallel):
             return self.model.module.register_forward_pre_hook(pre_hook)  # type: ignore
         else:
             return self.model.register_forward_pre_hook(pre_hook)  # type: ignore
+
+    def _hook_data_parallel_model(self) -> List[RemovableHandle]:
+        if isinstance(self.model, nn.DataParallel):
+
+            def _dp_hook(module, inputs, outputs):
+                return outputs.reshape((outputs.shape[0] // 2, 2) + outputs.shape[1:])
+
+            def _final_hook(module, inputs, outputs):
+                return torch.cat((outputs[:, 0], outputs[:, 1]))
+
+            forward_dp_hook = self.model.module.register_forward_hook(_dp_hook)
+            forward_full_hook = self.model.register_forward_hook(_final_hook)
+            return [forward_dp_hook, forward_full_hook]
+        return []
 
     def has_convergence_delta(self) -> bool:
         return True
@@ -810,7 +832,11 @@ class DeepLiftShap(DeepLift):
             target, base_bsz, expansion_type=ExpansionTypes.repeat_interleave
         )
         input_additional_args = (
-            _expand_additional_forward_args(additional_forward_args, base_bsz)
+            _expand_additional_forward_args(
+                additional_forward_args,
+                base_bsz,
+                expansion_type=ExpansionTypes.repeat_interleave,
+            )
             if additional_forward_args is not None
             else None
         )

--- a/captum/attr/_core/feature_ablation.py
+++ b/captum/attr/_core/feature_ablation.py
@@ -243,7 +243,7 @@ class FeatureAblation(PerturbationAttribution):
         feature_mask = _format_input(feature_mask) if feature_mask is not None else None
         assert (
             isinstance(perturbations_per_eval, int) and perturbations_per_eval >= 1
-        ), "Ablations per evaluation must be at least 1."
+        ), "Perturbations per evaluation must be an integer and at least 1."
         with torch.no_grad():
             # Computes initial evaluation with all features, which is compared
             # to each ablated result.

--- a/captum/attr/_core/layer/grad_cam.py
+++ b/captum/attr/_core/layer/grad_cam.py
@@ -207,6 +207,8 @@ class LayerGradCam(LayerAttribution, GradientAttribution):
                 dim=tuple(x for x in range(2, len(layer_grad.shape))),
                 keepdim=True,
             )
+            if len(layer_grad.shape) > 2
+            else layer_grad
             for layer_grad in layer_gradients
         )
 

--- a/captum/attr/_core/layer/layer_deep_lift.py
+++ b/captum/attr/_core/layer/layer_deep_lift.py
@@ -276,8 +276,7 @@ class LayerDeepLift(LayerAttribution, DeepLift):
 
         baselines = _tensorize_baseline(inputs, baselines)
 
-        main_model_pre_hook = self._pre_hook_main_model()
-        dp_model_hooks = self._hook_data_parallel_model()
+        main_model_hooks = self._hook_main_model()
 
         self.model.apply(self._register_hooks)
 
@@ -320,9 +319,8 @@ class LayerDeepLift(LayerAttribution, DeepLift):
                 custom_attribution_func, gradients, attr_inputs, attr_baselines
             )
         # remove hooks from all activations
-        main_model_pre_hook.remove()
         self._remove_hooks()
-        for hook in dp_model_hooks:
+        for hook in main_model_hooks:
             hook.remove()
 
         undo_gradient_requirements(inputs, gradient_mask)

--- a/captum/attr/_core/layer/layer_deep_lift.py
+++ b/captum/attr/_core/layer/layer_deep_lift.py
@@ -8,7 +8,6 @@ from torch.nn import Module
 
 from ...._utils.common import (
     ExpansionTypes,
-    _expand_additional_forward_args,
     _expand_target,
     _format_additional_forward_args,
     _format_input,
@@ -278,20 +277,18 @@ class LayerDeepLift(LayerAttribution, DeepLift):
         baselines = _tensorize_baseline(inputs, baselines)
 
         main_model_pre_hook = self._pre_hook_main_model()
+        dp_model_hooks = self._hook_data_parallel_model()
 
         self.model.apply(self._register_hooks)
 
         additional_forward_args = _format_additional_forward_args(
             additional_forward_args
         )
-        input_base_additional_args = _expand_additional_forward_args(
-            additional_forward_args, 2, ExpansionTypes.repeat
-        )
         expanded_target = _expand_target(
             target, 2, expansion_type=ExpansionTypes.repeat
         )
         wrapped_forward_func = self._construct_forward_func(
-            self.model, (inputs, baselines), expanded_target, input_base_additional_args
+            self.model, (inputs, baselines), expanded_target, additional_forward_args,
         )
 
         def chunk_output_fn(out: TensorOrTupleOfTensorsGeneric,) -> Sequence:
@@ -325,6 +322,8 @@ class LayerDeepLift(LayerAttribution, DeepLift):
         # remove hooks from all activations
         main_model_pre_hook.remove()
         self._remove_hooks()
+        for hook in dp_model_hooks:
+            hook.remove()
 
         undo_gradient_requirements(inputs, gradient_mask)
         return _compute_conv_delta_and_format_attrs(


### PR DESCRIPTION
This PR adds only the bug fixes identified from refactoring and adding dynamic tests.

1. Additional forward arguments were not working appropriately with DeepLift on a DataParallel model. This is because the device split of expanded additional forward args didn't necessarily match that of inputs. The behavior has been changed to expand the additional args in the hook function (after device split), which ensures the additional args and inputs remain matched.
2. Different targets per example was not working appropriately with DeepLift on a DataParallel model. This is because the model output concatenated the outputs of the devices in DataParallel, which mixed input / baseline outputs, inhibiting appropriate matching between input example and target. Additional forward hooks have been added to appropriately return the output with all inputs followed by all baselines.
3. GradCAM is primarily intended for layers with >= 3 dimensions, since it computes average gradient for each example / channel. For layers with 2 dimensions, the mean gradient over all dimensions was being taken. This has been updated to use the layer gradients directly in this case, which better aligns with the behavior for >= 3 dimensions.
4. DeepLiftShap (and Neuron / Layer variants) were incorrectly repeating additional forward args, this has been fixed to use repeat interleave instead.