### PR TITLE
Updates division to be true_division

### DIFF
--- a/captum/attr/_utils/stat.py
+++ b/captum/attr/_utils/stat.py
@@ -191,7 +191,7 @@ class Var(Stat):
         if n <= self.order:
             return torch.zeros_like(mse)
 
-        return mse / (n - self.order)
+        return torch.true_divide(mse, n - self.order)
 
 
 class StdDev(Stat):

--- a/captum/attr/_utils/stat.py
+++ b/captum/attr/_utils/stat.py
@@ -194,7 +194,7 @@ class Var(Stat):
         # NOTE: The following ensures mse is a float tensor. 
         #   torch.true_divide is available in PyTorch 1.5 and later. 
         #   This is for compatibility with 1.4.
-        return mse.to(torch.float64) / n - self.order
+        return mse.to(torch.float64) / (n - self.order)
 
 
 class StdDev(Stat):

--- a/captum/attr/_utils/stat.py
+++ b/captum/attr/_utils/stat.py
@@ -191,8 +191,8 @@ class Var(Stat):
         if n <= self.order:
             return torch.zeros_like(mse)
 
-        # NOTE: The following ensures mse is a float tensor. 
-        #   torch.true_divide is available in PyTorch 1.5 and later. 
+        # NOTE: The following ensures mse is a float tensor.
+        #   torch.true_divide is available in PyTorch 1.5 and later.
         #   This is for compatibility with 1.4.
         return mse.to(torch.float64) / (n - self.order)
 

--- a/captum/attr/_utils/stat.py
+++ b/captum/attr/_utils/stat.py
@@ -191,7 +191,10 @@ class Var(Stat):
         if n <= self.order:
             return torch.zeros_like(mse)
 
-        return torch.true_divide(mse, n - self.order)
+        # NOTE: The following ensures mse is a float tensor. 
+        #   torch.true_divide is available in PyTorch 1.5 and later. 
+        #   This is for compatibility with 1.4.
+        return mse.to(torch.float64) / n - self.order
 
 
 class StdDev(Stat):


### PR DESCRIPTION
PyTorch 1.5 deprecated the torch.div() and the division operator performing integer division, and in PyTorch 1.6 this will throw a runtime error. Per discussion with @miguelmartin75, this case should always perform a true division, not a floor (integer) division.

