### PR TITLE
Check presence of attribution configs

### DIFF
--- a/captum/insights/attr_vis/attribution_calculation.py
+++ b/captum/insights/attr_vis/attribution_calculation.py
@@ -117,7 +117,7 @@ class AttributionCalculation:
         attribution_cls = ATTRIBUTION_NAMES_TO_METHODS[attribution_method_name]
         attribution_method = attribution_cls(model)
         if attribution_method_name in ATTRIBUTION_METHOD_CONFIG:
-            param_config = ATTRIBUTION_METHOD_CONFIG[attribution_method_name] 
+            param_config = ATTRIBUTION_METHOD_CONFIG[attribution_method_name]
             if param_config.post_process:
                 for k, v in attribution_arguments.items():
                     if k in param_config.post_process:

--- a/captum/insights/attr_vis/attribution_calculation.py
+++ b/captum/insights/attr_vis/attribution_calculation.py
@@ -116,11 +116,12 @@ class AttributionCalculation:
     ) -> Tuple[Tensor, ...]:
         attribution_cls = ATTRIBUTION_NAMES_TO_METHODS[attribution_method_name]
         attribution_method = attribution_cls(model)
-        param_config = ATTRIBUTION_METHOD_CONFIG[attribution_method_name]
-        if param_config.post_process:
-            for k, v in attribution_arguments.items():
-                if k in param_config.post_process:
-                    attribution_arguments[k] = param_config.post_process[k](v)
+        if attribution_method_name in ATTRIBUTION_METHOD_CONFIG:
+            param_config = ATTRIBUTION_METHOD_CONFIG[attribution_method_name] 
+            if param_config.post_process:
+                for k, v in attribution_arguments.items():
+                    if k in param_config.post_process:
+                        attribution_arguments[k] = param_config.post_process[k](v)
 
         # TODO support multiple baselines
         baseline = baselines[0] if baselines and len(baselines) > 0 else None


### PR DESCRIPTION
Only post-process arguments if a config has been defined for the attribution method in config.py (issue #608)

The JavaScript part correctly tests for the presence of config entries:
https://github.com/pytorch/captum/blob/master/captum/insights/attr_vis/frontend/src/components/Filter.tsx#L71