### PR TITLE
Move captum.attr gradient utils to general utils

### DIFF
--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -2,14 +2,19 @@
 import typing
 from enum import Enum
 from inspect import signature
-from typing import Any, Callable, List, Tuple, Union, cast, overload
+from typing import Any, Callable, Dict, List, Tuple, Union, cast, overload
 
 import numpy as np
 import torch
 from torch import Tensor, device
 from torch.nn import Module
 
-from .._utils.typing import BaselineType, Literal, TargetType
+from .._utils.typing import (
+    BaselineType,
+    Literal,
+    TargetType,
+    TupleOrTensorOrBoolGeneric,
+)
 
 
 class ExpansionTypes(Enum):
@@ -414,3 +419,65 @@ def _extract_device(
         return hook_outputs[0].device
 
     return params[0].device
+
+
+def _reduce_list(
+    val_list: List[TupleOrTensorOrBoolGeneric],
+    red_func: Callable[[List], Any] = torch.cat,
+) -> TupleOrTensorOrBoolGeneric:
+    """
+    Applies reduction function to given list. If each element in the list is
+    a Tensor, applies reduction function to all elements of the list, and returns
+    the output Tensor / value. If each element is a boolean, apply any method (or).
+    If each element is a tuple, applies reduction
+    function to corresponding elements of each tuple in the list, and returns
+    tuple of reduction function outputs with length matching the length of tuple
+    val_list[0]. It is assumed that all tuples in the list have the same length
+    and red_func can be applied to all elements in each corresponding position.
+    """
+    if isinstance(val_list[0], torch.Tensor):
+        return red_func(val_list)
+    elif isinstance(val_list[0], bool):
+        return any(val_list)
+    elif isinstance(val_list[0], tuple):
+        final_out = []
+        for i in range(len(val_list[0])):
+            final_out.append(
+                _reduce_list([val_elem[i] for val_elem in val_list], red_func)
+            )
+    else:
+        raise AssertionError(
+            "Elements to be reduced can only be"
+            "either Tensors or tuples containing Tensors."
+        )
+    return tuple(final_out)
+
+
+def _sort_key_list(
+    keys: List[device], device_ids: Union[None, List[int]] = None
+) -> List[device]:
+    """
+    Sorts list of torch devices (keys) by given index list, device_ids. If keys
+    contains only one device, then the list is returned unchanged. If keys
+    contains a device for which the id is not contained in device_ids, then
+    an error is returned. This method is used to identify the order of DataParallel
+    batched devices, given the device ID ordering.
+    """
+    if len(keys) == 1:
+        return keys
+    id_dict: Dict[int, device] = {}
+    assert device_ids is not None, "Device IDs must be provided with multiple devices."
+    for key in keys:
+        if key.index in id_dict:
+            raise AssertionError("Duplicate CUDA Device ID identified in device list.")
+        id_dict[key.index] = key
+
+    out_list = [
+        id_dict[device_id]
+        for device_id in filter(lambda device_id: device_id in id_dict, device_ids)
+    ]
+
+    assert len(out_list) == len(keys), "Given Device ID List does not match"
+    "devices with computed tensors."
+
+    return out_list

--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -8,9 +8,8 @@ import torch
 from torch import Tensor, device
 from torch.nn import Module
 
-from ..._utils.common import _run_forward, _verify_select_column
-from ..._utils.typing import Literal, TargetType, TensorOrTupleOfTensorsGeneric
-from .batching import _reduce_list, _sort_key_list
+from .common import _reduce_list, _run_forward, _sort_key_list, _verify_select_column
+from .typing import Literal, TargetType, TensorOrTupleOfTensorsGeneric
 
 
 def apply_gradient_requirements(inputs: Tuple[Tensor, ...]) -> List[bool]:

--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -25,6 +25,7 @@ from ..._utils.common import (
     _run_forward,
     _select_targets,
 )
+from ..._utils.gradient import apply_gradient_requirements, undo_gradient_requirements
 from ..._utils.typing import (
     BaselineType,
     Literal,
@@ -40,7 +41,6 @@ from .._utils.common import (
     _tensorize_baseline,
     _validate_input,
 )
-from .._utils.gradient import apply_gradient_requirements, undo_gradient_requirements
 
 
 # Check if module backward hook can safely be used for the module that produced

--- a/captum/attr/_core/guided_backprop_deconvnet.py
+++ b/captum/attr/_core/guided_backprop_deconvnet.py
@@ -11,10 +11,10 @@ from torch.utils.hooks import RemovableHandle
 from captum.log import log_usage
 
 from ..._utils.common import _format_input, _is_tuple
+from ..._utils.gradient import apply_gradient_requirements, undo_gradient_requirements
 from ..._utils.typing import TargetType, TensorOrTupleOfTensorsGeneric
 from .._utils.attribution import GradientAttribution
 from .._utils.common import _format_attributions
-from .._utils.gradient import apply_gradient_requirements, undo_gradient_requirements
 
 
 class ModifiedReluGradientAttribution(GradientAttribution):

--- a/captum/attr/_core/input_x_gradient.py
+++ b/captum/attr/_core/input_x_gradient.py
@@ -4,10 +4,10 @@ from typing import Any, Callable
 from captum.log import log_usage
 
 from ..._utils.common import _format_input, _is_tuple
+from ..._utils.gradient import apply_gradient_requirements, undo_gradient_requirements
 from ..._utils.typing import TargetType, TensorOrTupleOfTensorsGeneric
 from .._utils.attribution import GradientAttribution
 from .._utils.common import _format_attributions
-from .._utils.gradient import apply_gradient_requirements, undo_gradient_requirements
 
 
 class InputXGradient(GradientAttribution):

--- a/captum/attr/_core/layer/grad_cam.py
+++ b/captum/attr/_core/layer/grad_cam.py
@@ -9,14 +9,14 @@ from torch.nn import Module
 from captum.log import log_usage
 
 from ...._utils.common import _format_additional_forward_args, _format_input
-from ...._utils.typing import TargetType
-from ..._utils.attribution import GradientAttribution, LayerAttribution
-from ..._utils.common import _format_attributions
-from ..._utils.gradient import (
+from ...._utils.gradient import (
     apply_gradient_requirements,
     compute_layer_gradients_and_eval,
     undo_gradient_requirements,
 )
+from ...._utils.typing import TargetType
+from ..._utils.attribution import GradientAttribution, LayerAttribution
+from ..._utils.common import _format_attributions
 
 
 class LayerGradCam(LayerAttribution, GradientAttribution):

--- a/captum/attr/_core/layer/internal_influence.py
+++ b/captum/attr/_core/layer/internal_influence.py
@@ -12,6 +12,7 @@ from ...._utils.common import (
     _expand_target,
     _format_additional_forward_args,
 )
+from ...._utils.gradient import compute_layer_gradients_and_eval
 from ...._utils.typing import BaselineType, TargetType
 from ..._utils.approximation_methods import approximation_parameters
 from ..._utils.attribution import GradientAttribution, LayerAttribution
@@ -22,7 +23,6 @@ from ..._utils.common import (
     _reshape_and_sum,
     _validate_input,
 )
-from ..._utils.gradient import compute_layer_gradients_and_eval
 
 
 class InternalInfluence(LayerAttribution, GradientAttribution):

--- a/captum/attr/_core/layer/layer_activation.py
+++ b/captum/attr/_core/layer/layer_activation.py
@@ -7,9 +7,9 @@ from torch.nn import Module
 
 from captum.log import log_usage
 
+from ...._utils.gradient import _forward_layer_eval
 from ..._utils.attribution import LayerAttribution
 from ..._utils.common import _format_attributions
-from ..._utils.gradient import _forward_layer_eval
 
 
 class LayerActivation(LayerAttribution):

--- a/captum/attr/_core/layer/layer_conductance.py
+++ b/captum/attr/_core/layer/layer_conductance.py
@@ -13,6 +13,7 @@ from ...._utils.common import (
     _expand_target,
     _format_additional_forward_args,
 )
+from ...._utils.gradient import compute_layer_gradients_and_eval
 from ...._utils.typing import BaselineType, Literal, TargetType
 from ..._utils.approximation_methods import approximation_parameters
 from ..._utils.attribution import GradientAttribution, LayerAttribution
@@ -23,7 +24,6 @@ from ..._utils.common import (
     _reshape_and_sum,
     _validate_input,
 )
-from ..._utils.gradient import compute_layer_gradients_and_eval
 
 
 class LayerConductance(LayerAttribution, GradientAttribution):

--- a/captum/attr/_core/layer/layer_deep_lift.py
+++ b/captum/attr/_core/layer/layer_deep_lift.py
@@ -15,6 +15,11 @@ from ...._utils.common import (
     _format_baseline,
     _format_input,
 )
+from ...._utils.gradient import (
+    apply_gradient_requirements,
+    compute_layer_gradients_and_eval,
+    undo_gradient_requirements,
+)
 from ...._utils.typing import (
     BaselineType,
     Literal,
@@ -29,11 +34,6 @@ from ..._utils.common import (
     _format_callable_baseline,
     _tensorize_baseline,
     _validate_input,
-)
-from ..._utils.gradient import (
-    apply_gradient_requirements,
-    compute_layer_gradients_and_eval,
-    undo_gradient_requirements,
 )
 
 

--- a/captum/attr/_core/layer/layer_feature_ablation.py
+++ b/captum/attr/_core/layer/layer_feature_ablation.py
@@ -14,10 +14,10 @@ from ...._utils.common import (
     _format_input,
     _run_forward,
 )
+from ...._utils.gradient import _forward_layer_eval
 from ...._utils.typing import BaselineType, TargetType
 from ..._utils.attribution import LayerAttribution, PerturbationAttribution
 from ..._utils.common import _format_attributions
-from ..._utils.gradient import _forward_layer_eval
 from ..feature_ablation import FeatureAblation
 
 

--- a/captum/attr/_core/layer/layer_gradient_shap.py
+++ b/captum/attr/_core/layer/layer_gradient_shap.py
@@ -10,6 +10,7 @@ from torch.nn import Module
 
 from captum.log import log_usage
 
+from ...._utils.gradient import _forward_layer_eval, compute_layer_gradients_and_eval
 from ...._utils.typing import Literal, TargetType, TensorOrTupleOfTensorsGeneric
 from ..._utils.attribution import GradientAttribution, LayerAttribution
 from ..._utils.common import (
@@ -17,7 +18,6 @@ from ..._utils.common import (
     _format_callable_baseline,
     _format_input_baseline,
 )
-from ..._utils.gradient import _forward_layer_eval, compute_layer_gradients_and_eval
 from ..gradient_shap import _scale_input
 from ..noise_tunnel import NoiseTunnel
 

--- a/captum/attr/_core/layer/layer_gradient_x_activation.py
+++ b/captum/attr/_core/layer/layer_gradient_x_activation.py
@@ -7,14 +7,14 @@ from torch.nn import Module
 from captum.log import log_usage
 
 from ...._utils.common import _format_additional_forward_args, _format_input
-from ...._utils.typing import TargetType
-from ..._utils.attribution import GradientAttribution, LayerAttribution
-from ..._utils.common import _format_attributions
-from ..._utils.gradient import (
+from ...._utils.gradient import (
     apply_gradient_requirements,
     compute_layer_gradients_and_eval,
     undo_gradient_requirements,
 )
+from ...._utils.typing import TargetType
+from ..._utils.attribution import GradientAttribution, LayerAttribution
+from ..._utils.common import _format_attributions
 
 
 class LayerGradientXActivation(LayerAttribution, GradientAttribution):

--- a/captum/attr/_core/layer/layer_integrated_gradients.py
+++ b/captum/attr/_core/layer/layer_integrated_gradients.py
@@ -7,6 +7,7 @@ from torch import Tensor
 from torch.nn import Module
 from torch.nn.parallel.scatter_gather import scatter
 
+from captum._utils.gradient import _forward_layer_eval, _run_forward
 from captum.attr._core.integrated_gradients import IntegratedGradients
 from captum.attr._utils.attribution import GradientAttribution, LayerAttribution
 from captum.attr._utils.common import (
@@ -15,7 +16,6 @@ from captum.attr._utils.common import (
     _tensorize_baseline,
     _validate_input,
 )
-from captum.attr._utils.gradient import _forward_layer_eval, _run_forward
 from captum.log import log_usage
 
 from ...._utils.common import _extract_device, _format_additional_forward_args

--- a/captum/attr/_core/neuron/neuron_conductance.py
+++ b/captum/attr/_core/neuron/neuron_conductance.py
@@ -14,6 +14,7 @@ from ...._utils.common import (
     _is_tuple,
     _verify_select_column,
 )
+from ...._utils.gradient import compute_layer_gradients_and_eval
 from ...._utils.typing import BaselineType, TargetType, TensorOrTupleOfTensorsGeneric
 from ..._utils.approximation_methods import approximation_parameters
 from ..._utils.attribution import GradientAttribution, NeuronAttribution
@@ -24,7 +25,6 @@ from ..._utils.common import (
     _reshape_and_sum,
     _validate_input,
 )
-from ..._utils.gradient import compute_layer_gradients_and_eval
 
 
 class NeuronConductance(NeuronAttribution, GradientAttribution):

--- a/captum/attr/_core/neuron/neuron_deep_lift.py
+++ b/captum/attr/_core/neuron/neuron_deep_lift.py
@@ -6,9 +6,9 @@ from torch.nn import Module
 
 from captum.log import log_usage
 
+from ...._utils.gradient import construct_neuron_grad_fn
 from ...._utils.typing import BaselineType, TensorOrTupleOfTensorsGeneric
 from ..._utils.attribution import GradientAttribution, NeuronAttribution
-from ..._utils.gradient import construct_neuron_grad_fn
 from ..deep_lift import DeepLift, DeepLiftShap
 
 

--- a/captum/attr/_core/neuron/neuron_feature_ablation.py
+++ b/captum/attr/_core/neuron/neuron_feature_ablation.py
@@ -7,9 +7,9 @@ from torch.nn import Module
 from captum.log import log_usage
 
 from ...._utils.common import _verify_select_column
+from ...._utils.gradient import _forward_layer_eval
 from ...._utils.typing import BaselineType, TensorOrTupleOfTensorsGeneric
 from ..._utils.attribution import NeuronAttribution, PerturbationAttribution
-from ..._utils.gradient import _forward_layer_eval
 from ..feature_ablation import FeatureAblation
 
 

--- a/captum/attr/_core/neuron/neuron_gradient.py
+++ b/captum/attr/_core/neuron/neuron_gradient.py
@@ -6,14 +6,14 @@ from torch.nn import Module
 from captum.log import log_usage
 
 from ...._utils.common import _format_additional_forward_args, _format_input, _is_tuple
-from ...._utils.typing import TensorOrTupleOfTensorsGeneric
-from ..._utils.attribution import GradientAttribution, NeuronAttribution
-from ..._utils.common import _format_attributions
-from ..._utils.gradient import (
+from ...._utils.gradient import (
     _forward_layer_eval_with_neuron_grads,
     apply_gradient_requirements,
     undo_gradient_requirements,
 )
+from ...._utils.typing import TensorOrTupleOfTensorsGeneric
+from ..._utils.attribution import GradientAttribution, NeuronAttribution
+from ..._utils.common import _format_attributions
 
 
 class NeuronGradient(NeuronAttribution, GradientAttribution):

--- a/captum/attr/_core/neuron/neuron_gradient_shap.py
+++ b/captum/attr/_core/neuron/neuron_gradient_shap.py
@@ -5,9 +5,9 @@ from torch.nn import Module
 
 from captum.log import log_usage
 
+from ...._utils.gradient import construct_neuron_grad_fn
 from ...._utils.typing import TensorOrTupleOfTensorsGeneric
 from ..._utils.attribution import GradientAttribution, NeuronAttribution
-from ..._utils.gradient import construct_neuron_grad_fn
 from ..gradient_shap import GradientShap
 
 

--- a/captum/attr/_core/neuron/neuron_guided_backprop_deconvnet.py
+++ b/captum/attr/_core/neuron/neuron_guided_backprop_deconvnet.py
@@ -5,9 +5,9 @@ from torch.nn import Module
 
 from captum.log import log_usage
 
+from ...._utils.gradient import construct_neuron_grad_fn
 from ...._utils.typing import TensorOrTupleOfTensorsGeneric
 from ..._utils.attribution import GradientAttribution, NeuronAttribution
-from ..._utils.gradient import construct_neuron_grad_fn
 from ..guided_backprop_deconvnet import Deconvolution, GuidedBackprop
 
 

--- a/captum/attr/_core/neuron/neuron_integrated_gradients.py
+++ b/captum/attr/_core/neuron/neuron_integrated_gradients.py
@@ -6,9 +6,9 @@ from torch.nn import Module
 
 from captum.log import log_usage
 
+from ...._utils.gradient import construct_neuron_grad_fn
 from ...._utils.typing import TensorOrTupleOfTensorsGeneric
 from ..._utils.attribution import GradientAttribution, NeuronAttribution
-from ..._utils.gradient import construct_neuron_grad_fn
 from ..integrated_gradients import IntegratedGradients
 
 

--- a/captum/attr/_core/saliency.py
+++ b/captum/attr/_core/saliency.py
@@ -7,10 +7,10 @@ import torch
 from captum.log import log_usage
 
 from ..._utils.common import _format_input, _is_tuple
+from ..._utils.gradient import apply_gradient_requirements, undo_gradient_requirements
 from ..._utils.typing import TargetType, TensorOrTupleOfTensorsGeneric
 from .._utils.attribution import GradientAttribution
 from .._utils.common import _format_attributions
-from .._utils.gradient import apply_gradient_requirements, undo_gradient_requirements
 
 
 class Saliency(GradientAttribution):

--- a/captum/attr/_utils/attribution.py
+++ b/captum/attr/_utils/attribution.py
@@ -14,9 +14,9 @@ from ..._utils.common import (
     _run_forward,
     _validate_target,
 )
+from ..._utils.gradient import compute_gradients
 from ..._utils.typing import TargetType
 from .common import _format_input_baseline, _tensorize_baseline, _validate_input
-from .gradient import compute_gradients
 
 
 class Attribution:

--- a/captum/attr/_utils/batching.py
+++ b/captum/attr/_utils/batching.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python3
 import typing
 import warnings
-from typing import Any, Callable, Dict, Iterator, List, Tuple, Union
+from typing import Any, Callable, Iterator, Tuple, Union
 
 import torch
-from torch import Tensor, device
+from torch import Tensor
 
-from ..._utils.common import _format_additional_forward_args, _format_input
+from ..._utils.common import (
+    _format_additional_forward_args,
+    _format_input,
+    _reduce_list,
+)
 from ..._utils.typing import (
     TargetType,
     TensorOrTupleOfTensorsGeneric,
@@ -119,68 +123,6 @@ def _tuple_splice_range(
     return tuple(
         inp[start:end] if isinstance(inp, torch.Tensor) else inp for inp in inputs
     )
-
-
-def _reduce_list(
-    val_list: List[TupleOrTensorOrBoolGeneric],
-    red_func: Callable[[List], Any] = torch.cat,
-) -> TupleOrTensorOrBoolGeneric:
-    """
-    Applies reduction function to given list. If each element in the list is
-    a Tensor, applies reduction function to all elements of the list, and returns
-    the output Tensor / value. If each element is a boolean, apply any method (or).
-    If each element is a tuple, applies reduction
-    function to corresponding elements of each tuple in the list, and returns
-    tuple of reduction function outputs with length matching the length of tuple
-    val_list[0]. It is assumed that all tuples in the list have the same length
-    and red_func can be applied to all elements in each corresponding position.
-    """
-    if isinstance(val_list[0], torch.Tensor):
-        return red_func(val_list)
-    elif isinstance(val_list[0], bool):
-        return any(val_list)
-    elif isinstance(val_list[0], tuple):
-        final_out = []
-        for i in range(len(val_list[0])):
-            final_out.append(
-                _reduce_list([val_elem[i] for val_elem in val_list], red_func)
-            )
-    else:
-        raise AssertionError(
-            "Elements to be reduced can only be"
-            "either Tensors or tuples containing Tensors."
-        )
-    return tuple(final_out)
-
-
-def _sort_key_list(
-    keys: List[device], device_ids: Union[None, List[int]] = None
-) -> List[device]:
-    """
-    Sorts list of torch devices (keys) by given index list, device_ids. If keys
-    contains only one device, then the list is returned unchanged. If keys
-    contains a device for which the id is not contained in device_ids, then
-    an error is returned. This method is used to identify the order of DataParallel
-    batched devices, given the device ID ordering.
-    """
-    if len(keys) == 1:
-        return keys
-    id_dict: Dict[int, device] = {}
-    assert device_ids is not None, "Device IDs must be provided with multiple devices."
-    for key in keys:
-        if key.index in id_dict:
-            raise AssertionError("Duplicate CUDA Device ID identified in device list.")
-        id_dict[key.index] = key
-
-    out_list = [
-        id_dict[device_id]
-        for device_id in filter(lambda device_id: device_id in id_dict, device_ids)
-    ]
-
-    assert len(out_list) == len(keys), "Given Device ID List does not match"
-    "devices with computed tensors."
-
-    return out_list
 
 
 def _batched_generator(

--- a/captum/attr/_utils/class_summarizer.py
+++ b/captum/attr/_utils/class_summarizer.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from collections import defaultdict
-from typing import Any, Dict, List, Union, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from torch import Tensor
 

--- a/captum/insights/config.py
+++ b/captum/insights/config.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from typing import Dict, List, NamedTuple, Optional, Tuple, Callable, Any, Union
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Union
 
 from captum.attr import (
     Deconvolution,
@@ -8,8 +8,8 @@ from captum.attr import (
     GuidedBackprop,
     InputXGradient,
     IntegratedGradients,
-    Saliency,
     Occlusion,
+    Saliency,
 )
 from captum.attr._utils.approximation_methods import SUPPORTED_METHODS
 

--- a/tests/attr/helpers/conductance_reference.py
+++ b/tests/attr/helpers/conductance_reference.py
@@ -2,13 +2,13 @@
 import numpy as np
 import torch
 
-from captum.attr._utils.approximation_methods import approximation_parameters
-from captum.attr._utils.attribution import LayerAttribution
-from captum.attr._utils.common import _reshape_and_sum
-from captum.attr._utils.gradient import (
+from captum._utils.gradient import (
     apply_gradient_requirements,
     undo_gradient_requirements,
 )
+from captum.attr._utils.approximation_methods import approximation_parameters
+from captum.attr._utils.attribution import LayerAttribution
+from captum.attr._utils.common import _reshape_and_sum
 
 
 """

--- a/tests/attr/neuron/test_neuron_gradient.py
+++ b/tests/attr/neuron/test_neuron_gradient.py
@@ -7,10 +7,10 @@ import torch
 from torch import Tensor
 from torch.nn import Module
 
+from captum._utils.gradient import _forward_layer_eval
 from captum._utils.typing import TensorOrTupleOfTensorsGeneric
 from captum.attr._core.neuron.neuron_gradient import NeuronGradient
 from captum.attr._core.saliency import Saliency
-from captum.attr._utils.gradient import _forward_layer_eval
 
 from ...helpers.basic import (
     BaseTest,

--- a/tests/attr/test_saliency.py
+++ b/tests/attr/test_saliency.py
@@ -5,10 +5,10 @@ import torch
 from torch import Tensor
 from torch.nn import Module
 
+from captum._utils.gradient import compute_gradients
 from captum._utils.typing import TensorOrTupleOfTensorsGeneric
 from captum.attr._core.noise_tunnel import NoiseTunnel
 from captum.attr._core.saliency import Saliency
-from captum.attr._utils.gradient import compute_gradients
 
 from ..helpers.basic import BaseTest, assertArraysAlmostEqual
 from ..helpers.basic_models import BasicModel, BasicModel5_MultiArgs

--- a/tests/attr/test_utils_batching.py
+++ b/tests/attr/test_utils_batching.py
@@ -5,8 +5,6 @@ import torch
 from captum.attr._utils.batching import (
     _batched_generator,
     _batched_operator,
-    _reduce_list,
-    _sort_key_list,
     _tuple_splice_range,
 )
 
@@ -33,39 +31,6 @@ class Test(BaseTest):
         spliced_tuple = _tuple_splice_range(test_tuple, 1, 2)
         assertTensorAlmostEqual(self, spliced_tuple[0], [[[6, 7, 8], [6, 7, 8]]])
         self.assertEqual(spliced_tuple[1], "test")
-
-    def test_reduce_list_tensors(self):
-        tensors = [torch.tensor([[3, 4, 5]]), torch.tensor([[0, 1, 2]])]
-        reduced = _reduce_list(tensors)
-        assertTensorAlmostEqual(self, reduced, [[3, 4, 5], [0, 1, 2]])
-
-    def test_reduce_list_tuples(self):
-        tensors = [
-            (torch.tensor([[3, 4, 5]]), torch.tensor([[0, 1, 2]])),
-            (torch.tensor([[3, 4, 5]]), torch.tensor([[0, 1, 2]])),
-        ]
-        reduced = _reduce_list(tensors)
-        assertTensorAlmostEqual(self, reduced[0], [[3, 4, 5], [3, 4, 5]])
-        assertTensorAlmostEqual(self, reduced[1], [[0, 1, 2], [0, 1, 2]])
-
-    def test_sort_key_list(self):
-        key_list = [
-            torch.device("cuda:13"),
-            torch.device("cuda:17"),
-            torch.device("cuda:10"),
-            torch.device("cuda:0"),
-        ]
-        device_index_list = [0, 10, 13, 17]
-        sorted_keys = _sort_key_list(key_list, device_index_list)
-        for i in range(len(key_list)):
-            self.assertEqual(sorted_keys[i].index, device_index_list[i])
-
-    def test_sort_key_list_incomplete(self):
-        key_list = [torch.device("cuda:10"), torch.device("cuda:0")]
-        device_index_list = [0, 10, 13, 17]
-        sorted_keys = _sort_key_list(key_list, device_index_list)
-        for i in range(len(key_list)):
-            self.assertEqual(sorted_keys[i].index, device_index_list[i])
 
     def test_batched_generator(self):
         def sample_operator(inputs, additional_forward_args, target_ind, scale):

--- a/tests/utils/test_gradient.py
+++ b/tests/utils/test_gradient.py
@@ -5,7 +5,7 @@ from typing import cast
 import torch
 from torch import Tensor
 
-from captum.attr._utils.gradient import (
+from captum._utils.gradient import (
     apply_gradient_requirements,
     compute_gradients,
     compute_layer_gradients_and_eval,


### PR DESCRIPTION
Summary:
Move captum/attr/_utils/gradient.py to captum/_utils/gradient.py along with the
corresponding test file. Change related imports.

Differential Revision: D21689565

