### PR TITLE
Add BaseFeature, ImageFeature, TextFeature, GeneralFeature in the in __init__.py

### DIFF
--- a/captum/insights/__init__.py
+++ b/captum/insights/__init__.py
@@ -1,1 +1,2 @@
 from captum.insights.attr_vis import AttributionVisualizer, Batch  # noqa
+from captum.insights.attr_vis.features import BaseFeature, ImageFeature, TextFeature, GeneralFeature


### PR DESCRIPTION
Currently, in tutorial [here](https://captum.ai/tutorials/Multimodal_VQA_Captum_Insights), the command: `from captum.insights.features import ImageFeature, TextFeature` can not be loaded.

I have added the Features in the __init__ module. It works great.

