### PR TITLE
Multiple Layer Support in LayerIG

### DIFF
--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -354,6 +354,43 @@ def _format_output(
     return output if is_inputs_tuple else output[0]
 
 
+@typing.overload
+def _format_outputs(
+    is_multiple_inputs: Literal[False], outputs: List[Tuple[Tensor, ...]]
+) -> Union[Tensor, Tuple[Tensor, ...]]:
+    ...
+
+
+@typing.overload
+def _format_outputs(
+    is_multiple_inputs: Literal[True], outputs: List[Tuple[Tensor, ...]]
+) -> List[Union[Tensor, Tuple[Tensor, ...]]]:
+    ...
+
+
+@typing.overload
+def _format_outputs(
+    is_multiple_inputs: bool, outputs: List[Tuple[Tensor, ...]]
+) -> Union[Tensor, Tuple[Tensor, ...], List[Union[Tensor, Tuple[Tensor, ...]]]]:
+    ...
+
+
+def _format_outputs(
+    is_multiple_inputs: bool, outputs: List[Tuple[Tensor, ...]]
+) -> Union[Tensor, Tuple[Tensor, ...], List[Union[Tensor, Tuple[Tensor, ...]]]]:
+    assert isinstance(outputs, list), "Outputs must be a list"
+    assert is_multiple_inputs or len(outputs) == 1, (
+        "outputs should contain multiple inputs or have a single output"
+        f"however the number of outputs is: {len(outputs)}"
+    )
+
+    return (
+        [_format_output(len(output) > 1, output) for output in outputs]
+        if is_multiple_inputs
+        else _format_output(len(outputs[0]) > 1, outputs[0])
+    )
+
+
 def _run_forward(
     forward_func: Callable,
     inputs: Union[Tensor, Tuple[Tensor, ...]],

--- a/captum/attr/_core/layer/layer_integrated_gradients.py
+++ b/captum/attr/_core/layer/layer_integrated_gradients.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python3
-import typing
-from typing import Any, Callable, List, Tuple, Union
+import functools
+import warnings
+from typing import Any, Callable, List, Tuple, Union, overload
 
 import torch
 from torch import Tensor
-from torch.nn import Module
 from torch.nn.parallel.scatter_gather import scatter
 
 from captum._utils.common import (
     _extract_device,
     _format_additional_forward_args,
-    _format_output,
+    _format_outputs,
 )
 from captum._utils.gradient import _forward_layer_eval, _run_forward
-from captum._utils.typing import BaselineType, Literal, TargetType
+from captum._utils.typing import BaselineType, Literal, ModuleOrModuleList, TargetType
 from captum.attr._core.integrated_gradients import IntegratedGradients
 from captum.attr._utils.attribution import GradientAttribution, LayerAttribution
 from captum.attr._utils.common import (
@@ -48,7 +48,7 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
     def __init__(
         self,
         forward_func: Callable,
-        layer: Module,
+        layer: ModuleOrModuleList,
         device_ids: Union[None, List[int]] = None,
         multiply_by_inputs: bool = True,
     ) -> None:
@@ -56,12 +56,25 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
         Args:
             forward_func (callable):  The forward function of the model or any
                         modification of it
-            layer (torch.nn.Module): Layer for which attributions are computed.
-                        Output size of attribute matches this layer's input or
-                        output dimensions, depending on whether we attribute to
-                        the inputs or outputs of the layer, corresponding to
-                        the attribution of each neuron in the input or output
-                        of this layer.
+            layer (ModuleOrModuleList):
+                        Layer or list of layers for which attributions are computed.
+                        For each layer the output size of the attribute matches
+                        this layer's input or output dimensions, depending on
+                        whether we attribute to the inputs or outputs of the
+                        layer, corresponding to the attribution of each neuron
+                        in the input or output of this layer.
+
+                        Please note that layers to attribute on cannot be
+                        dependent on each other. That is, a subset of layers in
+                        `layer` cannot produce the inputs for another layer.
+
+                        For example, if your model is of a simple linked-list
+                        based graph structure (think nn.Sequence), e.g. x -> l1
+                        -> l2 -> l3 -> output. If you pass in any one of those
+                        layers, you cannot pass in another due to the
+                        dependence, e.g.  if you pass in l2 you cannot pass in
+                        l1 or l3.
+
             device_ids (list(int)): Device ID list, necessary only if forward_func
                         applies a DataParallel model. This allows reconstruction of
                         intermediate outputs from batched results across devices.
@@ -86,22 +99,48 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
         GradientAttribution.__init__(self, forward_func)
         self.ig = IntegratedGradients(forward_func, multiply_by_inputs)
 
-    @typing.overload
+        if isinstance(layer, list) and len(layer) > 1:
+            warnings.warn(
+                "Multiple layers provided. Please ensure that each layer is"
+                "**not** solely solely dependent on the outputs of"
+                "another layer. Please refer to the documentation for more"
+                "detail."
+            )
+
+    @overload
     def attribute(
         self,
         inputs: Union[Tensor, Tuple[Tensor, ...]],
-        baselines: BaselineType = None,
-        target: TargetType = None,
-        additional_forward_args: Any = None,
-        n_steps: int = 50,
-        method: str = "gausslegendre",
-        internal_batch_size: Union[None, int] = None,
-        return_convergence_delta: Literal[False] = False,
-        attribute_to_layer_input: bool = False,
-    ) -> Union[Tensor, Tuple[Tensor, ...]]:
+        baselines: BaselineType,
+        target: TargetType,
+        additional_forward_args: Any,
+        n_steps: int,
+        method: str,
+        internal_batch_size: Union[None, int],
+        return_convergence_delta: Literal[False],
+        attribute_to_layer_input: bool,
+    ) -> Union[Tensor, Tuple[Tensor, ...], List[Union[Tensor, Tuple[Tensor, ...]]]]:
         ...
 
-    @typing.overload
+    @overload
+    def attribute(
+        self,
+        inputs: Union[Tensor, Tuple[Tensor, ...]],
+        baselines: BaselineType,
+        target: TargetType,
+        additional_forward_args: Any,
+        n_steps: int,
+        method: str,
+        internal_batch_size: Union[None, int],
+        return_convergence_delta: Literal[True],
+        attribute_to_layer_input: bool,
+    ) -> Tuple[
+        Union[Tensor, Tuple[Tensor, ...], List[Union[Tensor, Tuple[Tensor, ...]]]],
+        Tensor,
+    ]:
+        ...
+
+    @overload
     def attribute(
         self,
         inputs: Union[Tensor, Tuple[Tensor, ...]],
@@ -111,10 +150,15 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
         n_steps: int = 50,
         method: str = "gausslegendre",
         internal_batch_size: Union[None, int] = None,
-        *,
-        return_convergence_delta: Literal[True],
+        return_convergence_delta: bool = False,
         attribute_to_layer_input: bool = False,
-    ) -> Tuple[Union[Tensor, Tuple[Tensor, ...]], Tensor]:
+    ) -> Union[
+        Union[Tensor, Tuple[Tensor, ...], List[Union[Tensor, Tuple[Tensor, ...]]]],
+        Tuple[
+            Union[Tensor, Tuple[Tensor, ...], List[Union[Tensor, Tuple[Tensor, ...]]]],
+            Tensor,
+        ],
+    ]:
         ...
 
     @log_usage()
@@ -130,7 +174,11 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
         return_convergence_delta: bool = False,
         attribute_to_layer_input: bool = False,
     ) -> Union[
-        Tensor, Tuple[Tensor, ...], Tuple[Union[Tensor, Tuple[Tensor, ...]], Tensor]
+        Union[Tensor, Tuple[Tensor, ...], List[Union[Tensor, Tuple[Tensor, ...]]]],
+        Tuple[
+            Union[Tensor, Tuple[Tensor, ...], List[Union[Tensor, Tuple[Tensor, ...]]]],
+            Tensor,
+        ],
     ]:
         r"""
         This method attributes the output of the model with given target index
@@ -257,16 +305,25 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
                         Default: False
             Returns:
                 **attributions** or 2-element tuple of **attributions**, **delta**:
-                - **attributions** (*tensor* or tuple of *tensors*):
+                - **attributions** (*tensor*, tuple of *tensors* or tuple of *tensors*):
                         Integrated gradients with respect to `layer`'s inputs or
                         outputs. Attributions will always be the same size and
                         dimensionality as the input or output of the given layer,
                         depending on whether we attribute to the inputs or outputs
                         of the layer which is decided by the input flag
                         `attribute_to_layer_input`.
-                        Attributions are returned in a tuple if
+
+                        For a single layer, attributions are returned in a tuple if
                         the layer inputs / outputs contain multiple tensors,
                         otherwise a single tensor is returned.
+
+                        For multiple layers, attributions will always be
+                        returned as a list. Each element in this list will be
+                        equivalent to that of a single layer output, i.e. in the
+                        case that one layer, in the given layers, inputs / outputs
+                        multiple tensors: the corresponding output element will be
+                        a tuple of tensors. The ordering of the outputs will be
+                        the same order as the layers given in the constructor.
                 - **delta** (*tensor*, returned if return_convergence_delta=True):
                         The difference between the total approximated and true
                         integrated gradients. This is computed using the property
@@ -298,6 +355,11 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
             additional_forward_args
         )
 
+        def flatten_tuple(tup):
+            return tuple(
+                sum((list(x) if isinstance(x, (tuple, list)) else [x] for x in tup), [])
+            )
+
         if self.device_ids is None:
             self.device_ids = getattr(self.forward_func, "device_ids", None)
         inputs_layer = _forward_layer_eval(
@@ -309,6 +371,16 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
             attribute_to_layer_input=attribute_to_layer_input,
         )
 
+        # if we have one output
+        if not isinstance(self.layer, list):
+            inputs_layer = (inputs_layer,)
+
+        num_outputs = [1 if isinstance(x, Tensor) else len(x) for x in inputs_layer]
+        num_outputs_cumsum = torch.cumsum(
+            torch.IntTensor([0] + num_outputs), dim=0  # type: ignore
+        )
+        inputs_layer = flatten_tuple(inputs_layer)
+
         baselines_layer = _forward_layer_eval(
             self.forward_func,
             baselines,
@@ -317,6 +389,7 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
             additional_forward_args=additional_forward_args,
             attribute_to_layer_input=attribute_to_layer_input,
         )
+        baselines_layer = flatten_tuple(baselines_layer)
 
         # inputs -> these inputs are scaled
         def gradient_func(
@@ -341,30 +414,60 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
 
             with torch.autograd.set_grad_enabled(True):
 
-                def layer_forward_hook(module, hook_inputs, hook_outputs=None):
+                def layer_forward_hook(
+                    module, hook_inputs, hook_outputs=None, layer_idx=0
+                ):
                     device = _extract_device(module, hook_inputs, hook_outputs)
                     is_layer_tuple = (
                         isinstance(hook_outputs, tuple)
+                        # hook_outputs is None if attribute_to_layer_input == True
                         if hook_outputs is not None
                         else isinstance(hook_inputs, tuple)
                     )
-                    if is_layer_tuple:
-                        return scattered_inputs_dict[device]
-                    return scattered_inputs_dict[device][0]
 
-                hook = None
+                    if is_layer_tuple:
+                        return scattered_inputs_dict[device][
+                            num_outputs_cumsum[layer_idx] : num_outputs_cumsum[
+                                layer_idx + 1
+                            ]
+                        ]
+
+                    return scattered_inputs_dict[device][num_outputs_cumsum[layer_idx]]
+
+                hooks = []
                 try:
-                    if attribute_to_layer_input:
-                        hook = self.layer.register_forward_pre_hook(layer_forward_hook)
-                    else:
-                        hook = self.layer.register_forward_hook(layer_forward_hook)
+
+                    layers = self.layer
+                    if not isinstance(layers, list):
+                        layers = [self.layer]
+
+                    for layer_idx, layer in enumerate(layers):
+                        hook = None
+                        # TODO:
+                        # Allow multiple attribute_to_layer_input flags for
+                        # each layer, i.e. attribute_to_layer_input[layer_idx]
+                        if attribute_to_layer_input:
+                            hook = layer.register_forward_pre_hook(
+                                functools.partial(
+                                    layer_forward_hook, layer_idx=layer_idx
+                                )
+                            )
+                        else:
+                            hook = layer.register_forward_hook(
+                                functools.partial(
+                                    layer_forward_hook, layer_idx=layer_idx
+                                )
+                            )
+
+                        hooks.append(hook)
 
                     output = _run_forward(
                         self.forward_func, tuple(), target_ind, additional_forward_args
                     )
                 finally:
-                    if hook is not None:
-                        hook.remove()
+                    for hook in hooks:
+                        if hook is not None:
+                            hook.remove()
 
                 assert output[0].numel() == 1, (
                     "Target not provided when necessary, cannot"
@@ -381,6 +484,7 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
             if additional_forward_args is not None
             else inps
         )
+
         attributions = self.ig.attribute.__wrapped__(  # type: ignore
             self.ig,  # self
             inputs_layer,
@@ -393,6 +497,16 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
             return_convergence_delta=False,
         )
 
+        # handle multiple outputs
+        output: List[Tuple[Tensor, ...]] = [
+            tuple(
+                attributions[
+                    int(num_outputs_cumsum[i]) : int(num_outputs_cumsum[i + 1])
+                ]
+            )
+            for i in range(len(num_outputs))
+        ]
+
         if return_convergence_delta:
             start_point, end_point = baselines, inps
             # computes approximation error based on the completeness axiom
@@ -403,8 +517,8 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
                 additional_forward_args=additional_forward_args,
                 target=target,
             )
-            return _format_output(len(attributions) > 1, attributions), delta
-        return _format_output(len(attributions) > 1, attributions)
+            return _format_outputs(isinstance(self.layer, list), output), delta
+        return _format_outputs(isinstance(self.layer, list), output)
 
     def has_convergence_delta(self) -> bool:
         return True

--- a/tests/attr/helpers/test_config.py
+++ b/tests/attr/helpers/test_config.py
@@ -41,6 +41,7 @@ from tests.helpers.basic_models import (
     BasicModel_ConvNet,
     BasicModel_MultiLayer,
     BasicModel_MultiLayer_MultiInput,
+    BasicModel_MultiLayer_TrueMultiInput,
     ReLULinearModel,
 )
 
@@ -1143,5 +1144,20 @@ config = [
         "model": BasicModel_MultiLayer(multi_input_module=True),
         "layer": ["multi_relu", "linear1", "linear0"],
         "attribute_args": {"inputs": torch.randn(4, 3), "target": 0},
+    },
+    {
+        "name": "basic_layer_ig_multi_layer_multi_output",
+        "algorithms": [LayerIntegratedGradients],
+        "model": BasicModel_MultiLayer_TrueMultiInput(),
+        "layer": ["m1", "m234"],
+        "attribute_args": {
+            "inputs": (
+                torch.randn(5, 3),
+                torch.randn(5, 3),
+                torch.randn(5, 3),
+                torch.randn(5, 3),
+            ),
+            "target": 0,
+        },
     },
 ]

--- a/tests/attr/layer/test_layer_integrated_gradients.py
+++ b/tests/attr/layer/test_layer_integrated_gradients.py
@@ -19,7 +19,11 @@ from tests.helpers.basic import (
     assertArraysAlmostEqual,
     assertTensorTuplesAlmostEqual,
 )
-from tests.helpers.basic_models import BasicEmbeddingModel, BasicModel_MultiLayer
+from tests.helpers.basic_models import (
+    BasicEmbeddingModel,
+    BasicModel_MultiLayer,
+    BasicModel_MultiLayer_TrueMultiInput,
+)
 
 
 class Test(BaseTest):
@@ -86,6 +90,109 @@ class Test(BaseTest):
             ([[90.0, 100.0, 100.0, 100.0]], [[90.0, 100.0, 100.0, 100.0]]),
         )
 
+    def test_multiple_layers_single_inputs(self) -> None:
+        input1 = torch.tensor([[2, 5, 0, 1], [3, 1, 1, 0]])
+        input2 = torch.tensor([[0, 2, 4, 1], [2, 3, 5, 7]])
+        input3 = torch.tensor([[3, 5, 6, 7], [2, 3, 0, 1]])
+
+        inputs = (input1, input2, input3)
+        baseline = tuple(torch.zeros_like(inp) for inp in inputs)
+
+        self._assert_compare_with_emb_patching(
+            inputs,
+            baseline,
+            multiple_emb=True,
+            additional_args=None,
+        )
+
+    def test_multiple_layers_multiple_inputs_shared_input(self) -> None:
+        input1 = torch.randn(5, 3)
+        input2 = torch.randn(5, 3)
+        input3 = torch.randn(5, 3)
+        inputs = (input1, input2, input3)
+        baseline = tuple(torch.zeros_like(inp) for inp in inputs)
+
+        net = BasicModel_MultiLayer_TrueMultiInput()
+
+        lig = LayerIntegratedGradients(net, layer=[net.m1, net.m234])
+        ig = IntegratedGradients(net)
+
+        # test layer inputs
+        attribs_inputs = lig.attribute(
+            inputs, baseline, target=0, attribute_to_layer_input=True
+        )
+        attribs_inputs_regular_ig = ig.attribute(inputs, baseline, target=0)
+
+        self.assertIsInstance(attribs_inputs, list)
+        self.assertEqual(len(attribs_inputs), 2)
+        self.assertIsInstance(attribs_inputs[0], Tensor)
+        self.assertIsInstance(attribs_inputs[1], tuple)
+        self.assertEqual(len(attribs_inputs[1]), 3)
+
+        assertTensorTuplesAlmostEqual(
+            self,
+            # last input for second layer is first input =>
+            # add the attributions
+            (attribs_inputs[0] + attribs_inputs[1][-1],) + attribs_inputs[1][0:-1],
+            attribs_inputs_regular_ig,
+            delta=1e-5,
+        )
+
+        # test layer outputs
+        attribs = lig.attribute(inputs, baseline, target=0)
+        ig = IntegratedGradients(lambda x, y: x + y)
+        attribs_ig = ig.attribute(
+            (net.m1(input1), net.m234(input2, input3, input1, 1)),
+            (net.m1(baseline[0]), net.m234(baseline[1], baseline[2], baseline[1], 1)),
+            target=0,
+        )
+
+        assertTensorTuplesAlmostEqual(self, attribs, attribs_ig, delta=1e-5)
+
+    def test_multiple_layers_multiple_input_outputs(self) -> None:
+        # test with multiple layers, where one layer accepts multiple inputs
+        input1 = torch.randn(5, 3)
+        input2 = torch.randn(5, 3)
+        input3 = torch.randn(5, 3)
+        input4 = torch.randn(5, 3)
+        inputs = (input1, input2, input3, input4)
+        baseline = tuple(torch.zeros_like(inp) for inp in inputs)
+
+        net = BasicModel_MultiLayer_TrueMultiInput()
+
+        lig = LayerIntegratedGradients(net, layer=[net.m1, net.m234])
+        ig = IntegratedGradients(net)
+
+        # test layer inputs
+        attribs_inputs = lig.attribute(
+            inputs, baseline, target=0, attribute_to_layer_input=True
+        )
+        attribs_inputs_regular_ig = ig.attribute(inputs, baseline, target=0)
+
+        self.assertIsInstance(attribs_inputs, list)
+        self.assertEqual(len(attribs_inputs), 2)
+        self.assertIsInstance(attribs_inputs[0], Tensor)
+        self.assertIsInstance(attribs_inputs[1], tuple)
+        self.assertEqual(len(attribs_inputs[1]), 3)
+
+        assertTensorTuplesAlmostEqual(
+            self,
+            (attribs_inputs[0],) + attribs_inputs[1],
+            attribs_inputs_regular_ig,
+            delta=1e-7,
+        )
+
+        # test layer outputs
+        attribs = lig.attribute(inputs, baseline, target=0)
+        ig = IntegratedGradients(lambda x, y: x + y)
+        attribs_ig = ig.attribute(
+            (net.m1(input1), net.m234(input2, input3, input4, 1)),
+            (net.m1(baseline[0]), net.m234(baseline[1], baseline[2], baseline[3], 1)),
+            target=0,
+        )
+
+        assertTensorTuplesAlmostEqual(self, attribs, attribs_ig, delta=1e-7)
+
     def test_multiple_tensors_compare_with_exp_wo_mult_by_inputs(self) -> None:
         net = BasicModel_MultiLayer(multi_input_module=True)
         inp = torch.tensor([[0.0, 100.0, 0.0]])
@@ -139,20 +246,24 @@ class Test(BaseTest):
             attribute_to_layer_input=attribute_to_layer_input,
         )
         assertArraysAlmostEqual(attribution, attributions2, 0.01)
-        assertArraysAlmostEqual(delta, delta2, 0.05)
+        assertArraysAlmostEqual(delta, delta2, 0.5)
 
     def _assert_compare_with_emb_patching(
         self,
-        input: Tensor,
-        baseline: Tensor,
-        additional_args: Tuple[Tensor, ...],
+        input: Union[Tensor, Tuple[Tensor, ...]],
+        baseline: Union[Tensor, Tuple[Tensor, ...]],
+        additional_args: Union[None, Tuple[Tensor, ...]],
         multiply_by_inputs: bool = True,
+        multiple_emb: bool = False,
     ):
         model = BasicEmbeddingModel(nested_second_embedding=True)
-        lig = LayerIntegratedGradients(
-            model, model.embedding1, multiply_by_inputs=multiply_by_inputs
-        )
 
+        emb_layers = (
+            [model.embedding1, model.embedding2] if multiple_emb else model.embedding1
+        )
+        lig = LayerIntegratedGradients(
+            model, emb_layers, multiply_by_inputs=multiply_by_inputs
+        )
         attributions, delta = lig.attribute(
             input,
             baselines=baseline,
@@ -162,11 +273,23 @@ class Test(BaseTest):
 
         # now let's interpret with standard integrated gradients and
         # the embeddings for monkey patching
-        interpretable_embedding = configure_interpretable_embedding_layer(
-            model, "embedding1"
+        e1 = configure_interpretable_embedding_layer(model, "embedding1")
+        e1_input_emb = e1.indices_to_embeddings(input[0] if multiple_emb else input)
+        e1_baseline_emb = e1.indices_to_embeddings(
+            baseline[0] if multiple_emb else baseline
         )
-        input_emb = interpretable_embedding.indices_to_embeddings(input)
-        baseline_emb = interpretable_embedding.indices_to_embeddings(baseline)
+
+        input_emb = e1_input_emb
+        baseline_emb = e1_baseline_emb
+        e2 = None
+        if multiple_emb:
+            e2 = configure_interpretable_embedding_layer(model, "embedding2")
+            e2_input_emb = e2.indices_to_embeddings(*input[1:])
+            e2_baseline_emb = e2.indices_to_embeddings(*baseline[1:])
+
+            input_emb = (e1_input_emb, e2_input_emb)
+            baseline_emb = (e1_baseline_emb, e2_baseline_emb)
+
         ig = IntegratedGradients(model, multiply_by_inputs=multiply_by_inputs)
         attributions_with_ig, delta_with_ig = ig.attribute(
             input_emb,
@@ -175,9 +298,33 @@ class Test(BaseTest):
             target=0,
             return_convergence_delta=True,
         )
-        remove_interpretable_embedding_layer(model, interpretable_embedding)
+        remove_interpretable_embedding_layer(model, e1)
+        if e2 is not None:
+            remove_interpretable_embedding_layer(model, e2)
 
-        assertArraysAlmostEqual(attributions, attributions_with_ig)
+        self.assertEqual(
+            isinstance(attributions_with_ig, tuple), isinstance(attributions, list)
+        )
+
+        self.assertTrue(
+            isinstance(attributions_with_ig, tuple)
+            if multiple_emb
+            else not isinstance(attributions_with_ig, tuple)
+        )
+
+        # convert to tuple for comparison
+        if not isinstance(attributions_with_ig, tuple):
+            attributions = (attributions,)
+            attributions_with_ig = (attributions_with_ig,)
+        else:
+            # convert list to tuple
+            self.assertIsInstance(attributions, list)
+            attributions = tuple(attributions)
+
+        for attr_lig, attr_ig in zip(attributions, attributions_with_ig):
+            self.assertEqual(attr_lig.shape, attr_ig.shape)
+            assertArraysAlmostEqual(attributions, attributions_with_ig)
+
         if multiply_by_inputs:
             assertArraysAlmostEqual(delta, delta_with_ig)
 

--- a/tests/helpers/basic_models.py
+++ b/tests/helpers/basic_models.py
@@ -362,6 +362,24 @@ class BasicModel_MultiLayer_MultiInput(nn.Module):
         return self.model(scale * (x1 + x2 + x3))
 
 
+class BasicModel_MultiLayer_TrueMultiInput(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.m1 = BasicModel_MultiLayer()
+        self.m234 = BasicModel_MultiLayer_MultiInput()
+
+    @no_type_check
+    def forward(
+        self, x1: Tensor, x2: Tensor, x3: Tensor, x4: Optional[Tensor] = None
+    ) -> Tensor:
+        a = self.m1(x1)
+        if x4 is None:
+            b = self.m234(x2, x3, x1, scale=1)
+        else:
+            b = self.m234(x2, x3, x4, scale=1)
+        return a + b
+
+
 class BasicModel_ConvNet_One_Conv(nn.Module):
     def __init__(self, inplace: bool = False):
         super().__init__()


### PR DESCRIPTION
Addding multiple layer support in LayerIntegratedGradients
Added two test cases. Both compare output to regular IG. One patches multiple embedding layers, the other patches layers of a new model. Added a new model due to existing models not having layers/sub-modules accepting multiple arguments.
Updated documentation.

Differential Revision: D25042339
