### PR TITLE
Supporting non C contigous tensors

### DIFF
--- a/captum/attr/_utils/attribution.py
+++ b/captum/attr/_utils/attribution.py
@@ -269,7 +269,9 @@ class GradientAttribution(Attribution):
         _validate_target(num_samples, target)
 
         def _sum_rows(input: Tensor) -> Tensor:
-            return input.view(input.shape[0], -1).sum(1)
+            #return input.view(input.shape[0], -1).sum(1)
+	    #CHANGED HERE TO RESHAPE
+            return input.reshape(input.shape[0], -1).sum(1)
 
         with torch.no_grad():
             start_out_sum = _sum_rows(

--- a/captum/attr/_utils/attribution.py
+++ b/captum/attr/_utils/attribution.py
@@ -269,8 +269,6 @@ class GradientAttribution(Attribution):
         _validate_target(num_samples, target)
 
         def _sum_rows(input: Tensor) -> Tensor:
-            #return input.view(input.shape[0], -1).sum(1)
-	    #CHANGED HERE TO RESHAPE
             return input.reshape(input.shape[0], -1).sum(1)
 
         with torch.no_grad():


### PR DESCRIPTION
Replaced the view function with reshape. Reshape() can operate on both contiguous and non-contiguous tensors while view() can only operate on contiguous tensors. According to the [documentation](https://pytorch.org/docs/master/generated/torch.reshape.html#torch.reshape) the reshape() returns a view of the input when possible. 
Error:
"RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead."