### PR TITLE
Fix CI Build Segfaults

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,7 @@ jobs:
     steps:
       - checkout
       - pip_install:
-          args: "-n -f"
+          args: "-n"
       - lint_flake8
       - lint_black
       - isort
@@ -148,8 +148,7 @@ jobs:
       - image: circleci/python:3.6.8
     steps:
       - checkout
-      - pip_install:
-          args: "-f"
+      - pip_install
       - lint_flake8
       - lint_black
       - isort
@@ -163,7 +162,7 @@ jobs:
     steps:
       - checkout
       - pip_install:
-          args: "-f -v 1.3"
+          args: "-v 1.3"
       - unit_tests
 
   test_py36_pip_torch_1_2:
@@ -172,7 +171,7 @@ jobs:
     steps:
       - checkout
       - pip_install:
-          args: "-f -v 1.2"
+          args: "-v 1.2"
       - unit_tests
 
   lint_test_py37_conda:
@@ -205,7 +204,7 @@ jobs:
     steps:
       - checkout
       - pip_install:
-          args: "-n -f -d"
+          args: "-n -d"
       - lint_flake8
       - lint_black
       - isort


### PR DESCRIPTION
Disable pytext install in pip builds to avoid segfault