### PR TITLE
accept slices of tensors as neuron index for gradient computation

### DIFF
--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -418,9 +418,9 @@ def _select_targets(output: Tensor, target: TargetType) -> Tensor:
 
 
 def _verify_select_column(
-    output: Tensor, target: Union[int, Tuple[int, ...]]
+    output: Tensor, target: Union[int, Tuple[Union[int, slice], ...]]
 ) -> Tensor:
-    target = cast(Tuple[int, ...], (target,) if isinstance(target, int) else target)
+    target = (target,) if isinstance(target, int) else target
     assert (
         len(target) <= len(output.shape) - 1
     ), "Cannot choose target column with output shape %r." % (output.shape,)

--- a/captum/attr/_core/neuron/neuron_deep_lift.py
+++ b/captum/attr/_core/neuron/neuron_deep_lift.py
@@ -79,7 +79,7 @@ class NeuronDeepLift(NeuronAttribution, GradientAttribution):
     def attribute(
         self,
         inputs: TensorOrTupleOfTensorsGeneric,
-        neuron_index: Union[int, Tuple[int, ...]],
+        neuron_index: Union[int, Tuple[Union[int, slice], ...]],
         baselines: BaselineType = None,
         additional_forward_args: Any = None,
         attribute_to_neuron_input: bool = False,
@@ -97,13 +97,21 @@ class NeuronDeepLift(NeuronAttribution, GradientAttribution):
                         corresponds to the number of examples (aka batch size),
                         and if multiple input tensors are provided, the examples
                         must be aligned appropriately.
-            neuron_index (int or tuple): Index of neuron in output of given
-                        layer for which attribution is desired. Length of
-                        this tuple must be one less than the number of
+            neuron_index (int or tuple): Index of neuron or neurons in output
+                        of given layer for which attribution is desired. Length
+                        of this tuple must be one less than the number of
                         dimensions in the output of the given layer (since
                         dimension 0 corresponds to number of examples).
+                        The elements of the tuple can be either integers or
+                        slice objects (slice object also allows indexing a
+                        range of neurons rather individual ones).
                         An integer may be provided instead of a tuple of
                         length 1.
+                        If any of the tuple elements is a slice object, the
+                        indexed output tensor is used for attribution. Note
+                        that specifying a slice of a tesnor would amount to
+                        computing the attribution of the sum of the specified
+                        neurons, and not the individual neurons independantly.
             baselines (scalar, tensor, tuple of scalars or tensors, optional):
                         Baselines define reference samples that are compared with
                         the inputs. In order to assign attribution scores DeepLift
@@ -280,7 +288,7 @@ class NeuronDeepLiftShap(NeuronAttribution, GradientAttribution):
     def attribute(
         self,
         inputs: TensorOrTupleOfTensorsGeneric,
-        neuron_index: Union[int, Tuple[int, ...]],
+        neuron_index: Union[int, Tuple[Union[int, slice], ...]],
         baselines: Union[
             TensorOrTupleOfTensorsGeneric, Callable[..., TensorOrTupleOfTensorsGeneric]
         ],
@@ -300,13 +308,21 @@ class NeuronDeepLiftShap(NeuronAttribution, GradientAttribution):
                         corresponds to the number of examples (aka batch size),
                         and if multiple input tensors are provided, the examples
                         must be aligned appropriately.
-            neuron_index (int or tuple): Index of neuron in output of given
-                        layer for which attribution is desired. Length of
+            neuron_index (int or tuple): Index of neuron or neurons in output of
+                        given layer for which attribution is desired. Length of
                         this tuple must be one less than the number of
                         dimensions in the output of the given layer (since
                         dimension 0 corresponds to number of examples).
+                        The elements of the tuple can be either integers or
+                        slice objects (slice object also allows indexing a
+                        range of neurons rather individual ones).
                         An integer may be provided instead of a tuple of
                         length 1.
+                        If any of the tuple elements is a slice object, the
+                        indexed output tensor is used for attribution. Note
+                        that specifying a slice of a tesnor would amount to
+                        computing the attribution of the sum of the specified
+                        neurons, and not the individual neurons independantly.
             baselines (tensor, tuple of tensors, callable):
                         Baselines define reference samples that are compared with
                         the inputs. In order to assign attribution scores DeepLift

--- a/captum/attr/_core/neuron/neuron_gradient.py
+++ b/captum/attr/_core/neuron/neuron_gradient.py
@@ -59,7 +59,7 @@ class NeuronGradient(NeuronAttribution, GradientAttribution):
     def attribute(
         self,
         inputs: TensorOrTupleOfTensorsGeneric,
-        neuron_index: Union[int, Tuple[int, ...]],
+        neuron_index: Union[int, Tuple[Union[int, slice], ...]],
         additional_forward_args: Any = None,
         attribute_to_neuron_input: bool = False,
     ) -> TensorOrTupleOfTensorsGeneric:
@@ -74,13 +74,21 @@ class NeuronGradient(NeuronAttribution, GradientAttribution):
                         that for all given input tensors, dimension 0 corresponds
                         to the number of examples, and if multiple input tensors
                         are provided, the examples must be aligned appropriately.
-            neuron_index (int or tuple): Index of neuron in output of given
-                            layer for which attribution is desired. Length of
-                            this tuple must be one less than the number of
-                            dimensions in the output of the given layer (since
-                            dimension 0 corresponds to number of examples).
-                            An integer may be provided instead of a tuple of
-                            length 1.
+            neuron_index (int or tuple): Index of neuron or neurons in output of
+                        given layer for which attribution is desired. Length of
+                        this tuple must be one less than the number of
+                        dimensions in the output of the given layer (since
+                        dimension 0 corresponds to number of examples).
+                        The elements of the tuple can be either integers or
+                        slice objects (slice object also allows indexing a
+                        range of neurons rather individual ones).
+                        An integer may be provided instead of a tuple of
+                        length 1.
+                        If any of the tuple elements is a slice object, the
+                        indexed output tensor is used for attribution. Note
+                        that specifying a slice of a tesnor would amount to
+                        computing the attribution of the sum of the specified
+                        neurons, and not the individual neurons independantly.
             additional_forward_args (any, optional): If the forward function
                         requires additional arguments other than the inputs for
                         which attributions should not be computed, this argument

--- a/captum/attr/_core/neuron/neuron_gradient_shap.py
+++ b/captum/attr/_core/neuron/neuron_gradient_shap.py
@@ -96,7 +96,7 @@ class NeuronGradientShap(NeuronAttribution, GradientAttribution):
     def attribute(
         self,
         inputs: TensorOrTupleOfTensorsGeneric,
-        neuron_index: Union[int, Tuple[int, ...]],
+        neuron_index: Union[int, Tuple[Union[int, slice], ...]],
         baselines: Union[
             TensorOrTupleOfTensorsGeneric, Callable[..., TensorOrTupleOfTensorsGeneric]
         ],
@@ -116,13 +116,21 @@ class NeuronGradientShap(NeuronAttribution, GradientAttribution):
                         that for all given input tensors, dimension 0 corresponds
                         to the number of examples, and if multiple input tensors
                         are provided, the examples must be aligned appropriately.
-            neuron_index (int or tuple): Index of neuron in output of given
-                        layer for which attribution is desired. Length of
-                        this tuple must be one less than the number of
-                        dimensions in the output of the given layer (since
-                        dimension 0 corresponds to number of examples).
+            neuron_index (int or tuple): Index of neuron or neurons in output of
+                        given layer for which attribution is desired. Length of
+                        this tuple must be one less than the number of dimensions
+                        in the output of the given layer (since dimension 0
+                        corresponds to number of examples).
+                        The elements of the tuple can be either integers or slice
+                        objects (slice object also allows indexing a range of
+                        neurons rather individual ones).
                         An integer may be provided instead of a tuple of
                         length 1.
+                        If any of the tuple elements is a slice object, the indexed
+                        output tensor is used for attribution. Note that specifying
+                        a slice of a tesnor would amount to computing the attribution
+                        of the sum of the specified neurons, and not the individual
+                        neurons independantly.
             baselines (tensor, tuple of tensors, callable):
                         Baselines define the starting point from which expectation
                         is computed and can be provided as:

--- a/captum/attr/_core/neuron/neuron_guided_backprop_deconvnet.py
+++ b/captum/attr/_core/neuron/neuron_guided_backprop_deconvnet.py
@@ -60,7 +60,7 @@ class NeuronDeconvolution(NeuronAttribution, GradientAttribution):
     def attribute(
         self,
         inputs: TensorOrTupleOfTensorsGeneric,
-        neuron_index: Union[int, Tuple[int, ...]],
+        neuron_index: Union[int, Tuple[Union[int, slice], ...]],
         additional_forward_args: Any = None,
         attribute_to_neuron_input: bool = False,
     ) -> TensorOrTupleOfTensorsGeneric:
@@ -76,13 +76,19 @@ class NeuronDeconvolution(NeuronAttribution, GradientAttribution):
                         to the number of examples (aka batch size), and if
                         multiple input tensors are provided, the examples must
                         be aligned appropriately.
-            neuron_index (int or tuple): Index of neuron in output of given
-                          layer for which attribution is desired. Length of
-                          this tuple must be one less than the number of
-                          dimensions in the output of the given layer (since
-                          dimension 0 corresponds to number of examples).
-                          An integer may be provided instead of a tuple of
-                          length 1.
+            neuron_index (int or tuple): Index of neuron or neurons in output of
+                        given layer for which attribution is desired. Length of
+                        this tuple must be one less than the number of dimensions
+                        in the output of the given layer (since dimension 0
+                        corresponds to number of examples). The elements of the
+                        tuple can be either integers or slice objects (slice object
+                        also allows indexing a range of neurons rather individual
+                        ones). An integer may be provided instead of a tuple of
+                        length 1. If any of the tuple elements is a slice object,
+                        the indexed output tensor is used for attribution. Note
+                        that specifying a slice of a tesnor would amount to computing
+                        the attribution of the sum of the specified neurons, and not
+                        the individual neurons independantly.
             additional_forward_args (any, optional): If the forward function
                         requires additional arguments other than the inputs for
                         which attributions should not be computed, this argument
@@ -188,7 +194,7 @@ class NeuronGuidedBackprop(NeuronAttribution, GradientAttribution):
     def attribute(
         self,
         inputs: TensorOrTupleOfTensorsGeneric,
-        neuron_index: Union[int, Tuple[int, ...]],
+        neuron_index: Union[int, Tuple[Union[int, slice], ...]],
         additional_forward_args: Any = None,
         attribute_to_neuron_input: bool = False,
     ) -> TensorOrTupleOfTensorsGeneric:
@@ -204,13 +210,19 @@ class NeuronGuidedBackprop(NeuronAttribution, GradientAttribution):
                         to the number of examples (aka batch size), and if
                         multiple input tensors are provided, the examples must
                         be aligned appropriately.
-            neuron_index (int or tuple): Index of neuron in output of given
-                          layer for which attribution is desired. Length of
-                          this tuple must be one less than the number of
-                          dimensions in the output of the given layer (since
-                          dimension 0 corresponds to number of examples).
-                          An integer may be provided instead of a tuple of
-                          length 1.
+            neuron_index (int or tuple): Index of neuron or neurons in output of
+                        given layer for which attribution is desired. Length of
+                        this tuple must be one less than the number of dimensions
+                        in the output of the given layer (since dimension 0
+                        corresponds to number of examples). The elements of the
+                        tuple can be either integers or slice objects (slice object
+                        also allows indexing a range of neurons rather individual
+                        ones). An integer may be provided instead of a tuple of
+                        length 1. If any of the tuple elements is a slice object,
+                        the indexed output tensor is used for attribution. Note
+                        that specifying a slice of a tesnor would amount to computing
+                        the attribution of the sum of the specified neurons, and not
+                        the individual neurons independantly.
             additional_forward_args (any, optional): If the forward function
                         requires additional arguments other than the inputs for
                         which attributions should not be computed, this argument

--- a/captum/attr/_core/neuron/neuron_integrated_gradients.py
+++ b/captum/attr/_core/neuron/neuron_integrated_gradients.py
@@ -75,7 +75,7 @@ class NeuronIntegratedGradients(NeuronAttribution, GradientAttribution):
     def attribute(
         self,
         inputs: TensorOrTupleOfTensorsGeneric,
-        neuron_index: Union[int, Tuple[int, ...]],
+        neuron_index: Union[int, Tuple[Union[int, slice], ...]],
         baselines: Union[None, Tensor, Tuple[Tensor, ...]] = None,
         additional_forward_args: Any = None,
         n_steps: int = 50,
@@ -94,13 +94,21 @@ class NeuronIntegratedGradients(NeuronAttribution, GradientAttribution):
                         that for all given input tensors, dimension 0 corresponds
                         to the number of examples, and if multiple input tensors
                         are provided, the examples must be aligned appropriately.
-            neuron_index (int or tuple): Index of neuron in output of given
-                            layer for which attribution is desired. Length of
-                            this tuple must be one less than the number of
+            neuron_index (int or tuple): Index of neuron or neurons in output of
+                            given layer for which attribution is desired. Length
+                            of this tuple must be one less than the number of
                             dimensions in the output of the given layer (since
                             dimension 0 corresponds to number of examples).
+                            The elements of the tuple can be either integers or
+                            slice objects (slice object also allows indexing a
+                            range of neurons rather individual ones).
                             An integer may be provided instead of a tuple of
                             length 1.
+                            If any of the tuple elements is a slice object, the
+                            indexed output tensor is used for attribution. Note
+                            that specifying a slice of a tesnor would amount to
+                            computing the attribution of the sum of the specified
+                            neurons, and not the individual neurons independantly.
             baselines (scalar, tensor, tuple of scalars or tensors, optional):
                         Baselines define the starting point from which integral
                         is computed.

--- a/tests/attr/neuron/test_neuron_gradient.py
+++ b/tests/attr/neuron/test_neuron_gradient.py
@@ -57,6 +57,13 @@ class Test(BaseTest):
         inp = torch.tensor([[0.0, 5.0, 4.0]])
         self._gradient_input_test_assert(net, net.relu, inp, 1, [1.0, 1.0, 1.0])
 
+    def test_simple_gradient_input_relu2_agg_neurons(self) -> None:
+        net = BasicModel_MultiLayer()
+        inp = torch.tensor([[0.0, 5.0, 4.0]])
+        self._gradient_input_test_assert(
+            net, net.relu, inp, (slice(0, 2, 1),), [1.0, 1.0, 1.0]
+        )
+
     def test_simple_gradient_multi_input_linear2(self) -> None:
         net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[0.0, 100.0, 0.0]])
@@ -100,7 +107,7 @@ class Test(BaseTest):
         model: Module,
         target_layer: Module,
         test_input: TensorOrTupleOfTensorsGeneric,
-        test_neuron_index: Union[int, Tuple[int, ...]],
+        test_neuron_index: Union[int, Tuple[Union[int, slice], ...]],
         expected_input_gradient: Union[List[float], Tuple[List[float], ...]],
         additional_input: Any = None,
         attribute_to_neuron_input: bool = False,

--- a/tests/attr/neuron/test_neuron_gradient_shap.py
+++ b/tests/attr/neuron/test_neuron_gradient_shap.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from typing import Callable, Union
+from typing import Callable, Tuple, Union
 
 import torch
 from torch import Tensor
@@ -36,6 +36,17 @@ class Test(BaseTest):
 
         self._assert_attributions(model, model.linear1, inputs, baselines, 0, 60)
 
+    def test_basic_multilayer_wo_mult_by_inputs_agg_neurons(self) -> None:
+        model = BasicModel_MultiLayer(inplace=True)
+        model.eval()
+
+        inputs = torch.tensor([[1.0, 20.0, 10.0]])
+        baselines = torch.randn(2, 3)
+
+        self._assert_attributions(
+            model, model.linear1, inputs, baselines, (slice(0, 1, 1),), 60
+        )
+
     def test_classification(self) -> None:
         def custom_baseline_fn(inputs: Tensor) -> Tensor:
             num_in = inputs.shape[1]  # type: ignore
@@ -59,7 +70,7 @@ class Test(BaseTest):
         layer: Module,
         inputs: Tensor,
         baselines: Union[Tensor, Callable[..., Tensor]],
-        neuron_ind: Union[int, tuple],
+        neuron_ind: Union[int, Tuple[Union[int, slice], ...]],
         n_samples: int = 5,
     ) -> None:
         ngs = NeuronGradientShap(model, layer)

--- a/tests/attr/neuron/test_neuron_integrated_gradients.py
+++ b/tests/attr/neuron/test_neuron_integrated_gradients.py
@@ -35,12 +35,7 @@ class Test(BaseTest):
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[100.0, 100.0, 100.0]])
         self._ig_input_test_assert(
-            net,
-            net.linear2,
-            inp,
-            0,
-            [3.96, 3.96, 3.96],
-            multiply_by_inputs=False,
+            net, net.linear2, inp, 0, [3.96, 3.96, 3.96], multiply_by_inputs=False
         )
 
     def test_simple_ig_input_linear1(self) -> None:
@@ -57,6 +52,13 @@ class Test(BaseTest):
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 5.0, 4.0]])
         self._ig_input_test_assert(net, net.relu, inp, 1, [0.0, 5.0, 4.0])
+
+    def test_simple_ig_input_relu2_agg_neurons(self) -> None:
+        net = BasicModel_MultiLayer()
+        inp = torch.tensor([[0.0, 5.0, 4.0]])
+        self._ig_input_test_assert(
+            net, net.relu, inp, (slice(0, 2, 1),), [0.0, 5.0, 4.0]
+        )
 
     def test_simple_ig_multi_input_linear2(self) -> None:
         net = BasicModel_MultiLayer_MultiInput()
@@ -111,16 +113,14 @@ class Test(BaseTest):
         model: Module,
         target_layer: Module,
         test_input: TensorOrTupleOfTensorsGeneric,
-        test_neuron: Union[int, Tuple[int, ...]],
+        test_neuron: Union[int, Tuple[Union[int, slice], ...]],
         expected_input_ig: Union[List[float], Tuple[List[List[float]], ...]],
         additional_input: Any = None,
         multiply_by_inputs: bool = True,
     ) -> None:
         for internal_batch_size in [None, 5, 20]:
             grad = NeuronIntegratedGradients(
-                model,
-                target_layer,
-                multiply_by_inputs=multiply_by_inputs,
+                model, target_layer, multiply_by_inputs=multiply_by_inputs
             )
             self.assertEquals(grad.multiplies_by_inputs, multiply_by_inputs)
             attributions = grad.attribute(

--- a/tests/attr/test_deconvolution.py
+++ b/tests/attr/test_deconvolution.py
@@ -41,6 +41,17 @@ class Test(BaseTest):
         ]
         self._neuron_deconv_test_assert(net, net.fc1, (0,), (inp,), (exp,))
 
+    def test_simple_input_conv_neuron_deconv_agg_neurons(self) -> None:
+        net = BasicModel_ConvNet_One_Conv()
+        inp = 1.0 * torch.arange(16, dtype=torch.float).view(1, 1, 4, 4)
+        exp = [
+            [2.0, 3.0, 3.0, 1.0],
+            [3.0, 5.0, 5.0, 2.0],
+            [3.0, 5.0, 5.0, 2.0],
+            [1.0, 2.0, 2.0, 1.0],
+        ]
+        self._neuron_deconv_test_assert(net, net.fc1, (slice(0, 1, 1),), (inp,), (exp,))
+
     def test_simple_multi_input_conv_deconv(self) -> None:
         net = BasicModel_ConvNet_One_Conv()
         inp = torch.arange(16, dtype=torch.float).view(1, 1, 4, 4)
@@ -90,7 +101,7 @@ class Test(BaseTest):
         self,
         model: Module,
         layer: Module,
-        neuron_index: Union[int, Tuple[int, ...]],
+        neuron_index: Union[int, Tuple[Union[int, slice], ...]],
         test_input: TensorOrTupleOfTensorsGeneric,
         expected: Tuple[List[List[float]], ...],
         additional_input: Any = None,

--- a/tests/attr/test_guided_backprop.py
+++ b/tests/attr/test_guided_backprop.py
@@ -39,6 +39,19 @@ class Test(BaseTest):
         ]
         self._neuron_guided_backprop_test_assert(net, net.fc1, (0,), (inp,), (exp,))
 
+    def test_simple_input_conv_neuron_gb_agg_neurons(self) -> None:
+        net = BasicModel_ConvNet_One_Conv()
+        inp = 1.0 * torch.arange(16, dtype=torch.float).view(1, 1, 4, 4)
+        exp = [
+            [0.0, 1.0, 1.0, 1.0],
+            [1.0, 3.0, 3.0, 2.0],
+            [1.0, 3.0, 3.0, 2.0],
+            [1.0, 2.0, 2.0, 1.0],
+        ]
+        self._neuron_guided_backprop_test_assert(
+            net, net.fc1, (slice(0, 1, 1),), (inp,), (exp,)
+        )
+
     def test_simple_multi_input_conv_gb(self) -> None:
         net = BasicModel_ConvNet_One_Conv()
         inp = torch.arange(16, dtype=torch.float).view(1, 1, 4, 4)
@@ -88,7 +101,7 @@ class Test(BaseTest):
         self,
         model: Module,
         layer: Module,
-        neuron_index: Union[int, Tuple[int, ...]],
+        neuron_index: Union[int, Tuple[Union[int, slice], ...]],
         test_input: TensorOrTupleOfTensorsGeneric,
         expected: Tuple[List[List[float]], ...],
         additional_input: Any = None,


### PR DESCRIPTION
Summary: Thus far, we supported gradient computation of a specific neuron indexed by `neuron_index`. With this change, we allow gradient computation of the aggregate of multiple neurons, by specifying slices of tensors.

Reviewed By: vivekmig

Differential Revision: D24010060

