### PR TITLE
Remove tests from Captum distributions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,7 @@ if __name__ == "__main__":
         long_description_content_type="text/markdown",
         python_requires=">=3.6",
         install_requires=["matplotlib", "numpy", "torch>=1.2"],
-        packages=find_packages(),
+        packages=find_packages(exclude=("tests","tests.*")),
         extras_require={
             "dev": DEV_REQUIRES,
             "insights": INSIGHTS_REQUIRES,

--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,7 @@ if __name__ == "__main__":
         long_description_content_type="text/markdown",
         python_requires=">=3.6",
         install_requires=["matplotlib", "numpy", "torch>=1.2"],
-        packages=find_packages(exclude=("tests","tests.*")),
+        packages=find_packages(exclude=("tests", "tests.*")),
         extras_require={
             "dev": DEV_REQUIRES,
             "insights": INSIGHTS_REQUIRES,


### PR DESCRIPTION
Update package exclusion to include tests. Previously tests were included in Captum distributions unnecessarily, outside of the captum package, causing conflicts with other packages.