### PR TITLE
update conda node version

### DIFF
--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -20,8 +20,9 @@ while getopts 'nf' flag; do
 # required to use conda develop
 conda install -y conda-build
 
-# install yarn for insights build
+# install node/yarn for insights build
 conda install -y -c conda-forge yarn
+conda install -y -c conda-forge nodejs
 
 # install other frameworks if asked for and make sure this is before pytorch
 if [[ $FRAMEWORKS == true ]]; then


### PR DESCRIPTION
The conda docker container occasionally fails with:

```
error react-scripts@3.2.0: The engine "node" is incompatible with this module. Expected version ">=8.10". Got "6.13.1"
```

Add nodejs as an explicit package to install, because installing it before yarn causes conda to downgrade nodejs into an incompatible version.