### PR TITLE
Speed up pytorch_captum tests by moving calculation of torch.cuda.is_available() up to module level

### DIFF
--- a/tests/attr/test_data_parallel.py
+++ b/tests/attr/test_data_parallel.py
@@ -20,7 +20,7 @@ from captum.attr._core.noise_tunnel import NoiseTunnel
 from captum.attr._models.base import _get_deep_layer_name
 from captum.attr._utils.attribution import Attribution, InternalAttribution
 
-from ..helpers.basic import BaseGPUTest, assertTensorTuplesAlmostEqual, deep_copy_args
+from ..helpers.basic import BaseTest, assertTensorTuplesAlmostEqual, deep_copy_args
 from .helpers.gen_test_utils import gen_test_name, parse_test_config
 from .helpers.test_config import config
 
@@ -238,5 +238,7 @@ class DataParallelMeta(type):
         return data_parallel_test_assert
 
 
-class DataParallelTest(BaseGPUTest, metaclass=DataParallelMeta):
-    pass
+if torch.cuda.is_available() and torch.cuda.device_count() != 0:
+
+    class DataParallelTest(BaseTest, metaclass=DataParallelMeta):
+        pass

--- a/tests/attr/test_jit.py
+++ b/tests/attr/test_jit.py
@@ -189,5 +189,7 @@ class JITMeta(type):
         return jit_test_assert
 
 
-class JITTest(BaseTest, metaclass=JITMeta):
-    pass
+if torch.cuda.is_available() and torch.cuda.device_count() != 0:
+
+    class JITTest(BaseTest, metaclass=JITMeta):
+        pass

--- a/tests/helpers/basic.py
+++ b/tests/helpers/basic.py
@@ -100,16 +100,3 @@ class BaseTest(unittest.TestCase):
     def setUp(self):
         set_all_random_seeds(1234)
         set_environment("test")
-
-
-class BaseGPUTest(BaseTest):
-    """
-    This class provides a basic framework for all Captum tests requiring
-    CUDA and available GPUs to run appropriately, such as tests for
-    DataParallel models. If CUDA is not available, these tests are skipped.
-    """
-
-    def setUp(self):
-        super().setUp()
-        if not torch.cuda.is_available() or torch.cuda.device_count() == 0:
-            raise unittest.SkipTest("Skipping GPU test since CUDA not available.")


### PR DESCRIPTION
Summary:
In this diff we attempt to prevent listing of the tests in `test_jit.py` and `test_data_parallel.py` if CUDA is not available by moving the CUDA check up to the module level. This way we don't have to discover these tests and then attempt to run them only for it to trigger this exact code path somewhere down the setup stage for each test case.

The main reason why this takes so long is that the computation for `torch.cuda.is_available()` requires the import of the module `torch._C` which we've profiled in the past to take anywhere between 15-20 seconds. To do this for over 1000 tests every single time we test `//pytorch/captum:attributions` is expensive (both timewise and resource wise).

 ---

Differential Revision: D21966198

