### PR TITLE
Optim-wip: Correct weight visualization citation

### DIFF
--- a/captum/optim/_utils/circuits.py
+++ b/captum/optim/_utils/circuits.py
@@ -20,8 +20,9 @@ def extract_expanded_weights(
     Extract meaningful weight interactions from between neurons which aren’t
     literally adjacent in a neural network, or where the weights aren’t directly
     represented in a single weight tensor.
-    Schubert, et al., "Visualizing Weights", Distill, 2021.
-    See: https://distill.pub/2021/circuits/visualizing-weights/
+
+    Voss, et al., "Visualizing Weights", Distill, 2021.
+    See: https://distill.pub/2020/circuits/visualizing-weights/
 
     Args:
         model (nn.Module):  The reference to PyTorch model instance.

--- a/tutorials/optimviz/WeightVisualization_OptimViz.ipynb
+++ b/tutorials/optimviz/WeightVisualization_OptimViz.ipynb
@@ -760,7 +760,7 @@
       "source": [
         "# Visualizing weights with captum.optim\r\n",
         "\r\n",
-        "This notebook demonstrates the use of the captum.optim submodule for visualizing the weights of the InceptionV1 model imported from Caffe.\r\n",
+        "This notebook is a based on [Visualizing Weights](https://distill.pub/2020/circuits/visualizing-weights), and demonstrates the use of the captum.optim submodule for visualizing the weights of the InceptionV1 model imported from Caffe.\r\n",
         " \r\n",
         "In this tutorial we will walk you through how to use the captum.optim submodule to visualize neuron weights and the circuits that they are a part of. We will also see how to use non-negative matrix factorization (NMF) to visualize weights with more than 3 channel dimensions, and how to contextualize neurons with the use of expanded weights."
       ]
@@ -1537,7 +1537,7 @@
         "\r\n",
         "One-sided NMF dimensionality reduction can also be used to describe multiple related neurons with a small number of factors.\r\n",
         "\r\n",
-        "Below we demonstrate this with [high-low frequency detectors](https://distill.pub/2020/circuits/early-vision/#group_mixed3a_high_low_frequency) (forthcoming paper by Schubert et al). The weights have one side / factor corresponding to high frequency and another to low. These two factors are arranged in different patterns for each neuron, and we can easily visualize them.\r\n",
+        "Below we demonstrate this with [high-low frequency detectors](https://distill.pub/2020/circuits/frequency-edges/) (Schubert et al). The weights have one side / factor corresponding to high frequency and another to low. These two factors are arranged in different patterns for each neuron, and we can easily visualize them.\r\n",
         "\r\n",
         "We can also visualize the weight analogue of “Neuron Groups” visualization from the [Building Blocks](https://distill.pub/2018/building-blocks/) research article. We do this by treating the two main factors as direction vectors."
       ]


### PR DESCRIPTION
* Fixed the link in `extract_expanded_weights` so that it now correctly points to the research article: https://distill.pub/2020/circuits/visualizing-weights/

* Corrected the first author name to be Chelsea Voss (@csvoss) in the `extract_expanded_weights` citation.

Should I also add a link to the article in the notebook?