### PR TITLE
CircleCI Flask Compress Fix

### DIFF
--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -35,7 +35,7 @@ fi
 
 # install other deps
 conda install -y numpy sphinx pytest flake8 ipywidgets ipython scikit-learn
-conda install -y -c conda-forge black matplotlib pytest-cov sphinx-autodoc-typehints mypy flask isort
+conda install -y -c conda-forge black matplotlib pytest-cov sphinx-autodoc-typehints mypy flask isort flask-compress
 
 # install node/yarn for insights build
 conda install -y -c conda-forge yarn


### PR DESCRIPTION
CircleCI conda tests are currently failing due to the missing dependency of flask-compress; this adds flask-compress to conda test setup.