### PR TITLE
Remove redundant 'object' inheritance reference from classes

### DIFF
--- a/captum/attr/_models/pytext.py
+++ b/captum/attr/_models/pytext.py
@@ -76,7 +76,7 @@ class PyTextInterpretableEmbedding(EmbeddingBase):
         return attribution_map
 
 
-class BaselineGenerator(object):
+class BaselineGenerator:
     r"""
     This is an example input baseline generator for DocNN model which uses
     word and dict features.

--- a/captum/insights/attr_vis/app.py
+++ b/captum/insights/attr_vis/app.py
@@ -136,7 +136,7 @@ class Batch:
         self.additional_args = additional_args
 
 
-class AttributionVisualizer(object):
+class AttributionVisualizer:
     def __init__(
         self,
         models: Union[List[Module], Module],

--- a/captum/insights/attr_vis/attribution_calculation.py
+++ b/captum/insights/attr_vis/attribution_calculation.py
@@ -27,7 +27,7 @@ from captum.insights.attr_vis.features import BaseFeature
 OutputScore = namedtuple("OutputScore", "score index label")
 
 
-class AttributionCalculation(object):
+class AttributionCalculation:
     def __init__(
         self,
         models: Sequence[Module],


### PR DESCRIPTION
As I understand, Captum uses Python 3, which means that classes don't need to inherit from object as it done implicitly already. 