### PR TITLE
Add model inputs' marginal effects flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ commands:
     steps:
       - run:
           name: "Check import order with isort"
-          command: isort --check-only -v
+          command: isort --check-only -v .
 
   mypy_check:
     description: "Static type checking with mypy"

--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -23,17 +23,17 @@ class ExpansionTypes(Enum):
 
 
 def safe_div(
-    nominator: Tensor, denom: Union[Tensor, float], default_value: Tensor
+    numerator: Tensor, denom: Union[Tensor, float], default_value: Tensor
 ) -> Tensor:
     r"""
-        A simple utility function to perform `denom / quotient`
+        A simple utility function to perform `numerator / denom`
         if the statement is undefined => result will be `default_value`
     """
     if isinstance(denom, float):
-        return nominator / denom if denom != 0.0 else default_value
+        return numerator / denom if denom != 0.0 else default_value
 
     # if denominator is a tensor
-    return nominator / torch.where(denom != 0.0, denom, default_value)
+    return numerator / torch.where(denom != 0.0, denom, default_value)
 
 
 @typing.overload

--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -23,17 +23,17 @@ class ExpansionTypes(Enum):
 
 
 def safe_div(
-    denom: Tensor, quotient: Union[Tensor, float], default_value: Tensor
+    nominator: Tensor, denom: Union[Tensor, float], default_value: Tensor
 ) -> Tensor:
     r"""
         A simple utility function to perform `denom / quotient`
         if the statement is undefined => result will be `default_value`
     """
-    if isinstance(quotient, float):
-        return denom / quotient if quotient != 0.0 else default_value
+    if isinstance(denom, float):
+        return nominator / denom if denom != 0.0 else default_value
 
-    # if quotient is a tensor
-    return denom / torch.where(quotient != 0.0, quotient, default_value)
+    # if denominator is a tensor
+    return nominator / torch.where(denom != 0.0, denom, default_value)
 
 
 @typing.overload

--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -119,7 +119,7 @@ class DeepLift(GradientAttribution):
                         https://arxiv.org/abs/1711.06104
 
                         In case of DeepLift, if `multiply_by_inputs`
-                        is set to True, final sensitivity scores, aka mulitipliers
+                        is set to True, final sensitivity scores
                         are being multiplied by (inputs - baselines).
                         This flag applies only if `custom_attribution_func` is
                         set to None.
@@ -619,7 +619,7 @@ class DeepLiftShap(DeepLift):
                         https://arxiv.org/abs/1711.06104
 
                         In case of DeepLiftShap, if `multiply_by_inputs`
-                        is set to True, final sensitivity scores, aka mulitipliers
+                        is set to True, final sensitivity scores
                         are being multiplied by (inputs - baselines).
                         This flag applies only if `custom_attribution_func` is
                         set to None.

--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -1052,17 +1052,18 @@ def maxpool(
                 list(cast(torch.Size, module.input.shape)),
             ),
         )
-    assert grad_input[0].shape == inputs.shape, (
-        "A problem occurred during maxpool modul's backward pass. "
-        "The gradients with respect to inputs include only a "
-        "subset of inputs. More details about this issue can "
-        "be found here: "
-        "https://pytorch.org/docs/stable/"
-        "nn.html#torch.nn.Module.register_backward_hook "
-        "This can happen for example if you attribute to the outputs of a "
-        "MaxPool. As a workaround, please, attribute to the inputs of "
-        "the following layer."
-    )
+    if grad_input[0].shape != inputs.shape:
+        raise AssertionError(
+            "A problem occurred during maxpool modul's backward pass. "
+            "The gradients with respect to inputs include only a "
+            "subset of inputs. More details about this issue can "
+            "be found here: "
+            "https://pytorch.org/docs/stable/"
+            "nn.html#torch.nn.Module.register_backward_hook "
+            "This can happen for example if you attribute to the outputs of a "
+            "MaxPool. As a workaround, please, attribute to the inputs of "
+            "the following layer."
+        )
 
     new_grad_inp = torch.where(
         abs(delta_in) < eps, grad_input[0], unpool_grad_out_delta / delta_in

--- a/captum/attr/_core/guided_grad_cam.py
+++ b/captum/attr/_core/guided_grad_cam.py
@@ -202,6 +202,7 @@ class GuidedGradCam(GradientAttribution):
             target=target,
             additional_forward_args=additional_forward_args,
         )
+        print("inputs: ", inputs, target)
         output_attr: List[Tensor] = []
         for i in range(len(inputs)):
             try:
@@ -213,6 +214,15 @@ class GuidedGradCam(GradientAttribution):
                         interpolate_mode=interpolate_mode,
                     )
                 )
+                print(
+                    guided_backprop_attr[i],
+                    LayerAttribution.interpolate(
+                        grad_cam_attr,
+                        inputs[i].shape[2:],
+                        interpolate_mode=interpolate_mode,
+                    ),
+                )
+                print(output_attr)
             except RuntimeError:
                 warnings.warn(
                     "Couldn't appropriately interpolate GradCAM attributions for some "

--- a/captum/attr/_core/guided_grad_cam.py
+++ b/captum/attr/_core/guided_grad_cam.py
@@ -212,6 +212,7 @@ class GuidedGradCam(GradientAttribution):
                         inputs[i].shape[2:],
                         interpolate_mode=interpolate_mode,
                     )
+                )
             except RuntimeError:
                 warnings.warn(
                     "Couldn't appropriately interpolate GradCAM attributions for some "

--- a/captum/attr/_core/guided_grad_cam.py
+++ b/captum/attr/_core/guided_grad_cam.py
@@ -202,7 +202,6 @@ class GuidedGradCam(GradientAttribution):
             target=target,
             additional_forward_args=additional_forward_args,
         )
-        print("inputs: ", inputs, target)
         output_attr: List[Tensor] = []
         for i in range(len(inputs)):
             try:
@@ -213,16 +212,6 @@ class GuidedGradCam(GradientAttribution):
                         inputs[i].shape[2:],
                         interpolate_mode=interpolate_mode,
                     )
-                )
-                print(
-                    guided_backprop_attr[i],
-                    LayerAttribution.interpolate(
-                        grad_cam_attr,
-                        inputs[i].shape[2:],
-                        interpolate_mode=interpolate_mode,
-                    ),
-                )
-                print(output_attr)
             except RuntimeError:
                 warnings.warn(
                     "Couldn't appropriately interpolate GradCAM attributions for some "

--- a/captum/attr/_core/input_x_gradient.py
+++ b/captum/attr/_core/input_x_gradient.py
@@ -16,9 +16,7 @@ class InputXGradient(GradientAttribution):
     https://arxiv.org/abs/1611.07270
     """
 
-    def __init__(
-        self, forward_func: Callable, use_input_marginal_effects: bool = True,
-    ) -> None:
+    def __init__(self, forward_func: Callable) -> None:
         r"""
         Args:
 
@@ -26,7 +24,6 @@ class InputXGradient(GradientAttribution):
                           modification of it
         """
         GradientAttribution.__init__(self, forward_func)
-        self._use_input_marginal_effects = use_input_marginal_effects
 
     @log_usage()
     def attribute(
@@ -118,16 +115,14 @@ class InputXGradient(GradientAttribution):
         gradients = self.gradient_func(
             self.forward_func, inputs, target, additional_forward_args
         )
-        if self.uses_input_marginal_effects:
-            attributions = tuple(
-                input * gradient for input, gradient in zip(inputs, gradients)
-            )
-        else:
-            attributions = gradients
+
+        attributions = tuple(
+            input * gradient for input, gradient in zip(inputs, gradients)
+        )
 
         undo_gradient_requirements(inputs, gradient_mask)
         return _format_output(is_inputs_tuple, attributions)
 
     @property
-    def uses_input_marginal_effects(self):
-        return self._use_input_marginal_effects
+    def multiplies_by_inputs(self):
+        return True

--- a/captum/attr/_core/integrated_gradients.py
+++ b/captum/attr/_core/integrated_gradients.py
@@ -361,12 +361,10 @@ class IntegratedGradients(GradientAttribution):
         # aggregates across all steps for each tensor in the input tuple
         # total_grads has the same dimensionality as inputs
         total_grads = tuple(
-            [
-                _reshape_and_sum(
-                    scaled_grad, n_steps, grad.shape[0] // n_steps, grad.shape[1:]
-                )
-                for (scaled_grad, grad) in zip(scaled_grads, grads)
-            ]
+            _reshape_and_sum(
+                scaled_grad, n_steps, grad.shape[0] // n_steps, grad.shape[1:]
+            )
+            for (scaled_grad, grad) in zip(scaled_grads, grads)
         )
 
         # computes attribution for each tensor in input tuple

--- a/captum/attr/_core/integrated_gradients.py
+++ b/captum/attr/_core/integrated_gradients.py
@@ -53,10 +53,10 @@ class IntegratedGradients(GradientAttribution):
                     modification of it
             use_input_marginal_effects (bool): Indicates whether to factor
                     model inputs' marginal effects in the final attribution scores.
-                    In this literature this is also known as local vs global attribution.
-                    If input's marginal effects aren't factored in, then this type of
-                    attribution method is also called local attribution. If they are,
-                    then it is called global.
+                    In the literature this is also known as local vs global
+                    attribution. If input's marginal effects aren't factored in,
+                    then this type of attribution method is also called local
+                    attribution. If they are, then it is called global.
                     More detailed can be found here:
                     https://arxiv.org/abs/1711.06104
 

--- a/captum/attr/_core/integrated_gradients.py
+++ b/captum/attr/_core/integrated_gradients.py
@@ -44,28 +44,29 @@ class IntegratedGradients(GradientAttribution):
     """
 
     def __init__(
-        self, forward_func: Callable, use_input_marginal_effects: bool = True,
+        self, forward_func: Callable, multiply_by_inputs: bool = True,
     ) -> None:
         r"""
         Args:
 
             forward_func (callable):  The forward function of the model or any
                     modification of it
-            use_input_marginal_effects (bool): Indicates whether to factor
-                    model inputs' marginal effects in the final attribution scores.
+            multiply_by_inputs (bool, optional): Indicates whether to factor
+                    model inputs' multiplier in the final attribution scores.
                     In the literature this is also known as local vs global
-                    attribution. If input's marginal effects aren't factored in,
-                    then this type of attribution method is also called local
-                    attribution. If they are, then it is called global.
+                    attribution. If inputs' multiplier isn't factored in,
+                    then that type of attribution method is also called local
+                    attribution. If it is, then that type of attribution
+                    method is called global.
                     More detailed can be found here:
                     https://arxiv.org/abs/1711.06104
 
-                    In case of integrated gradients, if `use_input_marginal_effects`
+                    In case of integrated gradients, if `multiply_by_inputs`
                     is set to True, final sensitivity scores are being multiplied by
                     (inputs - baselines).
         """
         GradientAttribution.__init__(self, forward_func)
-        self._use_input_marginal_effects = use_input_marginal_effects
+        self._multiply_by_inputs = multiply_by_inputs
 
     # The following overloaded method signatures correspond to the case where
     # return_convergence_delta is False, then only attributions are returned,
@@ -370,7 +371,7 @@ class IntegratedGradients(GradientAttribution):
 
         # computes attribution for each tensor in input tuple
         # attributions has the same dimensionality as inputs
-        if not self.uses_input_marginal_effects:
+        if not self.multiplies_by_inputs:
             attributions = total_grads
         else:
             attributions = tuple(
@@ -383,5 +384,5 @@ class IntegratedGradients(GradientAttribution):
         return True
 
     @property
-    def uses_input_marginal_effects(self):
-        return self._use_input_marginal_effects
+    def multiplies_by_inputs(self):
+        return self._multiply_by_inputs

--- a/captum/attr/_core/layer/layer_activation.py
+++ b/captum/attr/_core/layer/layer_activation.py
@@ -42,10 +42,6 @@ class LayerActivation(LayerAttribution):
         """
         LayerAttribution.__init__(self, forward_func, layer, device_ids)
 
-    @property
-    def uses_input_marginal_effects(self):
-        return True
-
     @log_usage()
     def attribute(
         self,

--- a/captum/attr/_core/layer/layer_activation.py
+++ b/captum/attr/_core/layer/layer_activation.py
@@ -42,6 +42,10 @@ class LayerActivation(LayerAttribution):
         """
         LayerAttribution.__init__(self, forward_func, layer, device_ids)
 
+    @property
+    def uses_input_marginal_effects(self):
+        return True
+
     @log_usage()
     def attribute(
         self,
@@ -121,3 +125,7 @@ class LayerActivation(LayerAttribution):
                 attribute_to_layer_input=attribute_to_layer_input,
             )
         return _format_output(is_layer_tuple, layer_eval)
+
+    @property
+    def uses_input_marginal_effects(self):
+        return True

--- a/captum/attr/_core/layer/layer_activation.py
+++ b/captum/attr/_core/layer/layer_activation.py
@@ -123,5 +123,5 @@ class LayerActivation(LayerAttribution):
         return _format_output(is_layer_tuple, layer_eval)
 
     @property
-    def uses_input_marginal_effects(self):
+    def multiplies_by_inputs(self):
         return True

--- a/captum/attr/_core/layer/layer_conductance.py
+++ b/captum/attr/_core/layer/layer_conductance.py
@@ -393,3 +393,7 @@ class LayerConductance(LayerAttribution, GradientAttribution):
             )
         )
         return _format_output(is_layer_tuple, attributions)
+
+    @property
+    def uses_input_marginal_effects(self):
+        return True

--- a/captum/attr/_core/layer/layer_conductance.py
+++ b/captum/attr/_core/layer/layer_conductance.py
@@ -395,5 +395,5 @@ class LayerConductance(LayerAttribution, GradientAttribution):
         return _format_output(is_layer_tuple, attributions)
 
     @property
-    def uses_input_marginal_effects(self):
+    def multiplies_by_inputs(self):
         return True

--- a/captum/attr/_core/layer/layer_deep_lift.py
+++ b/captum/attr/_core/layer/layer_deep_lift.py
@@ -292,9 +292,7 @@ class LayerDeepLift(LayerAttribution, DeepLift):
         """
         inputs = _format_input(inputs)
         baselines = _format_baseline(baselines, inputs)
-        print("before requires grad ... ", inputs)
         gradient_mask = apply_gradient_requirements(inputs)
-        print("after requires grad ... ")
         _validate_input(inputs, baselines)
 
         baselines = _tensorize_baseline(inputs, baselines)

--- a/captum/attr/_core/layer/layer_deep_lift.py
+++ b/captum/attr/_core/layer/layer_deep_lift.py
@@ -89,7 +89,7 @@ class LayerDeepLift(LayerAttribution, DeepLift):
                         https://arxiv.org/abs/1711.06104
 
                         In case of Layer DeepLift, if `multiply_by_inputs`
-                        is set to True, final sensitivity scores, aka mulitipliers
+                        is set to True, final sensitivity scores
                         are being multiplied by
                         layer activations for inputs - layer activations for baselines.
                         This flag applies only if `custom_attribution_func` is
@@ -418,8 +418,8 @@ class LayerDeepLiftShap(LayerDeepLift, DeepLiftShap):
                         https://arxiv.org/abs/1711.06104
 
                         In case of LayerDeepLiftShap, if `multiply_by_inputs`
-                        is set to True, final sensitivity scores, aka mulitipliers
-                        are being multiplied by
+                        is set to True, final sensitivity scores are being
+                        multiplied by
                         layer activations for inputs - layer activations for baselines
                         This flag applies only if `custom_attribution_func` is
                         set to None.

--- a/captum/attr/_core/layer/layer_deep_lift.py
+++ b/captum/attr/_core/layer/layer_deep_lift.py
@@ -91,7 +91,7 @@ class LayerDeepLift(LayerAttribution, DeepLift):
                         In case of Layer DeepLift, if `multiply_by_inputs`
                         is set to True, final sensitivity scores, aka mulitipliers
                         are being multiplied by
-                        (layer activations for inputs - layer activations for baselines).
+                        layer activations for inputs - layer activations for baselines.
                         This flag applies only if `custom_attribution_func` is
                         set to None.
         """
@@ -420,7 +420,7 @@ class LayerDeepLiftShap(LayerDeepLift, DeepLiftShap):
                         In case of LayerDeepLiftShap, if `multiply_by_inputs`
                         is set to True, final sensitivity scores, aka mulitipliers
                         are being multiplied by
-                        (layer activations for inputs - layer activations for baselines).
+                        layer activations for inputs - layer activations for baselines
                         This flag applies only if `custom_attribution_func` is
                         set to None.
         """

--- a/captum/attr/_core/layer/layer_gradient_shap.py
+++ b/captum/attr/_core/layer/layer_gradient_shap.py
@@ -95,7 +95,7 @@ class LayerGradientShap(LayerAttribution, GradientAttribution):
                         In case of layer gradient shap, if `multiply_by_inputs`
                         is set to True, the sensitivity scores for scaled inputs
                         are being multiplied by
-                        (layer activations for inputs - layer activations for baselines).
+                        layer activations for inputs - layer activations for baselines.
 
         """
         LayerAttribution.__init__(self, forward_func, layer, device_ids)
@@ -365,7 +365,7 @@ class LayerInputBaselineXGradient(LayerAttribution, GradientAttribution):
                         In case of layer input minus baseline x gradient,
                         if `multiply_by_inputs` is set to True, the sensitivity scores
                         for scaled inputs are being multiplied by
-                        (layer activations for inputs - layer activations for baselines).
+                        layer activations for inputs - layer activations for baselines.
 
         """
         LayerAttribution.__init__(self, forward_func, layer, device_ids)

--- a/captum/attr/_core/layer/layer_gradient_shap.py
+++ b/captum/attr/_core/layer/layer_gradient_shap.py
@@ -64,28 +64,43 @@ class LayerGradientShap(LayerAttribution, GradientAttribution):
         forward_func: Callable,
         layer: Module,
         device_ids: Union[None, List[int]] = None,
-        use_input_marginal_effects: bool = True,
+        multiply_by_inputs: bool = True,
     ) -> None:
         r"""
         Args:
 
             forward_func (callable):  The forward function of the model or any
-                          modification of it
+                        modification of it
             layer (torch.nn.Module): Layer for which attributions are computed.
-                          Output size of attribute matches this layer's input or
-                          output dimensions, depending on whether we attribute to
-                          the inputs or outputs of the layer, corresponding to
-                          attribution of each neuron in the input or output of
-                          this layer.
+                        Output size of attribute matches this layer's input or
+                        output dimensions, depending on whether we attribute to
+                        the inputs or outputs of the layer, corresponding to
+                        attribution of each neuron in the input or output of
+                        this layer.
             device_ids (list(int)): Device ID list, necessary only if forward_func
-                          applies a DataParallel model. This allows reconstruction of
-                          intermediate outputs from batched results across devices.
-                          If forward_func is given as the DataParallel model itself,
-                          then it is not necessary to provide this argument.
+                        applies a DataParallel model. This allows reconstruction of
+                        intermediate outputs from batched results across devices.
+                        If forward_func is given as the DataParallel model itself,
+                        then it is not necessary to provide this argument.
+            multiply_by_inputs (bool, optional): Indicates whether to factor
+                        model inputs' multiplier in the final attribution scores.
+                        In the literature this is also known as local vs global
+                        attribution. If inputs' multiplier isn't factored in,
+                        then this type of attribution method is also called local
+                        attribution. If it is, then that type of attribution
+                        method is called global.
+                        More detailed can be found here:
+                        https://arxiv.org/abs/1711.06104
+
+                        In case of layer gradient shap, if `multiply_by_inputs`
+                        is set to True, the sensitivity scores for scaled inputs
+                        are being multiplied by
+                        (layer activations for inputs - layer activations for baselines).
+
         """
         LayerAttribution.__init__(self, forward_func, layer, device_ids)
         GradientAttribution.__init__(self, forward_func)
-        self._use_input_marginal_effects = use_input_marginal_effects
+        self._multiply_by_inputs = multiply_by_inputs
 
     @typing.overload
     def attribute(
@@ -284,7 +299,7 @@ class LayerGradientShap(LayerAttribution, GradientAttribution):
             self.forward_func,
             self.layer,
             device_ids=self.device_ids,
-            use_input_marginal_effects=self.uses_input_marginal_effects,
+            multiply_by_inputs=self.multiplies_by_inputs,
         )
 
         nt = NoiseTunnel(input_min_baseline_x_grad)
@@ -309,8 +324,8 @@ class LayerGradientShap(LayerAttribution, GradientAttribution):
         return True
 
     @property
-    def uses_input_marginal_effects(self):
-        return self._use_input_marginal_effects
+    def multiplies_by_inputs(self):
+        return self._multiply_by_inputs
 
 
 class LayerInputBaselineXGradient(LayerAttribution, GradientAttribution):
@@ -319,28 +334,43 @@ class LayerInputBaselineXGradient(LayerAttribution, GradientAttribution):
         forward_func: Callable,
         layer: Module,
         device_ids: Union[None, List[int]] = None,
-        use_input_marginal_effects: bool = True,
+        multiply_by_inputs: bool = True,
     ):
         r"""
         Args:
 
             forward_func (callable):  The forward function of the model or any
-                          modification of it
+                        modification of it
             layer (torch.nn.Module): Layer for which attributions are computed.
-                          Output size of attribute matches this layer's input or
-                          output dimensions, depending on whether we attribute to
-                          the inputs or outputs of the layer, corresponding to
-                          attribution of each neuron in the input or output of
-                          this layer.
+                        Output size of attribute matches this layer's input or
+                        output dimensions, depending on whether we attribute to
+                        the inputs or outputs of the layer, corresponding to
+                        attribution of each neuron in the input or output of
+                        this layer.
             device_ids (list(int)): Device ID list, necessary only if forward_func
-                          applies a DataParallel model. This allows reconstruction of
-                          intermediate outputs from batched results across devices.
-                          If forward_func is given as the DataParallel model itself,
-                          then it is not necessary to provide this argument.
+                        applies a DataParallel model. This allows reconstruction of
+                        intermediate outputs from batched results across devices.
+                        If forward_func is given as the DataParallel model itself,
+                        then it is not necessary to provide this argument.
+            multiply_by_inputs (bool, optional): Indicates whether to factor
+                        model inputs' multiplier in the final attribution scores.
+                        In the literature this is also known as local vs global
+                        attribution. If inputs' multiplier isn't factored in,
+                        then this type of attribution method is also called local
+                        attribution. If it is, then that type of attribution
+                        method is called global.
+                        More detailed can be found here:
+                        https://arxiv.org/abs/1711.06104
+
+                        In case of layer input minus baseline x gradient,
+                        if `multiply_by_inputs` is set to True, the sensitivity scores
+                        for scaled inputs are being multiplied by
+                        (layer activations for inputs - layer activations for baselines).
+
         """
         LayerAttribution.__init__(self, forward_func, layer, device_ids)
         GradientAttribution.__init__(self, forward_func)
-        self._use_input_marginal_effects = use_input_marginal_effects
+        self._multiply_by_inputs = multiply_by_inputs
 
     @typing.overload
     def attribute(
@@ -417,13 +447,18 @@ class LayerInputBaselineXGradient(LayerAttribution, GradientAttribution):
             device_ids=self.device_ids,
             attribute_to_layer_input=attribute_to_layer_input,
         )
-        input_baseline_diffs = tuple(
-            input - baseline for input, baseline in zip(attr_inputs, attr_baselines)
-        )
-        attributions = tuple(
-            input_baseline_diff * grad
-            for input_baseline_diff, grad in zip(input_baseline_diffs, grads)
-        )
+
+        if self.multiplies_by_inputs:
+            input_baseline_diffs = tuple(
+                input - baseline for input, baseline in zip(attr_inputs, attr_baselines)
+            )
+            attributions = tuple(
+                input_baseline_diff * grad
+                for input_baseline_diff, grad in zip(input_baseline_diffs, grads)
+            )
+        else:
+            attributions = grads
+
         return _compute_conv_delta_and_format_attrs(
             self,
             return_convergence_delta,
@@ -439,5 +474,5 @@ class LayerInputBaselineXGradient(LayerAttribution, GradientAttribution):
         return True
 
     @property
-    def uses_input_marginal_effects(self):
-        return self._use_input_marginal_effects
+    def multiplies_by_inputs(self):
+        return self._multiply_by_inputs

--- a/captum/attr/_core/layer/layer_gradient_shap.py
+++ b/captum/attr/_core/layer/layer_gradient_shap.py
@@ -64,6 +64,7 @@ class LayerGradientShap(LayerAttribution, GradientAttribution):
         forward_func: Callable,
         layer: Module,
         device_ids: Union[None, List[int]] = None,
+        use_input_marginal_effects: bool = True,
     ) -> None:
         r"""
         Args:
@@ -84,6 +85,7 @@ class LayerGradientShap(LayerAttribution, GradientAttribution):
         """
         LayerAttribution.__init__(self, forward_func, layer, device_ids)
         GradientAttribution.__init__(self, forward_func)
+        self._use_input_marginal_effects = use_input_marginal_effects
 
     @typing.overload
     def attribute(
@@ -279,7 +281,10 @@ class LayerGradientShap(LayerAttribution, GradientAttribution):
         )
 
         input_min_baseline_x_grad = LayerInputBaselineXGradient(
-            self.forward_func, self.layer, device_ids=self.device_ids
+            self.forward_func,
+            self.layer,
+            device_ids=self.device_ids,
+            use_input_marginal_effects=self.uses_input_marginal_effects,
         )
 
         nt = NoiseTunnel(input_min_baseline_x_grad)
@@ -303,6 +308,10 @@ class LayerGradientShap(LayerAttribution, GradientAttribution):
     def has_convergence_delta(self) -> bool:
         return True
 
+    @property
+    def uses_input_marginal_effects(self):
+        return self._use_input_marginal_effects
+
 
 class LayerInputBaselineXGradient(LayerAttribution, GradientAttribution):
     def __init__(
@@ -310,6 +319,7 @@ class LayerInputBaselineXGradient(LayerAttribution, GradientAttribution):
         forward_func: Callable,
         layer: Module,
         device_ids: Union[None, List[int]] = None,
+        use_input_marginal_effects: bool = True,
     ):
         r"""
         Args:
@@ -330,6 +340,7 @@ class LayerInputBaselineXGradient(LayerAttribution, GradientAttribution):
         """
         LayerAttribution.__init__(self, forward_func, layer, device_ids)
         GradientAttribution.__init__(self, forward_func)
+        self._use_input_marginal_effects = use_input_marginal_effects
 
     @typing.overload
     def attribute(
@@ -426,3 +437,7 @@ class LayerInputBaselineXGradient(LayerAttribution, GradientAttribution):
 
     def has_convergence_delta(self) -> bool:
         return True
+
+    @property
+    def uses_input_marginal_effects(self):
+        return self._use_input_marginal_effects

--- a/captum/attr/_core/layer/layer_gradient_x_activation.py
+++ b/captum/attr/_core/layer/layer_gradient_x_activation.py
@@ -31,33 +31,46 @@ class LayerGradientXActivation(LayerAttribution, GradientAttribution):
         forward_func: Callable,
         layer: Module,
         device_ids: Union[None, List[int]] = None,
-        use_input_marginal_effects: bool = True,
+        multiply_by_inputs: bool = True,
     ) -> None:
         r"""
         Args:
 
             forward_func (callable):  The forward function of the model or any
-                          modification of it
+                        modification of it
             layer (torch.nn.Module): Layer for which attributions are computed.
-                          Output size of attribute matches this layer's input or
-                          output dimensions, depending on whether we attribute to
-                          the inputs or outputs of the layer, corresponding to
-                          attribution of each neuron in the input or output of
-                          this layer.
+                        Output size of attribute matches this layer's input or
+                        output dimensions, depending on whether we attribute to
+                        the inputs or outputs of the layer, corresponding to
+                        attribution of each neuron in the input or output of
+                        this layer.
             device_ids (list(int)): Device ID list, necessary only if forward_func
-                          applies a DataParallel model. This allows reconstruction of
-                          intermediate outputs from batched results across devices.
-                          If forward_func is given as the DataParallel model itself,
-                          then it is not necessary to provide this argument.
-            use_input_marginal_effects(boolean): TODO
+                        applies a DataParallel model. This allows reconstruction of
+                        intermediate outputs from batched results across devices.
+                        If forward_func is given as the DataParallel model itself,
+                        then it is not necessary to provide this argument.
+            multiply_by_inputs (bool, optional): Indicates whether to factor
+                        model inputs' multiplier in the final attribution scores.
+                        In the literature this is also known as local vs global
+                        attribution. If inputs' multiplier isn't factored in,
+                        then this type of attribution method is also called local
+                        attribution. If it is, then that type of attribution
+                        method is called global.
+                        More detailed can be found here:
+                        https://arxiv.org/abs/1711.06104
+
+                        In case of layer gradient x activation, if `multiply_by_inputs`
+                        is set to True, final sensitivity scores are being multiplied by
+                        layer activations for inputs.
+
         """
         LayerAttribution.__init__(self, forward_func, layer, device_ids)
         GradientAttribution.__init__(self, forward_func)
-        self._use_input_marginal_effects = use_input_marginal_effects
+        self._multiply_by_inputs = multiply_by_inputs
 
     @property
-    def uses_input_marginal_effects(self):
-        return self._use_input_marginal_effects
+    def multiplies_by_inputs(self):
+        return self._multiply_by_inputs
 
     @log_usage()
     def attribute(
@@ -170,7 +183,7 @@ class LayerGradientXActivation(LayerAttribution, GradientAttribution):
             is_layer_tuple,
             tuple(
                 layer_gradient * layer_eval
-                if self.uses_input_marginal_effects
+                if self.multiplies_by_inputs
                 else layer_gradient
                 for layer_gradient, layer_eval in zip(layer_gradients, layer_evals)
             ),

--- a/captum/attr/_core/layer/layer_integrated_gradients.py
+++ b/captum/attr/_core/layer/layer_integrated_gradients.py
@@ -80,7 +80,7 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
 
                         In case of layer integrated gradients, if `multiply_by_inputs`
                         is set to True, final sensitivity scores are being multiplied by
-                        (layer activations for inputs - layer activations for baselines).
+                        layer activations for inputs - layer activations for baselines.
 
         """
         LayerAttribution.__init__(self, forward_func, layer, device_ids=device_ids)

--- a/captum/attr/_core/layer/layer_integrated_gradients.py
+++ b/captum/attr/_core/layer/layer_integrated_gradients.py
@@ -51,6 +51,7 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
         forward_func: Callable,
         layer: Module,
         device_ids: Union[None, List[int]] = None,
+        use_input_marginal_effects: bool = True,
     ) -> None:
         r"""
         Args:
@@ -71,7 +72,8 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
         """
         LayerAttribution.__init__(self, forward_func, layer, device_ids=device_ids)
         GradientAttribution.__init__(self, forward_func)
-        self.ig = IntegratedGradients(forward_func)
+        self._use_input_marginal_effects = use_input_marginal_effects
+        self.ig = IntegratedGradients(forward_func, use_input_marginal_effects)
 
     @typing.overload
     def attribute(
@@ -387,3 +389,7 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
 
     def has_convergence_delta(self) -> bool:
         return True
+
+    @property
+    def uses_input_marginal_effects(self):
+        return self._use_input_marginal_effects

--- a/captum/attr/_core/layer/layer_integrated_gradients.py
+++ b/captum/attr/_core/layer/layer_integrated_gradients.py
@@ -51,29 +51,41 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
         forward_func: Callable,
         layer: Module,
         device_ids: Union[None, List[int]] = None,
-        use_input_marginal_effects: bool = True,
+        multiply_by_inputs: bool = True,
     ) -> None:
         r"""
         Args:
             forward_func (callable):  The forward function of the model or any
-                          modification of it
+                        modification of it
             layer (torch.nn.Module): Layer for which attributions are computed.
-                          Output size of attribute matches this layer's input or
-                          output dimensions, depending on whether we attribute to
-                          the inputs or outputs of the layer, corresponding to
-                          the attribution of each neuron in the input or output
-                          of this layer.
+                        Output size of attribute matches this layer's input or
+                        output dimensions, depending on whether we attribute to
+                        the inputs or outputs of the layer, corresponding to
+                        the attribution of each neuron in the input or output
+                        of this layer.
             device_ids (list(int)): Device ID list, necessary only if forward_func
-                          applies a DataParallel model. This allows reconstruction of
-                          intermediate outputs from batched results across devices.
-                          If forward_func is given as the DataParallel model itself,
-                          then it is not necessary to provide this argument.
+                        applies a DataParallel model. This allows reconstruction of
+                        intermediate outputs from batched results across devices.
+                        If forward_func is given as the DataParallel model itself,
+                        then it is not necessary to provide this argument.
+            multiply_by_inputs (bool, optional): Indicates whether to factor
+                        model inputs' multiplier in the final attribution scores.
+                        In the literature this is also known as local vs global
+                        attribution. If inputs' multiplier isn't factored in,
+                        then this type of attribution method is also called local
+                        attribution. If it is, then that type of attribution
+                        method is called global.
+                        More detailed can be found here:
+                        https://arxiv.org/abs/1711.06104
+
+                        In case of layer integrated gradients, if `multiply_by_inputs`
+                        is set to True, final sensitivity scores are being multiplied by
+                        (layer activations for inputs - layer activations for baselines).
 
         """
         LayerAttribution.__init__(self, forward_func, layer, device_ids=device_ids)
         GradientAttribution.__init__(self, forward_func)
-        self._use_input_marginal_effects = use_input_marginal_effects
-        self.ig = IntegratedGradients(forward_func, use_input_marginal_effects)
+        self.ig = IntegratedGradients(forward_func, multiply_by_inputs)
 
     @typing.overload
     def attribute(
@@ -391,5 +403,5 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
         return True
 
     @property
-    def uses_input_marginal_effects(self):
-        return self._use_input_marginal_effects
+    def multiplies_by_inputs(self):
+        return self.ig.multiplies_by_inputs

--- a/captum/attr/_core/neuron/neuron_conductance.py
+++ b/captum/attr/_core/neuron/neuron_conductance.py
@@ -37,37 +37,52 @@ class NeuronConductance(NeuronAttribution, GradientAttribution):
         forward_func: Callable,
         layer: Module,
         device_ids: Union[None, List[int]] = None,
-        use_input_marginal_effects: bool = True,
+        multiply_by_inputs: bool = True,
     ) -> None:
         r"""
         Args:
 
             forward_func (callable):  The forward function of the model or any
-                          modification of it
+                        modification of it
             layer (torch.nn.Module): Layer for which neuron attributions are computed.
-                          Attributions for a particular neuron in the input or output
-                          of this layer are computed using the argument neuron_index
-                          in the attribute method.
-                          Currently, only layers with a single tensor input or output
-                          are supported.
+                        Attributions for a particular neuron in the input or output
+                        of this layer are computed using the argument neuron_index
+                        in the attribute method.
+                        Currently, only layers with a single tensor input or output
+                        are supported.
             layer (torch.nn.Module): Layer for which attributions are computed.
-                          Output size of attribute matches this layer's input or
-                          output dimensions, depending on whether we attribute to
-                          the inputs or outputs of the layer, corresponding to
-                          attribution of each neuron in the input or output of
-                          this layer.
-                          Currently, it is assumed that the inputs or the outputs
-                          of the layer, depending on which one is used for
-                          attribution, can only be a single tensor.
+                        Output size of attribute matches this layer's input or
+                        output dimensions, depending on whether we attribute to
+                        the inputs or outputs of the layer, corresponding to
+                        attribution of each neuron in the input or output of
+                        this layer.
+                        Currently, it is assumed that the inputs or the outputs
+                        of the layer, depending on which one is used for
+                        attribution, can only be a single tensor.
             device_ids (list(int)): Device ID list, necessary only if forward_func
-                          applies a DataParallel model. This allows reconstruction of
-                          intermediate outputs from batched results across devices.
-                          If forward_func is given as the DataParallel model itself,
-                          then it is not necessary to provide this argument.
+                        applies a DataParallel model. This allows reconstruction of
+                        intermediate outputs from batched results across devices.
+                        If forward_func is given as the DataParallel model itself,
+                        then it is not necessary to provide this argument.
+            multiply_by_inputs (bool, optional): Indicates whether to factor
+                        model inputs' multiplier in the final attribution scores.
+                        In the literature this is also known as local vs global
+                        attribution. If inputs' multiplier isn't factored in
+                        then that type of attribution method is also called local
+                        attribution. If it is, then that type of attribution
+                        method is called global.
+                        More detailed can be found here:
+                        https://arxiv.org/abs/1711.06104
+
+                        In case of Neuron Conductance,
+                        if `multiply_by_inputs` is set to True, final
+                        sensitivity scores are being multiplied
+                        by (inputs - baselines).
+
         """
         NeuronAttribution.__init__(self, forward_func, layer, device_ids)
         GradientAttribution.__init__(self, forward_func)
-        self._use_input_marginal_effects = use_input_marginal_effects
+        self._multiply_by_inputs = multiply_by_inputs
 
     @log_usage()
     def attribute(
@@ -354,7 +369,7 @@ class NeuronConductance(NeuronAttribution, GradientAttribution):
             for (scaled_grad, input_grad) in zip(scaled_grads, input_grads)
         )
 
-        if self.uses_input_marginal_effects:
+        if self.multiplies_by_inputs:
             # computes attribution for each tensor in input tuple
             # attributions has the same dimensionality as inputs
             attributions = tuple(
@@ -367,5 +382,5 @@ class NeuronConductance(NeuronAttribution, GradientAttribution):
         return attributions
 
     @property
-    def uses_input_marginal_effects(self):
-        return self._use_input_marginal_effects
+    def multiplies_by_inputs(self):
+        return self._multiply_by_inputs

--- a/captum/attr/_core/neuron/neuron_deep_lift.py
+++ b/captum/attr/_core/neuron/neuron_deep_lift.py
@@ -66,7 +66,7 @@ class NeuronDeepLift(NeuronAttribution, GradientAttribution):
                         https://arxiv.org/abs/1711.06104
 
                         In case of Neuron DeepLift, if `multiply_by_inputs`
-                        is set to True, final sensitivity scores, aka mulitipliers
+                        is set to True, final sensitivity scores
                         are being multiplied by (inputs - baselines).
                         This flag applies only if `custom_attribution_func` is
                         set to None.
@@ -267,7 +267,7 @@ class NeuronDeepLiftShap(NeuronAttribution, GradientAttribution):
                         https://arxiv.org/abs/1711.06104
 
                         In case of Neuron DeepLift Shap, if `multiply_by_inputs`
-                        is set to True, final sensitivity scores, aka mulitipliers
+                        is set to True, final sensitivity scores
                         are being multiplied by (inputs - baselines).
                         This flag applies only if `custom_attribution_func` is
                         set to None.

--- a/captum/attr/_core/neuron/neuron_deep_lift.py
+++ b/captum/attr/_core/neuron/neuron_deep_lift.py
@@ -41,7 +41,9 @@ class NeuronDeepLift(NeuronAttribution, GradientAttribution):
     https://pytorch.org/blog/optimizing-cuda-rnn-with-torchscript/
     """
 
-    def __init__(self, model: Module, layer: Module) -> None:
+    def __init__(
+        self, model: Module, layer: Module, use_input_marginal_effects: bool = True
+    ) -> None:
         r"""
         Args:
 
@@ -56,6 +58,7 @@ class NeuronDeepLift(NeuronAttribution, GradientAttribution):
         """
         NeuronAttribution.__init__(self, model, layer)
         GradientAttribution.__init__(self, model)
+        self._use_input_marginal_effects = use_input_marginal_effects
 
     @log_usage()
     def attribute(
@@ -183,7 +186,7 @@ class NeuronDeepLift(NeuronAttribution, GradientAttribution):
             >>> # index (4,1,2).
             >>> attribution = dl.attribute(input, (4,1,2))
         """
-        dl = DeepLift(cast(Module, self.forward_func))
+        dl = DeepLift(cast(Module, self.forward_func), self.uses_input_marginal_effects)
         dl.gradient_func = construct_neuron_grad_fn(
             self.layer,
             neuron_index,
@@ -198,6 +201,10 @@ class NeuronDeepLift(NeuronAttribution, GradientAttribution):
             additional_forward_args=additional_forward_args,
             custom_attribution_func=custom_attribution_func,
         )
+
+    @property
+    def uses_input_marginal_effects(self):
+        return self._use_input_marginal_effects
 
 
 class NeuronDeepLiftShap(NeuronAttribution, GradientAttribution):
@@ -221,7 +228,9 @@ class NeuronDeepLiftShap(NeuronAttribution, GradientAttribution):
     model across multiple explanations can be complex and non-linear.
     """
 
-    def __init__(self, model: Module, layer: Module) -> None:
+    def __init__(
+        self, model: Module, layer: Module, use_input_marginal_effects: bool = True
+    ) -> None:
         r"""
         Args:
 
@@ -235,6 +244,7 @@ class NeuronDeepLiftShap(NeuronAttribution, GradientAttribution):
         """
         NeuronAttribution.__init__(self, model, layer)
         GradientAttribution.__init__(self, model)
+        self._use_input_marginal_effects = use_input_marginal_effects
 
     @log_usage()
     def attribute(
@@ -357,7 +367,9 @@ class NeuronDeepLiftShap(NeuronAttribution, GradientAttribution):
             >>> # index (4,1,2).
             >>> attribution = dl.attribute(input, (4,1,2))
         """
-        dl = DeepLiftShap(cast(Module, self.forward_func))
+        dl = DeepLiftShap(
+            cast(Module, self.forward_func), self.uses_input_marginal_effects
+        )
         dl.gradient_func = construct_neuron_grad_fn(
             self.layer,
             neuron_index,
@@ -372,3 +384,7 @@ class NeuronDeepLiftShap(NeuronAttribution, GradientAttribution):
             additional_forward_args=additional_forward_args,
             custom_attribution_func=custom_attribution_func,
         )
+
+    @property
+    def uses_input_marginal_effects(self):
+        return self._use_input_marginal_effects

--- a/captum/attr/_core/neuron/neuron_gradient_shap.py
+++ b/captum/attr/_core/neuron/neuron_gradient_shap.py
@@ -53,6 +53,7 @@ class NeuronGradientShap(NeuronAttribution, GradientAttribution):
         forward_func: Callable,
         layer: Module,
         device_ids: Union[None, List[int]] = None,
+        use_input_marginal_effects: bool = True,
     ) -> None:
         r"""
         Args:
@@ -75,6 +76,7 @@ class NeuronGradientShap(NeuronAttribution, GradientAttribution):
         """
         NeuronAttribution.__init__(self, forward_func, layer, device_ids)
         GradientAttribution.__init__(self, forward_func)
+        self._use_input_marginal_effects = use_input_marginal_effects
 
     @log_usage()
     def attribute(
@@ -194,7 +196,7 @@ class NeuronGradientShap(NeuronAttribution, GradientAttribution):
                                                             baselines)
 
         """
-        gs = GradientShap(self.forward_func)
+        gs = GradientShap(self.forward_func, self.uses_input_marginal_effects)
         gs.gradient_func = construct_neuron_grad_fn(
             self.layer,
             neuron_index,
@@ -211,3 +213,7 @@ class NeuronGradientShap(NeuronAttribution, GradientAttribution):
             stdevs=stdevs,
             additional_forward_args=additional_forward_args,
         )
+
+    @property
+    def uses_input_marginal_effects(self):
+        return self._use_input_marginal_effects

--- a/captum/attr/_core/neuron/neuron_integrated_gradients.py
+++ b/captum/attr/_core/neuron/neuron_integrated_gradients.py
@@ -30,6 +30,7 @@ class NeuronIntegratedGradients(NeuronAttribution, GradientAttribution):
         forward_func: Callable,
         layer: Module,
         device_ids: Union[None, List[int]] = None,
+        use_input_marginal_effects: bool = True,
     ):
         r"""
         Args:
@@ -53,6 +54,7 @@ class NeuronIntegratedGradients(NeuronAttribution, GradientAttribution):
         """
         NeuronAttribution.__init__(self, forward_func, layer, device_ids)
         GradientAttribution.__init__(self, forward_func)
+        self._use_input_marginal_effects = use_input_marginal_effects
 
     @log_usage()
     def attribute(
@@ -190,7 +192,7 @@ class NeuronIntegratedGradients(NeuronAttribution, GradientAttribution):
             >>> # index (4,1,2).
             >>> attribution = neuron_ig.attribute(input, (4,1,2))
         """
-        ig = IntegratedGradients(self.forward_func)
+        ig = IntegratedGradients(self.forward_func, self.uses_input_marginal_effects)
         ig.gradient_func = construct_neuron_grad_fn(
             self.layer, neuron_index, self.device_ids, attribute_to_neuron_input
         )
@@ -205,3 +207,7 @@ class NeuronIntegratedGradients(NeuronAttribution, GradientAttribution):
             method=method,
             internal_batch_size=internal_batch_size,
         )
+
+    @property
+    def uses_input_marginal_effects(self):
+        return self._use_input_marginal_effects

--- a/captum/attr/_core/noise_tunnel.py
+++ b/captum/attr/_core/noise_tunnel.py
@@ -63,17 +63,15 @@ class NoiseTunnel(Attribution):
         """
         self.attribution_method = attribution_method
         self.is_delta_supported = self.attribution_method.has_convergence_delta()
-        self._use_input_marginal_effects = (
-            self.attribution_method.uses_input_marginal_effects
-        )
+        self._multiply_by_inputs = self.attribution_method.multiplies_by_inputs
         self.is_gradient_method = isinstance(
             self.attribution_method, GradientAttribution
         )
         Attribution.__init__(self, self.attribution_method.forward_func)
 
     @property
-    def uses_input_marginal_effects(self):
-        return self._use_input_marginal_effects
+    def multiplies_by_inputs(self):
+        return self._multiply_by_inputs
 
     @log_usage()
     def attribute(

--- a/captum/attr/_core/noise_tunnel.py
+++ b/captum/attr/_core/noise_tunnel.py
@@ -197,7 +197,6 @@ class NoiseTunnel(Attribution):
             # FIXME it look like it is very difficult to make torch.normal
             # deterministic this needs an investigation
             noise = torch.normal(0, stdev_expanded)
-
             return input.repeat_interleave(n_samples, dim=0) + noise
 
         def compute_expected_attribution_and_sq(attribution):

--- a/captum/attr/_core/noise_tunnel.py
+++ b/captum/attr/_core/noise_tunnel.py
@@ -63,10 +63,17 @@ class NoiseTunnel(Attribution):
         """
         self.attribution_method = attribution_method
         self.is_delta_supported = self.attribution_method.has_convergence_delta()
+        self._use_input_marginal_effects = (
+            self.attribution_method.uses_input_marginal_effects
+        )
         self.is_gradient_method = isinstance(
             self.attribution_method, GradientAttribution
         )
         Attribution.__init__(self, self.attribution_method.forward_func)
+
+    @property
+    def uses_input_marginal_effects(self):
+        return self._use_input_marginal_effects
 
     @log_usage()
     def attribute(
@@ -190,6 +197,7 @@ class NoiseTunnel(Attribution):
             # FIXME it look like it is very difficult to make torch.normal
             # deterministic this needs an investigation
             noise = torch.normal(0, stdev_expanded)
+
             return input.repeat_interleave(n_samples, dim=0) + noise
 
         def compute_expected_attribution_and_sq(attribution):

--- a/captum/attr/_core/saliency.py
+++ b/captum/attr/_core/saliency.py
@@ -31,6 +31,10 @@ class Saliency(GradientAttribution):
         """
         GradientAttribution.__init__(self, forward_func)
 
+    @property
+    def uses_input_marginal_effects(self):
+        return False
+
     @log_usage()
     def attribute(
         self,
@@ -120,7 +124,6 @@ class Saliency(GradientAttribution):
         # Keeps track whether original input is a tuple or not before
         # converting it into a tuple.
         is_inputs_tuple = _is_tuple(inputs)
-
         inputs = _format_input(inputs)
         gradient_mask = apply_gradient_requirements(inputs)
 

--- a/captum/attr/_core/saliency.py
+++ b/captum/attr/_core/saliency.py
@@ -124,6 +124,7 @@ class Saliency(GradientAttribution):
         # Keeps track whether original input is a tuple or not before
         # converting it into a tuple.
         is_inputs_tuple = _is_tuple(inputs)
+
         inputs = _format_input(inputs)
         gradient_mask = apply_gradient_requirements(inputs)
 

--- a/captum/attr/_utils/attribution.py
+++ b/captum/attr/_utils/attribution.py
@@ -65,7 +65,7 @@ class Attribution:
     """
 
     @property
-    def uses_input_marginal_effects(self):
+    def multiplies_by_inputs(self):
         return False
 
     def has_convergence_delta(self) -> bool:
@@ -313,7 +313,7 @@ class PerturbationAttribution(Attribution):
         Attribution.__init__(self, forward_func)
 
     @property
-    def uses_input_marginal_effects(self):
+    def multiplies_by_inputs(self):
         return True
 
 

--- a/captum/attr/_utils/attribution.py
+++ b/captum/attr/_utils/attribution.py
@@ -64,6 +64,10 @@ class Attribution:
 
     """
 
+    @property
+    def uses_input_marginal_effects(self):
+        return False
+
     def has_convergence_delta(self) -> bool:
         r"""
         This method informs the user whether the attribution algorithm provides
@@ -307,6 +311,10 @@ class PerturbationAttribution(Attribution):
                         function.
         """
         Attribution.__init__(self, forward_func)
+
+    @property
+    def uses_input_marginal_effects(self):
+        return True
 
 
 class InternalAttribution(Attribution):

--- a/captum/attr/_utils/visualization.py
+++ b/captum/attr/_utils/visualization.py
@@ -12,7 +12,7 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 from numpy import ndarray
 
 try:
-    from IPython.core.display import display, HTML
+    from IPython.core.display import HTML, display
 
     HAS_IPYTHON = True
 except ImportError:

--- a/captum/insights/attr_vis/app.py
+++ b/captum/insights/attr_vis/app.py
@@ -256,6 +256,7 @@ class AttributionVisualizer(object):
     @log_usage()
     def render(self, debug=True):
         from IPython.display import display
+
         from .widget import CaptumInsights
 
         widget = CaptumInsights(visualizer=self)
@@ -277,9 +278,10 @@ class AttributionVisualizer(object):
         return start_server(self, blocking=blocking, debug=debug, _port=port)
 
     def _serve_colab(self, blocking=False, debug=False, port=None):
-        from IPython.display import display, HTML
-        from .server import start_server
         import ipywidgets as widgets
+        from IPython.display import HTML, display
+
+        from .server import start_server
 
         # TODO: Output widget only captures beginning of server logs. It seems
         # the context manager isn't respected when the web server is run on a

--- a/captum/log/__init__.py
+++ b/captum/log/__init__.py
@@ -5,8 +5,8 @@ try:
         TimedLog,
         log,
         log_usage,
-        set_environment,
         patch_methods,
+        set_environment,
     )
 
     __all__ = ["log", "log_usage", "TimedLog", "set_environment"]

--- a/captum/metrics/_core/infidelity.py
+++ b/captum/metrics/_core/infidelity.py
@@ -15,79 +15,83 @@ from ..._utils.common import (
 )
 from .._utils.batching import _divide_and_aggregate_metrics
 
-
-def infidelity_perturb_func_decorator(pertub_func):
-    r"""
-    An auxiliary, decorator function that helps with computing
+def infidelity_perturb_func_decorator(use_input_marginal_effects=True):
+    r"""An auxiliary, decorator function that helps with computing
     perturbations given perturbed inputs. It can be useful for cases
     when `pertub_func` returns only perturbed inputs and we
     internally compute the perturbations as
-    (input - perturbed_input) / (input - baseline).
+    (input - perturbed_input) / (input - baseline) if
+    use_input_marginal_effects is set to True and
+    (input - perturbed_input) otherwise.
 
     If users decorate their `pertub_func` with
     `@infidelity_perturb_func_decorator` function then their `pertub_func`
     needs to only return perturbed inputs.
 
-    Note that if your attribution algorithm is inherently local such as
-    Saliency maps you should not use the decorator because the decorator
-    always divides by (input - baseline) and that is unnecessary for local
-    methods.
     Args:
 
-        pertub_func(callable): Input perturbation function that takes inputs
-            and optionally baselines and returns perturbed inputs
+        use_input_marginal_effects (bool): Indicates whether model inputs'
+                marginal effects are factored in the computation
+                of attribution scores.
 
-    Returns:
-
-        default_perturb_func(callable): Internal default perturbation
-        function that computes the perturbations internally and returns
-        perturbations and perturbed inputs.
-
-    Examples::
-        >>> @infidelity_perturb_func_decorator
-        >>> def perturb_fn(inputs):
-        >>>    noise = torch.tensor(np.random.normal(0, 0.003, inputs.shape)).float()
-        >>>    return inputs - noise
-        >>> # Computes infidelity score using `perturb_fn`
-        >>> infidelity = infidelity_attr(model, perturb_fn, input, ...)
-
-    """
-
-    def default_perturb_func(inputs, baselines=None):
-        r"""
         """
-        inputs_perturbed = (
-            pertub_func(inputs, baselines)
-            if baselines is not None
-            else pertub_func(inputs)
-        )
-        inputs_perturbed = _format_tensor_into_tuples(inputs_perturbed)
-        inputs = _format_tensor_into_tuples(inputs)
-        baselines = _format_tensor_into_tuples(baselines)
-        if baselines is None:
-            perturbations = tuple(
-                safe_div(
-                    input - input_perturbed,
-                    input,
-                    torch.tensor(1.0, device=input.device),
-                )
-                for input, input_perturbed in zip(inputs, inputs_perturbed)
-            )
-        else:
-            perturbations = tuple(
-                safe_div(
-                    input - input_perturbed,
-                    input - baseline,
-                    torch.tensor(1.0, device=input.device),
-                )
-                for input, input_perturbed, baseline in zip(
-                    inputs, inputs_perturbed, baselines
-                )
-            )
-        return perturbations, inputs_perturbed
+    def sub_infidelity_perturb_func_decorator(pertub_func):
+        r"""
+        Args:
 
-    return default_perturb_func
+            pertub_func(callable): Input perturbation function that takes inputs
+                and optionally baselines and returns perturbed inputs
 
+        Returns:
+
+            default_perturb_func(callable): Internal default perturbation
+            function that computes the perturbations internally and returns
+            perturbations and perturbed inputs.
+
+        Examples::
+            >>> @infidelity_perturb_func_decorator(True)
+            >>> def perturb_fn(inputs):
+            >>>    noise = torch.tensor(np.random.normal(0, 0.003, inputs.shape)).float()
+            >>>    return inputs - noise
+            >>> # Computes infidelity score using `perturb_fn`
+            >>> infidelity = infidelity_attr(model, perturb_fn, input, ...)
+
+        """
+        def default_perturb_func(inputs, baselines=None):
+            r"""
+            """
+            inputs_perturbed = (
+                pertub_func(inputs, baselines)
+                if baselines is not None
+                else pertub_func(inputs)
+            )
+            inputs_perturbed = _format_tensor_into_tuples(inputs_perturbed)
+            inputs = _format_tensor_into_tuples(inputs)
+            baselines = _format_tensor_into_tuples(baselines)
+            if baselines is None:
+                perturbations = tuple(
+                    safe_div(
+                        input - input_perturbed,
+                        input,
+                        torch.tensor(1.0, device=input.device),
+                    ) if use_input_marginal_effects else input - input_perturbed
+                    for input, input_perturbed in zip(inputs, inputs_perturbed)
+                )
+            else:
+                perturbations = tuple(
+                    safe_div(
+                        input - input_perturbed,
+                        input - baseline,
+                        torch.tensor(1.0, device=input.device),
+                    ) if use_input_marginal_effects else input - input_perturbed
+                    for input, input_perturbed, baseline in zip(
+                        inputs, inputs_perturbed, baselines
+                    )
+                )
+            return perturbations, inputs_perturbed
+
+        return default_perturb_func
+    return sub_infidelity_perturb_func_decorator
 
 def infidelity(
     forward_func,
@@ -154,11 +158,13 @@ def infidelity(
                 (input - perturbed_input) by (input - baselines) and the user needs to
                 only return perturbed inputs in `perturb_func` as described above.
 
-                `infidelity_perturb_func_decorator` makes sense to use only for global
-                attribution algorithms such as integrated gradients, deeplift, etc.
-                In case user has a local attribution algorithm or decides to compute
-                perturbations and perturbed inputs in `perturb_func` then they must not
-                use `infidelity_perturb_func_decorator`.
+                `infidelity_perturb_func_decorator` needs to be used with
+                `use_input_marginal_effects` flag set to False in case infidelity score is
+                being computed for attribution maps that are local aka that do not factor
+                in inputs' marginal effects to the final score.
+                Such attribution algorithms include Saliency, GradCam, Guided Backprop,
+                or Integrated Gradients and DeepLift attribution scores that are already
+                computed with `use_input_marginal_effects=False` flag.
 
                 If there are more than one inputs passed to infidelity function those
                 will be passed to `perturb_func` as tuples in the same order as they
@@ -225,22 +231,21 @@ def infidelity(
 
         attributions (tensor or tuple of tensors):
                 Attribution scores computed based on an attribution algorithm.
-                This attributions can be computed using the implementations
-                in the `captum.attr` package however some of those attributions
-                are so called global attributions as described in:
+                This attribution scores can be computed using the implementations
+                in the `captum.attr` package. Some of those attributions
+                are so called global attributions, which means that they
+                foctor in inputs marginal effects, as described in:
                 https://arxiv.org/pdf/1711.06104.pdf
-                In order to estimate the infidelity of the local attributions
-                using real-valued perturbations as described in the:
-                https://arxiv.org/pdf/1901.09392.pdf
-                we will need to divide those attributions by inputs
-                or (inputs - baselines) depending on the type of the algorithm
-                that we use. Later, we'll add an option to
-                compute both local and global attributions without a need to
-                perform that division after retrieving the attributions.
-                Also, note that not all attribution algorithms exposed in
-                captum are global.
-                Examples of local attribution methods are Saliency,
+                Many of them can be easly turned into local attributions,
+                aka attribution mothods that do not factor in inputs'
+                marginal effects but constructing them with
+                `use_input_marginal_effects=False` flag.
+                Examples inherently local attribution methods include:
                 Guided GradCam, Guided Backprop and Deconvolution.
+
+                For local attributions we can use real-valued perturbations
+                whereas for global attributions that perturbation is binary.
+                https://arxiv.org/pdf/1901.09392.pdf
 
                 If we want to compute the infidelity of global attributions we
                 can use a binary perturbation matrix that will allow us to select
@@ -253,7 +258,11 @@ def infidelity(
                 tensor as well. If inputs is provided as a tuple of tensors
                 then attributions will be tuples of tensors as well.
 
-                For more details on when to use `infidelity_perturb_func_decorator`,
+                `infidelity_perturb_func_decorator` function decorator is a helper
+                function that computes perturbations under the hood if perturbed
+                inputs are provided.
+
+                For more details on how to use `infidelity_perturb_func_decorator`,
                 please, read the documentation about `perturb_func`
 
         additional_forward_args (any, optional): If the forward function
@@ -442,12 +451,14 @@ def infidelity(
                 attributions_expanded, perturbations
             )
         )
+
         attribution_times_perturb_sums = sum(
             [
                 torch.sum(attribution_times_perturb, dim=1)
                 for attribution_times_perturb in attributions_times_perturb
             ]
         )
+
         return torch.sum(
             torch.pow(
                 attribution_times_perturb_sums - inputs_minus_perturb.view(-1), 2

--- a/captum/metrics/_core/infidelity.py
+++ b/captum/metrics/_core/infidelity.py
@@ -159,19 +159,23 @@ def infidelity(
                 `infidelity_perturb_func_decorator` decorator such as:
 
                 from captum.metrics import infidelity_perturb_func_decorator
-                @infidelity_perturb_func_decorator
+                @infidelity_perturb_func_decorator(<use_input_marginal_effects flag>)
                 def my_perturb_func(inputs):
                     <MY-LOGIC-HERE>
                     return perturbed_inputs
 
-                In this case we compute perturbations by dividing
-                (input - perturbed_input) by (input - baselines) and the user needs to
-                only return perturbed inputs in `perturb_func` as described above.
+                In this case we compute perturbations by `input - perturbed_input`
+                difference in case `use_input_marginal_effects` is False and by
+                dividing (input - perturbed_input) by (input - baselines) in case
+                `use_input_marginal_effects` flag is True.
+                The user needs to only return perturbed inputs in `perturb_func`
+                as described above.
 
                 `infidelity_perturb_func_decorator` needs to be used with
                 `use_input_marginal_effects` flag set to False in case infidelity
                 score is being computed for attribution maps that are local aka
-                that do not factor in inputs' marginal effects to the final score.
+                that do not factor in inputs' marginal effects in the final
+                attribution score.
                 Such attribution algorithms include Saliency, GradCam, Guided Backprop,
                 or Integrated Gradients and DeepLift attribution scores that are already
                 computed with `use_input_marginal_effects=False` flag.
@@ -242,16 +246,22 @@ def infidelity(
         attributions (tensor or tuple of tensors):
                 Attribution scores computed based on an attribution algorithm.
                 This attribution scores can be computed using the implementations
-                in the `captum.attr` package. Some of those attributions
-                are so called global attributions, which means that they
-                foctor in inputs marginal effects, as described in:
+                provided in the `captum.attr` package. Some of those attribution
+                approaches are so called global methods, which means that
+                they foctor in inputs' marginal effects, as described in:
                 https://arxiv.org/pdf/1711.06104.pdf
-                Many of them can be easly turned into local attributions,
-                aka attribution mothods that do not factor in inputs'
-                marginal effects but constructing them with
-                `use_input_marginal_effects=False` flag.
-                Examples inherently local attribution methods include:
-                Guided GradCam, Guided Backprop and Deconvolution.
+                Many global attribution algorithms can be used in local modes,
+                meaning that the inputs' marginal effects aren't factored in the
+                attribution scores.
+                This can be done duing the definition of the attribution algorithm
+                by passing `use_input_marginal_effects=False` flag.
+                For example in case of Integrated Gradients (IG) we can, obtain
+                local attribution scores if we define the constructor of IG as:
+                ig = IntegratedGradients(use_input_marginal_effects=False)
+
+                Some attribution algorithms are inherently local.
+                Examples of inherently local attribution methods include:
+                Saliency, Guided GradCam, Guided Backprop and Deconvolution.
 
                 For local attributions we can use real-valued perturbations
                 whereas for global attributions that perturbation is binary.
@@ -263,17 +273,17 @@ def infidelity(
                 This will allow us to approximate sensitivity-n for a global
                 attribution algorithm.
 
-                Attributions have the same shape and dimensionality as the inputs.
-                If inputs is a single tensor then the attributions is a single
-                tensor as well. If inputs is provided as a tuple of tensors
-                then attributions will be tuples of tensors as well.
-
                 `infidelity_perturb_func_decorator` function decorator is a helper
                 function that computes perturbations under the hood if perturbed
                 inputs are provided.
 
                 For more details on how to use `infidelity_perturb_func_decorator`,
                 please, read the documentation about `perturb_func`
+
+                Attributions have the same shape and dimensionality as the inputs.
+                If inputs is a single tensor then the attributions is a single
+                tensor as well. If inputs is provided as a tuple of tensors
+                then attributions will be tuples of tensors as well.
 
         additional_forward_args (any, optional): If the forward function
                 requires additional arguments other than the inputs for

--- a/captum/metrics/_core/infidelity.py
+++ b/captum/metrics/_core/infidelity.py
@@ -15,6 +15,7 @@ from ..._utils.common import (
 )
 from .._utils.batching import _divide_and_aggregate_metrics
 
+
 def infidelity_perturb_func_decorator(use_input_marginal_effects=True):
     r"""An auxiliary, decorator function that helps with computing
     perturbations given perturbed inputs. It can be useful for cases
@@ -35,6 +36,7 @@ def infidelity_perturb_func_decorator(use_input_marginal_effects=True):
                 of attribution scores.
 
         """
+
     def sub_infidelity_perturb_func_decorator(pertub_func):
         r"""
         Args:
@@ -51,12 +53,14 @@ def infidelity_perturb_func_decorator(use_input_marginal_effects=True):
         Examples::
             >>> @infidelity_perturb_func_decorator(True)
             >>> def perturb_fn(inputs):
-            >>>    noise = torch.tensor(np.random.normal(0, 0.003, inputs.shape)).float()
+            >>>    noise = torch.tensor(np.random.normal(0, 0.003,
+            >>>                         inputs.shape)).float()
             >>>    return inputs - noise
             >>> # Computes infidelity score using `perturb_fn`
-            >>> infidelity = infidelity_attr(model, perturb_fn, input, ...)
+            >>> infidelity = infidelity(model, perturb_fn, input, ...)
 
         """
+
         def default_perturb_func(inputs, baselines=None):
             r"""
             """
@@ -74,7 +78,9 @@ def infidelity_perturb_func_decorator(use_input_marginal_effects=True):
                         input - input_perturbed,
                         input,
                         torch.tensor(1.0, device=input.device),
-                    ) if use_input_marginal_effects else input - input_perturbed
+                    )
+                    if use_input_marginal_effects
+                    else input - input_perturbed
                     for input, input_perturbed in zip(inputs, inputs_perturbed)
                 )
             else:
@@ -83,7 +89,9 @@ def infidelity_perturb_func_decorator(use_input_marginal_effects=True):
                         input - input_perturbed,
                         input - baseline,
                         torch.tensor(1.0, device=input.device),
-                    ) if use_input_marginal_effects else input - input_perturbed
+                    )
+                    if use_input_marginal_effects
+                    else input - input_perturbed
                     for input, input_perturbed, baseline in zip(
                         inputs, inputs_perturbed, baselines
                     )
@@ -91,7 +99,9 @@ def infidelity_perturb_func_decorator(use_input_marginal_effects=True):
             return perturbations, inputs_perturbed
 
         return default_perturb_func
+
     return sub_infidelity_perturb_func_decorator
+
 
 def infidelity(
     forward_func,
@@ -159,9 +169,9 @@ def infidelity(
                 only return perturbed inputs in `perturb_func` as described above.
 
                 `infidelity_perturb_func_decorator` needs to be used with
-                `use_input_marginal_effects` flag set to False in case infidelity score is
-                being computed for attribution maps that are local aka that do not factor
-                in inputs' marginal effects to the final score.
+                `use_input_marginal_effects` flag set to False in case infidelity
+                score is being computed for attribution maps that are local aka
+                that do not factor in inputs' marginal effects to the final score.
                 Such attribution algorithms include Saliency, GradCam, Guided Backprop,
                 or Integrated Gradients and DeepLift attribution scores that are already
                 computed with `use_input_marginal_effects=False` flag.

--- a/captum/metrics/_core/infidelity.py
+++ b/captum/metrics/_core/infidelity.py
@@ -164,10 +164,10 @@ def infidelity(
                     <MY-LOGIC-HERE>
                     return perturbed_inputs
 
-                In this case we compute perturbations by `input - perturbed_input`
-                difference in case `multipy_by_inputs` is False and by
-                dividing (input - perturbed_input) by (input - baselines) in case
-                `multipy_by_inputs` flag is True.
+                In case `multipy_by_inputs` is False we compute perturbations by
+                `input - perturbed_input` difference and in case `multipy_by_inputs`
+                flag is True we compute it by dividing
+                (input - perturbed_input) by (input - baselines).
                 The user needs to only return perturbed inputs in `perturb_func`
                 as described above.
 
@@ -247,14 +247,14 @@ def infidelity(
                 This attribution scores can be computed using the implementations
                 provided in the `captum.attr` package. Some of those attribution
                 approaches are so called global methods, which means that
-                they factor in the inputs multiplier, as described in:
+                they factor in model inputs' multiplier, as described in:
                 https://arxiv.org/pdf/1711.06104.pdf
                 Many global attribution algorithms can be used in local modes,
                 meaning that the inputs multiplier isn't factored in the
                 attribution scores.
                 This can be done duing the definition of the attribution algorithm
                 by passing `multipy_by_inputs=False` flag.
-                For example in case of Integrated Gradients (IG) we can, obtain
+                For example in case of Integrated Gradients (IG) we can obtain
                 local attribution scores if we define the constructor of IG as:
                 ig = IntegratedGradients(multipy_by_inputs=False)
 
@@ -276,7 +276,7 @@ def infidelity(
                 function that computes perturbations under the hood if perturbed
                 inputs are provided.
 
-                For more details on how to use `infidelity_perturb_func_decorator`,
+                For more details about how to use `infidelity_perturb_func_decorator`,
                 please, read the documentation about `perturb_func`
 
                 Attributions have the same shape and dimensionality as the inputs.

--- a/captum/metrics/_core/sensitivity.py
+++ b/captum/metrics/_core/sensitivity.py
@@ -26,9 +26,9 @@ def default_perturb_func(inputs, perturb_radius=0.02):
     inputs = _format_input(inputs)
     perturbed_input = tuple(
         input
-        + torch.FloatTensor(input.size(), device=input.device).uniform_(
-            -perturb_radius, perturb_radius
-        )
+        + torch.FloatTensor(input.size())
+        .uniform_(-perturb_radius, perturb_radius)
+        .to(input.device)
         for input in inputs
     )
     return perturbed_input
@@ -166,7 +166,7 @@ def sensitivity_max(
         >>> saliency = Saliency(net)
         >>> input = torch.randn(2, 3, 32, 32, requires_grad=True)
         >>> # Computes sensitivity score for saliency maps
-        >>> sens = sensitivity_max(net, saliency.attribute)
+        >>> sens = sensitivity_max(saliency.attribute, input)
 
     """
 

--- a/tests/attr/helpers/conductance_reference.py
+++ b/tests/attr/helpers/conductance_reference.py
@@ -10,7 +10,6 @@ from captum.attr._utils.approximation_methods import approximation_parameters
 from captum.attr._utils.attribution import LayerAttribution
 from captum.attr._utils.common import _reshape_and_sum
 
-
 """
 Note: This implementation of conductance follows the procedure described in the original
 paper exactly (https://arxiv.org/abs/1805.12233), computing gradients of output with

--- a/tests/attr/layer/test_grad_cam.py
+++ b/tests/attr/layer/test_grad_cam.py
@@ -93,7 +93,7 @@ class Test(BaseTest):
         relu_attributions: bool = False,
     ):
         layer_gc = LayerGradCam(model, target_layer)
-        self.assertFalse(layer_gc.uses_input_marginal_effects)
+        self.assertFalse(layer_gc.multiplies_by_inputs)
         attributions = layer_gc.attribute(
             test_input,
             target=0,

--- a/tests/attr/layer/test_grad_cam.py
+++ b/tests/attr/layer/test_grad_cam.py
@@ -93,6 +93,7 @@ class Test(BaseTest):
         relu_attributions: bool = False,
     ):
         layer_gc = LayerGradCam(model, target_layer)
+        self.assertFalse(layer_gc.uses_input_marginal_effects)
         attributions = layer_gc.attribute(
             test_input,
             target=0,

--- a/tests/attr/layer/test_internal_influence.py
+++ b/tests/attr/layer/test_internal_influence.py
@@ -158,6 +158,7 @@ class Test(BaseTest):
     ):
         for internal_batch_size in [None, 5, 20]:
             int_inf = InternalInfluence(model, target_layer)
+            self.assertFalse(int_inf.uses_input_marginal_effects)
             attributions = int_inf.attribute(
                 test_input,
                 baselines=baseline,

--- a/tests/attr/layer/test_internal_influence.py
+++ b/tests/attr/layer/test_internal_influence.py
@@ -158,7 +158,7 @@ class Test(BaseTest):
     ):
         for internal_batch_size in [None, 5, 20]:
             int_inf = InternalInfluence(model, target_layer)
-            self.assertFalse(int_inf.uses_input_marginal_effects)
+            self.assertFalse(int_inf.multiplies_by_inputs)
             attributions = int_inf.attribute(
                 test_input,
                 baselines=baseline,

--- a/tests/attr/layer/test_layer_activation.py
+++ b/tests/attr/layer/test_layer_activation.py
@@ -108,7 +108,7 @@ class Test(BaseTest):
         attribute_to_layer_input: bool = False,
     ):
         layer_act = LayerActivation(model, target_layer)
-        self.assertTrue(layer_act.uses_input_marginal_effects)
+        self.assertTrue(layer_act.multiplies_by_inputs)
         attributions = layer_act.attribute(
             test_input,
             additional_forward_args=additional_input,

--- a/tests/attr/layer/test_layer_activation.py
+++ b/tests/attr/layer/test_layer_activation.py
@@ -108,6 +108,7 @@ class Test(BaseTest):
         attribute_to_layer_input: bool = False,
     ):
         layer_act = LayerActivation(model, target_layer)
+        self.assertTrue(layer_act.uses_input_marginal_effects)
         attributions = layer_act.attribute(
             test_input,
             additional_forward_args=additional_input,

--- a/tests/attr/layer/test_layer_conductance.py
+++ b/tests/attr/layer/test_layer_conductance.py
@@ -143,7 +143,7 @@ class Test(BaseTest):
         additional_args: Any = None,
     ) -> None:
         cond = LayerConductance(model, target_layer)
-        self.assertTrue(cond.uses_input_marginal_effects)
+        self.assertTrue(cond.multiplies_by_inputs)
         for internal_batch_size in (None, 4, 20):
             attributions, delta = cond.attribute(
                 test_input,

--- a/tests/attr/layer/test_layer_conductance.py
+++ b/tests/attr/layer/test_layer_conductance.py
@@ -143,6 +143,7 @@ class Test(BaseTest):
         additional_args: Any = None,
     ) -> None:
         cond = LayerConductance(model, target_layer)
+        self.assertTrue(cond.uses_input_marginal_effects)
         for internal_batch_size in (None, 4, 20):
             attributions, delta = cond.attribute(
                 test_input,

--- a/tests/attr/layer/test_layer_deeplift.py
+++ b/tests/attr/layer/test_layer_deeplift.py
@@ -47,9 +47,7 @@ class TestDeepLift(BaseTest):
 
         layer_dl = LayerDeepLift(model, model.relu, use_input_marginal_effects=False)
         attributions = layer_dl.attribute(
-            inputs,
-            baselines,
-            attribute_to_layer_input=True,
+            inputs, baselines, attribute_to_layer_input=True,
         )
         assertTensorAlmostEqual(self, attributions[0], [[0.0, 1.0]])
 
@@ -171,11 +169,11 @@ class TestDeepLift(BaseTest):
             inputs,
             baselines,
         ) = _create_inps_and_base_for_deepliftshap_neuron_layer_testing()
-        layer_dl_shap = LayerDeepLiftShap(model, model.relu, use_input_marginal_effects=False)
+        layer_dl_shap = LayerDeepLiftShap(
+            model, model.relu, use_input_marginal_effects=False
+        )
         attributions = layer_dl_shap.attribute(
-            inputs,
-            baselines,
-            attribute_to_layer_input=True,
+            inputs, baselines, attribute_to_layer_input=True,
         )
         assertTensorAlmostEqual(self, attributions[0], [[0.0, 1.0]])
 

--- a/tests/attr/layer/test_layer_deeplift.py
+++ b/tests/attr/layer/test_layer_deeplift.py
@@ -41,6 +41,18 @@ class TestDeepLift(BaseTest):
         assertTensorAlmostEqual(self, attributions[0], [[0.0, 15.0]])
         assert_delta(self, delta)
 
+    def test_relu_layer_deeplift_wo_inp_marginal_effects(self) -> None:
+        model = ReLULinearModel(inplace=True)
+        inputs, baselines = _create_inps_and_base_for_deeplift_neuron_layer_testing()
+
+        layer_dl = LayerDeepLift(model, model.relu, use_input_marginal_effects=False)
+        attributions = layer_dl.attribute(
+            inputs,
+            baselines,
+            attribute_to_layer_input=True,
+        )
+        assertTensorAlmostEqual(self, attributions[0], [[0.0, 1.0]])
+
     def test_relu_layer_deeplift_multiple_output(self) -> None:
         model = BasicModel_MultiLayer(multi_input_module=True)
         inputs, baselines = _create_inps_and_base_for_deeplift_neuron_layer_testing()
@@ -152,6 +164,20 @@ class TestDeepLift(BaseTest):
         )
         assertTensorAlmostEqual(self, attributions[0], [[0.0, 15.0]])
         assert_delta(self, delta)
+
+    def test_relu_layer_deepliftshap_wo_inp_marginal_effects(self) -> None:
+        model = ReLULinearModel()
+        (
+            inputs,
+            baselines,
+        ) = _create_inps_and_base_for_deepliftshap_neuron_layer_testing()
+        layer_dl_shap = LayerDeepLiftShap(model, model.relu, use_input_marginal_effects=False)
+        attributions = layer_dl_shap.attribute(
+            inputs,
+            baselines,
+            attribute_to_layer_input=True,
+        )
+        assertTensorAlmostEqual(self, attributions[0], [[0.0, 1.0]])
 
     def test_relu_layer_deepliftshap_multiple_output(self) -> None:
         model = BasicModel_MultiLayer(multi_input_module=True)

--- a/tests/attr/layer/test_layer_deeplift.py
+++ b/tests/attr/layer/test_layer_deeplift.py
@@ -41,11 +41,11 @@ class TestDeepLift(BaseTest):
         assertTensorAlmostEqual(self, attributions[0], [[0.0, 15.0]])
         assert_delta(self, delta)
 
-    def test_relu_layer_deeplift_wo_inp_marginal_effects(self) -> None:
+    def test_relu_layer_deeplift_wo_mutliplying_by_inputs(self) -> None:
         model = ReLULinearModel(inplace=True)
         inputs, baselines = _create_inps_and_base_for_deeplift_neuron_layer_testing()
 
-        layer_dl = LayerDeepLift(model, model.relu, use_input_marginal_effects=False)
+        layer_dl = LayerDeepLift(model, model.relu, multiply_by_inputs=False)
         attributions = layer_dl.attribute(
             inputs, baselines, attribute_to_layer_input=True,
         )
@@ -163,15 +163,13 @@ class TestDeepLift(BaseTest):
         assertTensorAlmostEqual(self, attributions[0], [[0.0, 15.0]])
         assert_delta(self, delta)
 
-    def test_relu_layer_deepliftshap_wo_inp_marginal_effects(self) -> None:
+    def test_relu_layer_deepliftshap_wo_mutliplying_by_inputs(self) -> None:
         model = ReLULinearModel()
         (
             inputs,
             baselines,
         ) = _create_inps_and_base_for_deepliftshap_neuron_layer_testing()
-        layer_dl_shap = LayerDeepLiftShap(
-            model, model.relu, use_input_marginal_effects=False
-        )
+        layer_dl_shap = LayerDeepLiftShap(model, model.relu, multiply_by_inputs=False)
         attributions = layer_dl_shap.attribute(
             inputs, baselines, attribute_to_layer_input=True,
         )

--- a/tests/attr/layer/test_layer_gradient_shap.py
+++ b/tests/attr/layer/test_layer_gradient_shap.py
@@ -8,6 +8,7 @@ from torch.nn import Module
 from captum._utils.typing import TargetType, TensorOrTupleOfTensorsGeneric
 from captum.attr._core.gradient_shap import GradientShap
 from captum.attr._core.layer.layer_gradient_shap import LayerGradientShap
+from captum.attr._core.layer.layer_activation import LayerActivation
 
 from ...helpers.basic import (
     BaseTest,
@@ -33,15 +34,15 @@ class Test(BaseTest):
 
         self._assert_attributions(model, model.linear2, inputs, baselines, 0, expected)
 
-    def test_basic_multilayer_wo_inp_marginal_effects(self) -> None:
+    def test_basic_multilayer_wo_multiplying_by_inputs(self) -> None:
         model = BasicModel_MultiLayer(inplace=True)
         model.eval()
 
         inputs = torch.tensor([[1.0, -20.0, 10.0]])
         baselines = torch.zeros(3, 3)
-        lgs = LayerGradientShap(model, model.linear2, use_input_marginal_effects=False)
+        lgs = LayerGradientShap(model, model.linear2, multiply_by_inputs=False)
         attrs = lgs.attribute(inputs, baselines, target=0, stdevs=0.0,)
-        assertTensorAlmostEqual(self, attrs, torch.tensor([[-3.0, 0.0]]))
+        assertTensorAlmostEqual(self, attrs, torch.tensor([[1.0, 0.0]]))
 
     def test_basic_multi_tensor_output(self) -> None:
         model = BasicModel_MultiLayer(multi_input_module=True)

--- a/tests/attr/layer/test_layer_gradient_shap.py
+++ b/tests/attr/layer/test_layer_gradient_shap.py
@@ -8,7 +8,6 @@ from torch.nn import Module
 from captum._utils.typing import TargetType, TensorOrTupleOfTensorsGeneric
 from captum.attr._core.gradient_shap import GradientShap
 from captum.attr._core.layer.layer_gradient_shap import LayerGradientShap
-from captum.attr._core.layer.layer_activation import LayerActivation
 
 from ...helpers.basic import (
     BaseTest,

--- a/tests/attr/layer/test_layer_gradient_shap.py
+++ b/tests/attr/layer/test_layer_gradient_shap.py
@@ -33,6 +33,22 @@ class Test(BaseTest):
 
         self._assert_attributions(model, model.linear2, inputs, baselines, 0, expected)
 
+    def test_basic_multilayer_wo_inp_marginal_effects(self) -> None:
+        model = BasicModel_MultiLayer(inplace=True)
+        model.eval()
+
+        inputs = torch.tensor([[1.0, -20.0, 10.0]])
+        baselines = torch.zeros(3,3)
+        lgs = LayerGradientShap(model, model.linear2, use_input_marginal_effects=False
+        )
+        attrs  = lgs.attribute(
+                    inputs,
+                    baselines,
+                    target=0,
+                    stdevs=0.0,
+                )
+        assertTensorAlmostEqual(self, attrs, torch.tensor([[-3.0, 0.0]]))
+
     def test_basic_multi_tensor_output(self) -> None:
         model = BasicModel_MultiLayer(multi_input_module=True)
         model.eval()

--- a/tests/attr/layer/test_layer_gradient_shap.py
+++ b/tests/attr/layer/test_layer_gradient_shap.py
@@ -38,15 +38,9 @@ class Test(BaseTest):
         model.eval()
 
         inputs = torch.tensor([[1.0, -20.0, 10.0]])
-        baselines = torch.zeros(3,3)
-        lgs = LayerGradientShap(model, model.linear2, use_input_marginal_effects=False
-        )
-        attrs  = lgs.attribute(
-                    inputs,
-                    baselines,
-                    target=0,
-                    stdevs=0.0,
-                )
+        baselines = torch.zeros(3, 3)
+        lgs = LayerGradientShap(model, model.linear2, use_input_marginal_effects=False)
+        attrs = lgs.attribute(inputs, baselines, target=0, stdevs=0.0,)
         assertTensorAlmostEqual(self, attrs, torch.tensor([[-3.0, 0.0]]))
 
     def test_basic_multi_tensor_output(self) -> None:

--- a/tests/attr/layer/test_layer_gradient_x_activation.py
+++ b/tests/attr/layer/test_layer_gradient_x_activation.py
@@ -86,7 +86,7 @@ class Test(BaseTest):
         additional_input: Any = None,
     ) -> None:
         layer_act = LayerGradientXActivation(model, target_layer)
-        self.assertTrue(layer_act.uses_input_marginal_effects)
+        self.assertTrue(layer_act.multiplies_by_inputs)
         attributions = layer_act.attribute(
             test_input, target=0, additional_forward_args=additional_input
         )
@@ -95,10 +95,10 @@ class Test(BaseTest):
         )
         # test Layer Gradient without multiplying with activations
         layer_grads = LayerGradientXActivation(
-            model, target_layer, use_input_marginal_effects=False
+            model, target_layer, multiply_by_inputs=False
         )
         layer_act = LayerActivation(model, target_layer)
-        self.assertFalse(layer_grads.uses_input_marginal_effects)
+        self.assertFalse(layer_grads.multiplies_by_inputs)
         grads = layer_grads.attribute(
             test_input, target=0, additional_forward_args=additional_input
         )

--- a/tests/attr/layer/test_layer_gradient_x_activation.py
+++ b/tests/attr/layer/test_layer_gradient_x_activation.py
@@ -6,8 +6,8 @@ import torch
 from torch import Tensor
 from torch.nn import Module
 
-from captum.attr._core.layer.layer_gradient_x_activation import LayerGradientXActivation
 from captum.attr._core.layer.layer_activation import LayerActivation
+from captum.attr._core.layer.layer_gradient_x_activation import LayerGradientXActivation
 
 from ...helpers.basic import BaseTest, assertTensorTuplesAlmostEqual
 from ...helpers.basic_models import (

--- a/tests/attr/layer/test_layer_gradient_x_activation.py
+++ b/tests/attr/layer/test_layer_gradient_x_activation.py
@@ -6,8 +6,8 @@ import torch
 from torch import Tensor
 from torch.nn import Module
 
-from captum.attr._core.layer.layer_activation import LayerActivation
 from captum.attr._core.layer.layer_gradient_x_activation import LayerGradientXActivation
+from captum.attr._core.layer.layer_activation import LayerActivation
 
 from ...helpers.basic import BaseTest, assertTensorTuplesAlmostEqual
 from ...helpers.basic_models import (

--- a/tests/attr/layer/test_layer_integrated_gradients.py
+++ b/tests/attr/layer/test_layer_integrated_gradients.py
@@ -7,8 +7,8 @@ from torch import Tensor
 from torch.nn import Module
 
 from captum.attr._core.integrated_gradients import IntegratedGradients
-from captum.attr._core.layer.layer_conductance import LayerConductance
 from captum.attr._core.layer.layer_activation import LayerActivation
+from captum.attr._core.layer.layer_conductance import LayerConductance
 from captum.attr._core.layer.layer_integrated_gradients import LayerIntegratedGradients
 from captum.attr._models.base import (
     configure_interpretable_embedding_layer,

--- a/tests/attr/layer/test_layer_integrated_gradients.py
+++ b/tests/attr/layer/test_layer_integrated_gradients.py
@@ -35,7 +35,7 @@ class Test(BaseTest):
             input1, baseline1, additional_args=(input2, input3)
         )
 
-    def test_compare_with_emb_patching_wo_inp_marginal_effects(self) -> None:
+    def test_compare_with_emb_patching_wo_mult_by_inputs(self) -> None:
         input1 = torch.tensor([[2, 5, 0, 1]])
         baseline1 = torch.tensor([[0, 0, 0, 0]])
         # these ones will be use as an additional forward args
@@ -43,7 +43,10 @@ class Test(BaseTest):
         input3 = torch.tensor([[2, 3, 0, 1]])
 
         self._assert_compare_with_emb_patching(
-            input1, baseline1, additional_args=(input2, input3)
+            input1,
+            baseline1,
+            additional_args=(input2, input3),
+            multiply_by_inputs=False,
         )
 
     def test_compare_with_emb_patching_batch(self) -> None:
@@ -84,18 +87,18 @@ class Test(BaseTest):
             ([[90.0, 100.0, 100.0, 100.0]], [[90.0, 100.0, 100.0, 100.0]]),
         )
 
-    def test_multiple_tensors_compare_with_exp_wo_inp_marginal_effects(self) -> None:
+    def test_multiple_tensors_compare_with_exp_wo_mult_by_inputs(self) -> None:
         net = BasicModel_MultiLayer(multi_input_module=True)
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         base = torch.tensor([[0.0, 0.0, 0.0]])
         target_layer = net.multi_relu
         layer_ig = LayerIntegratedGradients(net, target_layer)
-        layer_ig_wo_marginal_effects = LayerIntegratedGradients(
-            net, target_layer, use_input_marginal_effects=False
+        layer_ig_wo_mult_by_inputs = LayerIntegratedGradients(
+            net, target_layer, multiply_by_inputs=False
         )
         layer_act = LayerActivation(net, target_layer)
         attributions = layer_ig.attribute(inp, target=0)
-        attributions_wo_marginal_eff = layer_ig_wo_marginal_effects.attribute(
+        attributions_wo_mult_by_inputs = layer_ig_wo_mult_by_inputs.attribute(
             inp, target=0
         )
         inp_minus_baseline_activ = tuple(
@@ -107,9 +110,9 @@ class Test(BaseTest):
         assertTensorTuplesAlmostEqual(
             self,
             tuple(
-                attr_wo_eff * inp_min_base
-                for attr_wo_eff, inp_min_base in zip(
-                    attributions_wo_marginal_eff, inp_minus_baseline_activ
+                attr_wo_mult * inp_min_base
+                for attr_wo_mult, inp_min_base in zip(
+                    attributions_wo_mult_by_inputs, inp_minus_baseline_activ
                 )
             ),
             attributions,
@@ -140,10 +143,16 @@ class Test(BaseTest):
         assertArraysAlmostEqual(delta, delta2, 0.05)
 
     def _assert_compare_with_emb_patching(
-        self, input: Tensor, baseline: Tensor, additional_args: Tuple[Tensor, ...]
+        self,
+        input: Tensor,
+        baseline: Tensor,
+        additional_args: Tuple[Tensor, ...],
+        multiply_by_inputs: bool = True,
     ):
         model = BasicEmbeddingModel(nested_second_embedding=True)
-        lig = LayerIntegratedGradients(model, model.embedding1)
+        lig = LayerIntegratedGradients(
+            model, model.embedding1, multiply_by_inputs=multiply_by_inputs
+        )
 
         attributions, delta = lig.attribute(
             input,
@@ -159,7 +168,7 @@ class Test(BaseTest):
         )
         input_emb = interpretable_embedding.indices_to_embeddings(input)
         baseline_emb = interpretable_embedding.indices_to_embeddings(baseline)
-        ig = IntegratedGradients(model)
+        ig = IntegratedGradients(model, multiply_by_inputs=multiply_by_inputs)
         attributions_with_ig, delta_with_ig = ig.attribute(
             input_emb,
             baselines=baseline_emb,
@@ -170,7 +179,8 @@ class Test(BaseTest):
         remove_interpretable_embedding_layer(model, interpretable_embedding)
 
         assertArraysAlmostEqual(attributions, attributions_with_ig)
-        assertArraysAlmostEqual(delta, delta_with_ig)
+        if multiply_by_inputs:
+            assertArraysAlmostEqual(delta, delta_with_ig)
 
     def _assert_compare_with_expected(
         self,

--- a/tests/attr/layer/test_layer_integrated_gradients.py
+++ b/tests/attr/layer/test_layer_integrated_gradients.py
@@ -90,18 +90,30 @@ class Test(BaseTest):
         base = torch.tensor([[0.0, 0.0, 0.0]])
         target_layer = net.multi_relu
         layer_ig = LayerIntegratedGradients(net, target_layer)
-        layer_ig_wo_marginal_effects = LayerIntegratedGradients(net,
-            target_layer, use_input_marginal_effects=False)
+        layer_ig_wo_marginal_effects = LayerIntegratedGradients(
+            net, target_layer, use_input_marginal_effects=False
+        )
         layer_act = LayerActivation(net, target_layer)
         attributions = layer_ig.attribute(inp, target=0)
         attributions_wo_marginal_eff = layer_ig_wo_marginal_effects.attribute(
-            inp, target=0)
-        activations = layer_act.attribute(inp)
-        inp_minus_baseline_activ = tuple(inp_act - base_act for inp_act, base_act in \
-            zip(layer_act.attribute(inp), layer_act.attribute(base)))
-        assertTensorTuplesAlmostEqual(self, tuple(attr_wo_eff * inp_min_base \
-            for attr_wo_eff, inp_min_base in \
-            zip(attributions_wo_marginal_eff, inp_minus_baseline_activ)), attributions)
+            inp, target=0
+        )
+        inp_minus_baseline_activ = tuple(
+            inp_act - base_act
+            for inp_act, base_act in zip(
+                layer_act.attribute(inp), layer_act.attribute(base)
+            )
+        )
+        assertTensorTuplesAlmostEqual(
+            self,
+            tuple(
+                attr_wo_eff * inp_min_base
+                for attr_wo_eff, inp_min_base in zip(
+                    attributions_wo_marginal_eff, inp_minus_baseline_activ
+                )
+            ),
+            attributions,
+        )
 
     def _assert_compare_with_layer_conductance(
         self, model: Module, input: Tensor, attribute_to_layer_input: bool = False

--- a/tests/attr/models/test_pytext.py
+++ b/tests/attr/models/test_pytext.py
@@ -11,21 +11,22 @@ import torch
 HAS_PYTEXT = True
 try:
     from pytext.common.constants import DatasetFieldName
-    from pytext.data import CommonMetadata
-    from pytext.fields import FieldMeta
-    from pytext.config.component import create_model
-    from pytext.models.doc_model import DocModel_Deprecated
-    from pytext.models.decoders.mlp_decoder import MLPDecoder
-    from pytext.models.representations.bilstm_doc_attention import BiLSTMDocAttention
-    from pytext.models.embeddings.word_embedding import WordEmbedding
-    from pytext.config.component import create_featurizer
-    from pytext.config.field_config import FeatureConfig, WordFeatConfig
-    from pytext.data.featurizer import SimpleFeaturizer
-    from pytext.data.doc_classification_data_handler import DocClassificationDataHandler
+    from pytext.config.component import create_featurizer, create_model
     from pytext.config.doc_classification import ModelInputConfig, TargetConfig
+    from pytext.config.field_config import FeatureConfig, WordFeatConfig
+    from pytext.data import CommonMetadata
+    from pytext.data.doc_classification_data_handler import DocClassificationDataHandler
+    from pytext.data.featurizer import SimpleFeaturizer
+    from pytext.fields import FieldMeta
+    from pytext.models.decoders.mlp_decoder import MLPDecoder
+    from pytext.models.doc_model import DocModel_Deprecated
+    from pytext.models.embeddings.word_embedding import WordEmbedding
+    from pytext.models.representations.bilstm_doc_attention import BiLSTMDocAttention
 
-    from captum.attr._models.pytext import configure_model_integ_grads_embeddings
-    from captum.attr._models.pytext import BaselineGenerator
+    from captum.attr._models.pytext import (
+        BaselineGenerator,
+        configure_model_integ_grads_embeddings,
+    )
 except ImportError:
     HAS_PYTEXT = False
 

--- a/tests/attr/neuron/test_neuron_ablation.py
+++ b/tests/attr/neuron/test_neuron_ablation.py
@@ -227,6 +227,7 @@ class Test(BaseTest):
     ) -> None:
         for batch_size in perturbations_per_eval:
             ablation = NeuronFeatureAblation(model, layer)
+            self.assertTrue(ablation.uses_input_marginal_effects)
             attributions = ablation.attribute(
                 test_input,
                 neuron_index=neuron_index,

--- a/tests/attr/neuron/test_neuron_ablation.py
+++ b/tests/attr/neuron/test_neuron_ablation.py
@@ -227,7 +227,7 @@ class Test(BaseTest):
     ) -> None:
         for batch_size in perturbations_per_eval:
             ablation = NeuronFeatureAblation(model, layer)
-            self.assertTrue(ablation.uses_input_marginal_effects)
+            self.assertTrue(ablation.multiplies_by_inputs)
             attributions = ablation.attribute(
                 test_input,
                 neuron_index=neuron_index,

--- a/tests/attr/neuron/test_neuron_conductance.py
+++ b/tests/attr/neuron/test_neuron_conductance.py
@@ -27,23 +27,11 @@ class Test(BaseTest):
             net, net.linear2, inp, (0,), [0.0, 390.0, 0.0]
         )
 
-    def test_simple_conductance_input_linear2_wo_inp_marginal_effects(self) -> None:
+    def test_simple_conductance_input_linear2_wo_mult_by_inputs(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[100.0, 100.0, 100.0]], requires_grad=True)
         self._conductance_input_test_assert(
-            net,
-            net.linear2,
-            inp,
-            (0,),
-            [3.96, 3.96, 3.96],
-            use_input_marginal_effects=False,
-        )
-
-    def test_simple_conductance_input_linear2_wo_(self) -> None:
-        net = BasicModel_MultiLayer()
-        inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
-        self._conductance_input_test_assert(
-            net, net.linear2, inp, (0,), [0.0, 390.0, 0.0]
+            net, net.linear2, inp, (0,), [3.96, 3.96, 3.96], multiply_by_inputs=False,
         )
 
     def test_simple_conductance_input_linear1(self) -> None:
@@ -134,17 +122,13 @@ class Test(BaseTest):
         test_neuron: Union[int, Tuple[int, ...]],
         expected_input_conductance: Union[List[float], Tuple[List[List[float]], ...]],
         additional_input: Any = None,
-        use_input_marginal_effects: bool = True,
+        multiply_by_inputs: bool = True,
     ) -> None:
         for internal_batch_size in (None, 5, 20):
             cond = NeuronConductance(
-                model,
-                target_layer,
-                use_input_marginal_effects=use_input_marginal_effects,
+                model, target_layer, multiply_by_inputs=multiply_by_inputs,
             )
-            self.assertEquals(
-                cond.uses_input_marginal_effects, use_input_marginal_effects
-            )
+            self.assertEquals(cond.multiplies_by_inputs, multiply_by_inputs)
             attributions = cond.attribute(
                 test_input,
                 test_neuron,

--- a/tests/attr/neuron/test_neuron_conductance.py
+++ b/tests/attr/neuron/test_neuron_conductance.py
@@ -27,6 +27,21 @@ class Test(BaseTest):
             net, net.linear2, inp, (0,), [0.0, 390.0, 0.0]
         )
 
+    def test_simple_conductance_input_linear2_wo_inp_marginal_effects(self) -> None:
+        net = BasicModel_MultiLayer()
+        inp = torch.tensor([[100.0, 100.0, 100.0]], requires_grad=True)
+        self._conductance_input_test_assert(
+            net, net.linear2, inp, (0,), [3.96, 3.96, 3.96],
+            use_input_marginal_effects=False,
+        )
+
+    def test_simple_conductance_input_linear2_wo_(self) -> None:
+        net = BasicModel_MultiLayer()
+        inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
+        self._conductance_input_test_assert(
+            net, net.linear2, inp, (0,), [0.0, 390.0, 0.0]
+        )
+
     def test_simple_conductance_input_linear1(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
@@ -115,9 +130,11 @@ class Test(BaseTest):
         test_neuron: Union[int, Tuple[int, ...]],
         expected_input_conductance: Union[List[float], Tuple[List[List[float]], ...]],
         additional_input: Any = None,
+        use_input_marginal_effects: bool = True,
     ) -> None:
         for internal_batch_size in (None, 5, 20):
-            cond = NeuronConductance(model, target_layer)
+            cond = NeuronConductance(model, target_layer, use_input_marginal_effects=use_input_marginal_effects)
+            self.assertEquals(cond.uses_input_marginal_effects, use_input_marginal_effects)
             attributions = cond.attribute(
                 test_input,
                 test_neuron,

--- a/tests/attr/neuron/test_neuron_conductance.py
+++ b/tests/attr/neuron/test_neuron_conductance.py
@@ -31,7 +31,11 @@ class Test(BaseTest):
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[100.0, 100.0, 100.0]], requires_grad=True)
         self._conductance_input_test_assert(
-            net, net.linear2, inp, (0,), [3.96, 3.96, 3.96],
+            net,
+            net.linear2,
+            inp,
+            (0,),
+            [3.96, 3.96, 3.96],
             use_input_marginal_effects=False,
         )
 
@@ -133,8 +137,14 @@ class Test(BaseTest):
         use_input_marginal_effects: bool = True,
     ) -> None:
         for internal_batch_size in (None, 5, 20):
-            cond = NeuronConductance(model, target_layer, use_input_marginal_effects=use_input_marginal_effects)
-            self.assertEquals(cond.uses_input_marginal_effects, use_input_marginal_effects)
+            cond = NeuronConductance(
+                model,
+                target_layer,
+                use_input_marginal_effects=use_input_marginal_effects,
+            )
+            self.assertEquals(
+                cond.uses_input_marginal_effects, use_input_marginal_effects
+            )
             attributions = cond.attribute(
                 test_input,
                 test_neuron,

--- a/tests/attr/neuron/test_neuron_deeplift.py
+++ b/tests/attr/neuron/test_neuron_deeplift.py
@@ -66,7 +66,7 @@ class Test(BaseTest):
         attributions = neuron_dl.attribute(
             inputs, 0, baselines, attribute_to_neuron_input=False
         )
-        self.assertTrue(neuron_dl.uses_input_marginal_effects)
+        self.assertTrue(neuron_dl.multiplies_by_inputs)
         assertTensorAlmostEqual(self, attributions[0], [[-0.0, 0.0, -0.0]])
         assertTensorAlmostEqual(self, attributions[1], [[6.0, 9.0, 0.0]])
 
@@ -74,7 +74,7 @@ class Test(BaseTest):
         model = ReLULinearModel()
         inputs, baselines = _create_inps_and_base_for_deeplift_neuron_layer_testing()
 
-        neuron_dl = NeuronDeepLift(model, model.l3, use_input_marginal_effects=False)
+        neuron_dl = NeuronDeepLift(model, model.l3, multiply_by_inputs=False)
         attributions = neuron_dl.attribute(
             inputs, 0, baselines, attribute_to_neuron_input=False
         )
@@ -121,7 +121,7 @@ class Test(BaseTest):
             inputs, 0, baselines, attribute_to_neuron_input=False
         )
 
-        self.assertTrue(neuron_dl.uses_input_marginal_effects)
+        self.assertTrue(neuron_dl.multiplies_by_inputs)
         assertTensorAlmostEqual(self, attributions[0], [[-0.0, 0.0, -0.0]])
         assertTensorAlmostEqual(self, attributions[1], [[6.0, 9.0, 0.0]])
 
@@ -132,9 +132,7 @@ class Test(BaseTest):
             baselines,
         ) = _create_inps_and_base_for_deepliftshap_neuron_layer_testing()
 
-        neuron_dl = NeuronDeepLiftShap(
-            model, model.l3, use_input_marginal_effects=False
-        )
+        neuron_dl = NeuronDeepLiftShap(model, model.l3, multiply_by_inputs=False)
         attributions = neuron_dl.attribute(
             inputs, 0, baselines, attribute_to_neuron_input=False
         )

--- a/tests/attr/neuron/test_neuron_deeplift.py
+++ b/tests/attr/neuron/test_neuron_deeplift.py
@@ -132,8 +132,9 @@ class Test(BaseTest):
             baselines,
         ) = _create_inps_and_base_for_deepliftshap_neuron_layer_testing()
 
-        neuron_dl = NeuronDeepLiftShap(model, model.l3,
-            use_input_marginal_effects=False)
+        neuron_dl = NeuronDeepLiftShap(
+            model, model.l3, use_input_marginal_effects=False
+        )
         attributions = neuron_dl.attribute(
             inputs, 0, baselines, attribute_to_neuron_input=False
         )

--- a/tests/attr/neuron/test_neuron_deeplift.py
+++ b/tests/attr/neuron/test_neuron_deeplift.py
@@ -66,9 +66,20 @@ class Test(BaseTest):
         attributions = neuron_dl.attribute(
             inputs, 0, baselines, attribute_to_neuron_input=False
         )
-
+        self.assertTrue(neuron_dl.uses_input_marginal_effects)
         assertTensorAlmostEqual(self, attributions[0], [[-0.0, 0.0, -0.0]])
         assertTensorAlmostEqual(self, attributions[1], [[6.0, 9.0, 0.0]])
+
+    def test_linear_neuron_deeplift_wo_inp_marginal_effects(self) -> None:
+        model = ReLULinearModel()
+        inputs, baselines = _create_inps_and_base_for_deeplift_neuron_layer_testing()
+
+        neuron_dl = NeuronDeepLift(model, model.l3, use_input_marginal_effects=False)
+        attributions = neuron_dl.attribute(
+            inputs, 0, baselines, attribute_to_neuron_input=False
+        )
+        assertTensorAlmostEqual(self, attributions[0], [[-0.0, 0.0, -0.0]])
+        assertTensorAlmostEqual(self, attributions[1], [[2.0, 3.0, 0.0]])
 
     def test_relu_deeplift_with_custom_attr_func(self) -> None:
         model = ReLULinearModel()
@@ -110,8 +121,25 @@ class Test(BaseTest):
             inputs, 0, baselines, attribute_to_neuron_input=False
         )
 
+        self.assertTrue(neuron_dl.uses_input_marginal_effects)
         assertTensorAlmostEqual(self, attributions[0], [[-0.0, 0.0, -0.0]])
         assertTensorAlmostEqual(self, attributions[1], [[6.0, 9.0, 0.0]])
+
+    def test_linear_neuron_deeplift_shap_wo_inp_marginal_effects(self) -> None:
+        model = ReLULinearModel()
+        (
+            inputs,
+            baselines,
+        ) = _create_inps_and_base_for_deepliftshap_neuron_layer_testing()
+
+        neuron_dl = NeuronDeepLiftShap(model, model.l3,
+            use_input_marginal_effects=False)
+        attributions = neuron_dl.attribute(
+            inputs, 0, baselines, attribute_to_neuron_input=False
+        )
+
+        assertTensorAlmostEqual(self, attributions[0], [[-0.0, 0.0, -0.0]])
+        assertTensorAlmostEqual(self, attributions[1], [[2.0, 3.0, 0.0]])
 
     def test_relu_deepliftshap_with_custom_attr_func(self) -> None:
         model = ReLULinearModel()

--- a/tests/attr/neuron/test_neuron_gradient.py
+++ b/tests/attr/neuron/test_neuron_gradient.py
@@ -121,7 +121,7 @@ class Test(BaseTest):
         # Select first element of tuple
         out = out[0]
         gradient_attrib = NeuronGradient(model, output_layer)
-        self.assertFalse(gradient_attrib.uses_input_marginal_effects)
+        self.assertFalse(gradient_attrib.multiplies_by_inputs)
         for i in range(cast(Tuple[int, ...], out.shape)[1]):
             neuron: Tuple[int, ...] = (i,)
             while len(neuron) < len(out.shape) - 1:

--- a/tests/attr/neuron/test_neuron_gradient.py
+++ b/tests/attr/neuron/test_neuron_gradient.py
@@ -121,6 +121,7 @@ class Test(BaseTest):
         # Select first element of tuple
         out = out[0]
         gradient_attrib = NeuronGradient(model, output_layer)
+        self.assertFalse(gradient_attrib.uses_input_marginal_effects)
         for i in range(cast(Tuple[int, ...], out.shape)[1]):
             neuron: Tuple[int, ...] = (i,)
             while len(neuron) < len(out.shape) - 1:

--- a/tests/attr/neuron/test_neuron_gradient_shap.py
+++ b/tests/attr/neuron/test_neuron_gradient_shap.py
@@ -22,12 +22,12 @@ class Test(BaseTest):
 
         inputs = torch.tensor([[1.0, 20.0, 10.0]])
         baselines = torch.zeros(2, 3)
-        ngs = NeuronGradientShap(model, model.linear1, use_input_marginal_effects=False)
+        ngs = NeuronGradientShap(model, model.linear1, multiply_by_inputs=False)
         attr = ngs.attribute(inputs, 0, baselines=baselines, stdevs=0.0)
-        self.assertFalse(ngs.uses_input_marginal_effects)
+        self.assertFalse(ngs.multiplies_by_inputs)
         assertTensorAlmostEqual(self, attr, [1.0, 1.0, 1.0])
 
-    def test_basic_multilayer_wo_inp_marginal_effects(self) -> None:
+    def test_basic_multilayer_wo_mult_by_inputs(self) -> None:
         model = BasicModel_MultiLayer(inplace=True)
         model.eval()
 
@@ -77,5 +77,5 @@ class Test(BaseTest):
                 nig.attribute(inputs, neuron_ind, baselines=baseline.unsqueeze(0))
             )
         combined_attrs_ig = torch.stack(attrs_ig, dim=0).mean(dim=0)
-        self.assertTrue(ngs.uses_input_marginal_effects)
+        self.assertTrue(ngs.multiplies_by_inputs)
         assertTensorAlmostEqual(self, attrs_gs, combined_attrs_ig, 0.5)

--- a/tests/attr/neuron/test_neuron_gradient_shap.py
+++ b/tests/attr/neuron/test_neuron_gradient_shap.py
@@ -22,8 +22,7 @@ class Test(BaseTest):
 
         inputs = torch.tensor([[1.0, 20.0, 10.0]])
         baselines = torch.zeros(2, 3)
-        ngs = NeuronGradientShap(model, model.linear1,
-            use_input_marginal_effects=False)
+        ngs = NeuronGradientShap(model, model.linear1, use_input_marginal_effects=False)
         attr = ngs.attribute(inputs, 0, baselines=baselines, stdevs=0.0)
         self.assertFalse(ngs.uses_input_marginal_effects)
         assertTensorAlmostEqual(self, attr, [1.0, 1.0, 1.0])

--- a/tests/attr/neuron/test_neuron_gradient_shap.py
+++ b/tests/attr/neuron/test_neuron_gradient_shap.py
@@ -21,6 +21,18 @@ class Test(BaseTest):
         model.eval()
 
         inputs = torch.tensor([[1.0, 20.0, 10.0]])
+        baselines = torch.zeros(2, 3)
+        ngs = NeuronGradientShap(model, model.linear1,
+            use_input_marginal_effects=False)
+        attr = ngs.attribute(inputs, 0, baselines=baselines, stdevs=0.0)
+        self.assertFalse(ngs.uses_input_marginal_effects)
+        assertTensorAlmostEqual(self, attr, [1.0, 1.0, 1.0])
+
+    def test_basic_multilayer_wo_inp_marginal_effects(self) -> None:
+        model = BasicModel_MultiLayer(inplace=True)
+        model.eval()
+
+        inputs = torch.tensor([[1.0, 20.0, 10.0]])
         baselines = torch.randn(2, 3)
 
         self._assert_attributions(model, model.linear1, inputs, baselines, 0, 60)
@@ -66,4 +78,5 @@ class Test(BaseTest):
                 nig.attribute(inputs, neuron_ind, baselines=baseline.unsqueeze(0))
             )
         combined_attrs_ig = torch.stack(attrs_ig, dim=0).mean(dim=0)
+        self.assertTrue(ngs.uses_input_marginal_effects)
         assertTensorAlmostEqual(self, attrs_gs, combined_attrs_ig, 0.5)

--- a/tests/attr/neuron/test_neuron_integrated_gradients.py
+++ b/tests/attr/neuron/test_neuron_integrated_gradients.py
@@ -31,6 +31,12 @@ class Test(BaseTest):
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         self._ig_input_test_assert(net, net.linear2, inp, 0, [0.0, 390.0, 0.0])
 
+    def test_simple_ig_input_linear2_wo_inp_marginal_effects(self) -> None:
+        net = BasicModel_MultiLayer()
+        inp = torch.tensor([[100.0, 100.0, 100.0]])
+        self._ig_input_test_assert(net, net.linear2, inp, 0,
+            [3.96, 3.96, 3.96], use_input_marginal_effects=False)
+
     def test_simple_ig_input_linear1(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
@@ -102,9 +108,13 @@ class Test(BaseTest):
         test_neuron: Union[int, Tuple[int, ...]],
         expected_input_ig: Union[List[float], Tuple[List[List[float]], ...]],
         additional_input: Any = None,
+        use_input_marginal_effects: bool = True,
+
     ) -> None:
         for internal_batch_size in [None, 5, 20]:
-            grad = NeuronIntegratedGradients(model, target_layer)
+            grad = NeuronIntegratedGradients(model, target_layer,
+                use_input_marginal_effects=use_input_marginal_effects)
+            self.assertEquals(grad.uses_input_marginal_effects, use_input_marginal_effects)
             attributions = grad.attribute(
                 test_input,
                 test_neuron,

--- a/tests/attr/neuron/test_neuron_integrated_gradients.py
+++ b/tests/attr/neuron/test_neuron_integrated_gradients.py
@@ -31,16 +31,11 @@ class Test(BaseTest):
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         self._ig_input_test_assert(net, net.linear2, inp, 0, [0.0, 390.0, 0.0])
 
-    def test_simple_ig_input_linear2_wo_inp_marginal_effects(self) -> None:
+    def test_simple_ig_input_linear2_wo_mult_by_inputs(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[100.0, 100.0, 100.0]])
         self._ig_input_test_assert(
-            net,
-            net.linear2,
-            inp,
-            0,
-            [3.96, 3.96, 3.96],
-            use_input_marginal_effects=False,
+            net, net.linear2, inp, 0, [3.96, 3.96, 3.96], multiply_by_inputs=False,
         )
 
     def test_simple_ig_input_linear1(self) -> None:
@@ -114,17 +109,13 @@ class Test(BaseTest):
         test_neuron: Union[int, Tuple[int, ...]],
         expected_input_ig: Union[List[float], Tuple[List[List[float]], ...]],
         additional_input: Any = None,
-        use_input_marginal_effects: bool = True,
+        multiply_by_inputs: bool = True,
     ) -> None:
         for internal_batch_size in [None, 5, 20]:
             grad = NeuronIntegratedGradients(
-                model,
-                target_layer,
-                use_input_marginal_effects=use_input_marginal_effects,
+                model, target_layer, multiply_by_inputs=multiply_by_inputs,
             )
-            self.assertEquals(
-                grad.uses_input_marginal_effects, use_input_marginal_effects
-            )
+            self.assertEquals(grad.multiplies_by_inputs, multiply_by_inputs)
             attributions = grad.attribute(
                 test_input,
                 test_neuron,

--- a/tests/attr/neuron/test_neuron_integrated_gradients.py
+++ b/tests/attr/neuron/test_neuron_integrated_gradients.py
@@ -34,8 +34,14 @@ class Test(BaseTest):
     def test_simple_ig_input_linear2_wo_inp_marginal_effects(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[100.0, 100.0, 100.0]])
-        self._ig_input_test_assert(net, net.linear2, inp, 0,
-            [3.96, 3.96, 3.96], use_input_marginal_effects=False)
+        self._ig_input_test_assert(
+            net,
+            net.linear2,
+            inp,
+            0,
+            [3.96, 3.96, 3.96],
+            use_input_marginal_effects=False,
+        )
 
     def test_simple_ig_input_linear1(self) -> None:
         net = BasicModel_MultiLayer()
@@ -109,12 +115,16 @@ class Test(BaseTest):
         expected_input_ig: Union[List[float], Tuple[List[List[float]], ...]],
         additional_input: Any = None,
         use_input_marginal_effects: bool = True,
-
     ) -> None:
         for internal_batch_size in [None, 5, 20]:
-            grad = NeuronIntegratedGradients(model, target_layer,
-                use_input_marginal_effects=use_input_marginal_effects)
-            self.assertEquals(grad.uses_input_marginal_effects, use_input_marginal_effects)
+            grad = NeuronIntegratedGradients(
+                model,
+                target_layer,
+                use_input_marginal_effects=use_input_marginal_effects,
+            )
+            self.assertEquals(
+                grad.uses_input_marginal_effects, use_input_marginal_effects
+            )
             attributions = grad.attribute(
                 test_input,
                 test_neuron,

--- a/tests/attr/test_deconvolution.py
+++ b/tests/attr/test_deconvolution.py
@@ -112,6 +112,7 @@ class Test(BaseTest):
     ) -> None:
         out = model(test_input)
         attrib = Deconvolution(model)
+        self.assertFalse(attrib.uses_input_marginal_effects)
         neuron_attrib = NeuronDeconvolution(model, output_layer)
         for i in range(out.shape[1]):
             deconv_vals = attrib.attribute(test_input, target=i)

--- a/tests/attr/test_deconvolution.py
+++ b/tests/attr/test_deconvolution.py
@@ -112,7 +112,7 @@ class Test(BaseTest):
     ) -> None:
         out = model(test_input)
         attrib = Deconvolution(model)
-        self.assertFalse(attrib.uses_input_marginal_effects)
+        self.assertFalse(attrib.multiplies_by_inputs)
         neuron_attrib = NeuronDeconvolution(model, output_layer)
         for i in range(out.shape[1]):
             deconv_vals = attrib.attribute(test_input, target=i)

--- a/tests/attr/test_deeplift_basic.py
+++ b/tests/attr/test_deeplift_basic.py
@@ -58,6 +58,17 @@ class Test(BaseTest):
         self.assertEqual(attributions[1][0], 1.0)
         self.assertEqual(delta[0], 0.0)
 
+    def test_relu_deeplift_exact_match_wo_inp_marginal_effects(self) -> None:
+        x1 = torch.tensor([1.0])
+        x2 = torch.tensor([2.0])
+        inputs = (x1, x2)
+
+        model = ReLUDeepLiftModel()
+        dl = DeepLift(model, use_input_marginal_effects=False)
+        attributions = dl.attribute(inputs)
+        self.assertEqual(attributions[0][0], 2.0)
+        self.assertEqual(attributions[1][0], 0.5)
+
     def test_tanh_deeplift(self) -> None:
         x1 = torch.tensor([-1.0], requires_grad=True)
         x2 = torch.tensor([-2.0], requires_grad=True)
@@ -158,6 +169,22 @@ class Test(BaseTest):
 
         model = ReLUDeepLiftModel()
         self._deeplift_assert(model, DeepLiftShap(model), inputs, baselines)
+
+    def test_relu_deepliftshap_batch_4D_input_wo_inp_marginal_effects(self) -> None:
+        x1 = torch.ones(4, 1, 1, 1)
+        x2 = torch.tensor([[[[2.0]]]] * 4)
+
+        b1 = torch.zeros(4, 1, 1, 1)
+        b2 = torch.zeros(4, 1, 1, 1)
+
+        inputs = (x1, x2)
+        baselines = (b1, b2)
+
+        model = ReLUDeepLiftModel()
+        attr = DeepLiftShap(model,
+            use_input_marginal_effects=False).attribute(inputs, baselines)
+        assertTensorAlmostEqual(self, attr[0], 2 * torch.ones(4, 1))
+        assertTensorAlmostEqual(self, attr[1], 0.5 * torch.ones(4, 1))
 
     def test_relu_deepliftshap_multi_ref(self) -> None:
         x1 = torch.tensor([[1.0]], requires_grad=True)

--- a/tests/attr/test_deeplift_basic.py
+++ b/tests/attr/test_deeplift_basic.py
@@ -58,13 +58,13 @@ class Test(BaseTest):
         self.assertEqual(attributions[1][0], 1.0)
         self.assertEqual(delta[0], 0.0)
 
-    def test_relu_deeplift_exact_match_wo_inp_marginal_effects(self) -> None:
+    def test_relu_deeplift_exact_match_wo_mutliplying_by_inputs(self) -> None:
         x1 = torch.tensor([1.0])
         x2 = torch.tensor([2.0])
         inputs = (x1, x2)
 
         model = ReLUDeepLiftModel()
-        dl = DeepLift(model, use_input_marginal_effects=False)
+        dl = DeepLift(model, multiply_by_inputs=False)
         attributions = dl.attribute(inputs)
         self.assertEqual(attributions[0][0], 2.0)
         self.assertEqual(attributions[1][0], 0.5)
@@ -170,7 +170,7 @@ class Test(BaseTest):
         model = ReLUDeepLiftModel()
         self._deeplift_assert(model, DeepLiftShap(model), inputs, baselines)
 
-    def test_relu_deepliftshap_batch_4D_input_wo_inp_marginal_effects(self) -> None:
+    def test_relu_deepliftshap_batch_4D_input_wo_mutliplying_by_inputs(self) -> None:
         x1 = torch.ones(4, 1, 1, 1)
         x2 = torch.tensor([[[[2.0]]]] * 4)
 
@@ -181,7 +181,7 @@ class Test(BaseTest):
         baselines = (b1, b2)
 
         model = ReLUDeepLiftModel()
-        attr = DeepLiftShap(model, use_input_marginal_effects=False).attribute(
+        attr = DeepLiftShap(model, multiply_by_inputs=False).attribute(
             inputs, baselines
         )
         assertTensorAlmostEqual(self, attr[0], 2 * torch.ones(4, 1))

--- a/tests/attr/test_deeplift_basic.py
+++ b/tests/attr/test_deeplift_basic.py
@@ -181,8 +181,9 @@ class Test(BaseTest):
         baselines = (b1, b2)
 
         model = ReLUDeepLiftModel()
-        attr = DeepLiftShap(model,
-            use_input_marginal_effects=False).attribute(inputs, baselines)
+        attr = DeepLiftShap(model, use_input_marginal_effects=False).attribute(
+            inputs, baselines
+        )
         assertTensorAlmostEqual(self, attr[0], 2 * torch.ones(4, 1))
         assertTensorAlmostEqual(self, attr[1], 0.5 * torch.ones(4, 1))
 

--- a/tests/attr/test_feature_ablation.py
+++ b/tests/attr/test_feature_ablation.py
@@ -368,7 +368,7 @@ class Test(BaseTest):
     ) -> None:
         for batch_size in perturbations_per_eval:
             ablation = FeatureAblation(model)
-            self.assertTrue(ablation.uses_input_marginal_effects)
+            self.assertTrue(ablation.multiplies_by_inputs)
             attributions = ablation.attribute(
                 test_input,
                 target=target,

--- a/tests/attr/test_feature_ablation.py
+++ b/tests/attr/test_feature_ablation.py
@@ -368,6 +368,7 @@ class Test(BaseTest):
     ) -> None:
         for batch_size in perturbations_per_eval:
             ablation = FeatureAblation(model)
+            self.assertTrue(ablation.uses_input_marginal_effects)
             attributions = ablation.attribute(
                 test_input,
                 target=target,

--- a/tests/attr/test_gradient_shap.py
+++ b/tests/attr/test_gradient_shap.py
@@ -63,6 +63,48 @@ class Test(BaseTest):
         ):
             assertTensorAlmostEqual(self, attribution, attribution_without_delta)
 
+    def test_basic_multi_input_wo_inp_marginal_effects(self) -> None:
+        batch_size = 10
+
+        x1 = torch.ones(batch_size, 3)
+        x2 = torch.ones(batch_size, 4)
+        inputs = (x1, x2)
+
+        batch_size_baselines = 20
+        baselines = (
+            torch.ones(batch_size_baselines, 3) + 2e-5,
+            torch.ones(batch_size_baselines, 4) + 2e-5,
+        )
+
+        model = BasicLinearModel()
+        model.eval()
+        model.zero_grad()
+
+        np.random.seed(0)
+        torch.manual_seed(0)
+        gradient_shap = GradientShap(model)
+        gradient_shap_wo_inp_marginal_effects = GradientShap(model,
+            use_input_marginal_effects=False)
+        n_samples = 50
+        attributions = cast(
+            Tuple[Tuple[Tensor, ...], Tensor],
+            gradient_shap.attribute(
+                inputs, baselines, n_samples=n_samples,
+                stdevs = 0.0,
+            ),
+        )
+        attributions_wo_inp_marginal_effects = cast(
+            Tuple[Tuple[Tensor, ...], Tensor],
+            gradient_shap_wo_inp_marginal_effects.attribute(
+                inputs, baselines, n_samples=n_samples,
+                stdevs = 0.0,
+            ),
+        )
+        assertTensorAlmostEqual(self, attributions_wo_inp_marginal_effects[0] \
+            * (x1 - baselines[0][0:1]), attributions[0])
+        assertTensorAlmostEqual(self, attributions_wo_inp_marginal_effects[1] \
+            * (x2 - baselines[1][0:1]), attributions[1])
+
     def test_classification_baselines_as_function(self) -> None:
         num_in = 40
         inputs = torch.arange(0.0, num_in * 2.0).reshape(2, num_in)

--- a/tests/attr/test_gradient_shap.py
+++ b/tests/attr/test_gradient_shap.py
@@ -63,7 +63,7 @@ class Test(BaseTest):
         ):
             assertTensorAlmostEqual(self, attribution, attribution_without_delta)
 
-    def test_basic_multi_input_wo_inp_marginal_effects(self) -> None:
+    def test_basic_multi_input_wo_mutliplying_by_inputs(self) -> None:
         batch_size = 10
 
         x1 = torch.ones(batch_size, 3)
@@ -83,8 +83,8 @@ class Test(BaseTest):
         np.random.seed(0)
         torch.manual_seed(0)
         gradient_shap = GradientShap(model)
-        gradient_shap_wo_inp_marginal_effects = GradientShap(
-            model, use_input_marginal_effects=False
+        gradient_shap_wo_mutliplying_by_inputs = GradientShap(
+            model, multiply_by_inputs=False
         )
         n_samples = 50
         attributions = cast(
@@ -93,20 +93,20 @@ class Test(BaseTest):
                 inputs, baselines, n_samples=n_samples, stdevs=0.0,
             ),
         )
-        attributions_wo_inp_marginal_effects = cast(
+        attributions_wo_mutliplying_by_inputs = cast(
             Tuple[Tuple[Tensor, ...], Tensor],
-            gradient_shap_wo_inp_marginal_effects.attribute(
+            gradient_shap_wo_mutliplying_by_inputs.attribute(
                 inputs, baselines, n_samples=n_samples, stdevs=0.0,
             ),
         )
         assertTensorAlmostEqual(
             self,
-            attributions_wo_inp_marginal_effects[0] * (x1 - baselines[0][0:1]),
+            attributions_wo_mutliplying_by_inputs[0] * (x1 - baselines[0][0:1]),
             attributions[0],
         )
         assertTensorAlmostEqual(
             self,
-            attributions_wo_inp_marginal_effects[1] * (x2 - baselines[1][0:1]),
+            attributions_wo_mutliplying_by_inputs[1] * (x2 - baselines[1][0:1]),
             attributions[1],
         )
 

--- a/tests/attr/test_gradient_shap.py
+++ b/tests/attr/test_gradient_shap.py
@@ -83,27 +83,32 @@ class Test(BaseTest):
         np.random.seed(0)
         torch.manual_seed(0)
         gradient_shap = GradientShap(model)
-        gradient_shap_wo_inp_marginal_effects = GradientShap(model,
-            use_input_marginal_effects=False)
+        gradient_shap_wo_inp_marginal_effects = GradientShap(
+            model, use_input_marginal_effects=False
+        )
         n_samples = 50
         attributions = cast(
             Tuple[Tuple[Tensor, ...], Tensor],
             gradient_shap.attribute(
-                inputs, baselines, n_samples=n_samples,
-                stdevs = 0.0,
+                inputs, baselines, n_samples=n_samples, stdevs=0.0,
             ),
         )
         attributions_wo_inp_marginal_effects = cast(
             Tuple[Tuple[Tensor, ...], Tensor],
             gradient_shap_wo_inp_marginal_effects.attribute(
-                inputs, baselines, n_samples=n_samples,
-                stdevs = 0.0,
+                inputs, baselines, n_samples=n_samples, stdevs=0.0,
             ),
         )
-        assertTensorAlmostEqual(self, attributions_wo_inp_marginal_effects[0] \
-            * (x1 - baselines[0][0:1]), attributions[0])
-        assertTensorAlmostEqual(self, attributions_wo_inp_marginal_effects[1] \
-            * (x2 - baselines[1][0:1]), attributions[1])
+        assertTensorAlmostEqual(
+            self,
+            attributions_wo_inp_marginal_effects[0] * (x1 - baselines[0][0:1]),
+            attributions[0],
+        )
+        assertTensorAlmostEqual(
+            self,
+            attributions_wo_inp_marginal_effects[1] * (x2 - baselines[1][0:1]),
+            attributions[1],
+        )
 
     def test_classification_baselines_as_function(self) -> None:
         num_in = 40

--- a/tests/attr/test_guided_backprop.py
+++ b/tests/attr/test_guided_backprop.py
@@ -110,6 +110,7 @@ class Test(BaseTest):
     ):
         out = model(test_input)
         attrib = GuidedBackprop(model)
+        self.assertFalse(attrib.uses_input_marginal_effects)
         neuron_attrib = NeuronGuidedBackprop(model, output_layer)
         for i in range(out.shape[1]):
             gbp_vals = attrib.attribute(test_input, target=i)

--- a/tests/attr/test_guided_backprop.py
+++ b/tests/attr/test_guided_backprop.py
@@ -110,7 +110,7 @@ class Test(BaseTest):
     ):
         out = model(test_input)
         attrib = GuidedBackprop(model)
-        self.assertFalse(attrib.uses_input_marginal_effects)
+        self.assertFalse(attrib.multiplies_by_inputs)
         neuron_attrib = NeuronGuidedBackprop(model, output_layer)
         for i in range(out.shape[1]):
             gbp_vals = attrib.attribute(test_input, target=i)

--- a/tests/attr/test_guided_grad_cam.py
+++ b/tests/attr/test_guided_grad_cam.py
@@ -94,7 +94,7 @@ class Test(BaseTest):
         attribute_to_layer_input: bool = False,
     ) -> None:
         guided_gc = GuidedGradCam(model, target_layer)
-        self.assertFalse(guided_gc.uses_input_marginal_effects)
+        self.assertFalse(guided_gc.multiplies_by_inputs)
         attributions = guided_gc.attribute(
             test_input,
             target=0,

--- a/tests/attr/test_guided_grad_cam.py
+++ b/tests/attr/test_guided_grad_cam.py
@@ -94,6 +94,7 @@ class Test(BaseTest):
         attribute_to_layer_input: bool = False,
     ) -> None:
         guided_gc = GuidedGradCam(model, target_layer)
+        self.assertFalse(guided_gc.uses_input_marginal_effects)
         attributions = guided_gc.attribute(
             test_input,
             target=0,

--- a/tests/attr/test_hook_removal.py
+++ b/tests/attr/test_hook_removal.py
@@ -13,7 +13,6 @@ from ..helpers.basic import BaseTest, deep_copy_args
 from .helpers.gen_test_utils import gen_test_name, parse_test_config
 from .helpers.test_config import config
 
-
 """
 Tests in this file are dynamically generated based on the config
 defined in tests/attr/helpers/test_config.py. To add new test cases,

--- a/tests/attr/test_input_x_gradient.py
+++ b/tests/attr/test_input_x_gradient.py
@@ -19,16 +19,17 @@ class Test(BaseTest):
         self._input_x_gradient_base_assert(*_get_basic_config())
 
     def test_input_x_gradient_test_basic_vanilla_wo_marginal_effects(self) -> None:
-        self._input_x_gradient_base_assert(*_get_basic_config(),
-            use_input_marginal_effects=False)
+        self._input_x_gradient_base_assert(
+            *_get_basic_config(), use_input_marginal_effects=False
+        )
 
     def test_input_x_gradient_test_basic_smoothgrad(self) -> None:
         self._input_x_gradient_base_assert(*_get_basic_config(), nt_type="smoothgrad")
 
     def test_input_x_gradient_test_basic_smoothgrad_wo_marginal_effects(self) -> None:
-        self._input_x_gradient_base_assert(*_get_basic_config(),
-                                           nt_type="smoothgrad",
-                                           use_input_marginal_effects=False)
+        self._input_x_gradient_base_assert(
+            *_get_basic_config(), nt_type="smoothgrad", use_input_marginal_effects=False
+        )
 
     def test_input_x_gradient_test_basic_vargrad(self) -> None:
         self._input_x_gradient_base_assert(*_get_basic_config(), nt_type="vargrad")
@@ -62,10 +63,11 @@ class Test(BaseTest):
         expected_grads: TensorOrTupleOfTensorsGeneric,
         additional_forward_args: Any = None,
         nt_type: str = "vanilla",
-        use_input_marginal_effects = True,
+        use_input_marginal_effects=True,
     ) -> None:
-        input_x_grad = InputXGradient(model,
-            use_input_marginal_effects=use_input_marginal_effects,)
+        input_x_grad = InputXGradient(
+            model, use_input_marginal_effects=use_input_marginal_effects,
+        )
         attributions: TensorOrTupleOfTensorsGeneric
         if nt_type == "vanilla":
             attributions = input_x_grad.attribute(
@@ -86,21 +88,25 @@ class Test(BaseTest):
                 inputs, attributions, expected_grads
             ):
                 if nt_type == "vanilla":
-                    self._assert_attribution(expected_grad, input, attribution,
-                                             use_input_marginal_effects)
+                    self._assert_attribution(
+                        expected_grad, input, attribution, use_input_marginal_effects
+                    )
                 self.assertEqual(input.shape, attribution.shape)
         elif isinstance(attributions, Tensor):
             if nt_type == "vanilla":
-                self._assert_attribution(expected_grads, inputs, attributions,
-                                         use_input_marginal_effects)
+                self._assert_attribution(
+                    expected_grads, inputs, attributions, use_input_marginal_effects
+                )
             self.assertEqual(inputs.shape, attributions.shape)
 
-    def _assert_attribution(self, expected_grad, input, attribution,
-                            use_input_marginal_effects):
+    def _assert_attribution(
+        self, expected_grad, input, attribution, use_input_marginal_effects
+    ):
         assertArraysAlmostEqual(
             attribution.reshape(-1),
-            (expected_grad * input if use_input_marginal_effects \
-                else expected_grad).reshape(-1)
+            (
+                expected_grad * input if use_input_marginal_effects else expected_grad
+            ).reshape(-1),
         )
 
     def _input_x_gradient_classification_assert(self, nt_type: str = "vanilla") -> None:

--- a/tests/attr/test_integrated_gradients_basic.py
+++ b/tests/attr/test_integrated_gradients_basic.py
@@ -29,8 +29,9 @@ class Test(BaseTest):
         self._assert_multi_variable("vanilla", "riemann_right")
 
     def test_multivariable_vanilla_wo_inp_marginal_effects(self) -> None:
-        self._assert_multi_variable("vanilla", "riemann_right",
-            use_input_marginal_effects=False)
+        self._assert_multi_variable(
+            "vanilla", "riemann_right", use_input_marginal_effects=False
+        )
 
     def test_multivariable_smoothgrad(self) -> None:
         self._assert_multi_variable("smoothgrad", "riemann_left")
@@ -92,33 +93,37 @@ class Test(BaseTest):
     def test_batched_input_smoothgrad__wo_inp_marginal_effects(self) -> None:
         model = BasicModel_MultiLayer()
         inputs = torch.tensor(
-                [[1.5, 2.0, 1.3], [0.5, 0.1, 2.3], [1.5, 2.0, 1.3]], requires_grad=True
-            )
-        ig_wo_marginal_effects = IntegratedGradients(model, use_input_marginal_effects=False)
+            [[1.5, 2.0, 1.3], [0.5, 0.1, 2.3], [1.5, 2.0, 1.3]], requires_grad=True
+        )
+        ig_wo_marginal_effects = IntegratedGradients(
+            model, use_input_marginal_effects=False
+        )
         nt_wo_marginal_effects = NoiseTunnel(ig_wo_marginal_effects)
 
         ig = IntegratedGradients(model)
         nt = NoiseTunnel(ig)
         n_samples = 5
-        target=0
-        type = 'smoothgrad'
+        target = 0
+        type = "smoothgrad"
         attributions_wo_marginal_effects = nt_wo_marginal_effects.attribute(
-                inputs,
-                nt_type=type,
-                n_samples=n_samples,
-                stdevs=0.0,
-                target=target,
-                n_steps=500,
+            inputs,
+            nt_type=type,
+            n_samples=n_samples,
+            stdevs=0.0,
+            target=target,
+            n_steps=500,
         )
         attributions = nt.attribute(
-                inputs,
-                nt_type=type,
-                n_samples=n_samples,
-                stdevs=0.0,
-                target=target,
-                n_steps=500,
+            inputs,
+            nt_type=type,
+            n_samples=n_samples,
+            stdevs=0.0,
+            target=target,
+            n_steps=500,
         )
-        assertTensorAlmostEqual(self, attributions_wo_marginal_effects * inputs, attributions)
+        assertTensorAlmostEqual(
+            self, attributions_wo_marginal_effects * inputs, attributions
+        )
 
     def test_batched_multi_input_vanilla(self) -> None:
         self._assert_batched_tensor_multi_input("vanilla", "riemann_right")
@@ -133,7 +138,9 @@ class Test(BaseTest):
         self._assert_batched_tensor_multi_input("vargrad", "riemann_trapezoid")
 
     def _assert_multi_variable(
-        self, type: str, approximation_method: str = "gausslegendre",
+        self,
+        type: str,
+        approximation_method: str = "gausslegendre",
         use_input_marginal_effects: bool = True,
     ) -> None:
         model = BasicModel2()
@@ -153,10 +160,16 @@ class Test(BaseTest):
             use_input_marginal_effects=use_input_marginal_effects,
         )
         if type == "vanilla":
-            assertArraysAlmostEqual(attributions1[0].tolist(),
-                [1.5] if use_input_marginal_effects else [0.5], delta=0.05)
-            assertArraysAlmostEqual(attributions1[1].tolist(),
-                [-0.5] if use_input_marginal_effects else [-0.5], delta=0.05)
+            assertArraysAlmostEqual(
+                attributions1[0].tolist(),
+                [1.5] if use_input_marginal_effects else [0.5],
+                delta=0.05,
+            )
+            assertArraysAlmostEqual(
+                attributions1[1].tolist(),
+                [-0.5] if use_input_marginal_effects else [-0.5],
+                delta=0.05,
+            )
         model = BasicModel3()
         attributions2 = self._compute_attribution_and_evaluate(
             model,
@@ -167,10 +180,16 @@ class Test(BaseTest):
             use_input_marginal_effects=use_input_marginal_effects,
         )
         if type == "vanilla":
-            assertArraysAlmostEqual(attributions2[0].tolist(),
-                [1.5] if use_input_marginal_effects else [0.5], delta=0.05)
-            assertArraysAlmostEqual(attributions2[1].tolist(),
-                [-0.5] if use_input_marginal_effects else [-0.5], delta=0.05)
+            assertArraysAlmostEqual(
+                attributions2[0].tolist(),
+                [1.5] if use_input_marginal_effects else [0.5],
+                delta=0.05,
+            )
+            assertArraysAlmostEqual(
+                attributions2[1].tolist(),
+                [-0.5] if use_input_marginal_effects else [-0.5],
+                delta=0.05,
+            )
             # Verifies implementation invariance
             self.assertEqual(
                 sum(attribution for attribution in attributions1),
@@ -317,13 +336,14 @@ class Test(BaseTest):
         additional_forward_args: Any = None,
         type: str = "vanilla",
         approximation_method: str = "gausslegendre",
-        use_input_marginal_effects = True,
+        use_input_marginal_effects=True,
     ) -> Tuple[Tensor, ...]:
         r"""
             attrib_type: 'vanilla', 'smoothgrad', 'smoothgrad_sq', 'vargrad'
         """
-        ig = IntegratedGradients(model,
-            use_input_marginal_effects=use_input_marginal_effects)
+        ig = IntegratedGradients(
+            model, use_input_marginal_effects=use_input_marginal_effects
+        )
         self.assertEquals(ig.uses_input_marginal_effects, use_input_marginal_effects)
         if not isinstance(inputs, tuple):
             inputs = (inputs,)  # type: ignore
@@ -391,7 +411,9 @@ class Test(BaseTest):
                 method=approximation_method,
                 n_steps=500,
             )
-            self.assertEquals(nt.uses_input_marginal_effects, use_input_marginal_effects)
+            self.assertEquals(
+                nt.uses_input_marginal_effects, use_input_marginal_effects
+            )
             self.assertEqual([inputs[0].shape[0] * n_samples], list(delta.shape))
 
         for input, attribution in zip(inputs, attributions):

--- a/tests/attr/test_integrated_gradients_basic.py
+++ b/tests/attr/test_integrated_gradients_basic.py
@@ -28,6 +28,10 @@ class Test(BaseTest):
     def test_multivariable_vanilla(self) -> None:
         self._assert_multi_variable("vanilla", "riemann_right")
 
+    def test_multivariable_vanilla_wo_inp_marginal_effects(self) -> None:
+        self._assert_multi_variable("vanilla", "riemann_right",
+            use_input_marginal_effects=False)
+
     def test_multivariable_smoothgrad(self) -> None:
         self._assert_multi_variable("smoothgrad", "riemann_left")
 
@@ -85,6 +89,37 @@ class Test(BaseTest):
     def test_batched_input_vargrad(self) -> None:
         self._assert_batched_tensor_input("vargrad", "gausslegendre")
 
+    def test_batched_input_smoothgrad__wo_inp_marginal_effects(self) -> None:
+        model = BasicModel_MultiLayer()
+        inputs = torch.tensor(
+                [[1.5, 2.0, 1.3], [0.5, 0.1, 2.3], [1.5, 2.0, 1.3]], requires_grad=True
+            )
+        ig_wo_marginal_effects = IntegratedGradients(model, use_input_marginal_effects=False)
+        nt_wo_marginal_effects = NoiseTunnel(ig_wo_marginal_effects)
+
+        ig = IntegratedGradients(model)
+        nt = NoiseTunnel(ig)
+        n_samples = 5
+        target=0
+        type = 'smoothgrad'
+        attributions_wo_marginal_effects = nt_wo_marginal_effects.attribute(
+                inputs,
+                nt_type=type,
+                n_samples=n_samples,
+                stdevs=0.0,
+                target=target,
+                n_steps=500,
+        )
+        attributions = nt.attribute(
+                inputs,
+                nt_type=type,
+                n_samples=n_samples,
+                stdevs=0.0,
+                target=target,
+                n_steps=500,
+        )
+        assertTensorAlmostEqual(self, attributions_wo_marginal_effects * inputs, attributions)
+
     def test_batched_multi_input_vanilla(self) -> None:
         self._assert_batched_tensor_multi_input("vanilla", "riemann_right")
 
@@ -98,7 +133,8 @@ class Test(BaseTest):
         self._assert_batched_tensor_multi_input("vargrad", "riemann_trapezoid")
 
     def _assert_multi_variable(
-        self, type: str, approximation_method: str = "gausslegendre"
+        self, type: str, approximation_method: str = "gausslegendre",
+        use_input_marginal_effects: bool = True,
     ) -> None:
         model = BasicModel2()
 
@@ -114,10 +150,13 @@ class Test(BaseTest):
             (baseline1, baseline2),
             type=type,
             approximation_method=approximation_method,
+            use_input_marginal_effects=use_input_marginal_effects,
         )
         if type == "vanilla":
-            assertArraysAlmostEqual(attributions1[0].tolist(), [1.5], delta=0.05)
-            assertArraysAlmostEqual(attributions1[1].tolist(), [-0.5], delta=0.05)
+            assertArraysAlmostEqual(attributions1[0].tolist(),
+                [1.5] if use_input_marginal_effects else [0.5], delta=0.05)
+            assertArraysAlmostEqual(attributions1[1].tolist(),
+                [-0.5] if use_input_marginal_effects else [-0.5], delta=0.05)
         model = BasicModel3()
         attributions2 = self._compute_attribution_and_evaluate(
             model,
@@ -125,10 +164,13 @@ class Test(BaseTest):
             (baseline1, baseline2),
             type=type,
             approximation_method=approximation_method,
+            use_input_marginal_effects=use_input_marginal_effects,
         )
         if type == "vanilla":
-            assertArraysAlmostEqual(attributions2[0].tolist(), [1.5], delta=0.05)
-            assertArraysAlmostEqual(attributions2[1].tolist(), [-0.5], delta=0.05)
+            assertArraysAlmostEqual(attributions2[0].tolist(),
+                [1.5] if use_input_marginal_effects else [0.5], delta=0.05)
+            assertArraysAlmostEqual(attributions2[1].tolist(),
+                [-0.5] if use_input_marginal_effects else [-0.5], delta=0.05)
             # Verifies implementation invariance
             self.assertEqual(
                 sum(attribution for attribution in attributions1),
@@ -275,11 +317,14 @@ class Test(BaseTest):
         additional_forward_args: Any = None,
         type: str = "vanilla",
         approximation_method: str = "gausslegendre",
+        use_input_marginal_effects = True,
     ) -> Tuple[Tensor, ...]:
         r"""
             attrib_type: 'vanilla', 'smoothgrad', 'smoothgrad_sq', 'vargrad'
         """
-        ig = IntegratedGradients(model)
+        ig = IntegratedGradients(model,
+            use_input_marginal_effects=use_input_marginal_effects)
+        self.assertEquals(ig.uses_input_marginal_effects, use_input_marginal_effects)
         if not isinstance(inputs, tuple):
             inputs = (inputs,)  # type: ignore
         inputs: Tuple[Tensor, ...]
@@ -346,11 +391,13 @@ class Test(BaseTest):
                 method=approximation_method,
                 n_steps=500,
             )
+            self.assertEquals(nt.uses_input_marginal_effects, use_input_marginal_effects)
             self.assertEqual([inputs[0].shape[0] * n_samples], list(delta.shape))
 
         for input, attribution in zip(inputs, attributions):
             self.assertEqual(attribution.shape, input.shape)
-        self.assertTrue(all(abs(delta.numpy().flatten()) < 0.07))
+        if use_input_marginal_effects:
+            self.assertTrue(all(abs(delta.numpy().flatten()) < 0.07))
 
         # compare attributions retrieved with and without
         # `return_convergence_delta` flag

--- a/tests/attr/test_saliency.py
+++ b/tests/attr/test_saliency.py
@@ -74,6 +74,9 @@ class Test(BaseTest):
         nt_type: str = "vanilla",
     ) -> None:
         saliency = Saliency(model)
+
+        self.assertFalse(saliency.uses_input_marginal_effects)
+
         if nt_type == "vanilla":
             attributions = saliency.attribute(
                 inputs, additional_forward_args=additional_forward_args

--- a/tests/attr/test_targets.py
+++ b/tests/attr/test_targets.py
@@ -19,7 +19,6 @@ from ..helpers.basic_models import BasicModel_MultiLayer
 from .helpers.gen_test_utils import gen_test_name, parse_test_config
 from .helpers.test_config import config
 
-
 """
 Tests in this file are dynamically generated based on the config
 defined in tests/attr/helpers/test_config.py. To add new test cases,

--- a/tests/helpers/basic_models.py
+++ b/tests/helpers/basic_models.py
@@ -7,7 +7,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
 
-
 """
 @no_type_check annotation is applied to type-hinted models to avoid errors
 related to mismatch with parent (nn.Module) signature. # type_ignore is not

--- a/tests/insights/test_features.py
+++ b/tests/insights/test_features.py
@@ -1,16 +1,17 @@
-from captum.insights.attr_vis.features import (
-    TextFeature,
-    FeatureOutput,
-    EmptyFeature,
-    ImageFeature,
-    GeneralFeature,
-    _convert_figure_base64,
-)
-
-from tests.helpers.basic import BaseTest
 from unittest.mock import patch
+
 import torch
 from matplotlib.figure import Figure
+
+from captum.insights.attr_vis.features import (
+    EmptyFeature,
+    FeatureOutput,
+    GeneralFeature,
+    ImageFeature,
+    TextFeature,
+    _convert_figure_base64,
+)
+from tests.helpers.basic import BaseTest
 
 
 class TestTextFeature(BaseTest):

--- a/tests/metrics/test_infidelity.py
+++ b/tests/metrics/test_infidelity.py
@@ -77,7 +77,7 @@ class Test(BaseTest):
             inputs,
             expected,
             perturb_func=_local_perturb_func_default,
-            use_input_marginal_effects=False,
+            multiply_by_inputs=False,
         )
         assertTensorAlmostEqual(self, infid, infid_w_common_func)
 
@@ -335,10 +335,10 @@ class Test(BaseTest):
         n_perturb_samples=10,
         max_batch_size=None,
         perturb_func=_local_perturb_func,
-        use_input_marginal_effects=False,
+        multiply_by_inputs=False,
     ):
         ig = IntegratedGradients(model)
-        if use_input_marginal_effects:
+        if multiply_by_inputs:
             attrs = tuple(
                 attr / input for input, attr in zip(inputs, ig.attribute(inputs))
             )

--- a/tests/metrics/test_infidelity.py
+++ b/tests/metrics/test_infidelity.py
@@ -100,7 +100,7 @@ class Test(BaseTest):
             n_perturb_samples=5,
             max_batch_size=60,
         )
-        assertArraysAlmostEqual(infid1, infid2, 0.0)
+        assertArraysAlmostEqual(infid1, infid2, 0.01)
 
     def test_basic_infidelity_additional_forward_args1(self):
         model = BasicModel4_MultiArgs()

--- a/tests/metrics/test_infidelity.py
+++ b/tests/metrics/test_infidelity.py
@@ -14,7 +14,7 @@ from ..helpers.basic_models import (
 )
 
 
-@infidelity_perturb_func_decorator
+@infidelity_perturb_func_decorator(False)
 def _local_perturb_func_default(inputs):
     return _local_perturb_func(inputs)[1]
 
@@ -35,7 +35,7 @@ def _local_perturb_func(inputs):
     return (perturb1, perturb2), (input1 - perturb1, input2 - perturb2)
 
 
-@infidelity_perturb_func_decorator
+@infidelity_perturb_func_decorator(True)
 def _global_perturb_func1_default(inputs):
     return _global_perturb_func1(inputs)[1]
 
@@ -77,7 +77,7 @@ class Test(BaseTest):
             inputs,
             expected,
             perturb_func=_local_perturb_func_default,
-            local=False,
+            use_input_marginal_effects=False,
         )
         assertTensorAlmostEqual(self, infid, infid_w_common_func)
 
@@ -207,7 +207,7 @@ class Test(BaseTest):
         def perturbed_func2(inputs, baselines):
             return torch.ones(baselines.shape), baselines
 
-        @infidelity_perturb_func_decorator
+        @infidelity_perturb_func_decorator(True)
         def perturbed_func3(inputs, baselines):
             return baselines
 
@@ -231,6 +231,7 @@ class Test(BaseTest):
             n_perturb_samples=3,
             perturb_func=perturbed_func3,
         )
+
         infid2 = self.infidelity_assert(
             model,
             attr,
@@ -268,7 +269,7 @@ class Test(BaseTest):
             pert = torch.tensor([[0, 0, 1], [1, 0, 0], [0, 1, 0]]).float()
             return pert, (1 - pert) * input
 
-        @infidelity_perturb_func_decorator
+        @infidelity_perturb_func_decorator(True)
         def _global_perturb_func3_custom(input):
             return _global_perturb_func3(input)[1]
 
@@ -334,10 +335,10 @@ class Test(BaseTest):
         n_perturb_samples=10,
         max_batch_size=None,
         perturb_func=_local_perturb_func,
-        local=True,
+        use_input_marginal_effects=False,
     ):
         ig = IntegratedGradients(model)
-        if local:
+        if use_input_marginal_effects:
             attrs = tuple(
                 attr / input for input, attr in zip(inputs, ig.attribute(inputs))
             )


### PR DESCRIPTION
Adding a flag  that allows to switch on and off  inputs' marginal effects in some attribution algorithms.
If `use_input_marginal_effects ` flag is True then model inputs' marginal effects will be factored in, otherwise they won't.
Default behavior factors those effects in.

In addition to that I also made `infidelity_perturb_func_decorator` decorator parametrized. It allows as to take inputs marginal effects into account.

Fixed the documentation for infidelity and added an example documentation in IG for  `use_input_marginal_effects` argument. I'll copy that documentation in all affected arguments as well once it is reviewed.

Added test cases for all methods that are affected by this change.  