### PR TITLE
Fix the issue when the number of input samples in baselines and inputs are different in sensitivity_max

### DIFF
--- a/captum/attr/_core/gradient_shap.py
+++ b/captum/attr/_core/gradient_shap.py
@@ -414,6 +414,6 @@ def _scale_input(
     rand_coefficient = rand_coefficient.view(inp_shape)
 
     input_baseline_scaled = (
-        rand_coefficient * input + (torch.tensor(1) - rand_coefficient) * baseline
+        rand_coefficient * input + (1.0 - rand_coefficient) * baseline
     ).requires_grad_()
     return input_baseline_scaled

--- a/captum/attr/_core/gradient_shap.py
+++ b/captum/attr/_core/gradient_shap.py
@@ -414,6 +414,6 @@ def _scale_input(
     rand_coefficient = rand_coefficient.view(inp_shape)
 
     input_baseline_scaled = (
-        rand_coefficient * input + (torch.tensor(1) - rand_coefficient) * baseline
+        rand_coefficient * input + (1 - rand_coefficient) * baseline
     ).requires_grad_()
     return input_baseline_scaled

--- a/captum/attr/_core/gradient_shap.py
+++ b/captum/attr/_core/gradient_shap.py
@@ -414,6 +414,6 @@ def _scale_input(
     rand_coefficient = rand_coefficient.view(inp_shape)
 
     input_baseline_scaled = (
-        rand_coefficient * input + (torch.tensor(1.0) - rand_coefficient) * baseline
+        rand_coefficient * input + (torch.tensor(1) - rand_coefficient) * baseline
     ).requires_grad_()
     return input_baseline_scaled

--- a/captum/attr/_core/gradient_shap.py
+++ b/captum/attr/_core/gradient_shap.py
@@ -414,6 +414,6 @@ def _scale_input(
     rand_coefficient = rand_coefficient.view(inp_shape)
 
     input_baseline_scaled = (
-        rand_coefficient * input + (1.0 - rand_coefficient).float() * baseline
+        rand_coefficient * input + (torch.tensor(1.0) - rand_coefficient).float() * baseline
     ).requires_grad_()
     return input_baseline_scaled

--- a/captum/attr/_core/gradient_shap.py
+++ b/captum/attr/_core/gradient_shap.py
@@ -414,6 +414,6 @@ def _scale_input(
     rand_coefficient = rand_coefficient.view(inp_shape)
 
     input_baseline_scaled = (
-        rand_coefficient * input + (torch.tensor(1.0) - rand_coefficient).float() * baseline
+        rand_coefficient * input + (torch.tensor(1.0) - rand_coefficient) * baseline
     ).requires_grad_()
     return input_baseline_scaled

--- a/captum/attr/_core/gradient_shap.py
+++ b/captum/attr/_core/gradient_shap.py
@@ -414,6 +414,6 @@ def _scale_input(
     rand_coefficient = rand_coefficient.view(inp_shape)
 
     input_baseline_scaled = (
-        rand_coefficient * input + (1.0 - rand_coefficient) * baseline
+        rand_coefficient * input + (1.0 - rand_coefficient).float() * baseline
     ).requires_grad_()
     return input_baseline_scaled

--- a/captum/attr/_core/gradient_shap.py
+++ b/captum/attr/_core/gradient_shap.py
@@ -414,6 +414,6 @@ def _scale_input(
     rand_coefficient = rand_coefficient.view(inp_shape)
 
     input_baseline_scaled = (
-        rand_coefficient * input + (1 - rand_coefficient) * baseline
+        rand_coefficient * input + (1.0 - rand_coefficient) * baseline
     ).requires_grad_()
     return input_baseline_scaled

--- a/captum/metrics/_core/sensitivity.py
+++ b/captum/metrics/_core/sensitivity.py
@@ -9,6 +9,7 @@ from ..._utils.common import (
     _expand_and_update_additional_forward_args,
     _expand_and_update_baselines,
     _expand_and_update_target,
+    _format_baseline,
     _format_input,
     _format_tensor_into_tuples,
 )
@@ -214,7 +215,13 @@ def sensitivity_max(
                 current_n_perturb_samples, kwargs_copy
             )
             _expand_and_update_target(current_n_perturb_samples, kwargs_copy)
-            _expand_and_update_baselines(inputs, current_n_perturb_samples, kwargs_copy)
+            if "baselines" in kwargs:
+                baselines = kwargs["baselines"]
+                baselines = _format_baseline(baselines, inputs)
+                if baselines[0].shape == inputs[0].shape:
+                    _expand_and_update_baselines(
+                        inputs, current_n_perturb_samples, kwargs_copy
+                    )
 
         expl_perturbed_inputs = explanation_func(inputs_perturbed, **kwargs_copy)
 

--- a/tests/metrics/test_sensitivity.py
+++ b/tests/metrics/test_sensitivity.py
@@ -1,8 +1,15 @@
 #!/usr/bin/env python3
 
+import numpy as np
 import torch
 
-from captum.attr import DeepLift, GuidedBackprop, IntegratedGradients, Saliency
+from captum.attr import (
+    DeepLift,
+    GradientShap,
+    GuidedBackprop,
+    IntegratedGradients,
+    Saliency,
+)
 from captum.metrics import sensitivity_max
 from captum.metrics._core.sensitivity import default_perturb_func
 
@@ -61,6 +68,34 @@ class Test(BaseTest):
         )
         self.sensitivity_max_assert(
             sa.attribute, (input1, input2), [0.0] * 20, max_examples_per_batch=60
+        )
+
+    def test_basic_sensitivity_max_multiple_gradshap(self):
+        model = BasicModel2()
+        gs = GradientShap(model)
+
+        input1 = torch.tensor([3.0] * 5)
+        input2 = torch.tensor([1.0] * 5)
+
+        baseline1 = torch.arange(0, 2)
+        baseline2 = torch.arange(0, 2)
+
+        self.setUp()
+        self.sensitivity_max_assert(
+            gs.attribute,
+            (input1, input2),
+            [0.6082, 0.5440, 0.3457, 2.6726, 0.3360],
+            baselines=(baseline1, baseline2),
+            max_examples_per_batch=2,
+        )
+
+        self.setUp()
+        self.sensitivity_max_assert(
+            gs.attribute,
+            (input1, input2),
+            [0.6082, 0.5440, 0.3457, 2.6726, 0.3360],
+            baselines=(baseline1, baseline2),
+            max_examples_per_batch=2,
         )
 
     def test_convnet_multi_target(self):

--- a/tests/metrics/test_sensitivity.py
+++ b/tests/metrics/test_sensitivity.py
@@ -73,28 +73,26 @@ class Test(BaseTest):
         model = BasicModel2()
         gs = GradientShap(model)
 
-        input1 = torch.tensor([3.0] * 5)
-        input2 = torch.tensor([1.0] * 5)
+        input1 = torch.tensor([0.0] * 5)
+        input2 = torch.tensor([0.0] * 5)
 
-        baseline1 = torch.arange(0, 2).float()
-        baseline2 = torch.arange(0, 2).float()
+        baseline1 = torch.arange(0, 2).float() / 1000
+        baseline2 = torch.arange(0, 2).float() / 1000
 
-        self.setUp()
         self.sensitivity_max_assert(
             gs.attribute,
             (input1, input2),
-            [0.6082, 0.5440, 0.3457, 2.6726, 0.3360],
+            [0.0] * 5,
             baselines=(baseline1, baseline2),
             max_examples_per_batch=2,
         )
 
-        self.setUp()
         self.sensitivity_max_assert(
             gs.attribute,
             (input1, input2),
-            [0.6082, 0.5440, 0.3457, 2.6726, 0.3360],
+            [0.0] * 5,
             baselines=(baseline1, baseline2),
-            max_examples_per_batch=2,
+            max_examples_per_batch=20,
         )
 
     def test_convnet_multi_target(self):

--- a/tests/metrics/test_sensitivity.py
+++ b/tests/metrics/test_sensitivity.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import numpy as np
 import torch
 
 from captum.attr import (

--- a/tests/metrics/test_sensitivity.py
+++ b/tests/metrics/test_sensitivity.py
@@ -76,8 +76,8 @@ class Test(BaseTest):
         input1 = torch.tensor([3.0] * 5)
         input2 = torch.tensor([1.0] * 5)
 
-        baseline1 = torch.arange(0, 2)
-        baseline2 = torch.arange(0, 2)
+        baseline1 = torch.arange(0, 2).float()
+        baseline2 = torch.arange(0, 2).float()
 
         self.setUp()
         self.sensitivity_max_assert(


### PR DESCRIPTION
When the first dimensions of the inputs and baselines are different we do not need to expand baselines in that case.
GradientSHAP chooses randomly a sample from baseline's distribution and DeepLiftSHAP looks into all combinatorial pairs.