### PR TITLE
Fix require grad warning for non-leaf tensor in noise tunnel

### DIFF
--- a/captum/attr/_core/gradient_shap.py
+++ b/captum/attr/_core/gradient_shap.py
@@ -369,9 +369,9 @@ def _scale_input(
     inp_shape = (bsz,) + tuple([1] * len(inp_shape_wo_bsz))
 
     # expand and reshape the indices
-    rand_coefficient = rand_coefficient.view(inp_shape).requires_grad_()
+    rand_coefficient = rand_coefficient.view(inp_shape)
 
     input_baseline_scaled = (
         rand_coefficient * input + (torch.tensor(1) - rand_coefficient) * baseline
-    )
+    ).requires_grad_()
     return input_baseline_scaled

--- a/captum/attr/_core/noise_tunnel.py
+++ b/captum/attr/_core/noise_tunnel.py
@@ -199,81 +199,85 @@ class NoiseTunnel(Attribution):
             expected_attribution_sq = torch.mean(attribution ** 2, dim=1, keepdim=False)
             return expected_attribution, expected_attribution_sq
 
-        # Keeps track whether original input is a tuple or not before
-        # converting it into a tuple.
-        is_inputs_tuple = isinstance(inputs, tuple)
+        with torch.no_grad():
+            # Keeps track whether original input is a tuple or not before
+            # converting it into a tuple.
+            is_inputs_tuple = isinstance(inputs, tuple)
 
-        inputs = _format_input(inputs)
+            inputs = _format_input(inputs)
 
-        _validate_noise_tunnel_type(nt_type, SUPPORTED_NOISE_TUNNEL_TYPES)
+            _validate_noise_tunnel_type(nt_type, SUPPORTED_NOISE_TUNNEL_TYPES)
 
-        delta = None
-        inputs_with_noise = add_noise_to_inputs()
-        # if the algorithm supports targets, baselines and/or additional_forward_args
-        # they will be expanded based on the n_steps and corresponding kwargs
-        # variables will be updated accordingly
-        _expand_and_update_additional_forward_args(n_samples, kwargs)
-        _expand_and_update_target(n_samples, kwargs)
-        _expand_and_update_baselines(
-            inputs,
-            n_samples,
-            kwargs,
-            draw_baseline_from_distrib=draw_baseline_from_distrib,
-        )
-
-        # smoothgrad_Attr(x) = 1 / n * sum(Attr(x + N(0, sigma^2))
-        # NOTE: using __wrapped__ such that it does not log the inner logs
-        attributions = self.attribution_method.attribute.__wrapped__(  # type: ignore
-            self.attribution_method,  # self
-            inputs_with_noise if is_inputs_tuple else inputs_with_noise[0],
-            **kwargs,
-        )
-
-        return_convergence_delta = (
-            "return_convergence_delta" in kwargs and kwargs["return_convergence_delta"]
-        )
-
-        if self.is_delta_supported and return_convergence_delta:
-            attributions, delta = attributions
-
-        is_attrib_tuple = _is_tuple(attributions)
-        attributions = _format_tensor_into_tuples(attributions)
-
-        expected_attributions = []
-        expected_attributions_sq = []
-        for attribution in attributions:
-            expected_attr, expected_attr_sq = compute_expected_attribution_and_sq(
-                attribution
+            delta = None
+            inputs_with_noise = add_noise_to_inputs()
+            # if the algorithm supports targets, baselines and/or
+            # additional_forward_args they will be expanded based
+            # on the n_steps and corresponding kwargs
+            # variables will be updated accordingly
+            _expand_and_update_additional_forward_args(n_samples, kwargs)
+            _expand_and_update_target(n_samples, kwargs)
+            _expand_and_update_baselines(
+                inputs,
+                n_samples,
+                kwargs,
+                draw_baseline_from_distrib=draw_baseline_from_distrib,
             )
-            expected_attributions.append(expected_attr)
-            expected_attributions_sq.append(expected_attr_sq)
 
-        if NoiseTunnelType[nt_type] == NoiseTunnelType.smoothgrad:
+            # smoothgrad_Attr(x) = 1 / n * sum(Attr(x + N(0, sigma^2))
+            # NOTE: using __wrapped__ such that it does not log the inner logs
+            attr_func = self.attribution_method.attribute
+            attributions = attr_func.__wrapped__(  # type: ignore
+                self.attribution_method,  # self
+                inputs_with_noise if is_inputs_tuple else inputs_with_noise[0],
+                **kwargs,
+            )
+
+            return_convergence_delta = (
+                "return_convergence_delta" in kwargs
+                and kwargs["return_convergence_delta"]
+            )
+
+            if self.is_delta_supported and return_convergence_delta:
+                attributions, delta = attributions
+
+            is_attrib_tuple = _is_tuple(attributions)
+            attributions = _format_tensor_into_tuples(attributions)
+
+            expected_attributions = []
+            expected_attributions_sq = []
+            for attribution in attributions:
+                expected_attr, expected_attr_sq = compute_expected_attribution_and_sq(
+                    attribution
+                )
+                expected_attributions.append(expected_attr)
+                expected_attributions_sq.append(expected_attr_sq)
+
+            if NoiseTunnelType[nt_type] == NoiseTunnelType.smoothgrad:
+                return self._apply_checks_and_return_attributions(
+                    tuple(expected_attributions),
+                    is_attrib_tuple,
+                    return_convergence_delta,
+                    delta,
+                )
+
+            if NoiseTunnelType[nt_type] == NoiseTunnelType.smoothgrad_sq:
+                return self._apply_checks_and_return_attributions(
+                    tuple(expected_attributions_sq),
+                    is_attrib_tuple,
+                    return_convergence_delta,
+                    delta,
+                )
+
+            vargrad = tuple(
+                expected_attribution_sq - expected_attribution * expected_attribution
+                for expected_attribution, expected_attribution_sq in zip(
+                    expected_attributions, expected_attributions_sq
+                )
+            )
+
             return self._apply_checks_and_return_attributions(
-                tuple(expected_attributions),
-                is_attrib_tuple,
-                return_convergence_delta,
-                delta,
+                vargrad, is_attrib_tuple, return_convergence_delta, delta
             )
-
-        if NoiseTunnelType[nt_type] == NoiseTunnelType.smoothgrad_sq:
-            return self._apply_checks_and_return_attributions(
-                tuple(expected_attributions_sq),
-                is_attrib_tuple,
-                return_convergence_delta,
-                delta,
-            )
-
-        vargrad = tuple(
-            expected_attribution_sq - expected_attribution * expected_attribution
-            for expected_attribution, expected_attribution_sq in zip(
-                expected_attributions, expected_attributions_sq
-            )
-        )
-
-        return self._apply_checks_and_return_attributions(
-            vargrad, is_attrib_tuple, return_convergence_delta, delta
-        )
 
     def _apply_checks_and_return_attributions(
         self,

--- a/tests/attr/neuron/test_neuron_gradient.py
+++ b/tests/attr/neuron/test_neuron_gradient.py
@@ -126,7 +126,7 @@ class Test(BaseTest):
             while len(neuron) < len(out.shape) - 1:
                 neuron = neuron + (0,)
             input_attrib = Saliency(
-                lambda x: _forward_layer_eval(model, x, output_layer)[0][0][
+                lambda x: _forward_layer_eval(model, x, output_layer, grad_enabled=True)[0][0][
                     (slice(None), *neuron)
                 ]
             )

--- a/tests/attr/neuron/test_neuron_gradient.py
+++ b/tests/attr/neuron/test_neuron_gradient.py
@@ -126,9 +126,9 @@ class Test(BaseTest):
             while len(neuron) < len(out.shape) - 1:
                 neuron = neuron + (0,)
             input_attrib = Saliency(
-                lambda x: _forward_layer_eval(model, x, output_layer, grad_enabled=True)[0][0][
-                    (slice(None), *neuron)
-                ]
+                lambda x: _forward_layer_eval(
+                    model, x, output_layer, grad_enabled=True
+                )[0][0][(slice(None), *neuron)]
             )
             sal_vals = input_attrib.attribute(test_input, abs=False)
             grad_vals = gradient_attrib.attribute(test_input, neuron)


### PR DESCRIPTION
This will fix the warning error specifically related to NoiseTunnel in #421.
In addition to that I moved almost everything under no_grad in the attribute method. This will hopefully also help with runtime performance.
In the `_forward_layer_eval ` I had to add `grad_enabled ` flag in order to allow to enable the gradients externally. As it is also needed in `test_neuron_gradient.py` test case.