### PR TITLE
Fix Shapley Value for Non-Float Input

### DIFF
--- a/captum/attr/_core/shapley_value.py
+++ b/captum/attr/_core/shapley_value.py
@@ -294,7 +294,9 @@ class ShapleyValueSampling(PerturbationAttribution):
 
             # Initialize attribution totals and counts
             total_attrib = [
-                torch.zeros_like(input[0:1] if agg_output_mode else input)
+                torch.zeros_like(
+                    input[0:1] if agg_output_mode else input, dtype=torch.float
+                )
                 for input in inputs
             ]
 

--- a/tests/attr/test_shapley.py
+++ b/tests/attr/test_shapley.py
@@ -153,6 +153,30 @@ class Test(BaseTest):
             lambda inp: int(torch.sum(net(inp)).item())
         )
 
+    def test_single_shapley_int_batch_scalar_float(self) -> None:
+        net = BasicModel_MultiLayer()
+        self._single_int_input_multi_sample_batch_scalar_shapley_assert(
+            lambda inp: torch.sum(net(inp.float())).item()
+        )
+
+    def test_single_shapley_int_batch_scalar_tensor_0d(self) -> None:
+        net = BasicModel_MultiLayer()
+        self._single_int_input_multi_sample_batch_scalar_shapley_assert(
+            lambda inp: torch.sum(net(inp.float()))
+        )
+
+    def test_single_shapley_int_batch_scalar_tensor_1d(self) -> None:
+        net = BasicModel_MultiLayer()
+        self._single_int_input_multi_sample_batch_scalar_shapley_assert(
+            lambda inp: torch.sum(net(inp.float())).reshape(1)
+        )
+
+    def test_single_shapley_int_batch_scalar_tensor_int(self) -> None:
+        net = BasicModel_MultiLayer()
+        self._single_int_input_multi_sample_batch_scalar_shapley_assert(
+            lambda inp: int(torch.sum(net(inp.float())).item())
+        )
+
     def test_multi_sample_shapley_batch_scalar_float(self) -> None:
         net = BasicModel_MultiLayer()
         self._single_input_multi_sample_batch_scalar_shapley_assert(
@@ -218,6 +242,21 @@ class Test(BaseTest):
         self, func: Callable
     ) -> None:
         inp = torch.tensor([[2.0, 10.0, 3.0], [20.0, 50.0, 30.0]], requires_grad=True)
+        mask = torch.tensor([[0, 0, 1]])
+
+        self._shapley_test_assert(
+            func,
+            inp,
+            [[629.0, 629.0, 251.0]],
+            feature_mask=mask,
+            perturbations_per_eval=(1,),
+            target=None,
+        )
+
+    def _single_int_input_multi_sample_batch_scalar_shapley_assert(
+        self, func: Callable
+    ) -> None:
+        inp = torch.tensor([[2, 10, 3], [20, 50, 30]])
         mask = torch.tensor([[0, 0, 1]])
 
         self._shapley_test_assert(


### PR DESCRIPTION
Addresses #498 by adding torch.float when initializing attr and adding corresponding test cases for integer input.