### PR TITLE
[MRG] update the document example for function visualize_mutliple_image_attr

### DIFF
--- a/captum/attr/_utils/visualization.py
+++ b/captum/attr/_utils/visualization.py
@@ -384,8 +384,8 @@ def visualize_image_attr_multiple(
             >>> attribution, delta = ig.attribute(orig_image, target=3)
             >>> # Displays original image and heat map visualization of
             >>> # computed attributions side by side.
-            >>> _ = visualize_mutliple_image_attr(["original_image", "heat_map"],
-            >>>                     ["all", "positive"], attribution, orig_image)
+            >>> _ = visualize_mutliple_image_attr(attribution, orig_image, ["original_image", "heat_map"],
+            >>>                     ["all", "positive"])
     """
     assert len(methods) == len(signs), "Methods and signs array lengths must match."
     if titles is not None:

--- a/captum/attr/_utils/visualization.py
+++ b/captum/attr/_utils/visualization.py
@@ -384,8 +384,8 @@ def visualize_image_attr_multiple(
             >>> attribution, delta = ig.attribute(orig_image, target=3)
             >>> # Displays original image and heat map visualization of
             >>> # computed attributions side by side.
-            >>> _ = visualize_mutliple_image_attr(attribution, orig_image, ["original_image", "heat_map"],
-            >>>                     ["all", "positive"])
+            >>> _ = visualize_mutliple_image_attr(attribution, orig_image,
+            >>>                     ["original_image", "heat_map"], ["all", "positive"])
     """
     assert len(methods) == len(signs), "Methods and signs array lengths must match."
     if titles is not None:


### PR DESCRIPTION
Make the changes to ensure the argument order is the same as stated in function description for visualize_mutliple_image_attr

1. I didn't pass `pytest -ra` but I figured it should be fine as I didn't change the code (it's only documentation modification). 
2. I try to check the documents locally by `./scripts/build_docs.sh` which didn't give me the page for API descriptions.

Otherwise, the format checking has all been run. Do let me know if the above two error is crucial and I need to make some changes. 

This is related to the issue #437 