### PR TITLE
Updates rolling_mean to always be initialized to a float value

### DIFF
--- a/captum/attr/_utils/stat.py
+++ b/captum/attr/_utils/stat.py
@@ -116,7 +116,11 @@ class Mean(Stat):
         n = self.n.get()
 
         if self.rolling_mean is None:
-            self.rolling_mean = x
+            # Ensures rolling_mean is a float tensor
+            if x.is_floating_point():
+                self.rolling_mean = x
+            else:
+                self.rolling_mean = x.to(torch.float64)
         else:
             delta = x - self.rolling_mean
             self.rolling_mean += delta / n


### PR DESCRIPTION
The (delta / n) division can sometimes be integer division, and the division operator performing integer division is deprecated in PyTorch 1.5 and will throw a runtime error in PyTorch 1.6. This change always initialized rolling_mean to a float value so that delta is also a float and (delta / n) will no longer perform integer division. 

See related: https://github.com/pytorch/captum/commit/71b118eb2d8bb0d48ef3c147f7f50193f817644a.