### PR TITLE
Fix flake8 error in update_versions_html.py

### DIFF
--- a/scripts/update_versions_html.py
+++ b/scripts/update_versions_html.py
@@ -35,8 +35,8 @@ def updateVersionHTML(base_path, base_url=BASE_URL):
 
         # nav
         nav_links = soup.find("nav").findAll("a")
-        for l in nav_links:
-            l.attrs["href"] = prepend_url(l, base_url, v)
+        for link in nav_links:
+            link.attrs["href"] = prepend_url(link, base_url, v)
 
         # version link
         t = soup.find("h2", {"class": "headerTitleWithLogo"}).find_next("a")


### PR DESCRIPTION
Seeing this unrelated error in #369: https://circleci.com/gh/pytorch/captum/6777?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link.

