### PR TITLE
Move _format_attributions method to captum/_utils/common.py and rename it to _format_output

### DIFF
--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -316,6 +316,43 @@ def _expand_and_update_target(n_samples: int, kwargs: dict):
     kwargs["target"] = target
 
 
+@typing.overload
+def _format_output(
+    is_inputs_tuple: Literal[True], output: Tuple[Tensor, ...]
+) -> Tuple[Tensor, ...]:
+    ...
+
+
+@typing.overload
+def _format_output(
+    is_inputs_tuple: Literal[False], output: Tuple[Tensor, ...]
+) -> Tensor:
+    ...
+
+
+@typing.overload
+def _format_output(
+    is_inputs_tuple: bool, output: Tuple[Tensor, ...]
+) -> Union[Tensor, Tuple[Tensor, ...]]:
+    ...
+
+
+def _format_output(
+    is_inputs_tuple: bool, output: Tuple[Tensor, ...]
+) -> Union[Tensor, Tuple[Tensor, ...]]:
+    r"""
+    In case input is a tensor and the output is returned in form of a
+    tuple we take the first element of the output's tuple to match the
+    same shape signatues of the inputs
+    """
+    assert isinstance(output, tuple), "Output must be in shape of a tuple"
+    assert is_inputs_tuple or len(output) == 1, (
+        "The input is a single tensor however the output isn't."
+        "The number of output tensors is: {}".format(len(output))
+    )
+    return output if is_inputs_tuple else output[0]
+
+
 def _run_forward(
     forward_func: Callable,
     inputs: Union[Tensor, Tuple[Tensor, ...]],

--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -20,6 +20,7 @@ from ..._utils.common import (
     _format_additional_forward_args,
     _format_baseline,
     _format_input,
+    _format_output,
     _format_tensor_into_tuples,
     _is_tuple,
     _run_forward,
@@ -36,7 +37,6 @@ from .._utils.attribution import GradientAttribution
 from .._utils.common import (
     _call_custom_attribution_func,
     _compute_conv_delta_and_format_attrs,
-    _format_attributions,
     _format_callable_baseline,
     _tensorize_baseline,
     _validate_input,
@@ -811,9 +811,9 @@ class DeepLiftShap(DeepLift):
         )
 
         if return_convergence_delta:
-            return _format_attributions(is_inputs_tuple, attributions), delta
+            return _format_output(is_inputs_tuple, attributions), delta
         else:
-            return _format_attributions(is_inputs_tuple, attributions)
+            return _format_output(is_inputs_tuple, attributions)
 
     def _expand_inputs_baselines_targets(
         self,

--- a/captum/attr/_core/feature_ablation.py
+++ b/captum/attr/_core/feature_ablation.py
@@ -12,16 +12,13 @@ from ..._utils.common import (
     _expand_target,
     _format_additional_forward_args,
     _format_input,
+    _format_output,
     _is_tuple,
     _run_forward,
 )
 from ..._utils.typing import BaselineType, TargetType, TensorOrTupleOfTensorsGeneric
 from .._utils.attribution import PerturbationAttribution
-from .._utils.common import (
-    _find_output_mode_and_verify,
-    _format_attributions,
-    _format_input_baseline,
-)
+from .._utils.common import _find_output_mode_and_verify, _format_input_baseline
 
 
 class FeatureAblation(PerturbationAttribution):
@@ -334,7 +331,7 @@ class FeatureAblation(PerturbationAttribution):
                 )
             else:
                 attrib = tuple(total_attrib)
-            _result = _format_attributions(is_inputs_tuple, attrib)
+            _result = _format_output(is_inputs_tuple, attrib)
         return _result
 
     def _ablation_generator(

--- a/captum/attr/_core/guided_backprop_deconvnet.py
+++ b/captum/attr/_core/guided_backprop_deconvnet.py
@@ -10,11 +10,10 @@ from torch.utils.hooks import RemovableHandle
 
 from captum.log import log_usage
 
-from ..._utils.common import _format_input, _is_tuple
+from ..._utils.common import _format_input, _format_output, _is_tuple
 from ..._utils.gradient import apply_gradient_requirements, undo_gradient_requirements
 from ..._utils.typing import TargetType, TensorOrTupleOfTensorsGeneric
 from .._utils.attribution import GradientAttribution
-from .._utils.common import _format_attributions
 
 
 class ModifiedReluGradientAttribution(GradientAttribution):
@@ -70,7 +69,7 @@ class ModifiedReluGradientAttribution(GradientAttribution):
             self._remove_hooks()
 
         undo_gradient_requirements(inputs, gradient_mask)
-        return _format_attributions(is_inputs_tuple, gradients)
+        return _format_output(is_inputs_tuple, gradients)
 
     def _register_hooks(self, module: Module):
         if isinstance(module, torch.nn.ReLU):

--- a/captum/attr/_core/guided_grad_cam.py
+++ b/captum/attr/_core/guided_grad_cam.py
@@ -8,10 +8,9 @@ from torch.nn import Module
 
 from captum.log import log_usage
 
-from ..._utils.common import _format_input, _is_tuple
+from ..._utils.common import _format_input, _format_output, _is_tuple
 from ..._utils.typing import TargetType, TensorOrTupleOfTensorsGeneric
 from .._utils.attribution import GradientAttribution, LayerAttribution
-from .._utils.common import _format_attributions
 from .guided_backprop_deconvnet import GuidedBackprop
 from .layer.grad_cam import LayerGradCam
 
@@ -222,4 +221,4 @@ class GuidedGradCam(GradientAttribution):
                 )
                 output_attr.append(torch.empty(0))
 
-        return _format_attributions(is_inputs_tuple, tuple(output_attr))
+        return _format_output(is_inputs_tuple, tuple(output_attr))

--- a/captum/attr/_core/input_x_gradient.py
+++ b/captum/attr/_core/input_x_gradient.py
@@ -3,11 +3,10 @@ from typing import Any, Callable
 
 from captum.log import log_usage
 
-from ..._utils.common import _format_input, _is_tuple
+from ..._utils.common import _format_input, _format_output, _is_tuple
 from ..._utils.gradient import apply_gradient_requirements, undo_gradient_requirements
 from ..._utils.typing import TargetType, TensorOrTupleOfTensorsGeneric
 from .._utils.attribution import GradientAttribution
-from .._utils.common import _format_attributions
 
 
 class InputXGradient(GradientAttribution):
@@ -121,4 +120,4 @@ class InputXGradient(GradientAttribution):
             input * gradient for input, gradient in zip(inputs, gradients)
         )
         undo_gradient_requirements(inputs, gradient_mask)
-        return _format_attributions(is_inputs_tuple, attributions)
+        return _format_output(is_inputs_tuple, attributions)

--- a/captum/attr/_core/integrated_gradients.py
+++ b/captum/attr/_core/integrated_gradients.py
@@ -11,6 +11,7 @@ from ..._utils.common import (
     _expand_additional_forward_args,
     _expand_target,
     _format_additional_forward_args,
+    _format_output,
     _is_tuple,
 )
 from ..._utils.typing import (
@@ -22,12 +23,7 @@ from ..._utils.typing import (
 from .._utils.approximation_methods import approximation_parameters
 from .._utils.attribution import GradientAttribution
 from .._utils.batching import _batch_attribution
-from .._utils.common import (
-    _format_attributions,
-    _format_input_baseline,
-    _reshape_and_sum,
-    _validate_input,
-)
+from .._utils.common import _format_input_baseline, _reshape_and_sum, _validate_input
 
 
 class IntegratedGradients(GradientAttribution):
@@ -285,8 +281,8 @@ class IntegratedGradients(GradientAttribution):
                 additional_forward_args=additional_forward_args,
                 target=target,
             )
-            return _format_attributions(is_inputs_tuple, attributions), delta
-        return _format_attributions(is_inputs_tuple, attributions)
+            return _format_output(is_inputs_tuple, attributions), delta
+        return _format_output(is_inputs_tuple, attributions)
 
     def _attribute(
         self,

--- a/captum/attr/_core/layer/grad_cam.py
+++ b/captum/attr/_core/layer/grad_cam.py
@@ -8,7 +8,11 @@ from torch.nn import Module
 
 from captum.log import log_usage
 
-from ...._utils.common import _format_additional_forward_args, _format_input
+from ...._utils.common import (
+    _format_additional_forward_args,
+    _format_input,
+    _format_output,
+)
 from ...._utils.gradient import (
     apply_gradient_requirements,
     compute_layer_gradients_and_eval,
@@ -16,7 +20,6 @@ from ...._utils.gradient import (
 )
 from ...._utils.typing import TargetType
 from ..._utils.attribution import GradientAttribution, LayerAttribution
-from ..._utils.common import _format_attributions
 
 
 class LayerGradCam(LayerAttribution, GradientAttribution):
@@ -221,4 +224,4 @@ class LayerGradCam(LayerAttribution, GradientAttribution):
         )
         if relu_attributions:
             scaled_acts = tuple(F.relu(scaled_act) for scaled_act in scaled_acts)
-        return _format_attributions(is_layer_tuple, scaled_acts)
+        return _format_output(is_layer_tuple, scaled_acts)

--- a/captum/attr/_core/layer/internal_influence.py
+++ b/captum/attr/_core/layer/internal_influence.py
@@ -11,18 +11,14 @@ from ...._utils.common import (
     _expand_additional_forward_args,
     _expand_target,
     _format_additional_forward_args,
+    _format_output,
 )
 from ...._utils.gradient import compute_layer_gradients_and_eval
 from ...._utils.typing import BaselineType, TargetType
 from ..._utils.approximation_methods import approximation_parameters
 from ..._utils.attribution import GradientAttribution, LayerAttribution
 from ..._utils.batching import _batch_attribution
-from ..._utils.common import (
-    _format_attributions,
-    _format_input_baseline,
-    _reshape_and_sum,
-    _validate_input,
-)
+from ..._utils.common import _format_input_baseline, _reshape_and_sum, _validate_input
 
 
 class InternalInfluence(LayerAttribution, GradientAttribution):
@@ -310,4 +306,4 @@ class InternalInfluence(LayerAttribution, GradientAttribution):
             )
             for scaled_grad, layer_grad in zip(scaled_grads, layer_gradients)
         )
-        return _format_attributions(is_layer_tuple, attrs)
+        return _format_output(is_layer_tuple, attrs)

--- a/captum/attr/_core/layer/layer_activation.py
+++ b/captum/attr/_core/layer/layer_activation.py
@@ -7,9 +7,9 @@ from torch.nn import Module
 
 from captum.log import log_usage
 
+from ...._utils.common import _format_output
 from ...._utils.gradient import _forward_layer_eval
 from ..._utils.attribution import LayerAttribution
-from ..._utils.common import _format_attributions
 
 
 class LayerActivation(LayerAttribution):
@@ -120,4 +120,4 @@ class LayerActivation(LayerAttribution):
                 device_ids=self.device_ids,
                 attribute_to_layer_input=attribute_to_layer_input,
             )
-        return _format_attributions(is_layer_tuple, layer_eval)
+        return _format_output(is_layer_tuple, layer_eval)

--- a/captum/attr/_core/layer/layer_conductance.py
+++ b/captum/attr/_core/layer/layer_conductance.py
@@ -12,18 +12,14 @@ from ...._utils.common import (
     _expand_additional_forward_args,
     _expand_target,
     _format_additional_forward_args,
+    _format_output,
 )
 from ...._utils.gradient import compute_layer_gradients_and_eval
 from ...._utils.typing import BaselineType, Literal, TargetType
 from ..._utils.approximation_methods import approximation_parameters
 from ..._utils.attribution import GradientAttribution, LayerAttribution
 from ..._utils.batching import _batch_attribution
-from ..._utils.common import (
-    _format_attributions,
-    _format_input_baseline,
-    _reshape_and_sum,
-    _validate_input,
-)
+from ..._utils.common import _format_input_baseline, _reshape_and_sum, _validate_input
 
 
 class LayerConductance(LayerAttribution, GradientAttribution):
@@ -314,8 +310,8 @@ class LayerConductance(LayerAttribution, GradientAttribution):
                 target=target,
                 additional_forward_args=additional_forward_args,
             )
-            return _format_attributions(is_layer_tuple, attributions), delta
-        return _format_attributions(is_layer_tuple, attributions)
+            return _format_output(is_layer_tuple, attributions), delta
+        return _format_output(is_layer_tuple, attributions)
 
     def _attribute(
         self,
@@ -396,4 +392,4 @@ class LayerConductance(LayerAttribution, GradientAttribution):
                 layer_gradients, layer_evals, grad_diffs
             )
         )
-        return _format_attributions(is_layer_tuple, attributions)
+        return _format_output(is_layer_tuple, attributions)

--- a/captum/attr/_core/layer/layer_feature_ablation.py
+++ b/captum/attr/_core/layer/layer_feature_ablation.py
@@ -12,12 +12,12 @@ from ...._utils.common import (
     _extract_device,
     _format_additional_forward_args,
     _format_input,
+    _format_output,
     _run_forward,
 )
 from ...._utils.gradient import _forward_layer_eval
 from ...._utils.typing import BaselineType, TargetType
 from ..._utils.attribution import LayerAttribution, PerturbationAttribution
-from ..._utils.common import _format_attributions
 from ..feature_ablation import FeatureAblation
 
 
@@ -291,5 +291,5 @@ class LayerFeatureAblation(LayerAttribution, PerturbationAttribution):
                 feature_mask=layer_mask,
                 perturbations_per_eval=perturbations_per_eval,
             )
-            _attr = _format_attributions(is_layer_tuple, layer_attribs)
+            _attr = _format_output(is_layer_tuple, layer_attribs)
         return _attr

--- a/captum/attr/_core/layer/layer_gradient_x_activation.py
+++ b/captum/attr/_core/layer/layer_gradient_x_activation.py
@@ -6,7 +6,11 @@ from torch.nn import Module
 
 from captum.log import log_usage
 
-from ...._utils.common import _format_additional_forward_args, _format_input
+from ...._utils.common import (
+    _format_additional_forward_args,
+    _format_input,
+    _format_output,
+)
 from ...._utils.gradient import (
     apply_gradient_requirements,
     compute_layer_gradients_and_eval,
@@ -14,7 +18,6 @@ from ...._utils.gradient import (
 )
 from ...._utils.typing import TargetType
 from ..._utils.attribution import GradientAttribution, LayerAttribution
-from ..._utils.common import _format_attributions
 
 
 class LayerGradientXActivation(LayerAttribution, GradientAttribution):
@@ -156,7 +159,7 @@ class LayerGradientXActivation(LayerAttribution, GradientAttribution):
             attribute_to_layer_input=attribute_to_layer_input,
         )
         undo_gradient_requirements(inputs, gradient_mask)
-        return _format_attributions(
+        return _format_output(
             is_layer_tuple,
             tuple(
                 layer_gradient * layer_eval

--- a/captum/attr/_core/layer/layer_integrated_gradients.py
+++ b/captum/attr/_core/layer/layer_integrated_gradients.py
@@ -11,14 +11,17 @@ from captum._utils.gradient import _forward_layer_eval, _run_forward
 from captum.attr._core.integrated_gradients import IntegratedGradients
 from captum.attr._utils.attribution import GradientAttribution, LayerAttribution
 from captum.attr._utils.common import (
-    _format_attributions,
     _format_input_baseline,
     _tensorize_baseline,
     _validate_input,
 )
 from captum.log import log_usage
 
-from ...._utils.common import _extract_device, _format_additional_forward_args
+from ...._utils.common import (
+    _extract_device,
+    _format_additional_forward_args,
+    _format_output,
+)
 from ...._utils.typing import BaselineType, Literal, TargetType
 
 
@@ -379,8 +382,8 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
                 additional_forward_args=additional_forward_args,
                 target=target,
             )
-            return _format_attributions(is_layer_tuple, attributions), delta
-        return _format_attributions(is_layer_tuple, attributions)
+            return _format_output(is_layer_tuple, attributions), delta
+        return _format_output(is_layer_tuple, attributions)
 
     def has_convergence_delta(self) -> bool:
         return True

--- a/captum/attr/_core/neuron/neuron_conductance.py
+++ b/captum/attr/_core/neuron/neuron_conductance.py
@@ -11,6 +11,7 @@ from ...._utils.common import (
     _expand_additional_forward_args,
     _expand_target,
     _format_additional_forward_args,
+    _format_output,
     _is_tuple,
     _verify_select_column,
 )
@@ -19,12 +20,7 @@ from ...._utils.typing import BaselineType, TargetType, TensorOrTupleOfTensorsGe
 from ..._utils.approximation_methods import approximation_parameters
 from ..._utils.attribution import GradientAttribution, NeuronAttribution
 from ..._utils.batching import _batch_attribution
-from ..._utils.common import (
-    _format_attributions,
-    _format_input_baseline,
-    _reshape_and_sum,
-    _validate_input,
-)
+from ..._utils.common import _format_input_baseline, _reshape_and_sum, _validate_input
 
 
 class NeuronConductance(NeuronAttribution, GradientAttribution):
@@ -264,7 +260,7 @@ class NeuronConductance(NeuronAttribution, GradientAttribution):
                 method=method,
                 attribute_to_neuron_input=attribute_to_neuron_input,
             )
-        return _format_attributions(is_inputs_tuple, attrs)
+        return _format_output(is_inputs_tuple, attrs)
 
     def _attribute(
         self,

--- a/captum/attr/_core/neuron/neuron_gradient.py
+++ b/captum/attr/_core/neuron/neuron_gradient.py
@@ -5,7 +5,12 @@ from torch.nn import Module
 
 from captum.log import log_usage
 
-from ...._utils.common import _format_additional_forward_args, _format_input, _is_tuple
+from ...._utils.common import (
+    _format_additional_forward_args,
+    _format_input,
+    _format_output,
+    _is_tuple,
+)
 from ...._utils.gradient import (
     _forward_layer_eval_with_neuron_grads,
     apply_gradient_requirements,
@@ -13,7 +18,6 @@ from ...._utils.gradient import (
 )
 from ...._utils.typing import TensorOrTupleOfTensorsGeneric
 from ..._utils.attribution import GradientAttribution, NeuronAttribution
-from ..._utils.common import _format_attributions
 
 
 class NeuronGradient(NeuronAttribution, GradientAttribution):
@@ -148,4 +152,4 @@ class NeuronGradient(NeuronAttribution, GradientAttribution):
         )
 
         undo_gradient_requirements(inputs, gradient_mask)
-        return _format_attributions(is_inputs_tuple, input_grads)
+        return _format_output(is_inputs_tuple, input_grads)

--- a/captum/attr/_core/noise_tunnel.py
+++ b/captum/attr/_core/noise_tunnel.py
@@ -12,11 +12,12 @@ from ..._utils.common import (
     _expand_and_update_baselines,
     _expand_and_update_target,
     _format_input,
+    _format_output,
     _format_tensor_into_tuples,
     _is_tuple,
 )
 from .._utils.attribution import Attribution
-from .._utils.common import _format_attributions, _validate_noise_tunnel_type
+from .._utils.common import _validate_noise_tunnel_type
 
 
 class NoiseTunnelType(Enum):
@@ -281,7 +282,7 @@ class NoiseTunnel(Attribution):
         return_convergence_delta: bool,
         delta: Union[None, Tensor],
     ):
-        attributions = _format_attributions(is_attrib_tuple, attributions)
+        attributions = _format_output(is_attrib_tuple, attributions)
 
         return (
             (attributions, delta)

--- a/captum/attr/_core/saliency.py
+++ b/captum/attr/_core/saliency.py
@@ -6,11 +6,10 @@ import torch
 
 from captum.log import log_usage
 
-from ..._utils.common import _format_input, _is_tuple
+from ..._utils.common import _format_input, _format_output, _is_tuple
 from ..._utils.gradient import apply_gradient_requirements, undo_gradient_requirements
 from ..._utils.typing import TargetType, TensorOrTupleOfTensorsGeneric
 from .._utils.attribution import GradientAttribution
-from .._utils.common import _format_attributions
 
 
 class Saliency(GradientAttribution):
@@ -135,4 +134,4 @@ class Saliency(GradientAttribution):
         else:
             attributions = gradients
         undo_gradient_requirements(inputs, gradient_mask)
-        return _format_attributions(is_inputs_tuple, attributions)
+        return _format_output(is_inputs_tuple, attributions)

--- a/captum/attr/_core/shapley_value.py
+++ b/captum/attr/_core/shapley_value.py
@@ -14,6 +14,7 @@ from ..._utils.common import (
     _expand_target,
     _format_additional_forward_args,
     _format_input,
+    _format_output,
     _is_tuple,
     _run_forward,
 )
@@ -21,7 +22,6 @@ from ..._utils.typing import BaselineType, TargetType, TensorOrTupleOfTensorsGen
 from .._utils.attribution import PerturbationAttribution
 from .._utils.common import (
     _find_output_mode_and_verify,
-    _format_attributions,
     _format_input_baseline,
     _tensorize_baseline,
 )
@@ -361,7 +361,7 @@ class ShapleyValueSampling(PerturbationAttribution):
             attrib = tuple(
                 tensor_attrib_total / iter_count for tensor_attrib_total in total_attrib
             )
-            formatted_attr = _format_attributions(is_inputs_tuple, attrib)
+            formatted_attr = _format_output(is_inputs_tuple, attrib)
         return formatted_attr
 
     def _perturbation_generator(

--- a/captum/attr/_utils/common.py
+++ b/captum/attr/_utils/common.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Callable, List, Tuple, Union
 import torch
 from torch import Tensor
 
-from ..._utils.common import _format_baseline, _format_input
+from ..._utils.common import _format_baseline, _format_input, _format_output
 from ..._utils.common import _validate_input as _validate_input_basic
 from ..._utils.typing import (
     BaselineType,
@@ -136,43 +136,6 @@ def _format_callable_baseline(
     return _format_baseline(baselines, _format_input(inputs))
 
 
-@typing.overload
-def _format_attributions(
-    is_inputs_tuple: Literal[True], attributions: Tuple[Tensor, ...]
-) -> Tuple[Tensor, ...]:
-    ...
-
-
-@typing.overload
-def _format_attributions(
-    is_inputs_tuple: Literal[False], attributions: Tuple[Tensor, ...]
-) -> Tensor:
-    ...
-
-
-@typing.overload
-def _format_attributions(
-    is_inputs_tuple: bool, attributions: Tuple[Tensor, ...]
-) -> Union[Tensor, Tuple[Tensor, ...]]:
-    ...
-
-
-def _format_attributions(
-    is_inputs_tuple: bool, attributions: Tuple[Tensor, ...]
-) -> Union[Tensor, Tuple[Tensor, ...]]:
-    r"""
-    In case input is a tensor and the attributions is returned in form of a
-    tensor we take the first element of the attributions' tuple to match the
-    same shape signatues of the inputs
-    """
-    assert isinstance(attributions, tuple), "Attributions must be in shape of a tuple"
-    assert is_inputs_tuple or len(attributions) == 1, (
-        "The input is a single tensor however the attributions aren't."
-        "The number of attributed tensors is: {}".format(len(attributions))
-    )
-    return attributions if is_inputs_tuple else attributions[0]
-
-
 def _format_and_verify_strides(
     strides: Union[None, int, Tuple[int, ...], Tuple[Union[int, Tuple[int, ...]], ...]],
     inputs: Tuple[Tensor, ...],
@@ -277,9 +240,9 @@ def _compute_conv_delta_and_format_attrs(
             additional_forward_args=additional_forward_args,
             target=target,
         )
-        return _format_attributions(is_inputs_tuple, attributions), delta
+        return _format_output(is_inputs_tuple, attributions), delta
     else:
-        return _format_attributions(is_inputs_tuple, attributions)
+        return _format_output(is_inputs_tuple, attributions)
 
 
 def _tensorize_baseline(


### PR DESCRIPTION
Summary:
Changed _format_attribution method to _format_output, so that it can be used for general output.
Moved it from captum/attr/_utils/common.py to captum/_utils/common.py.

Differential Revision: D21887553

