### PR TITLE
Optim wip: Fix InceptionV1 color space

### DIFF
--- a/captum/optim/_models/inception_v1.py
+++ b/captum/optim/_models/inception_v1.py
@@ -134,8 +134,7 @@ class InceptionV1(nn.Module):
             assert x.min() >= 0.0 and x.max() <= 1.0
             x = x.unsqueeze(0) if x.dim() == 3 else x
             x = x * 255 - 117
-            if self.bgr_transform:
-                x = x.clone()[:, [2, 1, 0]]  # RGB to BGR
+            x = x[:, [2, 1, 0]] if self.bgr_transform else x
         return x
 
     def forward(

--- a/captum/optim/_models/inception_v1.py
+++ b/captum/optim/_models/inception_v1.py
@@ -1,3 +1,5 @@
+from typing import Tuple, Union, cast
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -25,10 +27,15 @@ def googlenet(
             training. Default: 1008 when pretrained is True.
         transform_input (bool): If True, preprocesses the input according to
             the method with which it was trained on ImageNet. Default: *False*
+        bgr_transform (bool): If True and transform_input is True, perform an
+            RGB to BGR transform in the internal preprocessing.
+            Default: *False*
     """
     if pretrained:
         if "transform_input" not in kwargs:
             kwargs["transform_input"] = True
+        if "bgr_transform" not in kwargs:
+            kwargs["bgr_transform"] = False
         if "aux_logits" not in kwargs:
             kwargs["aux_logits"] = False
         if "out_features" not in kwargs:
@@ -56,10 +63,12 @@ class InceptionV1(nn.Module):
         out_features: int = 1008,
         aux_logits: bool = False,
         transform_input: bool = False,
+        bgr_transform: bool = False,
     ) -> None:
         super(InceptionV1, self).__init__()
         self.aux_logits = aux_logits
         self.transform_input = transform_input
+        self.bgr_transform = bgr_transform
         lrn_vals = (9, 9.99999974738e-05, 0.5, 1.0)
 
         self.conv1 = nn.Conv2d(
@@ -125,9 +134,13 @@ class InceptionV1(nn.Module):
             assert x.min() >= 0.0 and x.max() <= 1.0
             x = x.unsqueeze(0) if x.dim() == 3 else x
             x = x * 255 - 117
+            if self.bgr_transform:
+                x = x.clone()[:, [2, 1, 0]]  # RGB to BGR
         return x
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, x: torch.Tensor
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
         x = self._transform_input(x)
         x = F.pad(x, (2, 3, 2, 3))
         x = self.conv1(x)
@@ -172,7 +185,7 @@ class InceptionV1(nn.Module):
         x = self.drop(x)
         x = self.fc(x)
         if not self.aux_logits:
-            return x
+            return cast(torch.Tensor, x)
         else:
             return x, aux1_output, aux2_output
 

--- a/captum/optim/_models/inception_v1.py
+++ b/captum/optim/_models/inception_v1.py
@@ -125,7 +125,6 @@ class InceptionV1(nn.Module):
             assert x.min() >= 0.0 and x.max() <= 1.0
             x = x.unsqueeze(0) if x.dim() == 3 else x
             x = x * 255 - 117
-            x = x.clone()[:, [2, 1, 0]]  # RGB to BGR
         return x
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/tests/optim/models/test_models.py
+++ b/tests/optim/models/test_models.py
@@ -33,6 +33,18 @@ class TestInceptionV1(BaseTest):
         expected_output = x * 255 - 117
         assertTensorAlmostEqual(self, output, expected_output, 0)
 
+    def test_transform_bgr_inceptionv1(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping inceptionV1 internal transform"
+                + " BGR due to insufficient Torch version."
+            )
+        x = torch.randn(1, 3, 224, 224).clamp(0, 1)
+        model = googlenet(pretrained=True, bgr_transform=True)
+        output = model._transform_input(x)
+        expected_output = x[:, [2, 1, 0]] * 255 - 117
+        assertTensorAlmostEqual(self, output, expected_output, 0)
+
     def test_load_and_forward_basic_inceptionv1(self) -> None:
         if torch.__version__ == "1.2.0":
             raise unittest.SkipTest(

--- a/tests/optim/models/test_models.py
+++ b/tests/optim/models/test_models.py
@@ -30,7 +30,7 @@ class TestInceptionV1(BaseTest):
         x = torch.randn(1, 3, 224, 224).clamp(0, 1)
         model = googlenet(pretrained=True)
         output = model._transform_input(x)
-        expected_output = x[:, [2, 1, 0]] * 255 - 117
+        expected_output = x * 255 - 117
         assertTensorAlmostEqual(self, output, expected_output, 0)
 
     def test_load_and_forward_basic_inceptionv1(self) -> None:


### PR DESCRIPTION
This PR doesn't overlap with any other PRs. We don't need a RGB to BGR transform inside the model. Currently InceptionV1 is optimizing images in RGB instead of BGR, which results in really bluish visualization images. Visualization results should now match the colors found on OpenAI Microscope: https://microscope.openai.com/models/inceptionv1/mixed4c_0/?models.op.feature_vis.type=channel&models.op.technique=feature_vis

Ludwig's model had the RGB to BGR transform commented out here as well: https://github.com/ludwigschubert/captum/blob/f1fd0729dece59564a7c10b7b397617d8a09a247/captum/optim/models/inception_v1.py#L200-L209

* I made the InceptionV1 model's internal BGR transform optional. By default it's set to False.