### PR TITLE
Fixing tutorial generation

### DIFF
--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -65,5 +65,5 @@ fi
 
 # install deployment bits if asked for
 if [[ $DEPLOY == true ]]; then
-  sudo pip install beautifulsoup4 ipython nbconvert
+  sudo pip install beautifulsoup4 ipython nbconvert==5.6.1
 fi


### PR DESCRIPTION
Version 6.0.3 of nbconvert causes parse_tutorials to fail, deleting all tutorials from the website. This sets version to 5.6.1 which works appropriately, will fix script and upgrade version in a separate diff.