### PR TITLE
Neuron Aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ In this case, we choose to analyze the first neuron in the linear layer.
 
 ```python
 nc = NeuronConductance(model, model.lin1)
-attributions = nc.attribute(input, neuron_index=1, target=0)
+attributions = nc.attribute(input, neuron_selector=1, target=0)
 print('Neuron Attributions:', attributions)
 ```
 Output

--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -417,6 +417,15 @@ def _select_targets(output: Tensor, target: TargetType) -> Tensor:
         raise AssertionError("Target type %r is not valid." % target)
 
 
+def _contains_slice(target: Union[int, Tuple[Union[int, slice], ...]]) -> bool:
+    if isinstance(target, tuple):
+        for index in target:
+            if isinstance(index, slice):
+                return True
+        return False
+    return isinstance(target, slice)
+
+
 def _verify_select_column(
     output: Tensor, target: Union[int, Tuple[Union[int, slice], ...]]
 ) -> Tensor:
@@ -425,6 +434,24 @@ def _verify_select_column(
         len(target) <= len(output.shape) - 1
     ), "Cannot choose target column with output shape %r." % (output.shape,)
     return output[(slice(None), *target)]
+
+
+def _verify_select_neuron(
+    layer_output: Tuple[Tensor, ...],
+    selector: Union[int, Tuple[Union[int, slice], ...], Callable],
+) -> Tensor:
+    if callable(selector):
+        return selector(layer_output if len(layer_output) > 1 else layer_output[0])
+
+    assert len(layer_output) == 1, (
+        "Cannot select neuron index from layer with multiple tensors,"
+        "consider providing a neuron selector function instead."
+    )
+
+    selected_neurons = _verify_select_column(layer_output[0], selector)
+    if _contains_slice(selector):
+        return selected_neurons.reshape(selected_neurons.shape[0], -1).sum(1)
+    return selected_neurons
 
 
 def _extract_device(

--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -423,9 +423,7 @@ def _forward_layer_eval_with_neuron_grads(
     evals in a dictionary protected by a lock, analogous to the gather implementation
     for the core PyTorch DataParallel implementation.
     """
-    grad_enabled = (
-        True if gradient_neuron_selector is not None or grad_enabled else False
-    )
+    grad_enabled = True if gradient_neuron_selector is not None else grad_enabled
 
     with torch.autograd.set_grad_enabled(grad_enabled):
         saved_layer = _forward_layer_distributed_eval(
@@ -469,7 +467,7 @@ def compute_layer_gradients_and_eval(
     target_ind: TargetType = None,
     additional_forward_args: Any = None,
     *,
-    gradient_neuron_selector: Union[int, Tuple[int, ...], Callable],
+    gradient_neuron_selector: Union[int, Tuple[Union[int, slice], ...], Callable],
     device_ids: Union[None, List[int]] = None,
     attribute_to_layer_input: bool = False,
     output_fn: Union[None, Callable] = None,
@@ -513,7 +511,9 @@ def compute_layer_gradients_and_eval(
     inputs: Union[Tensor, Tuple[Tensor, ...]],
     target_ind: TargetType = None,
     additional_forward_args: Any = None,
-    gradient_neuron_selector: Union[None, int, Tuple[int, ...], Callable] = None,
+    gradient_neuron_selector: Union[
+        None, int, Tuple[Union[int, slice], ...], Callable
+    ] = None,
     device_ids: Union[None, List[int]] = None,
     attribute_to_layer_input: bool = False,
     output_fn: Union[None, Callable] = None,

--- a/captum/attr/_core/neuron/neuron_deep_lift.py
+++ b/captum/attr/_core/neuron/neuron_deep_lift.py
@@ -99,9 +99,9 @@ class NeuronDeepLift(NeuronAttribution, GradientAttribution):
                         corresponds to the number of examples (aka batch size),
                         and if multiple input tensors are provided, the examples
                         must be aligned appropriately.
-            neuron_selector (int or tuple): Index of neuron or neurons in output
-                        of given layer for which attribution is desired. Length
-                        of this tuple must be one less than the number of
+            neuron_selector (int or tuple or callable): Index of neuron or neurons
+                        in output of given layer for which attribution is desired.
+                        Length of this tuple must be one less than the number of
                         dimensions in the output of the given layer (since
                         dimension 0 corresponds to number of examples).
                         The elements of the tuple can be either integers or
@@ -109,6 +109,15 @@ class NeuronDeepLift(NeuronAttribution, GradientAttribution):
                         range of neurons rather individual ones).
                         An integer may be provided instead of a tuple of
                         length 1.
+                        Alternatively, a callable can be provided, which should
+                        take the target layer as input (single tensor or tuple
+                        if multiple tensors are in layer) and return a neuron or
+                        aggregate of the layer's neurons for attribution.
+                        For example, this function could return the
+                        sum of the neurons in the layer or sum of neurons with
+                        activations in a particular range. It is expected that
+                        this function returns either a tensor with one element
+                        or a scalar per example.
                         If any of the tuple elements is a slice object, the
                         indexed output tensor is used for attribution. Note
                         that specifying a slice of a tesnor would amount to

--- a/captum/attr/_core/neuron/neuron_deep_lift.py
+++ b/captum/attr/_core/neuron/neuron_deep_lift.py
@@ -99,30 +99,40 @@ class NeuronDeepLift(NeuronAttribution, GradientAttribution):
                         corresponds to the number of examples (aka batch size),
                         and if multiple input tensors are provided, the examples
                         must be aligned appropriately.
-            neuron_selector (int or tuple or callable): Index of neuron or neurons
-                        in output of given layer for which attribution is desired.
-                        Length of this tuple must be one less than the number of
-                        dimensions in the output of the given layer (since
-                        dimension 0 corresponds to number of examples).
-                        The elements of the tuple can be either integers or
-                        slice objects (slice object also allows indexing a
-                        range of neurons rather individual ones).
-                        An integer may be provided instead of a tuple of
-                        length 1.
-                        Alternatively, a callable can be provided, which should
-                        take the target layer as input (single tensor or tuple
-                        if multiple tensors are in layer) and return a neuron or
-                        aggregate of the layer's neurons for attribution.
-                        For example, this function could return the
-                        sum of the neurons in the layer or sum of neurons with
-                        activations in a particular range. It is expected that
-                        this function returns either a tensor with one element
-                        or a scalar per example.
-                        If any of the tuple elements is a slice object, the
-                        indexed output tensor is used for attribution. Note
-                        that specifying a slice of a tesnor would amount to
-                        computing the attribution of the sum of the specified
-                        neurons, and not the individual neurons independantly.
+            neuron_selector (int, callable, or tuple of ints or slices):
+                        Selector for neuron
+                        in given layer for which attribution is desired.
+                        Neuron selector can be provided as:
+
+                        - a single integer, if the layer output is 2D. This integer
+                          selects the appropriate neuron column in the layer input
+                          or output
+
+                        - a tuple of integers or slice objects. Length of this
+                          tuple must be one less than the number of dimensions
+                          in the input / output of the given layer (since
+                          dimension 0 corresponds to number of examples).
+                          The elements of the tuple can be either integers or
+                          slice objects (slice object allows indexing a
+                          range of neurons rather individual ones).
+
+                          If any of the tuple elements is a slice object, the
+                          indexed output tensor is used for attribution. Note
+                          that specifying a slice of a tensor would amount to
+                          computing the attribution of the sum of the specified
+                          neurons, and not the individual neurons independantly.
+
+                        - a callable, which should
+                          take the target layer as input (single tensor or tuple
+                          if multiple tensors are in layer) and return a neuron or
+                          aggregate of the layer's neurons for attribution.
+                          For example, this function could return the
+                          sum of the neurons in the layer or sum of neurons with
+                          activations in a particular range. It is expected that
+                          this function returns either a tensor with one element
+                          or a 1D tensor with length equal to batch_size (one scalar
+                          per input example)
+
             baselines (scalar, tensor, tuple of scalars or tensors, optional):
                         Baselines define reference samples that are compared with
                         the inputs. In order to assign attribution scores DeepLift
@@ -299,7 +309,7 @@ class NeuronDeepLiftShap(NeuronAttribution, GradientAttribution):
     def attribute(
         self,
         inputs: TensorOrTupleOfTensorsGeneric,
-        neuron_selector: Union[int, Tuple[Union[int, slice], ...]],
+        neuron_selector: Union[int, Tuple[Union[int, slice], ...], Callable],
         baselines: Union[
             TensorOrTupleOfTensorsGeneric, Callable[..., TensorOrTupleOfTensorsGeneric]
         ],
@@ -319,21 +329,39 @@ class NeuronDeepLiftShap(NeuronAttribution, GradientAttribution):
                         corresponds to the number of examples (aka batch size),
                         and if multiple input tensors are provided, the examples
                         must be aligned appropriately.
-            neuron_selector (int or tuple): Index of neuron or neurons in output of
-                        given layer for which attribution is desired. Length of
-                        this tuple must be one less than the number of
-                        dimensions in the output of the given layer (since
-                        dimension 0 corresponds to number of examples).
-                        The elements of the tuple can be either integers or
-                        slice objects (slice object also allows indexing a
-                        range of neurons rather individual ones).
-                        An integer may be provided instead of a tuple of
-                        length 1.
-                        If any of the tuple elements is a slice object, the
-                        indexed output tensor is used for attribution. Note
-                        that specifying a slice of a tesnor would amount to
-                        computing the attribution of the sum of the specified
-                        neurons, and not the individual neurons independantly.
+            neuron_selector (int, callable, or tuple of ints or slices):
+                        Selector for neuron
+                        in given layer for which attribution is desired.
+                        Neuron selector can be provided as:
+
+                        - a single integer, if the layer output is 2D. This integer
+                          selects the appropriate neuron column in the layer input
+                          or output
+
+                        - a tuple of integers or slice objects. Length of this
+                          tuple must be one less than the number of dimensions
+                          in the input / output of the given layer (since
+                          dimension 0 corresponds to number of examples).
+                          The elements of the tuple can be either integers or
+                          slice objects (slice object allows indexing a
+                          range of neurons rather individual ones).
+
+                          If any of the tuple elements is a slice object, the
+                          indexed output tensor is used for attribution. Note
+                          that specifying a slice of a tensor would amount to
+                          computing the attribution of the sum of the specified
+                          neurons, and not the individual neurons independantly.
+
+                        - a callable, which should
+                          take the target layer as input (single tensor or tuple
+                          if multiple tensors are in layer) and return a neuron or
+                          aggregate of the layer's neurons for attribution.
+                          For example, this function could return the
+                          sum of the neurons in the layer or sum of neurons with
+                          activations in a particular range. It is expected that
+                          this function returns either a tensor with one element
+                          or a 1D tensor with length equal to batch_size (one scalar
+                          per input example)
             baselines (tensor, tuple of tensors, callable):
                         Baselines define reference samples that are compared with
                         the inputs. In order to assign attribution scores DeepLift

--- a/captum/attr/_core/neuron/neuron_deep_lift.py
+++ b/captum/attr/_core/neuron/neuron_deep_lift.py
@@ -306,6 +306,7 @@ class NeuronDeepLiftShap(NeuronAttribution, GradientAttribution):
         self._multiply_by_inputs = multiply_by_inputs
 
     @log_usage()
+    @neuron_index_deprecation_decorator
     def attribute(
         self,
         inputs: TensorOrTupleOfTensorsGeneric,

--- a/captum/attr/_core/neuron/neuron_feature_ablation.py
+++ b/captum/attr/_core/neuron/neuron_feature_ablation.py
@@ -61,7 +61,7 @@ class NeuronFeatureAblation(NeuronAttribution, PerturbationAttribution):
     def attribute(
         self,
         inputs: TensorOrTupleOfTensorsGeneric,
-        neuron_selector: Union[int, Tuple[int, ...], Callable],
+        neuron_selector: Union[int, Tuple[Union[int, slice], ...], Callable],
         baselines: BaselineType = None,
         additional_forward_args: Any = None,
         feature_mask: Union[None, TensorOrTupleOfTensorsGeneric] = None,
@@ -79,13 +79,39 @@ class NeuronFeatureAblation(NeuronAttribution, PerturbationAttribution):
                         that for all given input tensors, dimension 0 corresponds
                         to the number of examples, and if multiple input tensors
                         are provided, the examples must be aligned appropriately.
-            neuron_selector (int or tuple): Index of neuron in output of given
-                            layer for which attribution is desired. The length of
-                            this tuple must be one less than the number of
-                            dimensions in the output of the given layer (since
-                            dimension 0 corresponds to number of examples).
-                            An integer may be provided instead of a tuple of
-                            length 1.
+            neuron_selector (int, callable, or tuple of ints or slices):
+                        Selector for neuron
+                        in given layer for which attribution is desired.
+                        Neuron selector can be provided as:
+
+                        - a single integer, if the layer output is 2D. This integer
+                          selects the appropriate neuron column in the layer input
+                          or output
+
+                        - a tuple of integers or slice objects. Length of this
+                          tuple must be one less than the number of dimensions
+                          in the input / output of the given layer (since
+                          dimension 0 corresponds to number of examples).
+                          The elements of the tuple can be either integers or
+                          slice objects (slice object allows indexing a
+                          range of neurons rather individual ones).
+
+                          If any of the tuple elements is a slice object, the
+                          indexed output tensor is used for attribution. Note
+                          that specifying a slice of a tensor would amount to
+                          computing the attribution of the sum of the specified
+                          neurons, and not the individual neurons independantly.
+
+                        - a callable, which should
+                          take the target layer as input (single tensor or tuple
+                          if multiple tensors are in layer) and return a neuron or
+                          aggregate of the layer's neurons for attribution.
+                          For example, this function could return the
+                          sum of the neurons in the layer or sum of neurons with
+                          activations in a particular range. It is expected that
+                          this function returns either a tensor with one element
+                          or a 1D tensor with length equal to batch_size (one scalar
+                          per input example)
             baselines (scalar, tensor, tuple of scalars or tensors, optional):
                         Baselines define reference value which replaces each
                         feature when ablated.

--- a/captum/attr/_core/neuron/neuron_gradient.py
+++ b/captum/attr/_core/neuron/neuron_gradient.py
@@ -76,21 +76,39 @@ class NeuronGradient(NeuronAttribution, GradientAttribution):
                         that for all given input tensors, dimension 0 corresponds
                         to the number of examples, and if multiple input tensors
                         are provided, the examples must be aligned appropriately.
-            neuron_selector (int or tuple): Index of neuron or neurons in output of
-                        given layer for which attribution is desired. Length of
-                        this tuple must be one less than the number of
-                        dimensions in the output of the given layer (since
-                        dimension 0 corresponds to number of examples).
-                        The elements of the tuple can be either integers or
-                        slice objects (slice object also allows indexing a
-                        range of neurons rather individual ones).
-                        An integer may be provided instead of a tuple of
-                        length 1.
-                        If any of the tuple elements is a slice object, the
-                        indexed output tensor is used for attribution. Note
-                        that specifying a slice of a tesnor would amount to
-                        computing the attribution of the sum of the specified
-                        neurons, and not the individual neurons independantly.
+            neuron_selector (int, callable, or tuple of ints or slices):
+                        Selector for neuron
+                        in given layer for which attribution is desired.
+                        Neuron selector can be provided as:
+
+                        - a single integer, if the layer output is 2D. This integer
+                          selects the appropriate neuron column in the layer input
+                          or output
+
+                        - a tuple of integers or slice objects. Length of this
+                          tuple must be one less than the number of dimensions
+                          in the input / output of the given layer (since
+                          dimension 0 corresponds to number of examples).
+                          The elements of the tuple can be either integers or
+                          slice objects (slice object allows indexing a
+                          range of neurons rather individual ones).
+
+                          If any of the tuple elements is a slice object, the
+                          indexed output tensor is used for attribution. Note
+                          that specifying a slice of a tensor would amount to
+                          computing the attribution of the sum of the specified
+                          neurons, and not the individual neurons independantly.
+
+                        - a callable, which should
+                          take the target layer as input (single tensor or tuple
+                          if multiple tensors are in layer) and return a neuron or
+                          aggregate of the layer's neurons for attribution.
+                          For example, this function could return the
+                          sum of the neurons in the layer or sum of neurons with
+                          activations in a particular range. It is expected that
+                          this function returns either a tensor with one element
+                          or a 1D tensor with length equal to batch_size (one scalar
+                          per input example)
             additional_forward_args (any, optional): If the forward function
                         requires additional arguments other than the inputs for
                         which attributions should not be computed, this argument

--- a/captum/attr/_core/neuron/neuron_gradient.py
+++ b/captum/attr/_core/neuron/neuron_gradient.py
@@ -18,6 +18,7 @@ from ...._utils.gradient import (
 )
 from ...._utils.typing import TensorOrTupleOfTensorsGeneric
 from ..._utils.attribution import GradientAttribution, NeuronAttribution
+from ..._utils.common import neuron_index_deprecation_decorator
 
 
 class NeuronGradient(NeuronAttribution, GradientAttribution):
@@ -56,10 +57,11 @@ class NeuronGradient(NeuronAttribution, GradientAttribution):
         GradientAttribution.__init__(self, forward_func)
 
     @log_usage()
+    @neuron_index_deprecation_decorator
     def attribute(
         self,
         inputs: TensorOrTupleOfTensorsGeneric,
-        neuron_index: Union[int, Tuple[Union[int, slice], ...]],
+        neuron_selector: Union[int, Tuple[Union[int, slice], ...], Callable],
         additional_forward_args: Any = None,
         attribute_to_neuron_input: bool = False,
     ) -> TensorOrTupleOfTensorsGeneric:
@@ -74,7 +76,7 @@ class NeuronGradient(NeuronAttribution, GradientAttribution):
                         that for all given input tensors, dimension 0 corresponds
                         to the number of examples, and if multiple input tensors
                         are provided, the examples must be aligned appropriately.
-            neuron_index (int or tuple): Index of neuron or neurons in output of
+            neuron_selector (int or tuple): Index of neuron or neurons in output of
                         given layer for which attribution is desired. Length of
                         this tuple must be one less than the number of
                         dimensions in the output of the given layer (since
@@ -154,7 +156,7 @@ class NeuronGradient(NeuronAttribution, GradientAttribution):
             inputs,
             self.layer,
             additional_forward_args,
-            gradient_neuron_index=neuron_index,
+            gradient_neuron_selector=neuron_selector,
             device_ids=self.device_ids,
             attribute_to_layer_input=attribute_to_neuron_input,
         )

--- a/captum/attr/_core/neuron/neuron_gradient_shap.py
+++ b/captum/attr/_core/neuron/neuron_gradient_shap.py
@@ -118,21 +118,39 @@ class NeuronGradientShap(NeuronAttribution, GradientAttribution):
                         that for all given input tensors, dimension 0 corresponds
                         to the number of examples, and if multiple input tensors
                         are provided, the examples must be aligned appropriately.
-            neuron_selector (int or tuple): Index of neuron or neurons in output of
-                        given layer for which attribution is desired. Length of
-                        this tuple must be one less than the number of dimensions
-                        in the output of the given layer (since dimension 0
-                        corresponds to number of examples).
-                        The elements of the tuple can be either integers or slice
-                        objects (slice object also allows indexing a range of
-                        neurons rather individual ones).
-                        An integer may be provided instead of a tuple of
-                        length 1.
-                        If any of the tuple elements is a slice object, the indexed
-                        output tensor is used for attribution. Note that specifying
-                        a slice of a tesnor would amount to computing the attribution
-                        of the sum of the specified neurons, and not the individual
-                        neurons independantly.
+            neuron_selector (int, callable, or tuple of ints or slices):
+                        Selector for neuron
+                        in given layer for which attribution is desired.
+                        Neuron selector can be provided as:
+
+                        - a single integer, if the layer output is 2D. This integer
+                          selects the appropriate neuron column in the layer input
+                          or output
+
+                        - a tuple of integers or slice objects. Length of this
+                          tuple must be one less than the number of dimensions
+                          in the input / output of the given layer (since
+                          dimension 0 corresponds to number of examples).
+                          The elements of the tuple can be either integers or
+                          slice objects (slice object allows indexing a
+                          range of neurons rather individual ones).
+
+                          If any of the tuple elements is a slice object, the
+                          indexed output tensor is used for attribution. Note
+                          that specifying a slice of a tensor would amount to
+                          computing the attribution of the sum of the specified
+                          neurons, and not the individual neurons independantly.
+
+                        - a callable, which should
+                          take the target layer as input (single tensor or tuple
+                          if multiple tensors are in layer) and return a neuron or
+                          aggregate of the layer's neurons for attribution.
+                          For example, this function could return the
+                          sum of the neurons in the layer or sum of neurons with
+                          activations in a particular range. It is expected that
+                          this function returns either a tensor with one element
+                          or a 1D tensor with length equal to batch_size (one scalar
+                          per input example)
             baselines (tensor, tuple of tensors, callable):
                         Baselines define the starting point from which expectation
                         is computed and can be provided as:

--- a/captum/attr/_core/neuron/neuron_guided_backprop_deconvnet.py
+++ b/captum/attr/_core/neuron/neuron_guided_backprop_deconvnet.py
@@ -78,19 +78,39 @@ class NeuronDeconvolution(NeuronAttribution, GradientAttribution):
                         to the number of examples (aka batch size), and if
                         multiple input tensors are provided, the examples must
                         be aligned appropriately.
-            neuron_selector (int or tuple): Index of neuron or neurons in output of
-                        given layer for which attribution is desired. Length of
-                        this tuple must be one less than the number of dimensions
-                        in the output of the given layer (since dimension 0
-                        corresponds to number of examples). The elements of the
-                        tuple can be either integers or slice objects (slice object
-                        also allows indexing a range of neurons rather individual
-                        ones). An integer may be provided instead of a tuple of
-                        length 1. If any of the tuple elements is a slice object,
-                        the indexed output tensor is used for attribution. Note
-                        that specifying a slice of a tesnor would amount to computing
-                        the attribution of the sum of the specified neurons, and not
-                        the individual neurons independantly.
+            neuron_selector (int, callable, or tuple of ints or slices):
+                        Selector for neuron
+                        in given layer for which attribution is desired.
+                        Neuron selector can be provided as:
+
+                        - a single integer, if the layer output is 2D. This integer
+                          selects the appropriate neuron column in the layer input
+                          or output
+
+                        - a tuple of integers or slice objects. Length of this
+                          tuple must be one less than the number of dimensions
+                          in the input / output of the given layer (since
+                          dimension 0 corresponds to number of examples).
+                          The elements of the tuple can be either integers or
+                          slice objects (slice object allows indexing a
+                          range of neurons rather individual ones).
+
+                          If any of the tuple elements is a slice object, the
+                          indexed output tensor is used for attribution. Note
+                          that specifying a slice of a tensor would amount to
+                          computing the attribution of the sum of the specified
+                          neurons, and not the individual neurons independantly.
+
+                        - a callable, which should
+                          take the target layer as input (single tensor or tuple
+                          if multiple tensors are in layer) and return a neuron or
+                          aggregate of the layer's neurons for attribution.
+                          For example, this function could return the
+                          sum of the neurons in the layer or sum of neurons with
+                          activations in a particular range. It is expected that
+                          this function returns either a tensor with one element
+                          or a 1D tensor with length equal to batch_size (one scalar
+                          per input example)
             additional_forward_args (any, optional): If the forward function
                         requires additional arguments other than the inputs for
                         which attributions should not be computed, this argument

--- a/captum/attr/_core/neuron/neuron_guided_backprop_deconvnet.py
+++ b/captum/attr/_core/neuron/neuron_guided_backprop_deconvnet.py
@@ -213,6 +213,7 @@ class NeuronGuidedBackprop(NeuronAttribution, GradientAttribution):
         self.guided_backprop = GuidedBackprop(model)
 
     @log_usage()
+    @neuron_index_deprecation_decorator
     def attribute(
         self,
         inputs: TensorOrTupleOfTensorsGeneric,

--- a/captum/attr/_core/neuron/neuron_guided_backprop_deconvnet.py
+++ b/captum/attr/_core/neuron/neuron_guided_backprop_deconvnet.py
@@ -212,19 +212,39 @@ class NeuronGuidedBackprop(NeuronAttribution, GradientAttribution):
                         to the number of examples (aka batch size), and if
                         multiple input tensors are provided, the examples must
                         be aligned appropriately.
-            neuron_selector (int or tuple): Index of neuron or neurons in output of
-                        given layer for which attribution is desired. Length of
-                        this tuple must be one less than the number of dimensions
-                        in the output of the given layer (since dimension 0
-                        corresponds to number of examples). The elements of the
-                        tuple can be either integers or slice objects (slice object
-                        also allows indexing a range of neurons rather individual
-                        ones). An integer may be provided instead of a tuple of
-                        length 1. If any of the tuple elements is a slice object,
-                        the indexed output tensor is used for attribution. Note
-                        that specifying a slice of a tesnor would amount to computing
-                        the attribution of the sum of the specified neurons, and not
-                        the individual neurons independantly.
+            neuron_selector (int, callable, or tuple of ints or slices):
+                        Selector for neuron
+                        in given layer for which attribution is desired.
+                        Neuron selector can be provided as:
+
+                        - a single integer, if the layer output is 2D. This integer
+                          selects the appropriate neuron column in the layer input
+                          or output
+
+                        - a tuple of integers or slice objects. Length of this
+                          tuple must be one less than the number of dimensions
+                          in the input / output of the given layer (since
+                          dimension 0 corresponds to number of examples).
+                          The elements of the tuple can be either integers or
+                          slice objects (slice object allows indexing a
+                          range of neurons rather individual ones).
+
+                          If any of the tuple elements is a slice object, the
+                          indexed output tensor is used for attribution. Note
+                          that specifying a slice of a tensor would amount to
+                          computing the attribution of the sum of the specified
+                          neurons, and not the individual neurons independantly.
+
+                        - a callable, which should
+                          take the target layer as input (single tensor or tuple
+                          if multiple tensors are in layer) and return a neuron or
+                          aggregate of the layer's neurons for attribution.
+                          For example, this function could return the
+                          sum of the neurons in the layer or sum of neurons with
+                          activations in a particular range. It is expected that
+                          this function returns either a tensor with one element
+                          or a 1D tensor with length equal to batch_size (one scalar
+                          per input example)
             additional_forward_args (any, optional): If the forward function
                         requires additional arguments other than the inputs for
                         which attributions should not be computed, this argument

--- a/captum/attr/_core/neuron/neuron_integrated_gradients.py
+++ b/captum/attr/_core/neuron/neuron_integrated_gradients.py
@@ -96,21 +96,39 @@ class NeuronIntegratedGradients(NeuronAttribution, GradientAttribution):
                         that for all given input tensors, dimension 0 corresponds
                         to the number of examples, and if multiple input tensors
                         are provided, the examples must be aligned appropriately.
-            neuron_selector (int or tuple): Index of neuron or neurons in output of
-                            given layer for which attribution is desired. Length
-                            of this tuple must be one less than the number of
-                            dimensions in the output of the given layer (since
-                            dimension 0 corresponds to number of examples).
-                            The elements of the tuple can be either integers or
-                            slice objects (slice object also allows indexing a
-                            range of neurons rather individual ones).
-                            An integer may be provided instead of a tuple of
-                            length 1.
-                            If any of the tuple elements is a slice object, the
-                            indexed output tensor is used for attribution. Note
-                            that specifying a slice of a tesnor would amount to
-                            computing the attribution of the sum of the specified
-                            neurons, and not the individual neurons independantly.
+            neuron_selector (int, callable, or tuple of ints or slices):
+                        Selector for neuron
+                        in given layer for which attribution is desired.
+                        Neuron selector can be provided as:
+
+                        - a single integer, if the layer output is 2D. This integer
+                          selects the appropriate neuron column in the layer input
+                          or output
+
+                        - a tuple of integers or slice objects. Length of this
+                          tuple must be one less than the number of dimensions
+                          in the input / output of the given layer (since
+                          dimension 0 corresponds to number of examples).
+                          The elements of the tuple can be either integers or
+                          slice objects (slice object allows indexing a
+                          range of neurons rather individual ones).
+
+                          If any of the tuple elements is a slice object, the
+                          indexed output tensor is used for attribution. Note
+                          that specifying a slice of a tensor would amount to
+                          computing the attribution of the sum of the specified
+                          neurons, and not the individual neurons independantly.
+
+                        - a callable, which should
+                          take the target layer as input (single tensor or tuple
+                          if multiple tensors are in layer) and return a neuron or
+                          aggregate of the layer's neurons for attribution.
+                          For example, this function could return the
+                          sum of the neurons in the layer or sum of neurons with
+                          activations in a particular range. It is expected that
+                          this function returns either a tensor with one element
+                          or a 1D tensor with length equal to batch_size (one scalar
+                          per input example)
             baselines (scalar, tensor, tuple of scalars or tensors, optional):
                         Baselines define the starting point from which integral
                         is computed.

--- a/captum/attr/_utils/attribution.py
+++ b/captum/attr/_utils/attribution.py
@@ -461,7 +461,7 @@ class NeuronAttribution(InternalAttribution):
     Args:
 
             inputs:     A single high dimensional input tensor or a tuple of them.
-            neuron_index (int or tuple): Tuple providing index of neuron in output
+            neuron_selector (int or tuple): Tuple providing index of neuron in output
                     of given layer for which attribution is desired. Length of
                     this tuple must be one less than the number of
                     dimensions in the output of the given layer (since

--- a/captum/attr/_utils/common.py
+++ b/captum/attr/_utils/common.py
@@ -358,7 +358,7 @@ def neuron_index_deprecation_decorator(func):
             kwargs["neuron_selector"] = kwargs["neuron_index"]
             warnings.warn(
                 "neuron_index is being deprecated and replaced with neuron_selector "
-                "to support more general functionality, please update the parameter "
+                "to support more general functionality. Please update the parameter "
                 "name to neuron_selector. Support for neuron_index will be removed "
                 "in Captum 0.4.0",
                 DeprecationWarning,

--- a/captum/attr/_utils/common.py
+++ b/captum/attr/_utils/common.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
+import functools
 import typing
+import warnings
 from inspect import signature
 from typing import TYPE_CHECKING, Any, Callable, List, Tuple, Union
 
@@ -343,3 +345,25 @@ def _find_output_mode_and_verify(
             isinstance(initial_eval, torch.Tensor) and initial_eval[0].numel() == 1
         ), "Target should identify a single element in the model output."
     return agg_output_mode
+
+
+def neuron_index_deprecation_decorator(func):
+    r"""
+    Decorator to deprecate neuron_index parameter for Neuron Attribution methods.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        if "neuron_index" in kwargs:
+            kwargs["neuron_selector"] = kwargs["neuron_index"]
+            warnings.warn(
+                "neuron_index is being deprecated and replaced with neuron_selector "
+                "to support more general functionality, please update the parameter "
+                "name to neuron_selector. Support for neuron_index will be removed "
+                "in Captum 0.4.0",
+                DeprecationWarning,
+            )
+            del kwargs["neuron_index"]
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/tests/attr/helpers/test_config.py
+++ b/tests/attr/helpers/test_config.py
@@ -848,7 +848,7 @@ config = [
         ],
         "model": BasicModel_MultiLayer(),
         "layer": "relu",
-        "attribute_args": {"inputs": torch.randn(4, 3), "neuron_index": 3},
+        "attribute_args": {"inputs": torch.randn(4, 3), "neuron_selector": 3},
     },
     {
         "name": "conv_neuron",
@@ -864,7 +864,7 @@ config = [
         "layer": "conv2",
         "attribute_args": {
             "inputs": 100 * torch.randn(4, 1, 10, 10),
-            "neuron_index": (0, 1, 0),
+            "neuron_selector": (0, 1, 0),
         },
     },
     {
@@ -882,7 +882,7 @@ config = [
         "attribute_args": {
             "inputs": (10 * torch.randn(12, 3), 5 * torch.randn(12, 3)),
             "additional_forward_args": (2 * torch.randn(12, 3), 5),
-            "neuron_index": (3,),
+            "neuron_selector": (3,),
         },
     },
     # Neuron Conductance (with target)
@@ -891,7 +891,11 @@ config = [
         "algorithms": [NeuronConductance],
         "model": BasicModel_MultiLayer(),
         "layer": "relu",
-        "attribute_args": {"inputs": torch.randn(4, 3), "target": 1, "neuron_index": 3},
+        "attribute_args": {
+            "inputs": torch.randn(4, 3),
+            "target": 1,
+            "neuron_selector": 3,
+        },
     },
     {
         "name": "basic_neuron_multiple_target",
@@ -901,7 +905,7 @@ config = [
         "attribute_args": {
             "inputs": torch.randn(4, 3),
             "target": [0, 1, 1, 0],
-            "neuron_index": 3,
+            "neuron_selector": 3,
         },
     },
     {
@@ -912,7 +916,7 @@ config = [
         "attribute_args": {
             "inputs": 100 * torch.randn(4, 1, 10, 10),
             "target": 1,
-            "neuron_index": (0, 1, 0),
+            "neuron_selector": (0, 1, 0),
         },
     },
     {
@@ -924,7 +928,7 @@ config = [
             "inputs": (10 * torch.randn(6, 3), 5 * torch.randn(6, 3)),
             "additional_forward_args": (2 * torch.randn(6, 3), 5),
             "target": [0, 1, 1, 0, 0, 1],
-            "neuron_index": 3,
+            "neuron_selector": 3,
         },
     },
     {
@@ -935,7 +939,7 @@ config = [
         "attribute_args": {
             "inputs": torch.randn(4, 3),
             "target": torch.tensor([0, 1, 1, 0]),
-            "neuron_index": 3,
+            "neuron_selector": 3,
         },
     },
     {
@@ -947,7 +951,7 @@ config = [
             "inputs": torch.randn(4, 3),
             "target": [(1, 0, 0), (0, 1, 1), (1, 1, 1), (0, 0, 0)],
             "additional_forward_args": (None, True),
-            "neuron_index": 3,
+            "neuron_selector": 3,
         },
     },
     # Neuron Conductance with Internal Batching
@@ -961,7 +965,7 @@ config = [
             "target": [(1, 0, 0), (0, 1, 1), (1, 1, 1), (0, 0, 0)],
             "additional_forward_args": (None, True),
             "internal_batch_size": 2,
-            "neuron_index": 3,
+            "neuron_selector": 3,
         },
     },
     {
@@ -974,7 +978,7 @@ config = [
             "additional_forward_args": (2 * torch.randn(6, 3), 5),
             "target": [0, 1, 1, 0, 0, 1],
             "internal_batch_size": 2,
-            "neuron_index": 3,
+            "neuron_selector": 3,
         },
     },
     # Neuron Gradient SHAP
@@ -986,7 +990,7 @@ config = [
         "attribute_args": {
             "inputs": torch.randn(4, 3),
             "baselines": torch.randn(1, 3),
-            "neuron_index": 3,
+            "neuron_selector": 3,
         },
         "target_delta": 0.6,
         "baseline_distr": True,
@@ -1000,7 +1004,7 @@ config = [
             "inputs": (10 * torch.randn(6, 3), 5 * torch.randn(6, 3)),
             "baselines": (10 * torch.randn(1, 3), 5 * torch.randn(1, 3)),
             "additional_forward_args": (2 * torch.randn(6, 3), 5),
-            "neuron_index": 3,
+            "neuron_selector": 3,
         },
         "target_delta": 0.6,
         "baseline_distr": True,
@@ -1014,7 +1018,7 @@ config = [
         "attribute_args": {
             "inputs": torch.randn(4, 3),
             "baselines": 0.5 * torch.randn(6, 3),
-            "neuron_index": (3,),
+            "neuron_selector": (3,),
         },
         "baseline_distr": True,
     },
@@ -1027,7 +1031,7 @@ config = [
             "inputs": (10 * torch.randn(12, 3), 5 * torch.randn(12, 3)),
             "baselines": (torch.randn(4, 3), torch.randn(4, 3)),
             "additional_forward_args": (2 * torch.randn(12, 3), 5),
-            "neuron_index": 3,
+            "neuron_selector": 3,
         },
         "baseline_distr": True,
     },
@@ -1040,7 +1044,7 @@ config = [
         "attribute_args": {
             "inputs": torch.arange(400).view(4, 1, 10, 10).float(),
             "perturbations_per_eval": 20,
-            "neuron_index": (0, 1, 0),
+            "neuron_selector": (0, 1, 0),
         },
     },
     {
@@ -1052,8 +1056,45 @@ config = [
             "inputs": (10 * torch.randn(12, 3), 5 * torch.randn(12, 3)),
             "baselines": (10 * torch.randn(12, 3), 5 * torch.randn(12, 3)),
             "additional_forward_args": (2 * torch.randn(12, 3), 5),
-            "neuron_index": (3,),
+            "neuron_selector": (3,),
             "perturbations_per_eval": 2,
+        },
+    },
+    # Neuron Attribution with Functional Selector
+    {
+        "name": "basic_neuron_multi_input_function_selector",
+        "algorithms": [
+            NeuronGradient,
+            NeuronIntegratedGradients,
+            NeuronGuidedBackprop,
+            NeuronDeconvolution,
+            NeuronDeepLift,
+            NeuronFeatureAblation,
+        ],
+        "model": BasicModel_MultiLayer_MultiInput(),
+        "layer": "model.relu",
+        "attribute_args": {
+            "inputs": (10 * torch.randn(12, 3), 5 * torch.randn(12, 3)),
+            "additional_forward_args": (2 * torch.randn(12, 3), 5),
+            "neuron_selector": lambda x: torch.sum(x, 1),
+        },
+    },
+    # Neuron Attribution with slice Selector
+    {
+        "name": "conv_neuron_slice_selector",
+        "algorithms": [
+            NeuronGradient,
+            NeuronIntegratedGradients,
+            NeuronGuidedBackprop,
+            NeuronDeconvolution,
+            NeuronDeepLift,
+            NeuronFeatureAblation,
+        ],
+        "model": BasicModel_ConvNet(),
+        "layer": "conv2",
+        "attribute_args": {
+            "inputs": 100 * torch.randn(4, 1, 10, 10),
+            "neuron_selector": (slice(0, 2, 1), 1, slice(0, 2, 1)),
         },
     },
     # Layer Attribution with Multiple Layers

--- a/tests/attr/neuron/test_neuron_ablation.py
+++ b/tests/attr/neuron/test_neuron_ablation.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import unittest
-from typing import Any, List, Tuple, Union
+from typing import Any, Callable, List, Tuple, Union
 
 import torch
 from torch import Tensor
@@ -42,6 +42,20 @@ class Test(BaseTest):
             [[41.0, 41.0, 12.0], [280.0, 280.0, 120.0]],
             feature_mask=mask,
             perturbations_per_eval=(1, 2, 3),
+        )
+
+    def test_multi_sample_ablation_with_selector_fn(self) -> None:
+        net = BasicModel_MultiLayer()
+        inp = torch.tensor([[2.0, 10.0, 3.0], [20.0, 50.0, 30.0]], requires_grad=True)
+        mask = torch.tensor([[0, 0, 1], [1, 1, 0]])
+        self._ablation_test_assert(
+            net,
+            net.linear2,
+            inp,
+            [[82.0, 82.0, 24.0], [560.0, 560.0, 240.0]],
+            feature_mask=mask,
+            perturbations_per_eval=(1, 2, 3),
+            neuron_selector=lambda x: torch.sum(x, dim=1),
         )
 
     def test_multi_input_ablation_with_mask(self) -> None:
@@ -172,7 +186,7 @@ class Test(BaseTest):
             (torch.zeros_like(inp), torch.zeros_like(inp2)),
             feature_mask=(torch.tensor(0), torch.tensor(1)),
             perturbations_per_eval=(1, 2, 4, 8, 12, 16),
-            neuron_index=(1, 0, 0),
+            neuron_selector=(1, 0, 0),
         )
         self._ablation_test_assert(
             net,
@@ -181,7 +195,7 @@ class Test(BaseTest):
             (45 * torch.ones_like(inp), 9 * torch.ones_like(inp2)),
             feature_mask=(torch.tensor(0), torch.tensor(1)),
             perturbations_per_eval=(1, 2, 4, 8, 12, 16),
-            neuron_index=(1, 0, 0),
+            neuron_selector=(1, 0, 0),
             attribute_to_neuron_input=True,
         )
         self._ablation_test_assert(
@@ -203,7 +217,7 @@ class Test(BaseTest):
                 ],
             ),
             perturbations_per_eval=(1, 3, 7, 14),
-            neuron_index=(1, 0, 0),
+            neuron_selector=(1, 0, 0),
             attribute_to_neuron_input=True,
         )
 
@@ -222,7 +236,7 @@ class Test(BaseTest):
         additional_input: Any = None,
         perturbations_per_eval: Tuple[int, ...] = (1,),
         baselines: BaselineType = None,
-        neuron_index: Union[int, Tuple[int, ...]] = 0,
+        neuron_selector: Union[int, Tuple[int, ...], Callable] = 0,
         attribute_to_neuron_input: bool = False,
     ) -> None:
         for batch_size in perturbations_per_eval:
@@ -230,7 +244,7 @@ class Test(BaseTest):
             self.assertTrue(ablation.multiplies_by_inputs)
             attributions = ablation.attribute(
                 test_input,
-                neuron_index=neuron_index,
+                neuron_selector=neuron_selector,
                 feature_mask=feature_mask,
                 additional_forward_args=additional_input,
                 baselines=baselines,

--- a/tests/attr/neuron/test_neuron_ablation.py
+++ b/tests/attr/neuron/test_neuron_ablation.py
@@ -58,6 +58,20 @@ class Test(BaseTest):
             neuron_selector=lambda x: torch.sum(x, dim=1),
         )
 
+    def test_multi_sample_ablation_with_slice(self) -> None:
+        net = BasicModel_MultiLayer()
+        inp = torch.tensor([[2.0, 10.0, 3.0], [20.0, 50.0, 30.0]], requires_grad=True)
+        mask = torch.tensor([[0, 0, 1], [1, 1, 0]])
+        self._ablation_test_assert(
+            net,
+            net.linear2,
+            inp,
+            [[82.0, 82.0, 24.0], [560.0, 560.0, 240.0]],
+            feature_mask=mask,
+            perturbations_per_eval=(1, 2, 3),
+            neuron_selector=(slice(0, 2, 1),),
+        )
+
     def test_multi_input_ablation_with_mask(self) -> None:
         net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[23.0, 100.0, 0.0], [20.0, 50.0, 30.0]])
@@ -236,7 +250,7 @@ class Test(BaseTest):
         additional_input: Any = None,
         perturbations_per_eval: Tuple[int, ...] = (1,),
         baselines: BaselineType = None,
-        neuron_selector: Union[int, Tuple[int, ...], Callable] = 0,
+        neuron_selector: Union[int, Tuple[Union[int, slice], ...], Callable] = 0,
         attribute_to_neuron_input: bool = False,
     ) -> None:
         for batch_size in perturbations_per_eval:

--- a/tests/attr/neuron/test_neuron_deeplift.py
+++ b/tests/attr/neuron/test_neuron_deeplift.py
@@ -140,6 +140,13 @@ class Test(BaseTest):
         assertTensorAlmostEqual(self, attributions[0], [[-0.0, 0.0, -0.0]])
         assertTensorAlmostEqual(self, attributions[1], [[2.0, 3.0, 0.0]])
 
+        attributions = neuron_dl.attribute(
+            inputs, lambda x: x[:, 0], baselines, attribute_to_neuron_input=False
+        )
+
+        assertTensorAlmostEqual(self, attributions[0], [[-0.0, 0.0, -0.0]])
+        assertTensorAlmostEqual(self, attributions[1], [[2.0, 3.0, 0.0]])
+
     def test_relu_deepliftshap_with_custom_attr_func(self) -> None:
         model = ReLULinearModel()
         (
@@ -176,12 +183,12 @@ class Test(BaseTest):
 
         model = LinearMaxPoolLinearModel()
         ndl = NeuronDeepLift(model, model.pool1)
-        attr = ndl.attribute(inputs, neuron_index=(0), baselines=baselines)
+        attr = ndl.attribute(inputs, neuron_selector=(0), baselines=baselines)
 
         ndl2 = NeuronDeepLift(model, model.lin2)
         attr2 = ndl2.attribute(
             inputs,
-            neuron_index=(0),
+            neuron_selector=(0),
             baselines=baselines,
             attribute_to_neuron_input=True,
         )
@@ -192,11 +199,11 @@ class Test(BaseTest):
         model = BasicModel_ConvNet()
 
         ndl = NeuronDeepLift(model, model.pool1)
-        attr = ndl.attribute(inputs, neuron_index=(0, 0, 0))
+        attr = ndl.attribute(inputs, neuron_selector=(0, 0, 0))
 
         ndl2 = NeuronDeepLift(model, model.conv2)
         attr2 = ndl2.attribute(
-            inputs, neuron_index=(0, 0, 0), attribute_to_neuron_input=True
+            inputs, neuron_selector=(0, 0, 0), attribute_to_neuron_input=True
         )
 
         assertTensorAlmostEqual(self, attr.sum(), attr2.sum())
@@ -206,11 +213,11 @@ class Test(BaseTest):
         model = BasicModel_ConvNet_MaxPool3d()
 
         ndl = NeuronDeepLift(model, model.pool1)
-        attr = ndl.attribute(inputs, neuron_index=(0, 0, 0, 0))
+        attr = ndl.attribute(inputs, neuron_selector=(0, 0, 0, 0))
 
         ndl2 = NeuronDeepLift(model, model.conv2)
         attr2 = ndl2.attribute(
-            inputs, neuron_index=(0, 0, 0, 0), attribute_to_neuron_input=True
+            inputs, neuron_selector=(0, 0, 0, 0), attribute_to_neuron_input=True
         )
 
         assertTensorAlmostEqual(self, attr.sum(), attr2.sum())

--- a/tests/attr/neuron/test_neuron_gradient.py
+++ b/tests/attr/neuron/test_neuron_gradient.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import unittest
-from typing import Any, List, Tuple, Union, cast
+from typing import Any, Callable, List, Tuple, Union, cast
 
 import torch
 from torch import Tensor
@@ -25,6 +25,17 @@ from ...helpers.basic_models import (
 
 
 class Test(BaseTest):
+    def test_neuron_index_deprecated_warning(self) -> None:
+        net = BasicModel_MultiLayer()
+        grad = NeuronGradient(net, net.linear2)
+        inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
+        with self.assertWarns(DeprecationWarning):
+            attributions = grad.attribute(
+                inp,
+                neuron_index=(0,),
+            )
+        assertTensorTuplesAlmostEqual(self, attributions, [4.0, 4.0, 4.0])
+
     def test_simple_gradient_input_linear2(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
@@ -56,6 +67,13 @@ class Test(BaseTest):
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 5.0, 4.0]])
         self._gradient_input_test_assert(net, net.relu, inp, 1, [1.0, 1.0, 1.0])
+
+    def test_simple_gradient_input_relu_selector_fn(self) -> None:
+        net = BasicModel_MultiLayer()
+        inp = torch.tensor([[0.0, 5.0, 4.0]])
+        self._gradient_input_test_assert(
+            net, net.relu, inp, lambda x: torch.sum(x), [3.0, 3.0, 3.0]
+        )
 
     def test_simple_gradient_input_relu2_agg_neurons(self) -> None:
         net = BasicModel_MultiLayer()
@@ -107,7 +125,7 @@ class Test(BaseTest):
         model: Module,
         target_layer: Module,
         test_input: TensorOrTupleOfTensorsGeneric,
-        test_neuron_index: Union[int, Tuple[Union[int, slice], ...]],
+        test_neuron_selector: Union[int, Tuple[Union[int, slice], ...], Callable],
         expected_input_gradient: Union[List[float], Tuple[List[float], ...]],
         additional_input: Any = None,
         attribute_to_neuron_input: bool = False,
@@ -115,7 +133,7 @@ class Test(BaseTest):
         grad = NeuronGradient(model, target_layer)
         attributions = grad.attribute(
             test_input,
-            test_neuron_index,
+            test_neuron_selector,
             additional_forward_args=additional_input,
             attribute_to_neuron_input=attribute_to_neuron_input,
         )

--- a/tests/attr/neuron/test_neuron_gradient_shap.py
+++ b/tests/attr/neuron/test_neuron_gradient_shap.py
@@ -46,6 +46,9 @@ class Test(BaseTest):
         self._assert_attributions(
             model, model.linear1, inputs, baselines, (slice(0, 1, 1),), 60
         )
+        self._assert_attributions(
+            model, model.linear1, inputs, baselines, lambda x: x[:, 0:1], 60
+        )
 
     def test_classification(self) -> None:
         def custom_baseline_fn(inputs: Tensor) -> Tensor:
@@ -70,7 +73,7 @@ class Test(BaseTest):
         layer: Module,
         inputs: Tensor,
         baselines: Union[Tensor, Callable[..., Tensor]],
-        neuron_ind: Union[int, Tuple[Union[int, slice], ...]],
+        neuron_ind: Union[int, Tuple[Union[int, slice], ...], Callable],
         n_samples: int = 5,
     ) -> None:
         ngs = NeuronGradientShap(model, layer)

--- a/tests/attr/neuron/test_neuron_integrated_gradients.py
+++ b/tests/attr/neuron/test_neuron_integrated_gradients.py
@@ -109,6 +109,23 @@ class Test(BaseTest):
             (inp3, 0.5),
         )
 
+    def test_simple_ig_multi_input_relu_batch_selector_fn(self) -> None:
+        net = BasicModel_MultiLayer_MultiInput()
+        inp1 = torch.tensor([[0.0, 6.0, 14.0], [0.0, 80.0, 0.0]])
+        inp2 = torch.tensor([[0.0, 6.0, 14.0], [0.0, 20.0, 0.0]])
+        inp3 = torch.tensor([[0.0, 0.0, 0.0], [0.0, 20.0, 0.0]])
+        self._ig_input_test_assert(
+            net,
+            net.model.relu,
+            (inp1, inp2),
+            lambda x: torch.sum(x),
+            (
+                [[0.0, 10.5, 24.5], [0.0, 160.0, 0.0]],
+                [[0.0, 10.5, 24.5], [0.0, 40.0, 0.0]],
+            ),
+            (inp3, 0.5),
+        )
+
     def test_matching_output_gradient(self) -> None:
         net = BasicModel_ConvNet()
         inp = 100 * torch.randn(2, 1, 10, 10, requires_grad=True)

--- a/tests/attr/neuron/test_neuron_integrated_gradients.py
+++ b/tests/attr/neuron/test_neuron_integrated_gradients.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import unittest
-from typing import Any, List, Tuple, Union
+from typing import Any, Callable, List, Tuple, Union
 
 import torch
 from torch import Tensor
@@ -52,6 +52,13 @@ class Test(BaseTest):
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 5.0, 4.0]])
         self._ig_input_test_assert(net, net.relu, inp, 1, [0.0, 5.0, 4.0])
+
+    def test_simple_ig_input_relu_selector_fn(self) -> None:
+        net = BasicModel_MultiLayer()
+        inp = torch.tensor([[0.0, 5.0, 4.0]])
+        self._ig_input_test_assert(
+            net, net.relu, inp, lambda x: torch.sum(x[:, 2:]), [0.0, 10.0, 8.0]
+        )
 
     def test_simple_ig_input_relu2_agg_neurons(self) -> None:
         net = BasicModel_MultiLayer()
@@ -113,7 +120,7 @@ class Test(BaseTest):
         model: Module,
         target_layer: Module,
         test_input: TensorOrTupleOfTensorsGeneric,
-        test_neuron: Union[int, Tuple[Union[int, slice], ...]],
+        test_neuron: Union[int, Tuple[Union[int, slice], ...], Callable],
         expected_input_ig: Union[List[float], Tuple[List[List[float]], ...]],
         additional_input: Any = None,
         multiply_by_inputs: bool = True,

--- a/tests/attr/test_deconvolution.py
+++ b/tests/attr/test_deconvolution.py
@@ -101,7 +101,7 @@ class Test(BaseTest):
         self,
         model: Module,
         layer: Module,
-        neuron_index: Union[int, Tuple[Union[int, slice], ...]],
+        neuron_selector: Union[int, Tuple[Union[int, slice], ...]],
         test_input: TensorOrTupleOfTensorsGeneric,
         expected: Tuple[List[List[float]], ...],
         additional_input: Any = None,
@@ -109,7 +109,7 @@ class Test(BaseTest):
         deconv = NeuronDeconvolution(model, layer)
         attributions = deconv.attribute(
             test_input,
-            neuron_index=neuron_index,
+            neuron_selector=neuron_selector,
             additional_forward_args=additional_input,
         )
         for i in range(len(test_input)):

--- a/tests/attr/test_guided_backprop.py
+++ b/tests/attr/test_guided_backprop.py
@@ -101,7 +101,7 @@ class Test(BaseTest):
         self,
         model: Module,
         layer: Module,
-        neuron_index: Union[int, Tuple[Union[int, slice], ...]],
+        neuron_selector: Union[int, Tuple[Union[int, slice], ...]],
         test_input: TensorOrTupleOfTensorsGeneric,
         expected: Tuple[List[List[float]], ...],
         additional_input: Any = None,
@@ -109,7 +109,7 @@ class Test(BaseTest):
         guided_backprop = NeuronGuidedBackprop(model, layer)
         attributions = guided_backprop.attribute(
             test_input,
-            neuron_index=neuron_index,
+            neuron_selector=neuron_selector,
             additional_forward_args=additional_input,
         )
         for i in range(len(test_input)):

--- a/tests/attr/test_hook_removal.py
+++ b/tests/attr/test_hook_removal.py
@@ -27,7 +27,7 @@ class HookRemovalMode(Enum):
     `normal` - Verifies no hooks remain after running an attribution method
     normally
     `incorrect_target_or_neuron` - Verifies no hooks remain after an incorrect
-    target and neuron_index are provided, which causes an assertion error
+    target and neuron_selector are provided, which causes an assertion error
     in the algorithm.
     `invalid_module` - Verifies no hooks remain after an invalid module
     is executed, which causes an assertion error in model execution.
@@ -137,8 +137,8 @@ class HookRemovalMeta(type):
                 if "target" in args:
                     args["target"] = (9999,) * 20
                     expect_error = True
-                if "neuron_index" in args:
-                    args["neuron_index"] = (9999,) * 20
+                if "neuron_selector" in args:
+                    args["neuron_selector"] = (9999,) * 20
                     expect_error = True
 
             if expect_error:

--- a/tutorials/Titanic_Basic_Interpret.ipynb
+++ b/tutorials/Titanic_Basic_Interpret.ipynb
@@ -696,7 +696,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "neuron_cond_vals_10 = neuron_cond.attribute(test_input_tensor, neuron_index=10, target=1)"
+    "neuron_cond_vals_10 = neuron_cond.attribute(test_input_tensor, neuron_selector=10, target=1)"
    ]
   },
   {
@@ -705,7 +705,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "neuron_cond_vals_0 = neuron_cond.attribute(test_input_tensor, neuron_index=0, target=1)"
+    "neuron_cond_vals_0 = neuron_cond.attribute(test_input_tensor, neuron_selector=0, target=1)"
    ]
   },
   {


### PR DESCRIPTION
This adds support for neuron aggregation, neuron_selector can be a function which returns a custom aggregate of a layer's neurons for all neuron methods other than neuron conductance, which has dependence on output gradients. The neuron_index argument was renamed, and a deprecation decorator was added to provide a warning for usage of the old parameter as a keyword argument. This decorator can be removed prior to the 0.4.0 release.

Documentation of the new callable functionality has been added to NeuronDeepLift, this documentation will be propagated to other relevant methods after review.