### PR TITLE
fix import bug in insights

### DIFF
--- a/captum/insights/attr_vis/widget/__init__.py
+++ b/captum/insights/attr_vis/widget/__init__.py
@@ -1,5 +1,5 @@
-from captum.insights.attr_vis.widget import *  # noqa
 from captum.insights.attr_vis.widget._version import __version__, version_info  # noqa
+from captum.insights.attr_vis.widget.widget import *  # noqa
 
 
 def _jupyter_nbextension_paths():


### PR DESCRIPTION
Summary:
Bug introduced when converting to absolute imports.

This bug occurs when calling `AttributionVisualizer.render` (line of interest: https://fburl.com/llsznt50). This method is not covered in unit tests hence why it passed.

Reviewed By: NarineK

Differential Revision: D24912325

