### PR TITLE
Fix CI Failure

### DIFF
--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -22,11 +22,11 @@ while getopts 'ndfv:' flag; do
 # but users should hopefully be using conda installs.
 
 # install nodejs and yarn for insights build
+sudo apt update
 sudo apt install apt-transport-https ca-certificates
 curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
 curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
 echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-sudo apt update
 sudo apt install nodejs
 sudo apt install yarn
 

--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -22,12 +22,12 @@ while getopts 'ndfv:' flag; do
 # but users should hopefully be using conda installs.
 
 # install nodejs and yarn for insights build
-sudo apt update
+sudo apt-get update
 sudo apt install apt-transport-https ca-certificates
 curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
 curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
 echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-sudo apt remove cmdtest
+sudo apt update
 sudo apt install nodejs
 sudo apt install yarn
 

--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -27,6 +27,7 @@ sudo apt install apt-transport-https ca-certificates
 curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
 curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
 echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+sudo apt remove cmdtest
 sudo apt install nodejs
 sudo apt install yarn
 


### PR DESCRIPTION
CircleCI pip install tests are currently failing with this error:
```
0% [Working]Err:1 http://deb.debian.org/debian stretch/main amd64 apt-transport-https amd64 1.4.9
  404  Not Found
```
This requires running `sudo apt-get update `before installing `apt-transport-https`