### PR TITLE
Fixes to Lime Model Construction and API Docs

### DIFF
--- a/captum/attr/_core/kernel_shap.py
+++ b/captum/attr/_core/kernel_shap.py
@@ -130,27 +130,27 @@ class KernelShap(Lime):
                         Baselines can be provided as:
 
                         - a single tensor, if inputs is a single tensor, with
-                            exactly the same dimensions as inputs or the first
-                            dimension is one and the remaining dimensions match
-                            with inputs.
+                          exactly the same dimensions as inputs or the first
+                          dimension is one and the remaining dimensions match
+                          with inputs.
 
                         - a single scalar, if inputs is a single tensor, which will
-                            be broadcasted for each input value in input tensor.
+                          be broadcasted for each input value in input tensor.
 
                         - a tuple of tensors or scalars, the baseline corresponding
-                            to each tensor in the inputs' tuple can be:
+                          to each tensor in the inputs' tuple can be:
 
-                            - either a tensor with matching dimensions to
+                          - either a tensor with matching dimensions to
                             corresponding tensor in the inputs' tuple
                             or the first dimension is one and the remaining
                             dimensions match with the corresponding
                             input tensor.
 
-                            - or a scalar, corresponding to a tensor in the
+                          - or a scalar, corresponding to a tensor in the
                             inputs' tuple. This scalar value is broadcasted
                             for corresponding input tensor.
                         In the cases when `baselines` is not provided, we internally
-                        use zero corresponding to each input tensor.
+                        use zero scalar corresponding to each input tensor.
                         Default: None
             target (int, tuple, tensor or list, optional):  Output indices for
                         which surrogate model is trained

--- a/captum/attr/_core/lime.py
+++ b/captum/attr/_core/lime.py
@@ -88,10 +88,11 @@ class LimeBase(PerturbationAttribution):
             interpretable_model (Model): Model object to train interpretable model.
                     A Model object provides a `fit` method to train the model,
                     given a dataloader, with batches containing three tensors:
-                        interpretable_inputs: Tensor
-                                            [2D num_samples x num_interp_features],
-                        expected_outputs: Tensor [1D num_samples],
-                        weights: Tensor [1D num_samples]
+
+                    - interpretable_inputs: Tensor
+                      [2D num_samples x num_interp_features],
+                    - expected_outputs: Tensor [1D num_samples],
+                    - weights: Tensor [1D num_samples]
 
                     The model object must also provide a `representation` method to
                     access the appropriate coefficients or representation of the
@@ -113,13 +114,13 @@ class LimeBase(PerturbationAttribution):
 
                     The expected signature of this callable is:
 
-                    similarity_func(
-                        original_input: Tensor or tuple of Tensors,
-                        perturbed_input: Tensor or tuple of Tensors,
-                        perturbed_interpretable_input:
-                            Tensor [2D 1 x num_interp_features],
-                        **kwargs: Any
-                    ) -> float or Tensor containing float scalar
+                    >>> similarity_func(
+                    >>>    original_input: Tensor or tuple of Tensors,
+                    >>>    perturbed_input: Tensor or tuple of Tensors,
+                    >>>    perturbed_interpretable_input:
+                    >>>        Tensor [2D 1 x num_interp_features],
+                    >>>    **kwargs: Any
+                    >>> ) -> float or Tensor containing float scalar
 
                     perturbed_input and original_input will be the same type and
                     contain tensors of the same shape (regardless of whether or not
@@ -139,10 +140,10 @@ class LimeBase(PerturbationAttribution):
 
                     The expected signature of this callable is:
 
-                    perturb_func(
-                        original_input: Tensor or tuple of Tensors,
-                        **kwargs: Any
-                    ) -> Tensor or tuple of Tensors
+                    >>> perturb_func(
+                    >>>    original_input: Tensor or tuple of Tensors,
+                    >>>    **kwargs: Any
+                    >>> ) -> Tensor or tuple of Tensors
 
                     All kwargs passed to the attribute method are
                     provided as keyword arguments (kwargs) to this callable.
@@ -175,11 +176,11 @@ class LimeBase(PerturbationAttribution):
 
                     The expected signature of this callable is:
 
-                    from_interp_rep_transform(
-                        curr_sample: Tensor [2D 1 x num_interp_features]
-                        original_input: Tensor or Tuple of Tensors,
-                        **kwargs: Any
-                    ) -> Tensor or tuple of Tensors
+                    >>> from_interp_rep_transform(
+                    >>>    curr_sample: Tensor [2D 1 x num_interp_features]
+                    >>>    original_input: Tensor or Tuple of Tensors,
+                    >>>    **kwargs: Any
+                    >>> ) -> Tensor or tuple of Tensors
 
                     Returned sampled input should match the type of original_input
                     and corresponding tensor shapes.
@@ -197,11 +198,11 @@ class LimeBase(PerturbationAttribution):
 
                     The expected signature of this callable is:
 
-                    to_interp_rep_transform(
-                        curr_sample: Tensor or Tuple of Tensors,
-                        original_input: Tensor or Tuple of Tensors,
-                        **kwargs: Any
-                    ) -> Tensor [2D 1 x num_interp_features]
+                    >>> to_interp_rep_transform(
+                    >>>    curr_sample: Tensor or Tuple of Tensors,
+                    >>>    original_input: Tensor or Tuple of Tensors,
+                    >>>    **kwargs: Any
+                    >>> ) -> Tensor [2D 1 x num_interp_features]
 
                     curr_sample will match the type of original_input
                     and corresponding tensor shapes.
@@ -664,10 +665,11 @@ class Lime(LimeBase):
                     Alternatively, a custom model object must provide a `fit` method to
                     train the model, given a dataloader, with batches containing
                     three tensors:
-                        interpretable_inputs: Tensor
-                                            [2D num_samples x num_interp_features],
-                        expected_outputs: Tensor [1D num_samples],
-                        weights: Tensor [1D num_samples]
+
+                    - interpretable_inputs: Tensor
+                      [2D num_samples x num_interp_features],
+                    - expected_outputs: Tensor [1D num_samples],
+                    - weights: Tensor [1D num_samples]
 
                     The model object must also provide a `representation` method to
                     access the appropriate coefficients or representation of the
@@ -720,10 +722,10 @@ class Lime(LimeBase):
                     be implemented by providing a function with the
                     following expected signature:
 
-                    perturb_func(
-                        original_input: Tensor or tuple of Tensors,
-                        **kwargs: Any
-                    ) -> Tensor [Binary 2D Tensor 1 x num_interp_features]
+                    >>> perturb_func(
+                    >>>    original_input: Tensor or tuple of Tensors,
+                    >>>    **kwargs: Any
+                    >>> ) -> Tensor [Binary 2D Tensor 1 x num_interp_features]
 
                     kwargs includes baselines, feature_mask, num_interp_features
                     (integer, determined from feature mask).

--- a/captum/attr/_core/lime.py
+++ b/captum/attr/_core/lime.py
@@ -122,7 +122,7 @@ class LimeBase(PerturbationAttribution):
                     ) -> float or Tensor containing float scalar
 
                     perturbed_input and original_input will be the same type and
-                    contain tensors of the same shape (regardless of whether or notß
+                    contain tensors of the same shape (regardless of whether or not
                     the sampling function returns inputs in the interpretable
                     space). original_input is the same as the input provided
                     when calling attribute.

--- a/captum/attr/_core/lime.py
+++ b/captum/attr/_core/lime.py
@@ -678,7 +678,7 @@ class Lime(LimeBase):
                     Note that calling fit multiple times should retrain the
                     interpretable model, each attribution call reuses
                     the same given interpretable model object.
-            similarity_func (callable): Function which takes a single sample
+            similarity_func (optional, callable): Function which takes a single sample
                     along with its corresponding interpretable representation
                     and returns the weight of the interpretable sample for
                     training the interpretable model.

--- a/captum/attr/_core/lime.py
+++ b/captum/attr/_core/lime.py
@@ -642,7 +642,7 @@ class Lime(LimeBase):
         forward_func: Callable,
         interpretable_model: Optional[Model] = None,
         similarity_func: Optional[Callable] = None,
-        perturb_func: Optional[Callable] = default_perturb_func,
+        perturb_func: Optional[Callable] = None,
     ) -> None:
         r"""
 

--- a/sphinx/source/lime.rst
+++ b/sphinx/source/lime.rst
@@ -5,3 +5,5 @@ Lime
     :members:
 .. autoclass:: captum.attr.Lime
     :members:
+
+.. autofunction:: captum.attr._core.lime.get_exp_kernel_similarity_function


### PR DESCRIPTION
Minor fixes to LIME API documentation and updating so model construction occurs in constructor rather than in signature.