### PR TITLE
Re-sync with internal repository

### DIFF
--- a/captum/concept/__init__.py
+++ b/captum/concept/__init__.py
@@ -1,3 +1,0 @@
-#!/usr/bin/env python3
-
-__version__ = "0.3.0"


### PR DESCRIPTION
The internal and external repositories are out of sync. This attempts to brings them back in sync by patching the GitHub repository. Please carefully review this patch. You must disable ShipIt for your project in order to merge this pull request. DO NOT IMPORT this pull request. Instead, merge it directly on GitHub using the MERGE BUTTON. Re-enable ShipIt after merging.