### PR TITLE
GradCAM Test Fix

### DIFF
--- a/tests/attr/layer/test_grad_cam.py
+++ b/tests/attr/layer/test_grad_cam.py
@@ -48,9 +48,9 @@ class Test(BaseTest):
     def test_simple_input_conv_without_final_relu(self) -> None:
         net = BasicModel_ConvNet_One_Conv()
         inp = torch.arange(16).view(1, 1, 4, 4).float()
-        inp.requires_grad_()
         # Adding negative value to test final relu is not applied by default
         inp[0, 0, 1, 1] = -4.0
+        inp.requires_grad_()
         self._grad_cam_test_assert(
             net, net.conv1, inp, (0.5625 * inp,), attribute_to_layer_input=True
         )
@@ -58,9 +58,9 @@ class Test(BaseTest):
     def test_simple_input_conv_fc_with_final_relu(self) -> None:
         net = BasicModel_ConvNet_One_Conv()
         inp = torch.arange(16).view(1, 1, 4, 4).float()
-        inp.requires_grad_()
         # Adding negative value to test final relu is applied
         inp[0, 0, 1, 1] = -4.0
+        inp.requires_grad_()
         exp = 0.5625 * inp
         exp[0, 0, 1, 1] = 0.0
         self._grad_cam_test_assert(


### PR DESCRIPTION
Latest PyTorch is causing test failures in GradCam, since in-place modification of a tensor requiring grad now fails (https://github.com/pytorch/pytorch/pull/46204). Updates to set requires grad after in-place modification.