### PR TITLE
Fix Distributed Data Parallel Tests

### DIFF
--- a/tests/attr/test_data_parallel.py
+++ b/tests/attr/test_data_parallel.py
@@ -162,7 +162,9 @@ class DataParallelMeta(type):
 
                 model_1, model_2 = (
                     cuda_model,
-                    torch.nn.parallel.DistributedDataParallel(cuda_model),
+                    torch.nn.parallel.DistributedDataParallel(
+                        cuda_model, device_ids=[0], output_device=0
+                    ),
                 )
                 args_1, args_2 = cuda_args, cuda_args
             else:


### PR DESCRIPTION
This fixes issue causing Distributed Data Parallel tests to fail in torch 1.8. 

Context: The default mode of Distributed DataParallel operates similar to DataParallel with multiple GPUs, separating a batch and running on the set of available GPUs within one process. In torch 1.8, backward hooks seem to no longer work appropriately in this setup and only are invoked on device 0, which caused Deconvolution, DeepLift, and GuidedBackprop tests to fail. It appears the previous behavior may have been [undocumented](https://pytorch.org/docs/stable/generated/torch.nn.parallel.DistributedDataParallel.html), since DDP documentation has warnings regarding usage of hooks and autograd.grad. 

Additionally, since the expected / recommended usage of DDP is one process per GPU (warning is now issued: `UserWarning: Single-Process Multi-GPU is not the recommended mode for DDP. `), switching to test this approach and isolating DDP process to a single GPU.