### PR TITLE
add linear classifier

### DIFF
--- a/captum/_utils/models/linear_model/__init__.py
+++ b/captum/_utils/models/linear_model/__init__.py
@@ -1,4 +1,4 @@
-from captum._utils.models.linear_model import (
+from captum._utils.models.linear_model.model import (
     LinearModel,
     SGDLasso,
     SGDLinearModel,
@@ -9,10 +9,8 @@ from captum._utils.models.linear_model import (
     SkLearnLinearRegression,
     SkLearnRidge,
 )
-from captum._utils.models.model import Model
 
 __all__ = [
-    "Model",
     "LinearModel",
     "SGDLinearModel",
     "SGDLasso",

--- a/captum/_utils/models/linear_model/_test_linear_classifier.py
+++ b/captum/_utils/models/linear_model/_test_linear_classifier.py
@@ -1,0 +1,195 @@
+import argparse
+import random
+from typing import Optional
+
+import numpy as np
+import sklearn.datasets as datasets
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+import captum._utils.models.linear_model.model as pytorch_model_module
+from tests.utils.test_linear_model import _evaluate
+
+
+def sklearn_dataset_to_loaders(
+    data, train_prop=0.7, batch_size=64, num_workers=4, shuffle=False, one_hot=False
+):
+    xs, ys = data
+    if one_hot and ys.dtype != np.float:
+        oh = np.zeros((ys.size, ys.max() + 1))
+        oh[np.arange(ys.size), ys] = 1
+        ys = oh
+
+    dataset = TensorDataset(torch.FloatTensor(xs), torch.FloatTensor(ys))
+
+    lens = [int(train_prop * len(xs))]
+    lens += [len(xs) - lens[0]]
+    train_dset, val_dset = torch.utils.data.random_split(dataset, lens)
+
+    train_loader = DataLoader(
+        train_dset,
+        batch_size=min(batch_size, lens[0]),
+        shuffle=shuffle,
+        num_workers=num_workers,
+    )
+    val_loader = DataLoader(
+        val_dset,
+        batch_size=min(batch_size, lens[1]),
+        num_workers=num_workers,
+        shuffle=False,
+    )
+
+    return train_loader, val_loader, xs.shape[1], xs.shape[0]
+
+
+def compare_to_sk_learn(
+    max_epoch: int,
+    train_loader: DataLoader,
+    val_loader: DataLoader,
+    train_prop: float,
+    sklearn_model_type: str,
+    pytorch_model_type: str,
+    norm_type: Optional[str],
+    objective: str,
+    alpha: float,
+    init_scheme: str = "zeros",
+):
+    if "LinearRegression" not in sklearn_model_type:
+        sklearn_classifier = getattr(pytorch_model_module, sklearn_model_type)(
+            alpha=alpha
+        )
+    else:
+        sklearn_classifier = getattr(pytorch_model_module, sklearn_model_type)()
+
+    pytorch_classifier = getattr(pytorch_model_module, pytorch_model_type)(
+        norm_type=args.norm_type,
+    )
+
+    sklearn_stats = sklearn_classifier.fit(
+        train_data=train_loader,
+        norm_input=args.norm_sklearn,
+    )
+    pytorch_stats = pytorch_classifier.fit(
+        train_data=train_loader,
+        max_epoch=max_epoch,
+        init_scheme=init_scheme,
+        alpha=alpha,
+    )
+
+    sklearn_stats.update(_evaluate(val_loader, sklearn_classifier))
+    pytorch_stats.update(_evaluate(val_loader, pytorch_classifier))
+
+    train_stats_pytorch = _evaluate(train_loader, pytorch_classifier)
+    train_stats_sklearn = _evaluate(train_loader, sklearn_classifier)
+
+    o_pytorch = {"l2": train_stats_pytorch["l2"]}
+    o_sklearn = {"l2": train_stats_sklearn["l2"]}
+
+    pytorch_h = pytorch_classifier.representation()
+    sklearn_h = sklearn_classifier.representation()
+    if objective == "ridge":
+        o_pytorch["l2_reg"] = alpha * pytorch_h.norm(p=2, dim=-1)
+        o_sklearn["l2_reg"] = alpha * sklearn_h.norm(p=2, dim=-1)
+    elif objective == "lasso":
+        o_pytorch["l1_reg"] = alpha * pytorch_h.norm(p=1, dim=-1)
+        o_sklearn["l1_reg"] = alpha * sklearn_h.norm(p=1, dim=-1)
+
+    rel_diff = (sum(o_sklearn.values()) - sum(o_pytorch.values())) / abs(
+        sum(o_sklearn.values())
+    )
+    return (
+        {
+            "objective_rel_diff": rel_diff.tolist(),
+            "objective_pytorch": o_pytorch,
+            "objective_sklearn": o_sklearn,
+        },
+        sklearn_stats,
+        pytorch_stats,
+    )
+
+
+def main(args):
+    if args.seed:
+        torch.manual_seed(0)
+        random.seed(0)
+
+    assert args.norm_type in [None, "layer_norm", "batch_norm"]
+
+    print(
+        "dataset,num_samples,dimensionality,objective_diff,objective_pytorch,"
+        + "objective_sklearn,pytorch_time,sklearn_time,pytorch_l2_val,sklearn_l2_val"
+    )
+    for dataset in args.datasets:
+        dataset_fn = getattr(datasets, dataset)
+        data = dataset_fn(return_X_y=True)
+
+        (
+            train_loader,
+            val_loader,
+            in_features,
+            num_samples,
+        ) = sklearn_dataset_to_loaders(
+            data,
+            batch_size=args.batch_size,
+            num_workers=args.workers,
+            shuffle=args.shuffle,
+            one_hot=args.one_hot,
+        )
+
+        similarity, sklearn_stats, pytorch_stats = compare_to_sk_learn(
+            alpha=args.alpha,
+            max_epoch=args.max_epoch,
+            train_loader=train_loader,
+            val_loader=val_loader,
+            train_prop=args.training_prop,
+            pytorch_model_type=args.pytorch_model_type,
+            sklearn_model_type=args.sklearn_model_type,
+            norm_type=args.norm_type,
+            init_scheme=args.init_scheme,
+            objective=args.objective,
+        )
+
+        print(
+            f"{dataset},{num_samples},{in_features},{similarity['objective_rel_diff']},"
+            + f"{similarity['objective_pytorch']},{similarity['objective_sklearn']},"
+            + f"{pytorch_stats['train_time']},{sklearn_stats['train_time']},"
+            + f"{pytorch_stats['l2']},{sklearn_stats['l2']}"
+        )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="train & test linear model with SGD + compare to sklearn"
+    )
+    parser.add_argument(
+        "--norm_type",
+        type=str,
+        default=None,
+    )
+    parser.add_argument(
+        "--datasets",
+        type=str,
+        nargs="+",
+        default=[
+            "load_boston",
+            "load_breast_cancer",
+            "load_diabetes",
+            "fetch_california_housing",
+        ],
+    )
+    parser.add_argument("--initial_lr", type=float, default=0.01)
+    parser.add_argument("--alpha", type=float, default=1.0)
+    parser.add_argument("--max_epoch", type=int, default=100)
+    parser.add_argument("--seed", type=int, default=None)
+    parser.add_argument("--shuffle", default=False, action="store_true")
+    parser.add_argument("--one_hot", default=False, action="store_true")
+    parser.add_argument("--batch_size", type=int, default=256)
+    parser.add_argument("--training_prop", type=float, default=0.7)
+    parser.add_argument("--workers", type=int, default=1)
+    parser.add_argument("--sklearn_model_type", type=str, default="Lasso")
+    parser.add_argument("--pytorch_model_type", type=str, default="SGDLasso")
+    parser.add_argument("--init_scheme", type=str, default="xavier")
+    parser.add_argument("--norm_sklearn", default=False, action="store_true")
+    parser.add_argument("--objective", type=str, default="lasso")
+    args = parser.parse_args()
+    main(args)

--- a/captum/_utils/models/linear_model/model.py
+++ b/captum/_utils/models/linear_model/model.py
@@ -1,0 +1,297 @@
+from typing import Callable, List, Optional
+
+import torch.nn as nn
+from torch import Tensor
+from torch.utils.data import DataLoader
+
+from captum._utils.models.model import Model
+
+
+class LinearModel(nn.Module, Model):
+    SUPPORTED_NORMS: List[Optional[str]] = [None, "batch_norm", "layer_norm"]
+
+    def __init__(self, train_fn: Callable, **kwargs):
+        r"""
+        Constructs a linear model with a training function and additional
+        construction arguments that will be sent to
+        `self._construct_model_params` after a `self.fit` is called. Please note
+        that this assumes the `self.train_fn` will call
+        `self._construct_model_params`.
+
+        Please note that this is an experimental feature.
+
+        Args:
+            train_fn (callable)
+                The function to train with. See
+                `captum._utils.models.linear_model.train.sgd_train_linear_model`
+                and
+                `captum._utils.models.linear_model.train.sklearn_train_linear_model`
+                for examples
+            kwargs
+                Any additional keyword arguments to send to
+                `self._construct_model_params` once a `self.fit` is called.
+        """
+        super().__init__()
+
+        self.norm: Optional[nn.Module] = None
+        self.linear: Optional[nn.Linear] = None
+        self.train_fn = train_fn
+        self.construct_kwargs = kwargs
+
+    def _construct_model_params(
+        self,
+        in_features: Optional[int] = None,
+        out_features: Optional[int] = None,
+        norm_type: Optional[str] = None,
+        affine_norm: bool = False,
+        bias: bool = True,
+        weight_values: Optional[Tensor] = None,
+        bias_value: Optional[Tensor] = None,
+    ):
+        r"""
+        Lazily initializes a linear model. This will be called for you in a
+        train method.
+
+        Args:
+            in_features (int):
+                The number of input features
+            output_features (int):
+                The number of output features.
+            norm_type (str, optional):
+                The type of normalization that can occur. Please assign this
+                to one of `PyTorchLinearModel.SUPPORTED_NORMS`.
+            affine_norm (bool):
+                Whether or not to learn an affine transformation of the
+                normalization parameters used.
+            bias (bool):
+                Whether to add a bias term. Not needed if normalized input.
+            weight_values (tensor, optional):
+                The values to initialize the linear model with. This must be a
+                1D or 2D tensor, and of the form `(num_outputs, num_features)` or
+                `(num_features,)`. Additionally, if this is provided you need not
+                to provide `in_features` or `out_features`.
+            bias_value (tensor, optional):
+                The bias value to initialize the model with.
+        """
+
+        if norm_type not in LinearModel.SUPPORTED_NORMS:
+            raise ValueError(
+                f"{norm_type} not supported. Please use {LinearModel.SUPPORTED_NORMS}"
+            )
+
+        if weight_values is not None:
+            in_features = weight_values.shape[-1]
+            out_features = (
+                1 if len(weight_values.shape) == 1 else weight_values.shape[0]
+            )
+
+        if in_features is None or out_features is None:
+            raise ValueError(
+                "Please provide `in_features` and `out_features` or `weight_values`"
+            )
+
+        if norm_type == "batch_norm":
+            self.norm = nn.BatchNorm1d(in_features, eps=1e-8, affine=affine_norm)
+        elif norm_type == "layer_norm":
+            self.norm = nn.LayerNorm(
+                in_features, eps=1e-8, elementwise_affine=affine_norm
+            )
+        else:
+            self.norm = None
+
+        self.linear = nn.Linear(in_features, out_features, bias=bias)
+
+        if weight_values is not None:
+            self.linear.weight.data = weight_values
+
+        if bias_value is not None:
+            if not bias:
+                raise ValueError("`bias_value` is not None and bias is False")
+
+            self.linear.bias.data = bias_value
+
+    def fit(self, train_data: DataLoader, **kwargs):
+        r"""
+        Calls `self.train_fn`
+        """
+        return self.train_fn(
+            self,
+            dataloader=train_data,
+            construct_kwargs=self.construct_kwargs,
+            **kwargs,
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        assert self.linear is not None
+
+        if self.norm is not None:
+            x = self.norm(x)
+        return self.linear(x)
+
+    def representation(self) -> Tensor:
+        r"""
+        Returns a tensor which describes the hyper-plane input space. This does
+        not include the bias. For bias/intercept, please use `self.bias`
+        """
+        assert self.linear is not None
+        return self.linear.weight.detach()
+
+    def bias(self) -> Optional[Tensor]:
+        r"""
+        Returns the bias of the linear model
+        """
+        if self.linear is None or self.linear.bias is None:
+            return None
+        return self.linear.bias.detach()
+
+
+class SGDLinearModel(LinearModel):
+    def __init__(self, **kwargs):
+        r"""
+        Factory class. Construct a a `LinearModel` with the
+        `sgd_train_linear_model` as the train method
+
+        Args:
+            kwargs
+                Arguments send to `self._construct_model_params` after
+                `self.fit` is called. Please refer to that method for parameter
+                documentation.
+        """
+        # avoid cycles
+        from captum._utils.models.linear_model.train import sgd_train_linear_model
+
+        super().__init__(train_fn=sgd_train_linear_model, **kwargs)
+
+
+class SGDLasso(SGDLinearModel):
+    def __init__(self, **kwargs):
+        r"""
+        Factory class to train a `LinearModel` with SGD
+        (`sgd_train_linear_model`) whilst setting appropriate parameters to
+        optimize for ridge regression loss. This optimizes L2 loss + alpha * L1
+        regularization.
+
+        Please note that with SGD it is not guaranteed that weights will
+        converge to 0.
+        """
+        super().__init__(**kwargs)
+
+    def fit(self, train_data: DataLoader, **kwargs):
+        # avoid cycles
+        from captum._utils.models.linear_model.train import l2_loss
+
+        return super().fit(train_data=train_data, loss_fn=l2_loss, reg_term=1, **kwargs)
+
+
+class SGDRidge(SGDLinearModel):
+    def __init__(self, **kwargs):
+        r"""
+        Factory class to train a `LinearModel` with SGD
+        (`sgd_train_linear_model`) whilst setting appropriate parameters to
+        optimize for ridge regression loss. This optimizes L2 loss + alpha *
+        L2 regularization.
+        """
+        super().__init__(**kwargs)
+
+    def fit(self, train_data: DataLoader, **kwargs):
+        # avoid cycles
+        from captum._utils.models.linear_model.train import l2_loss
+
+        return super().fit(train_data=train_data, loss_fn=l2_loss, reg_term=2, **kwargs)
+
+
+class SGDLinearRegression(SGDLinearModel):
+    def __init__(self, **kwargs):
+        r"""
+        Factory class to train a `LinearModel` with SGD
+        (`sgd_train_linear_model`). For linear regression this assigns the loss
+        to L2 and no regularization.
+        """
+        super().__init__(**kwargs)
+
+    def fit(self, train_data: DataLoader, **kwargs):
+        # avoid cycles
+        from captum._utils.models.linear_model.train import l2_loss
+
+        return super().fit(
+            train_data=train_data, loss_fn=l2_loss, reg_term=None, **kwargs
+        )
+
+
+class SkLearnLinearModel(LinearModel):
+    def __init__(self, sklearn_module: str, **kwargs):
+        r"""
+        Factory class to construct a `LinearModel` with sklearn training method.
+
+        Please note that this assumes:
+
+        0. You have sklearn and numpy installed
+        1. The dataset can fit into memory
+
+        SkLearn support does introduce some slight overhead as we convert the
+        tensors to numpy and then convert the resulting trained model to a
+        `LinearModel` object. However, this conversion should be negligible.
+
+        Args:
+            sklearn_module
+                The module under sklearn to construct and use for training, e.g.
+                use "svm.LinearSVC" for an SVM or "linear_model.Lasso" for Lasso.
+
+                There are factory classes defined for you for common use cases,
+                such as `SkLearnLasso`.
+            kwargs
+                The kwargs to pass to the construction of the sklearn model
+        """
+        # avoid cycles
+        from captum._utils.models.linear_model.train import sklearn_train_linear_model
+
+        super().__init__(train_fn=sklearn_train_linear_model, **kwargs)
+
+        self.sklearn_module = sklearn_module
+
+    def fit(self, train_data: DataLoader, **kwargs):
+        r"""
+        Args:
+            train_data
+                Train data to use
+            kwargs
+                Arguments to feed to `.fit` method for sklearn
+        """
+        return super().fit(
+            train_data=train_data, sklearn_trainer=self.sklearn_module, **kwargs
+        )
+
+
+class SkLearnLasso(SkLearnLinearModel):
+    def __init__(self, **kwargs):
+        r"""
+        Factory class. Trains a `LinearModel` model with
+        `sklearn.linear_model.Lasso`. You will need sklearn version >= 0.23 to
+        support sample weights.
+        """
+        super().__init__(**kwargs, sklearn_module="linear_model.Lasso")
+
+    def fit(self, train_data: DataLoader, **kwargs):
+        return super().fit(train_data=train_data, **kwargs)
+
+
+class SkLearnRidge(SkLearnLinearModel):
+    def __init__(self, **kwargs):
+        r"""
+        Factory class. Trains a model with `sklearn.linear_model.Ridge`.
+        """
+        super().__init__(**kwargs, sklearn_module="linear_model.Ridge")
+
+    def fit(self, train_data: DataLoader, **kwargs):
+        return super().fit(train_data=train_data, **kwargs)
+
+
+class SkLearnLinearRegression(SkLearnLinearModel):
+    def __init__(self, **kwargs):
+        r"""
+        Factory class. Trains a model with `sklearn.linear_model.LinearRegression`.
+        """
+        super().__init__(**kwargs, sklearn_module="linear_model.LinearRegression")
+
+    def fit(self, train_data: DataLoader, **kwargs):
+        return super().fit(train_data=train_data, **kwargs)

--- a/captum/_utils/models/linear_model/train.py
+++ b/captum/_utils/models/linear_model/train.py
@@ -1,0 +1,342 @@
+import time
+from typing import Any, Callable, Dict, List, Optional
+
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader
+
+from captum._utils.models.linear_model.model import LinearModel
+
+
+def l2_loss(x1, x2, weights=None):
+    if weights is None:
+        return torch.mean((x1 - x2) ** 2) / 2.0
+    else:
+        return torch.sum((weights / weights.norm(p=1)) * ((x1 - x2) ** 2)) / 2.0
+
+
+def sgd_train_linear_model(
+    model: LinearModel,
+    dataloader: DataLoader,
+    construct_kwargs: Dict[str, Any],
+    max_epoch: int = 100,
+    reduce_lr: bool = True,
+    initial_lr: float = 0.01,
+    alpha: float = 1.0,
+    loss_fn: Callable = l2_loss,
+    reg_term: Optional[int] = 1,
+    patience: int = 10,
+    threshold: float = 1e-4,
+    running_loss_window: Optional[int] = None,
+    device: Optional[str] = None,
+    init_scheme: str = "zeros",
+    debug: bool = False,
+) -> Dict[str, float]:
+    r"""
+    Trains a linear model with SGD. This will continue to iterate your
+    dataloader until we converged to a solution or alternatively until we have
+    exhausted `max_epoch`.
+
+    Convergence is defined by the loss not changing by `threshold` amount for
+    `patience` number of iterations.
+
+    Args:
+        model
+            The model to train
+        dataloader
+            The data to train it with. We will assume the dataloader produces
+            either pairs or triples of the form (x, y) or (x, y, w). Where x and
+            y are typical pairs for supervised learning and w is a weight
+            vector.
+
+            We will call `model._construct_model_params` with construct_kwargs
+            and the input features set to `x.shape[1]` (`x.shape[0]` corresponds
+            to the batch size). We assume that `len(x.shape) == 2`, i.e. the
+            tensor is flat. The number of output features will be set to
+            y.shape[1] or 1 (if `len(y.shape) == 1`); we require `len(y.shape)
+            <= 2`.
+        max_epoch
+            The maximum number of epochs to exhaust
+        reduce_lr
+            Whether or not to reduce the learning rate as iterations progress.
+            Halves the learning rate when the training loss does not move. This
+            uses torch.optim.lr_scheduler.ReduceLROnPlateau and uses the
+            parameters `patience` and `threshold`
+        initial_lr
+            The initial learning rate to use.
+        alpha
+            A constant for the regularization term.
+        loss_fn
+            The loss to optimise for. This must accept three parameters:
+            x1 (predicted), x2 (labels) and a weight vector
+        reg_term
+            Regularization is defined by the `reg_term` norm of the weights.
+            Please use `None` if you do not wish to use regularization.
+        patience
+            Defines the number of iterations in a row the loss must remain
+            within `threshold` in order to be classified as converged.
+        threshold
+            Threshold for convergence detection.
+        running_loss_window
+            Used to report the training loss once we have finished training and
+            to determine when we have converged (along with reducing the
+            learning rate).
+
+            The reported training loss will take the last `running_loss_window`
+            iterations and average them.
+
+            If `None` we will approximate this to be the number of examples in
+            an epoch.
+        init_scheme
+            Initialization to use prior to training the linear model.
+        device
+            The device to send the model and data to. If None then no `.to` call
+            will be used.
+        debug
+            Whether to print the loss, learning rate per iteration
+
+    Returns
+        This will return the final training loss (averaged with
+        `running_loss_window`)
+    """
+
+    loss_window: List[torch.Tensor] = []
+    min_avg_loss = None
+    convergence_counter = 0
+    converged = False
+
+    def get_point(datapoint):
+        if len(datapoint) == 2:
+            x, y = datapoint
+            w = None
+        else:
+            x, y, w = datapoint
+
+        if device is not None:
+            x = x.to(device)
+            y = y.to(device)
+            if w is not None:
+                w = w.to(device)
+
+        return x, y, w
+
+    # get a point and construct the model
+    data_iter = iter(dataloader)
+    x, y, w = get_point(next(data_iter))
+
+    model._construct_model_params(
+        in_features=x.shape[1],
+        out_features=y.shape[1] if len(y.shape) == 2 else 1,
+        **construct_kwargs,
+    )
+    model.train()
+
+    assert model.linear is not None
+
+    if init_scheme is not None:
+        assert init_scheme in ["xavier", "zeros"]
+
+        with torch.no_grad():
+            if init_scheme == "xavier":
+                torch.nn.init.xavier_uniform_(model.linear.weight)
+            else:
+                model.linear.weight.zero_()
+
+            if model.linear.bias is not None:
+                model.linear.bias.zero_()
+
+    optim = torch.optim.SGD(model.parameters(), lr=initial_lr)
+    if reduce_lr:
+        scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+            optim, factor=0.5, patience=patience, threshold=threshold
+        )
+
+    t1 = time.time()
+    epoch = 0
+    i = 0
+    while epoch < max_epoch:
+        while True:  # for x, y, w in dataloader
+            if running_loss_window is None:
+                running_loss_window = x.shape[0] * len(dataloader)
+
+            y = y.view(x.shape[0], -1)
+            if w is not None:
+                w = w.view(x.shape[0], -1)
+
+            i += 1
+
+            out = model(x)
+
+            loss = loss_fn(y, out, w)
+            if reg_term is not None:
+                reg = torch.norm(model.linear.weight, p=reg_term)
+                loss += reg.sum() * alpha
+
+            if len(loss_window) >= running_loss_window:
+                loss_window = loss_window[1:]
+            loss_window.append(loss.clone().detach())
+            assert len(loss_window) <= running_loss_window
+
+            average_loss = torch.mean(torch.stack(loss_window))
+            if min_avg_loss is not None:
+                # if we haven't improved by at least `threshold`
+                if average_loss > min_avg_loss or torch.isclose(
+                    min_avg_loss, average_loss, atol=threshold
+                ):
+                    convergence_counter += 1
+                    if convergence_counter >= patience:
+                        converged = True
+                        break
+                else:
+                    convergence_counter = 0
+            if min_avg_loss is None or min_avg_loss >= average_loss:
+                min_avg_loss = average_loss.clone()
+
+            if debug:
+                print(
+                    f"lr={optim.param_groups[0]['lr']}, Loss={loss},"
+                    + "Aloss={average_loss}, min_avg_loss={min_avg_loss}"
+                )
+
+            loss.backward()
+
+            optim.step()
+            model.zero_grad()
+            if scheduler:
+                scheduler.step(average_loss)
+
+            temp = next(data_iter, None)
+            if temp is None:
+                break
+            x, y, w = get_point(temp)
+
+        if converged:
+            break
+
+        epoch += 1
+        data_iter = iter(dataloader)
+        x, y, w = get_point(next(data_iter))
+
+    t2 = time.time()
+    return {
+        "train_time": t2 - t1,
+        "train_loss": torch.mean(torch.stack(loss_window)).item(),
+        "train_iter": i,
+        "train_epoch": epoch,
+    }
+
+
+class NormLayer(nn.Module):
+    def __init__(self, mean, std, n=None, eps=1e-8):
+        super().__init__()
+        self.mean = mean
+        self.std = std
+        self.eps = eps
+
+    def forward(self, x):
+        return (x - self.mean) / (self.std + self.eps)
+
+
+def sklearn_train_linear_model(
+    model: LinearModel,
+    dataloader: DataLoader,
+    construct_kwargs: Dict[str, Any],
+    sklearn_trainer: str = "Lasso",
+    norm_input: bool = False,
+    **fit_kwargs,
+):
+    r"""
+    Alternative method to train with sklearn. This does introduce some slight
+    overhead as we convert the tensors to numpy and then convert the resulting
+    trained model to a `LinearModel` object. However, this conversion
+    should be negligible.
+
+    Please note that this assumes:
+
+    0. You have sklearn and numpy installed
+    1. The dataset can fit into memory
+
+    Args
+        model
+            The model to train.
+        dataloader
+            The data to use. This will be exhausted and converted to numpy
+            arrays. Therefore please do not feed an infinite dataloader.
+        norm_input
+            Whether or not to normalize the input
+        sklearn_trainer
+            The sklearn model to use to train the model. Please refer to
+            sklearn.linear_model for a list of modules to use.
+        construct_kwargs
+            Additional arguments provided to the `sklearn_trainer` constructor
+        fit_kwargs
+            Other arguments to send to `sklearn_trainer`'s `.fit` method
+    """
+    from functools import reduce
+
+    try:
+        import numpy as np
+    except ImportError:
+        raise ValueError("numpy is not available. Please install numpy.")
+
+    try:
+        import sklearn
+        import sklearn.linear_model
+        import sklearn.svm
+    except ImportError:
+        raise ValueError("sklearn is not available. Please install sklearn >= 0.23")
+
+    assert (
+        sklearn.__version__ >= "0.23.0"
+    ), "Must have sklearn version 0.23.0 or higher to use "
+    "sample_weight in Lasso regression."
+
+    num_batches = 0
+    xs, ys, ws = [], [], []
+    for data in dataloader:
+        if len(data) == 3:
+            x, y, w = data
+        else:
+            assert len(data) == 2
+            x, y = data
+            w = None
+
+        xs.append(x.cpu().numpy())
+        ys.append(y.cpu().numpy())
+        if w is not None:
+            ws.append(w.cpu().numpy())
+        num_batches += 1
+
+    x = np.concatenate(xs, axis=0)
+    y = np.concatenate(ys, axis=0)
+    if len(ws) > 0:
+        w = np.concatenate(ws, axis=0)
+    else:
+        w = None
+
+    if norm_input:
+        mean, std = x.mean(0), x.std(0)
+        x -= mean
+        x /= std
+
+    t1 = time.time()
+    sklearn_model = reduce(
+        lambda val, el: getattr(val, el), [sklearn] + sklearn_trainer.split(".")
+    )(**construct_kwargs)
+    sklearn_model.fit(x, y, sample_weight=w, **fit_kwargs)
+    t2 = time.time()
+
+    # Convert weights to pytorch
+    num_outputs = 1 if len(y.shape) == 1 else y.shape[1]
+    weight_values = torch.FloatTensor(sklearn_model.coef_)  # type: ignore
+    bias_values = torch.FloatTensor([sklearn_model.intercept_])  # type: ignore
+    model._construct_model_params(
+        norm_type=None,
+        weight_values=weight_values.view(num_outputs, -1),
+        bias_value=bias_values.squeeze().unsqueeze(0),
+    )
+
+    if norm_input:
+        model.norm = NormLayer(mean, std)
+
+    return {"train_time": t2 - t1}

--- a/captum/_utils/models/model.py
+++ b/captum/_utils/models/model.py
@@ -13,6 +13,8 @@ class Model(ABC):
     r"""
     Abstract Class to describe the interface of a trainable model to be used
     within the algorithms of captum.
+
+    Please note that this is an experimental feature.
     """
 
     @abstractmethod

--- a/tests/utils/test_linear_model.py
+++ b/tests/utils/test_linear_model.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+
+import torch
+
+from captum._utils.models.linear_model.model import (
+    SGDLasso,
+    SGDLinearRegression,
+    SGDRidge,
+)
+from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
+
+
+def _evaluate(test_data, classifier):
+    classifier.eval()
+
+    l1_loss = 0.0
+    l2_loss = 0.0
+    n = 0
+    l2_losses = []
+    with torch.no_grad():
+        for data in test_data:
+            if len(data) == 2:
+                x, y = data
+                w = None
+            else:
+                x, y, w = data
+
+            out = classifier(x)
+
+            y = y.view(x.shape[0], -1)
+            assert y.shape == out.shape
+
+            if w is None:
+                l1_loss += (out - y).abs().sum(0).to(dtype=torch.float64)
+                l2_loss += ((out - y) ** 2).sum(0).to(dtype=torch.float64)
+                l2_losses.append(((out - y) ** 2).to(dtype=torch.float64))
+            else:
+                l1_loss += (
+                    (w.view(-1, 1) * (out - y)).abs().sum(0).to(dtype=torch.float64)
+                )
+                l2_loss += (
+                    (w.view(-1, 1) * ((out - y) ** 2)).sum(0).to(dtype=torch.float64)
+                )
+                l2_losses.append(
+                    (w.view(-1, 1) * ((out - y) ** 2)).to(dtype=torch.float64)
+                )
+
+            n += x.shape[0]
+
+    l2_losses = torch.cat(l2_losses, dim=0)
+    assert n > 0
+
+    # just to double check
+    assert ((l2_losses.mean(0) - l2_loss / n).abs() <= 0.1).all()
+
+    classifier.train()
+    return {"l1": l1_loss / n, "l2": l2_loss / n}
+
+
+class TestLinearModel(BaseTest):
+    MAX_POINTS: int = 3
+
+    def train_and_compare(
+        self,
+        model_type,
+        xs,
+        ys,
+        expected_loss,
+        expected_reg=0.0,
+        expected_hyperplane=None,
+        norm_hyperplane=True,
+        weights=None,
+        delta=0.1,
+        init_scheme="zeros",
+        objective="lasso",
+        bias=True,
+    ):
+        assert objective in ["lasso", "ridge", "ols"]
+
+        if weights is None:
+            train_dataset = torch.utils.data.TensorDataset(xs, ys)
+        else:
+            train_dataset = torch.utils.data.TensorDataset(xs, ys, weights)
+
+        train_loader = torch.utils.data.DataLoader(
+            train_dataset, batch_size=len(train_dataset), num_workers=0
+        )
+
+        model = model_type(bias=bias)
+        model.fit(
+            train_loader,
+            init_scheme=init_scheme,
+            max_epoch=150,
+            initial_lr=0.1,
+            patience=5,
+        )
+
+        self.assertTrue(model.bias() is not None if bias else model.bias() is None)
+
+        l2_loss = _evaluate(train_loader, model)["l2"]
+
+        if objective == "lasso":
+            reg = model.representation().norm(p=1)
+        elif objective == "ridge":
+            reg = model.representation().norm(p=2)
+        else:
+            assert objective == "ols"
+            reg = torch.zeros_like(l2_loss)
+
+        assertTensorAlmostEqual(self, l2_loss, expected_loss, delta=delta)
+        assertTensorAlmostEqual(self, reg, expected_reg, delta=delta)
+
+        if expected_hyperplane is not None:
+            h = model.representation()
+            if norm_hyperplane:
+                h /= h.norm(p=2)
+            assertTensorAlmostEqual(self, h, expected_hyperplane, delta=delta)
+
+    def test_simple_linear_regression(self):
+        xs = torch.randn(TestLinearModel.MAX_POINTS, 1)
+        ys = 3 * xs + 1
+
+        self.train_and_compare(
+            SGDLinearRegression,
+            xs,
+            ys,
+            expected_loss=0,
+            expected_reg=0,
+            objective="ols",
+        )
+        self.train_and_compare(
+            SGDLasso,
+            xs,
+            ys,
+            expected_loss=3,
+            expected_reg=0,
+            objective="lasso",
+            delta=0.2,
+        )
+        self.train_and_compare(
+            SGDRidge,
+            xs,
+            ys,
+            expected_loss=3,
+            expected_reg=0,
+            objective="ridge",
+            delta=0.2,
+        )
+
+    def test_simple_multi_output(self):
+        xs = torch.randn(TestLinearModel.MAX_POINTS, 1)
+        y1 = 3 * xs + 1
+        y2 = -5 * xs
+        ys = torch.stack((y1, y2), dim=1).squeeze()
+
+        self.train_and_compare(
+            SGDLinearRegression,
+            xs,
+            ys,
+            expected_loss=torch.DoubleTensor([0, 0]),
+            expected_reg=torch.DoubleTensor([0, 0]),
+            objective="ols",
+        )
+
+    def test_simple_linear_classification(self):
+        xs = torch.tensor(
+            [
+                [0.5, 0.5],
+                [-0.5, -0.5],
+                [0.5, -0.5],
+                [-0.5, 0.5],
+            ]
+        )
+        ys = torch.tensor([1.0, -1.0, 1.0, -1.0])
+        self.train_and_compare(
+            SGDLinearRegression,
+            xs,
+            ys,
+            expected_loss=0,
+            expected_reg=0,
+            objective="ols",
+        )
+        self.train_and_compare(
+            SGDLasso, xs, ys, expected_loss=1, expected_reg=0, objective="lasso"
+        )
+        self.train_and_compare(
+            SGDRidge, xs, ys, expected_loss=1, expected_reg=0, objective="ridge"
+        )
+
+        ys = torch.tensor([1.0, 0.0, 1.0, 0.0])
+        self.train_and_compare(
+            SGDLinearRegression,
+            xs,
+            ys,
+            expected_loss=0,
+            expected_reg=0,
+            objective="ols",
+        )
+        self.train_and_compare(
+            SGDLasso, xs, ys, expected_loss=0.25, expected_reg=0, objective="lasso"
+        )
+        self.train_and_compare(
+            SGDRidge, xs, ys, expected_loss=0.25, expected_reg=0, objective="ridge"
+        )
+
+    def test_simple_xor_problem(self):
+        r"""
+           ^
+         o | x
+        ---|--->
+         x | o
+        """
+        xs = torch.tensor(
+            [
+                [0.5, 0.5],
+                [-0.5, -0.5],
+                [0.5, -0.5],
+                [-0.5, 0.5],
+            ]
+        )
+        ys = torch.tensor([1.0, 1.0, -1.0, -1.0])
+
+        expected_hyperplane = torch.Tensor([0, 0])
+        self.train_and_compare(
+            SGDLinearRegression,
+            xs,
+            ys,
+            expected_loss=1,
+            expected_reg=0,
+            objective="ols",
+            expected_hyperplane=expected_hyperplane,
+            norm_hyperplane=False,
+            bias=False,
+        )
+        self.train_and_compare(
+            SGDLasso,
+            xs,
+            ys,
+            expected_loss=1,
+            expected_reg=0,
+            objective="lasso",
+            expected_hyperplane=expected_hyperplane,
+            norm_hyperplane=False,
+            bias=False,
+        )
+        self.train_and_compare(
+            SGDRidge,
+            xs,
+            ys,
+            expected_loss=1,
+            expected_reg=0,
+            objective="ridge",
+            expected_hyperplane=expected_hyperplane,
+            norm_hyperplane=False,
+            bias=False,
+        )
+
+    def test_weighted_problem(self):
+        r"""
+           ^
+         0 | x
+        ---|--->
+         0 | o
+        """
+        xs = torch.tensor(
+            [
+                [0.5, 0.5],
+                [-0.5, -0.5],
+                [0.5, -0.5],
+                [-0.5, 0.5],
+            ]
+        )
+        ys = torch.tensor([1.0, 1.0, -1.0, -1.0])
+        weights = torch.tensor([1.0, 0.0, 1.0, 0.0])
+
+        self.train_and_compare(
+            SGDLinearRegression,
+            xs,
+            ys,
+            expected_loss=0,
+            expected_reg=0,
+            expected_hyperplane=torch.Tensor([0.0, 1.0]),
+            weights=weights,
+            norm_hyperplane=True,
+            init_scheme="zeros",
+            objective="ols",
+            bias=False,
+        )
+        self.train_and_compare(
+            SGDLasso,
+            xs,
+            ys,
+            expected_loss=0.5,
+            expected_reg=0,
+            expected_hyperplane=torch.Tensor([0.0, 0.0]),
+            weights=weights,
+            norm_hyperplane=False,
+            init_scheme="zeros",
+            objective="lasso",
+            bias=False,
+        )
+        self.train_and_compare(
+            SGDRidge,
+            xs,
+            ys,
+            expected_loss=0.5,
+            expected_reg=0,
+            expected_hyperplane=torch.Tensor([0.0, 0.0]),
+            weights=weights,
+            norm_hyperplane=False,
+            init_scheme="zeros",
+            objective="ridge",
+            bias=False,
+        )


### PR DESCRIPTION
To remove sklearn dependency.

# Unit Tests

- Basic regression problem (y=3x + 1)
- classification: 2D XOR problem (nonlinearly separable data)
- simple 2D classification problem (split across x-axis)
- weighted 2D XOR problem for the left (x < 0) examples set to nothing
- Added a test script _test_linear_classifier.py, which can be used to compare with sklearn.

# Results
How to interpret. objective_diff is simply: (sklearn_objective - pytorch_objective) / sklearn_objective. i.e. a negative value corresponds to the sklearn objective being smaller than the pytorch objective (bad for our case), and a positive value corresponds to being better than sklearn's objective value.

I was previously comparing the hyperplane but this is an unstable way to compare the solutions due to slight differences in achieved objective values (this probably wouldn't have been a problem for svm/hinge loss).

## Linear Regression (OLS)
Command
```
python3 captum/_utils/models/linear_model/_test_linear_classifier.py --max_epoch 5000 --initial_lr 0.01 --workers 0 --batch_size 256 --sklearn_model_type SkLearnLinearRegression --pytorch_model_type SGDLinearRegression --init_scheme zeros --shuffle --objective ols --alpha 1 --norm_type batch_norm --norm_sklearn
dataset,num_samples,dimensionality,objective_diff,objective_pytorch,objective_sklearn,pytorch_time,sklearn_time,pytorch_l2_val,sklearn_l2_val
```

```
dataset,num_samples,dimensionality,objective_diff,objective_pytorch,objective_sklearn,pytorch_time,sklearn_time,pytorch_l2_val,sklearn_l2_val
load_boston,506,13,[-0.022684543289923136],{'l2': tensor([24.4399], dtype=torch.float64)},{'l2': tensor([23.8978], dtype=torch.float64)},2.4438016414642334,0.004037618637084961,tensor([17.6246], dtype=torch.float64),tensor([17.9040], dtype=torch.float64)
load_breast_cancer,569,30,[-0.17331687403754384],{'l2': tensor([0.0597], dtype=torch.float64)},{'l2': tensor([0.0509], dtype=torch.float64)},1.6174609661102295,0.014079570770263672,tensor([0.0693], dtype=torch.float64),tensor([0.0635], dtype=torch.float64)
load_diabetes,442,10,[-0.009813820264827265],{'l2': tensor([3026.0265], dtype=torch.float64)},{'l2': tensor([2996.6182], dtype=torch.float64)},2.0466535091400146,0.0013270378112792969,tensor([2616.6062], dtype=torch.float64),tensor([2659.3940], dtype=torch.float64)
fetch_california_housing,20640,8,[-0.07994273070197096],{'l2': tensor([0.5718], dtype=torch.float64)},{'l2': tensor([0.5294], dtype=torch.float64)},5.508490562438965,0.008643150329589844,tensor([0.5331], dtype=torch.float64),tensor([0.5128], dtype=torch.float64)
```

SGD achieves about the same objective values. Validation loss is comparable.
## Ridge Regression

```
python3 captum/_utils/models/linear_model/_test_linear_classifier.py --max_epoch 5000 --initial_lr 0.01 --workers 0 --batch_size 256 --sklearn_model_type SkLearnRidge --pytorch_model_type SGDRidge --init_scheme zeros --shuffle --objective ridge --alpha 1 --norm_type batch_norm --norm_sklearn
```

Result

```
dataset,num_samples,dimensionality,objective_diff,objective_pytorch,objective_sklearn,pytorch_time,sklearn_time,pytorch_l2_val,sklearn_l2_val
load_boston,506,13,[0.015838349298618427],{'l2': tensor([24.0312], dtype=torch.float64), 'l2_reg': tensor([4.9091])},{'l2': tensor([22.2527], dtype=torch.float64), 'l2_reg': tensor([7.1533])},2.7282192707061768,0.010055780410766602,tensor([25.2590], dtype=torch.float64),tensor([22.2759], dtype=torch.float64)
load_breast_cancer,569,30,[0.7362548745779508],{'l2': tensor([0.1623], dtype=torch.float64), 'l2_reg': tensor([0.0282])},{'l2': tensor([0.0555], dtype=torch.float64), 'l2_reg': tensor([0.6667])},2.0088863372802734,0.014894485473632812,tensor([0.1655], dtype=torch.float64),tensor([0.0519], dtype=torch.float64)
load_diabetes,442,10,[-0.001802106462134922],{'l2': tensor([2714.5530], dtype=torch.float64), 'l2_reg': tensor([35.9192])},{'l2': tensor([2696.5926], dtype=torch.float64), 'l2_reg': tensor([48.9319])},2.060124158859253,0.0010554790496826172,tensor([3502.1473], dtype=torch.float64),tensor([3434.9784], dtype=torch.float64)
fetch_california_housing,20640,8,[-1.3502213162860555],{'l2': tensor([4.9017], dtype=torch.float64), 'l2_reg': tensor([0.0071])},{'l2': tensor([0.5280], dtype=torch.float64), 'l2_reg': tensor([1.5607])},0.049745798110961914,0.0040187835693359375,tensor([4.9014], dtype=torch.float64),tensor([0.5192], dtype=torch.float64)
```

Oddly enough for load_diabetes and fetch_california_housing SGD performs better by a significant margin.

With one-hot encoding for some problems (`--one_hot`):

```
dataset,num_samples,dimensionality,objective_diff,objective_pytorch,objective_sklearn,pytorch_time,sklearn_time,pytorch_l2_val,sklearn_l2_val
load_boston,506,13,[0.019378412398494242],{'l2': tensor([22.2482], dtype=torch.float64), 'l2_reg': tensor([4.5536])},{'l2': tensor([20.2486], dtype=torch.float64), 'l2_reg': tensor([7.0828])},2.6791810989379883,0.03125786781311035,tensor([31.4786], dtype=torch.float64),tensor([27.1142], dtype=torch.float64)
load_breast_cancer,569,30,[0.6389963079735729, 0.6289698111647188],{'l2': tensor([0.2294, 0.2359], dtype=torch.float64), 'l2_reg': tensor([0.0051, 0.0051])},{'l2': tensor([0.0510, 0.0510], dtype=torch.float64), 'l2_reg': tensor([0.5986, 0.5986])},1.814713478088379,0.018691062927246094,tensor([0.2063, 0.2375], dtype=torch.float64),tensor([0.0625, 0.0625], dtype=torch.float64)
load_diabetes,442,10,[-0.0030957983777401355],{'l2': tensor([3010.2659], dtype=torch.float64), 'l2_reg': tensor([40.7940])},{'l2': tensor([2981.0197], dtype=torch.float64), 'l2_reg': tensor([60.6239])},2.11592698097229,0.0008790493011474609,tensor([2640.7744], dtype=torch.float64),tensor([2664.3985], dtype=torch.float64)
fetch_california_housing,20640,8,[0.37429257170384267],{'l2': tensor([1.3068], dtype=torch.float64), 'l2_reg': tensor([0.0101])},{'l2': tensor([0.5182], dtype=torch.float64), 'l2_reg': tensor([1.5865])},5.223377466201782,0.003099203109741211,tensor([1.3379], dtype=torch.float64),tensor([0.5451], dtype=torch.float64)
```

## Lasso

```
python3 captum/_utils/models/linear_model/_test_linear_classifier.py --max_epoch 5000 --initial_lr 0.01 --workers 0 --batch_size 256 --sklearn_model_type SkLearnLasso --pytorch_model_type SGDLasso --init_scheme zeros --shuffle --objective lasso --alpha 1 --norm_type batch_norm --norm_sklearn
```

Result:

```
dataset,num_samples,dimensionality,objective_diff,objective_pytorch,objective_sklearn,pytorch_time,sklearn_time,pytorch_l2_val,sklearn_l2_val
load_boston,506,13,-0.005249488393770688,{'l2': 28.460180939927614, 'l1_reg': 7.937889099121094},{'l2': 28.236084674037784, 'l1_reg': 7.971911907196045},2.3680202960968018,0.0009419918060302734,30.09524696751645,29.86710719058388
load_breast_cancer,569,30,-2.1891737994281675,{'l2': 0.600513975823944, 'l1_reg': 0.14644668996334076},{'l2': 0.23421761019146023, 'l1_reg': 0.0},0.029883146286010742,0.0008683204650878906,0.6063908805624086,0.2327224776061655
load_diabetes,442,10,-0.0017107944727324858,{'l2': 3005.2191039644013, 'l1_reg': 89.52328491210938},{'l2': 2999.465210355987, 'l1_reg': 89.99175262451172},2.1832478046417236,0.0009443759918212891,2664.564614661654,2652.3023966165415
fetch_california_housing,20640,8,-0.0168192630543913,{'l2': 1.2933191476482466, 'l1_reg': 0.04585963115096092},{'l2': 1.3170273493604858, 'l1_reg': 0.0},4.275227308273315,0.008142232894897461,1.3398686166766693,1.3654809819656832
```

SGD archives significantly worse objective values for load_breast_cancer and for fetch_california_housing. This is expected as these two datasets have their l1 assigned to 0.


Differential Revision: D24183429

