### PR TITLE
fix broken api url in docs

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -44,7 +44,7 @@ View the tutorials page [here](../tutorials/).
 ## API Reference
 
 For an in-depth reference of the various Captum internals, see our
-[API Reference](../api).
+[API Reference](../api/).
 
 
 ## Contributing


### PR DESCRIPTION
The API link (https://captum.ai/api) in the "Getting started" under the docs is broken. 
I guess due to some expired endpoints mapping rules, it is redirected to `https://pytorch.org/captum/api/`
Appending a tail `/` fix it.

<img width="1468" alt="Screen Shot 2021-03-09 at 12 41 59 AM" src="https://user-images.githubusercontent.com/5113450/110424111-45c28300-8070-11eb-8c46-4b7498858844.png">

Same http redirect behavior happen to `/docs` `/tutorials`, but luckily all their appearance in docs have already ended with `/`