### PR TITLE
Fix issue with Flask app not accepting connections outside localhost.

### DIFF
--- a/captum/insights/attr_vis/app.py
+++ b/captum/insights/attr_vis/app.py
@@ -229,17 +229,21 @@ class AttributionVisualizer(object):
             display(widget.out)
 
     @log_usage()
-    def serve(self, blocking=False, debug=False, port=None):
+    def serve(self, blocking=False, debug=False, port=None, bind_all=False):
         context = _get_context()
         if context == _CONTEXT_COLAB:
             return self._serve_colab(blocking=blocking, debug=debug, port=port)
         else:
-            return self._serve(blocking=blocking, debug=debug, port=port)
+            return self._serve(
+                blocking=blocking, debug=debug, port=port, bind_all=bind_all
+            )
 
-    def _serve(self, blocking=False, debug=False, port=None):
+    def _serve(self, blocking=False, debug=False, port=None, bind_all=False):
         from .server import start_server
 
-        return start_server(self, blocking=blocking, debug=debug, _port=port)
+        return start_server(
+            self, blocking=blocking, debug=debug, _port=port, bind_all=bind_all
+        )
 
     def _serve_colab(self, blocking=False, debug=False, port=None):
         import ipywidgets as widgets

--- a/captum/insights/attr_vis/server.py
+++ b/captum/insights/attr_vis/server.py
@@ -74,13 +74,20 @@ def get_free_tcp_port():
     return port
 
 
-def run_app(debug: bool = True):
-    app.run(port=port, use_reloader=False, debug=debug)
+def run_app(debug: bool = True, bind_all: bool = False):
+    if bind_all:
+        app.run(port=port, use_reloader=False, debug=debug, host="0.0.0.0")
+    else:
+        app.run(port=port, use_reloader=False, debug=debug)
 
 
 @log_usage()
 def start_server(
-    _viz, blocking: bool = False, debug: bool = False, _port: Optional[int] = None
+    _viz,
+    blocking: bool = False,
+    debug: bool = False,
+    _port: Optional[int] = None,
+    bind_all: bool = False,
 ):
     global visualizer
     visualizer = _viz
@@ -95,7 +102,9 @@ def start_server(
 
         port = _port or get_free_tcp_port()
         # Start in a new thread to not block notebook execution
-        t = threading.Thread(target=run_app, kwargs={"debug": debug})
+        t = threading.Thread(
+            target=run_app, kwargs={"debug": debug, "bind_all": bind_all}
+        )
         t.start()
         sleep(0.01)  # add a short delay to allow server to start up
         if blocking:

--- a/setup.py
+++ b/setup.py
@@ -149,14 +149,14 @@ if __name__ == "__main__":
             (
                 "share/jupyter/nbextensions/jupyter-captum-insights",
                 [
-                    "captum/insights/widget/static/extension.js",
-                    "captum/insights/widget/static/index.js",
-                    "captum/insights/widget/static/index.js.map",
+                    "captum/insights/attr_vis/widget/static/extension.js",
+                    "captum/insights/attr_vis/widget/static/index.js",
+                    "captum/insights/attr_vis/widget/static/index.js.map",
                 ],
             ),
             (
                 "etc/jupyter/nbconfig/notebook.d",
-                ["captum/insights/widget/jupyter-captum-insights.json"],
+                ["captum/insights/attr_vis/widget/jupyter-captum-insights.json"],
             ),
         ],
     )


### PR DESCRIPTION
_Proposal_ for fixing #509. This allows running Insights inside Docker container and connecting to Flask app via port that is exposed to localhost (e.g. 6006).

Note: I couldn't get Insights widget to work, however, since I'm not expert with widgets. Probably when running `render` port is assigned automatically, since I don't see `port` argument there. To make connection to work, port would need to be set manually and binding flag passed in like in `server` method. Maybe somebody more knowledgeable with widgets could make that change?