### PR TITLE
Minor fixes in layer_gradient_x_activation and saliency

### DIFF
--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -33,7 +33,11 @@ def apply_gradient_requirements(inputs: Tuple[Tensor, ...]) -> List[bool]:
         assert isinstance(input, torch.Tensor), "Given input is not a torch.Tensor"
         grad_required.append(input.requires_grad)
         inputs_dtype = input.dtype
-        if not inputs_dtype.is_floating_point and not inputs_dtype.is_complex:
+        # Note: torch 1.2 doesn't support is_complex for dtype, this we check on the
+        # existance of is_complex method.
+        if not inputs_dtype.is_floating_point and not (
+            hasattr(inputs_dtype, "is_complex") and inputs_dtype.is_complex
+        ):
             warnings.warn(
                 """Input Tensor %d has a dtype of %s.
                 Gradients cannot be activated

--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -32,7 +32,14 @@ def apply_gradient_requirements(inputs: Tuple[Tensor, ...]) -> List[bool]:
     for index, input in enumerate(inputs):
         assert isinstance(input, torch.Tensor), "Given input is not a torch.Tensor"
         grad_required.append(input.requires_grad)
-        if not input.requires_grad:
+        inputs_dtype = input.dtype
+        if inputs_dtype == torch.long or inputs_dtype == torch.int:
+            warnings.warn(
+                "Input Tensor %d has a dtype of either torch.int "
+                "or torch.long. Gradients cannot "
+                "be activated for these data types." % index
+            )
+        elif not input.requires_grad:
             warnings.warn(
                 "Input Tensor %d did not already require gradients, "
                 "required_grads has been set automatically." % index

--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -33,8 +33,8 @@ def apply_gradient_requirements(inputs: Tuple[Tensor, ...]) -> List[bool]:
         assert isinstance(input, torch.Tensor), "Given input is not a torch.Tensor"
         grad_required.append(input.requires_grad)
         inputs_dtype = input.dtype
-        # Note: torch 1.2 doesn't support is_complex for dtype, this we check on the
-        # existance of is_complex method.
+        # Note: torch 1.2 doesn't support is_complex for dtype that's why we check
+        # on the existance of is_complex method.
         if not inputs_dtype.is_floating_point and not (
             hasattr(inputs_dtype, "is_complex") and inputs_dtype.is_complex
         ):

--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -33,11 +33,12 @@ def apply_gradient_requirements(inputs: Tuple[Tensor, ...]) -> List[bool]:
         assert isinstance(input, torch.Tensor), "Given input is not a torch.Tensor"
         grad_required.append(input.requires_grad)
         inputs_dtype = input.dtype
-        if inputs_dtype == torch.long or inputs_dtype == torch.int:
+        if not inputs_dtype.is_floating_point and not inputs_dtype.is_complex:
             warnings.warn(
-                "Input Tensor %d has a dtype of either torch.int "
-                "or torch.long. Gradients cannot "
-                "be activated for these data types." % index
+                """Input Tensor %d has a dtype of %s.
+                Gradients cannot be activated
+                for these data types."""
+                % (index, str(inputs_dtype))
             )
         elif not input.requires_grad:
             warnings.warn(

--- a/captum/attr/_core/saliency.py
+++ b/captum/attr/_core/saliency.py
@@ -31,10 +31,6 @@ class Saliency(GradientAttribution):
         """
         GradientAttribution.__init__(self, forward_func)
 
-    @property
-    def uses_input_marginal_effects(self):
-        return False
-
     @log_usage()
     def attribute(
         self,

--- a/tests/attr/layer/test_layer_gradient_x_activation.py
+++ b/tests/attr/layer/test_layer_gradient_x_activation.py
@@ -12,6 +12,7 @@ from captum.attr._core.layer.layer_gradient_x_activation import LayerGradientXAc
 
 from ...helpers.basic import BaseTest, assertTensorTuplesAlmostEqual
 from ...helpers.basic_models import (
+    BasicEmbeddingModel,
     BasicModel_MultiLayer,
     BasicModel_MultiLayer_MultiInput,
 )
@@ -97,6 +98,13 @@ class Test(BaseTest):
         self._layer_activation_test_assert(
             net, net.model.relu, (inp1, inp2), [90.0, 101.0, 101.0, 101.0], (inp3, 5)
         )
+
+    def test_gradient_activation_embedding(self) -> None:
+        input1 = torch.tensor([2, 5, 0, 1])
+        input2 = torch.tensor([3, 0, 0, 2])
+        model = BasicEmbeddingModel()
+        layer_act = LayerGradientXActivation(model, model.embedding1)
+        self.assertEqual(layer_act.attribute(inputs=(input1, input2)).shape, (4, 100))
 
     def _layer_activation_test_assert(
         self,

--- a/tests/attr/layer/test_layer_gradient_x_activation.py
+++ b/tests/attr/layer/test_layer_gradient_x_activation.py
@@ -104,8 +104,8 @@ class Test(BaseTest):
         input2 = torch.tensor([3, 0, 0, 2])
         model = BasicEmbeddingModel()
         layer_act = LayerGradientXActivation(model, model.embedding1)
-        self.assertEqual(tuple(layer_act.attribute(inputs=(input1,
-            input2)).shape), (4, 100))
+        self.assertEqual(list(layer_act.attribute(inputs=(input1,
+            input2)).shape), [4, 100])
 
     def _layer_activation_test_assert(
         self,

--- a/tests/attr/layer/test_layer_gradient_x_activation.py
+++ b/tests/attr/layer/test_layer_gradient_x_activation.py
@@ -104,8 +104,9 @@ class Test(BaseTest):
         input2 = torch.tensor([3, 0, 0, 2])
         model = BasicEmbeddingModel()
         layer_act = LayerGradientXActivation(model, model.embedding1)
-        self.assertEqual(list(layer_act.attribute(inputs=(input1,
-            input2)).shape), [4, 100])
+        self.assertEqual(
+            list(layer_act.attribute(inputs=(input1, input2)).shape), [4, 100]
+        )
 
     def _layer_activation_test_assert(
         self,

--- a/tests/attr/layer/test_layer_gradient_x_activation.py
+++ b/tests/attr/layer/test_layer_gradient_x_activation.py
@@ -104,7 +104,8 @@ class Test(BaseTest):
         input2 = torch.tensor([3, 0, 0, 2])
         model = BasicEmbeddingModel()
         layer_act = LayerGradientXActivation(model, model.embedding1)
-        self.assertEqual(layer_act.attribute(inputs=(input1, input2)).shape, (4, 100))
+        self.assertEqual(tuple(layer_act.attribute(inputs=(input1,
+            input2)).shape), (4, 100))
 
     def _layer_activation_test_assert(
         self,

--- a/tests/attr/test_saliency.py
+++ b/tests/attr/test_saliency.py
@@ -75,7 +75,7 @@ class Test(BaseTest):
     ) -> None:
         saliency = Saliency(model)
 
-        self.assertFalse(saliency.uses_input_marginal_effects)
+        self.assertFalse(saliency.multiplies_by_inputs)
 
         if nt_type == "vanilla":
             attributions = saliency.attribute(


### PR DESCRIPTION
Minor fixes:
 - It looks like I still had the old naming of `uses_input_marginal_effects` in saliency - fixed that.
- As I was running` LayerGradientActivation` for word indices, I noticed that applying gradients functionality is failing for non-decimal input types. I modified it and added a warning for those cases. Layer methods should still work for those cases and we do not necessarily always need `requires_grad` for the inputs of the layer attribution algorithms. 
 