### PR TITLE
Refactor relative imports to absolute

### DIFF
--- a/tests/attr/helpers/test_config.py
+++ b/tests/attr/helpers/test_config.py
@@ -36,9 +36,8 @@ from captum.attr._core.neuron.neuron_integrated_gradients import (
 from captum.attr._core.occlusion import Occlusion
 from captum.attr._core.saliency import Saliency
 from captum.attr._core.shapley_value import ShapleyValueSampling
-
-from ...helpers.basic import set_all_random_seeds
-from ...helpers.basic_models import (
+from tests.helpers.basic import set_all_random_seeds
+from tests.helpers.basic_models import (
     BasicModel_ConvNet,
     BasicModel_MultiLayer,
     BasicModel_MultiLayer_MultiInput,

--- a/tests/attr/layer/test_grad_cam.py
+++ b/tests/attr/layer/test_grad_cam.py
@@ -8,9 +8,11 @@ from torch import Tensor
 from torch.nn import Module
 
 from captum.attr._core.layer.grad_cam import LayerGradCam
-
-from ...helpers.basic import BaseTest, assertTensorTuplesAlmostEqual
-from ...helpers.basic_models import BasicModel_ConvNet_One_Conv, BasicModel_MultiLayer
+from tests.helpers.basic import BaseTest, assertTensorTuplesAlmostEqual
+from tests.helpers.basic_models import (
+    BasicModel_ConvNet_One_Conv,
+    BasicModel_MultiLayer,
+)
 
 
 class Test(BaseTest):

--- a/tests/attr/layer/test_internal_influence.py
+++ b/tests/attr/layer/test_internal_influence.py
@@ -8,9 +8,8 @@ from torch.nn import Module
 
 from captum._utils.typing import BaselineType
 from captum.attr._core.layer.internal_influence import InternalInfluence
-
-from ...helpers.basic import BaseTest, assertTensorTuplesAlmostEqual
-from ...helpers.basic_models import (
+from tests.helpers.basic import BaseTest, assertTensorTuplesAlmostEqual
+from tests.helpers.basic_models import (
     BasicModel_MultiLayer,
     BasicModel_MultiLayer_MultiInput,
 )

--- a/tests/attr/layer/test_layer_ablation.py
+++ b/tests/attr/layer/test_layer_ablation.py
@@ -9,9 +9,8 @@ from torch.nn import Module
 
 from captum._utils.typing import BaselineType
 from captum.attr._core.layer.layer_feature_ablation import LayerFeatureAblation
-
-from ...helpers.basic import BaseTest, assertTensorTuplesAlmostEqual
-from ...helpers.basic_models import (
+from tests.helpers.basic import BaseTest, assertTensorTuplesAlmostEqual
+from tests.helpers.basic_models import (
     BasicModel_ConvNet_One_Conv,
     BasicModel_MultiLayer,
     BasicModel_MultiLayer_MultiInput,

--- a/tests/attr/layer/test_layer_activation.py
+++ b/tests/attr/layer/test_layer_activation.py
@@ -9,13 +9,12 @@ from torch import Tensor
 from torch.nn import Module
 
 from captum.attr._core.layer.layer_activation import LayerActivation
-
-from ...helpers.basic import (
+from tests.helpers.basic import (
     BaseTest,
     assertTensorAlmostEqual,
     assertTensorTuplesAlmostEqual,
 )
-from ...helpers.basic_models import (
+from tests.helpers.basic_models import (
     BasicModel_MultiLayer,
     BasicModel_MultiLayer_MultiInput,
     Conv1dSeqModel,

--- a/tests/attr/layer/test_layer_conductance.py
+++ b/tests/attr/layer/test_layer_conductance.py
@@ -9,18 +9,17 @@ from torch.nn import Module
 
 from captum._utils.typing import BaselineType
 from captum.attr._core.layer.layer_conductance import LayerConductance
-
-from ...helpers.basic import (
+from tests.attr.helpers.conductance_reference import ConductanceReference
+from tests.helpers.basic import (
     BaseTest,
     assertArraysAlmostEqual,
     assertTensorTuplesAlmostEqual,
 )
-from ...helpers.basic_models import (
+from tests.helpers.basic_models import (
     BasicModel_ConvNet,
     BasicModel_MultiLayer,
     BasicModel_MultiLayer_MultiInput,
 )
-from ..helpers.conductance_reference import ConductanceReference
 
 
 class Test(BaseTest):

--- a/tests/attr/layer/test_layer_deeplift.py
+++ b/tests/attr/layer/test_layer_deeplift.py
@@ -8,15 +8,14 @@ import torch
 from torch import Tensor
 
 from captum.attr._core.layer.layer_deep_lift import LayerDeepLift, LayerDeepLiftShap
-
-from ...helpers.basic import (
+from tests.helpers.basic import (
     BaseTest,
     assert_delta,
     assertArraysAlmostEqual,
     assertTensorAlmostEqual,
     assertTensorTuplesAlmostEqual,
 )
-from ...helpers.basic_models import (
+from tests.helpers.basic_models import (
     BasicModel_ConvNet,
     BasicModel_ConvNet_MaxPool3d,
     BasicModel_MaxPool_ReLU,

--- a/tests/attr/layer/test_layer_gradient_shap.py
+++ b/tests/attr/layer/test_layer_gradient_shap.py
@@ -8,18 +8,17 @@ from torch.nn import Module
 from captum._utils.typing import TargetType, TensorOrTupleOfTensorsGeneric
 from captum.attr._core.gradient_shap import GradientShap
 from captum.attr._core.layer.layer_gradient_shap import LayerGradientShap
-
-from ...helpers.basic import (
+from tests.attr.test_gradient_shap import _assert_attribution_delta
+from tests.helpers.basic import (
     BaseTest,
     assertTensorAlmostEqual,
     assertTensorTuplesAlmostEqual,
 )
-from ...helpers.basic_models import (
+from tests.helpers.basic_models import (
     BasicModel_MultiLayer,
     BasicModel_MultiLayer_MultiInput,
 )
-from ...helpers.classification_models import SoftmaxModel
-from ..test_gradient_shap import _assert_attribution_delta
+from tests.helpers.classification_models import SoftmaxModel
 
 
 class Test(BaseTest):

--- a/tests/attr/layer/test_layer_gradient_x_activation.py
+++ b/tests/attr/layer/test_layer_gradient_x_activation.py
@@ -9,9 +9,8 @@ from torch.nn import Module
 from captum._utils.typing import ModuleOrModuleList
 from captum.attr._core.layer.layer_activation import LayerActivation
 from captum.attr._core.layer.layer_gradient_x_activation import LayerGradientXActivation
-
-from ...helpers.basic import BaseTest, assertTensorTuplesAlmostEqual
-from ...helpers.basic_models import (
+from tests.helpers.basic import BaseTest, assertTensorTuplesAlmostEqual
+from tests.helpers.basic_models import (
     BasicEmbeddingModel,
     BasicModel_MultiLayer,
     BasicModel_MultiLayer_MultiInput,

--- a/tests/attr/layer/test_layer_integrated_gradients.py
+++ b/tests/attr/layer/test_layer_integrated_gradients.py
@@ -14,13 +14,12 @@ from captum.attr._models.base import (
     configure_interpretable_embedding_layer,
     remove_interpretable_embedding_layer,
 )
-
-from ...helpers.basic import (
+from tests.helpers.basic import (
     BaseTest,
     assertArraysAlmostEqual,
     assertTensorTuplesAlmostEqual,
 )
-from ...helpers.basic_models import BasicEmbeddingModel, BasicModel_MultiLayer
+from tests.helpers.basic_models import BasicEmbeddingModel, BasicModel_MultiLayer
 
 
 class Test(BaseTest):

--- a/tests/attr/models/test_base.py
+++ b/tests/attr/models/test_base.py
@@ -12,9 +12,8 @@ from captum.attr._models.base import (
     configure_interpretable_embedding_layer,
     remove_interpretable_embedding_layer,
 )
-
-from ...helpers.basic import assertArraysAlmostEqual
-from ...helpers.basic_models import BasicEmbeddingModel, TextModule
+from tests.helpers.basic import assertArraysAlmostEqual
+from tests.helpers.basic_models import BasicEmbeddingModel, TextModule
 
 
 class Test(unittest.TestCase):

--- a/tests/attr/neuron/test_neuron_ablation.py
+++ b/tests/attr/neuron/test_neuron_ablation.py
@@ -9,9 +9,8 @@ from torch.nn import Module
 
 from captum._utils.typing import BaselineType, TensorOrTupleOfTensorsGeneric
 from captum.attr._core.neuron.neuron_feature_ablation import NeuronFeatureAblation
-
-from ...helpers.basic import BaseTest, assertTensorAlmostEqual
-from ...helpers.basic_models import (
+from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
+from tests.helpers.basic_models import (
     BasicModel_ConvNet_One_Conv,
     BasicModel_MultiLayer,
     BasicModel_MultiLayer_MultiInput,

--- a/tests/attr/neuron/test_neuron_conductance.py
+++ b/tests/attr/neuron/test_neuron_conductance.py
@@ -10,9 +10,8 @@ from torch.nn import Module
 from captum._utils.typing import BaselineType, TensorOrTupleOfTensorsGeneric
 from captum.attr._core.layer.layer_conductance import LayerConductance
 from captum.attr._core.neuron.neuron_conductance import NeuronConductance
-
-from ...helpers.basic import BaseTest, assertArraysAlmostEqual
-from ...helpers.basic_models import (
+from tests.helpers.basic import BaseTest, assertArraysAlmostEqual
+from tests.helpers.basic_models import (
     BasicModel_ConvNet,
     BasicModel_MultiLayer,
     BasicModel_MultiLayer_MultiInput,

--- a/tests/attr/neuron/test_neuron_deeplift.py
+++ b/tests/attr/neuron/test_neuron_deeplift.py
@@ -9,17 +9,16 @@ from torch import Tensor
 
 from captum._utils.typing import TensorOrTupleOfTensorsGeneric
 from captum.attr._core.neuron.neuron_deep_lift import NeuronDeepLift, NeuronDeepLiftShap
-
-from ...helpers.basic import BaseTest, assertTensorAlmostEqual
-from ...helpers.basic_models import (
+from tests.attr.layer.test_layer_deeplift import (
+    _create_inps_and_base_for_deeplift_neuron_layer_testing,
+    _create_inps_and_base_for_deepliftshap_neuron_layer_testing,
+)
+from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
+from tests.helpers.basic_models import (
     BasicModel_ConvNet,
     BasicModel_ConvNet_MaxPool3d,
     LinearMaxPoolLinearModel,
     ReLULinearModel,
-)
-from ..layer.test_layer_deeplift import (
-    _create_inps_and_base_for_deeplift_neuron_layer_testing,
-    _create_inps_and_base_for_deepliftshap_neuron_layer_testing,
 )
 
 

--- a/tests/attr/neuron/test_neuron_gradient.py
+++ b/tests/attr/neuron/test_neuron_gradient.py
@@ -11,13 +11,12 @@ from captum._utils.gradient import _forward_layer_eval
 from captum._utils.typing import TensorOrTupleOfTensorsGeneric
 from captum.attr._core.neuron.neuron_gradient import NeuronGradient
 from captum.attr._core.saliency import Saliency
-
-from ...helpers.basic import (
+from tests.helpers.basic import (
     BaseTest,
     assertArraysAlmostEqual,
     assertTensorTuplesAlmostEqual,
 )
-from ...helpers.basic_models import (
+from tests.helpers.basic_models import (
     BasicModel_ConvNet,
     BasicModel_MultiLayer,
     BasicModel_MultiLayer_MultiInput,

--- a/tests/attr/neuron/test_neuron_gradient_shap.py
+++ b/tests/attr/neuron/test_neuron_gradient_shap.py
@@ -9,10 +9,9 @@ from captum.attr._core.neuron.neuron_gradient_shap import NeuronGradientShap
 from captum.attr._core.neuron.neuron_integrated_gradients import (
     NeuronIntegratedGradients,
 )
-
-from ...helpers.basic import BaseTest, assertTensorAlmostEqual
-from ...helpers.basic_models import BasicModel_MultiLayer
-from ...helpers.classification_models import SoftmaxModel
+from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
+from tests.helpers.basic_models import BasicModel_MultiLayer
+from tests.helpers.classification_models import SoftmaxModel
 
 
 class Test(BaseTest):

--- a/tests/attr/neuron/test_neuron_integrated_gradients.py
+++ b/tests/attr/neuron/test_neuron_integrated_gradients.py
@@ -12,13 +12,12 @@ from captum.attr._core.integrated_gradients import IntegratedGradients
 from captum.attr._core.neuron.neuron_integrated_gradients import (
     NeuronIntegratedGradients,
 )
-
-from ...helpers.basic import (
+from tests.helpers.basic import (
     BaseTest,
     assertArraysAlmostEqual,
     assertTensorTuplesAlmostEqual,
 )
-from ...helpers.basic_models import (
+from tests.helpers.basic_models import (
     BasicModel_ConvNet,
     BasicModel_MultiLayer,
     BasicModel_MultiLayer_MultiInput,

--- a/tests/attr/test_approximation_methods.py
+++ b/tests/attr/test_approximation_methods.py
@@ -3,8 +3,7 @@
 import unittest
 
 from captum.attr._utils.approximation_methods import Riemann, riemann_builders
-
-from ..helpers.basic import assertArraysAlmostEqual
+from tests.helpers.basic import assertArraysAlmostEqual
 
 
 class Test(unittest.TestCase):

--- a/tests/attr/test_common.py
+++ b/tests/attr/test_common.py
@@ -4,8 +4,7 @@ import torch
 
 from captum.attr._core.noise_tunnel import SUPPORTED_NOISE_TUNNEL_TYPES
 from captum.attr._utils.common import _validate_input, _validate_noise_tunnel_type
-
-from ..helpers.basic import BaseTest
+from tests.helpers.basic import BaseTest
 
 
 class Test(BaseTest):

--- a/tests/attr/test_data_parallel.py
+++ b/tests/attr/test_data_parallel.py
@@ -18,15 +18,14 @@ from captum.attr._core.neuron.neuron_guided_backprop_deconvnet import (
 )
 from captum.attr._core.noise_tunnel import NoiseTunnel
 from captum.attr._utils.attribution import Attribution, InternalAttribution
-
-from ..helpers.basic import BaseTest, assertTensorTuplesAlmostEqual, deep_copy_args
-from .helpers.gen_test_utils import (
+from tests.attr.helpers.gen_test_utils import (
     gen_test_name,
     get_target_layer,
     parse_test_config,
     should_create_generated_test,
 )
-from .helpers.test_config import config
+from tests.attr.helpers.test_config import config
+from tests.helpers.basic import BaseTest, assertTensorTuplesAlmostEqual, deep_copy_args
 
 """
 Tests in this file are dynamically generated based on the config

--- a/tests/attr/test_deconvolution.py
+++ b/tests/attr/test_deconvolution.py
@@ -13,9 +13,8 @@ from captum.attr._core.guided_backprop_deconvnet import Deconvolution
 from captum.attr._core.neuron.neuron_guided_backprop_deconvnet import (
     NeuronDeconvolution,
 )
-
-from ..helpers.basic import BaseTest, assertTensorAlmostEqual
-from ..helpers.basic_models import BasicModel_ConvNet_One_Conv
+from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
+from tests.helpers.basic_models import BasicModel_ConvNet_One_Conv
 
 
 class Test(BaseTest):

--- a/tests/attr/test_deeplift_basic.py
+++ b/tests/attr/test_deeplift_basic.py
@@ -9,14 +9,13 @@ from torch.nn import Module
 
 from captum.attr._core.deep_lift import DeepLift, DeepLiftShap
 from captum.attr._core.integrated_gradients import IntegratedGradients
-
-from ..helpers.basic import (
+from tests.helpers.basic import (
     BaseTest,
     assertArraysAlmostEqual,
     assertAttributionComparision,
     assertTensorAlmostEqual,
 )
-from ..helpers.basic_models import (
+from tests.helpers.basic_models import (
     BasicModelWithReusableModules,
     Conv1dSeqModel,
     LinearMaxPoolLinearModel,

--- a/tests/attr/test_deeplift_classification.py
+++ b/tests/attr/test_deeplift_classification.py
@@ -9,14 +9,16 @@ from torch.nn import Module
 from captum._utils.typing import TargetType
 from captum.attr._core.deep_lift import DeepLift, DeepLiftShap
 from captum.attr._core.integrated_gradients import IntegratedGradients
-
-from ..helpers.basic import BaseTest, assertAttributionComparision
-from ..helpers.basic_models import (
+from tests.helpers.basic import BaseTest, assertAttributionComparision
+from tests.helpers.basic_models import (
     BasicModel_ConvNet,
     BasicModel_ConvNet_MaxPool1d,
     BasicModel_ConvNet_MaxPool3d,
 )
-from ..helpers.classification_models import SigmoidDeepLiftModel, SoftmaxDeepLiftModel
+from tests.helpers.classification_models import (
+    SigmoidDeepLiftModel,
+    SoftmaxDeepLiftModel,
+)
 
 
 class Test(BaseTest):

--- a/tests/attr/test_feature_ablation.py
+++ b/tests/attr/test_feature_ablation.py
@@ -8,9 +8,8 @@ from torch import Tensor
 
 from captum._utils.typing import BaselineType, TargetType, TensorOrTupleOfTensorsGeneric
 from captum.attr._core.feature_ablation import FeatureAblation
-
-from ..helpers.basic import BaseTest, assertTensorAlmostEqual
-from ..helpers.basic_models import (
+from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
+from tests.helpers.basic_models import (
     BasicModel,
     BasicModel_ConvNet_One_Conv,
     BasicModel_MultiLayer,

--- a/tests/attr/test_feature_permutation.py
+++ b/tests/attr/test_feature_permutation.py
@@ -5,9 +5,12 @@ import torch
 from torch import Tensor
 
 from captum.attr._core.feature_permutation import FeaturePermutation, _permute_feature
-
-from ..helpers.basic import BaseTest, assertArraysAlmostEqual, assertTensorAlmostEqual
-from ..helpers.basic_models import BasicModelWithSparseInputs
+from tests.helpers.basic import (
+    BaseTest,
+    assertArraysAlmostEqual,
+    assertTensorAlmostEqual,
+)
+from tests.helpers.basic_models import BasicModelWithSparseInputs
 
 
 class Test(BaseTest):

--- a/tests/attr/test_gradient_shap.py
+++ b/tests/attr/test_gradient_shap.py
@@ -9,10 +9,13 @@ from numpy import ndarray
 from captum._utils.typing import Tensor
 from captum.attr._core.gradient_shap import GradientShap
 from captum.attr._core.integrated_gradients import IntegratedGradients
-
-from ..helpers.basic import BaseTest, assertArraysAlmostEqual, assertTensorAlmostEqual
-from ..helpers.basic_models import BasicLinearModel, BasicModel2
-from ..helpers.classification_models import SoftmaxModel
+from tests.helpers.basic import (
+    BaseTest,
+    assertArraysAlmostEqual,
+    assertTensorAlmostEqual,
+)
+from tests.helpers.basic_models import BasicLinearModel, BasicModel2
+from tests.helpers.classification_models import SoftmaxModel
 
 
 class Test(BaseTest):

--- a/tests/attr/test_guided_backprop.py
+++ b/tests/attr/test_guided_backprop.py
@@ -11,9 +11,8 @@ from captum.attr._core.guided_backprop_deconvnet import GuidedBackprop
 from captum.attr._core.neuron.neuron_guided_backprop_deconvnet import (
     NeuronGuidedBackprop,
 )
-
-from ..helpers.basic import BaseTest, assertTensorAlmostEqual
-from ..helpers.basic_models import BasicModel_ConvNet_One_Conv
+from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
+from tests.helpers.basic_models import BasicModel_ConvNet_One_Conv
 
 
 class Test(BaseTest):

--- a/tests/attr/test_guided_grad_cam.py
+++ b/tests/attr/test_guided_grad_cam.py
@@ -8,9 +8,8 @@ from torch.nn import Module
 
 from captum._utils.typing import TensorOrTupleOfTensorsGeneric
 from captum.attr._core.guided_grad_cam import GuidedGradCam
-
-from ..helpers.basic import BaseTest, assertTensorAlmostEqual
-from ..helpers.basic_models import BasicModel_ConvNet_One_Conv
+from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
+from tests.helpers.basic_models import BasicModel_ConvNet_One_Conv
 
 
 class Test(BaseTest):

--- a/tests/attr/test_hook_removal.py
+++ b/tests/attr/test_hook_removal.py
@@ -8,15 +8,14 @@ from torch.nn import Module
 from captum.attr._core.noise_tunnel import NoiseTunnel
 from captum.attr._models.base import _set_deep_layer_value
 from captum.attr._utils.attribution import Attribution, InternalAttribution
-
-from ..helpers.basic import BaseTest, deep_copy_args
-from .helpers.gen_test_utils import (
+from tests.attr.helpers.gen_test_utils import (
     gen_test_name,
     get_target_layer,
     parse_test_config,
     should_create_generated_test,
 )
-from .helpers.test_config import config
+from tests.attr.helpers.test_config import config
+from tests.helpers.basic import BaseTest, deep_copy_args
 
 """
 Tests in this file are dynamically generated based on the config

--- a/tests/attr/test_input_x_gradient.py
+++ b/tests/attr/test_input_x_gradient.py
@@ -8,10 +8,9 @@ from torch.nn import Module
 from captum._utils.typing import TensorOrTupleOfTensorsGeneric
 from captum.attr._core.input_x_gradient import InputXGradient
 from captum.attr._core.noise_tunnel import NoiseTunnel
-
-from ..helpers.basic import BaseTest, assertArraysAlmostEqual
-from ..helpers.classification_models import SoftmaxModel
-from .test_saliency import _get_basic_config, _get_multiargs_basic_config
+from tests.attr.test_saliency import _get_basic_config, _get_multiargs_basic_config
+from tests.helpers.basic import BaseTest, assertArraysAlmostEqual
+from tests.helpers.classification_models import SoftmaxModel
 
 
 class Test(BaseTest):

--- a/tests/attr/test_integrated_gradients_basic.py
+++ b/tests/attr/test_integrated_gradients_basic.py
@@ -11,9 +11,12 @@ from captum._utils.typing import BaselineType, Tensor, TensorOrTupleOfTensorsGen
 from captum.attr._core.integrated_gradients import IntegratedGradients
 from captum.attr._core.noise_tunnel import NoiseTunnel
 from captum.attr._utils.common import _tensorize_baseline
-
-from ..helpers.basic import BaseTest, assertArraysAlmostEqual, assertTensorAlmostEqual
-from ..helpers.basic_models import (
+from tests.helpers.basic import (
+    BaseTest,
+    assertArraysAlmostEqual,
+    assertTensorAlmostEqual,
+)
+from tests.helpers.basic_models import (
     BasicModel,
     BasicModel2,
     BasicModel3,

--- a/tests/attr/test_integrated_gradients_classification.py
+++ b/tests/attr/test_integrated_gradients_classification.py
@@ -8,9 +8,8 @@ from torch.nn import Module
 from captum._utils.typing import BaselineType, Tensor
 from captum.attr._core.integrated_gradients import IntegratedGradients
 from captum.attr._core.noise_tunnel import NoiseTunnel
-
-from ..helpers.basic import BaseTest, assertTensorAlmostEqual
-from ..helpers.classification_models import SigmoidModel, SoftmaxModel
+from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
+from tests.helpers.classification_models import SigmoidModel, SoftmaxModel
 
 
 class Test(BaseTest):

--- a/tests/attr/test_jit.py
+++ b/tests/attr/test_jit.py
@@ -20,14 +20,13 @@ from captum.attr._core.occlusion import Occlusion
 from captum.attr._core.saliency import Saliency
 from captum.attr._core.shapley_value import ShapleyValueSampling
 from captum.attr._utils.attribution import Attribution
-
-from ..helpers.basic import BaseTest, assertTensorTuplesAlmostEqual, deep_copy_args
-from .helpers.gen_test_utils import (
+from tests.attr.helpers.gen_test_utils import (
     gen_test_name,
     parse_test_config,
     should_create_generated_test,
 )
-from .helpers.test_config import config
+from tests.attr.helpers.test_config import config
+from tests.helpers.basic import BaseTest, assertTensorTuplesAlmostEqual, deep_copy_args
 
 JIT_SUPPORTED = [
     IntegratedGradients,

--- a/tests/attr/test_occlusion.py
+++ b/tests/attr/test_occlusion.py
@@ -7,9 +7,8 @@ from torch import Tensor
 
 from captum._utils.typing import BaselineType, TargetType, TensorOrTupleOfTensorsGeneric
 from captum.attr._core.occlusion import Occlusion
-
-from ..helpers.basic import BaseTest, assertTensorAlmostEqual
-from ..helpers.basic_models import (
+from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
+from tests.helpers.basic_models import (
     BasicModel3,
     BasicModel_ConvNet_One_Conv,
     BasicModel_MultiLayer,

--- a/tests/attr/test_saliency.py
+++ b/tests/attr/test_saliency.py
@@ -9,10 +9,9 @@ from captum._utils.gradient import compute_gradients
 from captum._utils.typing import TensorOrTupleOfTensorsGeneric
 from captum.attr._core.noise_tunnel import NoiseTunnel
 from captum.attr._core.saliency import Saliency
-
-from ..helpers.basic import BaseTest, assertArraysAlmostEqual
-from ..helpers.basic_models import BasicModel, BasicModel5_MultiArgs
-from ..helpers.classification_models import SoftmaxModel
+from tests.helpers.basic import BaseTest, assertArraysAlmostEqual
+from tests.helpers.basic_models import BasicModel, BasicModel5_MultiArgs
+from tests.helpers.classification_models import SoftmaxModel
 
 
 def _get_basic_config() -> Tuple[Module, Tensor, Tensor, Any]:

--- a/tests/attr/test_shapley.py
+++ b/tests/attr/test_shapley.py
@@ -7,9 +7,8 @@ import torch
 
 from captum._utils.typing import BaselineType, TensorOrTupleOfTensorsGeneric
 from captum.attr._core.shapley_value import ShapleyValues, ShapleyValueSampling
-
-from ..helpers.basic import BaseTest, assertTensorTuplesAlmostEqual
-from ..helpers.basic_models import (
+from tests.helpers.basic import BaseTest, assertTensorTuplesAlmostEqual
+from tests.helpers.basic_models import (
     BasicModel_MultiLayer,
     BasicModel_MultiLayer_MultiInput,
 )

--- a/tests/attr/test_stat.py
+++ b/tests/attr/test_stat.py
@@ -5,8 +5,11 @@ import numpy as np
 import torch
 
 from captum.attr import MSE, Max, Mean, Min, StdDev, Sum, Summarizer, Var
-
-from ..helpers.basic import BaseTest, assertArraysAlmostEqual, assertTensorAlmostEqual
+from tests.helpers.basic import (
+    BaseTest,
+    assertArraysAlmostEqual,
+    assertTensorAlmostEqual,
+)
 
 
 def get_values(n=100, lo=None, hi=None, integers=False):

--- a/tests/attr/test_summarizer.py
+++ b/tests/attr/test_summarizer.py
@@ -2,8 +2,7 @@
 import torch
 
 from captum.attr import CommonStats, Summarizer
-
-from ..helpers.basic import BaseTest
+from tests.helpers.basic import BaseTest
 
 
 class Test(BaseTest):

--- a/tests/attr/test_targets.py
+++ b/tests/attr/test_targets.py
@@ -13,16 +13,15 @@ from captum.attr._core.integrated_gradients import IntegratedGradients
 from captum.attr._core.lime import Lime
 from captum.attr._core.noise_tunnel import NoiseTunnel
 from captum.attr._utils.attribution import Attribution, InternalAttribution
-
-from ..helpers.basic import BaseTest, assertTensorTuplesAlmostEqual, deep_copy_args
-from ..helpers.basic_models import BasicModel_MultiLayer
-from .helpers.gen_test_utils import (
+from tests.attr.helpers.gen_test_utils import (
     gen_test_name,
     get_target_layer,
     parse_test_config,
     should_create_generated_test,
 )
-from .helpers.test_config import config
+from tests.attr.helpers.test_config import config
+from tests.helpers.basic import BaseTest, assertTensorTuplesAlmostEqual, deep_copy_args
+from tests.helpers.basic_models import BasicModel_MultiLayer
 
 """
 Tests in this file are dynamically generated based on the config

--- a/tests/attr/test_utils_batching.py
+++ b/tests/attr/test_utils_batching.py
@@ -7,8 +7,7 @@ from captum.attr._utils.batching import (
     _batched_operator,
     _tuple_splice_range,
 )
-
-from ..helpers.basic import BaseTest, assertTensorAlmostEqual
+from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
 
 
 class Test(BaseTest):

--- a/tests/metrics/test_infidelity.py
+++ b/tests/metrics/test_infidelity.py
@@ -15,9 +15,12 @@ from captum.attr import (
     Saliency,
 )
 from captum.metrics import infidelity, infidelity_perturb_func_decorator
-
-from ..helpers.basic import BaseTest, assertArraysAlmostEqual, assertTensorAlmostEqual
-from ..helpers.basic_models import (
+from tests.helpers.basic import (
+    BaseTest,
+    assertArraysAlmostEqual,
+    assertTensorAlmostEqual,
+)
+from tests.helpers.basic_models import (
     BasicModel2,
     BasicModel4_MultiArgs,
     BasicModel_ConvNet_One_Conv,

--- a/tests/metrics/test_sensitivity.py
+++ b/tests/metrics/test_sensitivity.py
@@ -15,9 +15,8 @@ from captum.attr import (
 )
 from captum.metrics import sensitivity_max
 from captum.metrics._core.sensitivity import default_perturb_func
-
-from ..helpers.basic import BaseTest, assertTensorAlmostEqual
-from ..helpers.basic_models import (
+from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
+from tests.helpers.basic_models import (
     BasicModel2,
     BasicModel4_MultiArgs,
     BasicModel_ConvNet_One_Conv,

--- a/tests/utils/test_common.py
+++ b/tests/utils/test_common.py
@@ -5,8 +5,7 @@ from typing import List, Tuple, cast
 import torch
 
 from captum._utils.common import _reduce_list, _select_targets, _sort_key_list
-
-from ..helpers.basic import BaseTest, assertTensorAlmostEqual
+from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
 
 
 class Test(BaseTest):

--- a/tests/utils/test_gradient.py
+++ b/tests/utils/test_gradient.py
@@ -11,9 +11,8 @@ from captum._utils.gradient import (
     compute_layer_gradients_and_eval,
     undo_gradient_requirements,
 )
-
-from ..helpers.basic import BaseTest, assertArraysAlmostEqual
-from ..helpers.basic_models import (
+from tests.helpers.basic import BaseTest, assertArraysAlmostEqual
+from tests.helpers.basic_models import (
     BasicModel,
     BasicModel2,
     BasicModel4_MultiArgs,


### PR DESCRIPTION
Summary:
First I ran `find ~/fbsource/fbcode/pytorch/captum ! -path '*/fb/*' ! -path '*.mypy_cache*' -type f | grep tests` to determine which files needed to have relative imports be converted to absolute.

I then went into each file and converted the relative imports with its corresponding absolute path, according to the project's directory tree.

Reviewed By: miguelmartin75

Differential Revision: D24803774

