### PR TITLE
correct attribution tests with show_progress

### DIFF
--- a/tests/attr/test_feature_ablation.py
+++ b/tests/attr/test_feature_ablation.py
@@ -490,40 +490,54 @@ class Test(BaseTest):
     def test_simple_ablation_with_show_progress(self, mock_stderr) -> None:
         ablation_algo = FeatureAblation(BasicModel_MultiLayer())
         inp = torch.tensor([[20.0, 50.0, 30.0]], requires_grad=True)
-        self._ablation_test_assert(
-            ablation_algo,
-            inp,
-            [[80.0, 200.0, 120.0]],
-            perturbations_per_eval=(1, 2, 3),
-            show_progress=True,
-        )
 
-        output = mock_stderr.getvalue()
-        assert "Feature Ablation attribution:" in output
+        # test progress output for each batch size
+        for bsz in (1, 2, 3):
+            self._ablation_test_assert(
+                ablation_algo,
+                inp,
+                [[80.0, 200.0, 120.0]],
+                perturbations_per_eval=(bsz,),
+                show_progress=True,
+            )
 
-        # to test if progress calculation aligns with the actual iteration
-        # all perturbations_per_eval should reach progress of 100%
-        assert output.count("100%") == 3
+            output = mock_stderr.getvalue()
+
+            # to test if progress calculation aligns with the actual iteration
+            # all perturbations_per_eval should reach progress of 100%
+            assert (
+                "Feature Ablation attribution: 100%" in output
+            ), f"Error progress output: {repr(output)}"
+
+            mock_stderr.seek(0)
+            mock_stderr.truncate(0)
 
     @unittest.mock.patch("sys.stderr", new_callable=io.StringIO)
     def test_simple_ablation_with_mask_and_show_progress(self, mock_stderr) -> None:
         ablation_algo = FeatureAblation(BasicModel_MultiLayer())
         inp = torch.tensor([[20.0, 50.0, 30.0]], requires_grad=True)
-        self._ablation_test_assert(
-            ablation_algo,
-            inp,
-            [[280.0, 280.0, 120.0]],
-            feature_mask=torch.tensor([[0, 0, 1]]),
-            perturbations_per_eval=(1, 2, 3),
-            show_progress=True,
-        )
 
-        output = mock_stderr.getvalue()
-        assert "Feature Ablation attribution:" in output
+        # test progress output for each batch size
+        for bsz in (1, 2, 3):
+            self._ablation_test_assert(
+                ablation_algo,
+                inp,
+                [[280.0, 280.0, 120.0]],
+                feature_mask=torch.tensor([[0, 0, 1]]),
+                perturbations_per_eval=(bsz,),
+                show_progress=True,
+            )
 
-        # to test if progress calculation aligns with the actual iteration
-        # all perturbations_per_eval should reach progress of 100%
-        assert output.count("100%") == 3
+            output = mock_stderr.getvalue()
+
+            # to test if progress calculation aligns with the actual iteration
+            # all perturbations_per_eval should reach progress of 100%
+            assert (
+                "Feature Ablation attribution: 100%" in output
+            ), f"Error progress output: {repr(output)}"
+
+            mock_stderr.seek(0)
+            mock_stderr.truncate(0)
 
     def _single_input_one_sample_batch_scalar_ablation_assert(
         self, ablation_algo: Attribution, dtype: torch.dtype = torch.float32

--- a/tests/attr/test_kernel_shap.py
+++ b/tests/attr/test_kernel_shap.py
@@ -73,20 +73,27 @@ class Test(BaseTest):
     def test_simple_kernel_shap_with_show_progress(self, mock_stderr) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[20.0, 50.0, 30.0]], requires_grad=True)
-        self._kernel_shap_test_assert(
-            net,
-            inp,
-            [76.66666, 196.66666, 116.66666],
-            perturbations_per_eval=(1, 2, 3),
-            n_perturb_samples=500,
-            show_progress=True,
-        )
-        output = mock_stderr.getvalue()
-        assert "Kernel Shap attribution:" in output
 
-        # to test if progress calculation aligns with the actual iteration
-        # all perturbations_per_eval should reach progress of 100%
-        assert output.count("100%") == 3
+        # test progress output for each batch size
+        for bsz in (1, 2, 3):
+            self._kernel_shap_test_assert(
+                net,
+                inp,
+                [76.66666, 196.66666, 116.66666],
+                perturbations_per_eval=(bsz,),
+                n_perturb_samples=500,
+                show_progress=True,
+            )
+            output = mock_stderr.getvalue()
+
+            # to test if progress calculation aligns with the actual iteration
+            # all perturbations_per_eval should reach progress of 100%
+            assert (
+                "Kernel Shap attribution: 100%" in output
+            ), f"Error progress output: {repr(output)}"
+
+            mock_stderr.seek(0)
+            mock_stderr.truncate(0)
 
     def test_simple_kernel_shap_with_baselines(self) -> None:
         net = BasicModel_MultiLayer()

--- a/tests/attr/test_shapley.py
+++ b/tests/attr/test_shapley.py
@@ -228,41 +228,59 @@ class Test(BaseTest):
     def test_shapley_sampling_with_show_progress(self, mock_stderr) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[20.0, 50.0, 30.0]], requires_grad=True)
-        self._shapley_test_assert(
-            net,
-            inp,
-            [76.66666, 196.66666, 116.66666],
-            perturbations_per_eval=(1, 2, 3),
-            n_samples=250,
-            show_progress=True,
-        )
-        output = mock_stderr.getvalue()
-        assert "Shapley Value Sampling attribution:" in output
-        assert "Shapley Values attribution:" in output
 
-        # to test if progress calculation aligns with the actual iteration
-        # all perturbations_per_eval should reach progress of 100%
-        assert output.count("100%") == 3 * 2
+        # test progress output for each batch size
+        for bsz in (1, 2, 3):
+            self._shapley_test_assert(
+                net,
+                inp,
+                [76.66666, 196.66666, 116.66666],
+                perturbations_per_eval=(bsz,),
+                n_samples=250,
+                show_progress=True,
+            )
+            output = mock_stderr.getvalue()
+
+            # to test if progress calculation aligns with the actual iteration
+            # all perturbations_per_eval should reach progress of 100%
+            assert (
+                "Shapley Value Sampling attribution: 100%" in output
+            ), f"Error progress output: {repr(output)}"
+            assert (
+                "Shapley Values attribution: 100%" in output
+            ), f"Error progress output: {repr(output)}"
+
+            mock_stderr.seek(0)
+            mock_stderr.truncate(0)
 
     @unittest.mock.patch("sys.stderr", new_callable=io.StringIO)
     def test_shapley_sampling_with_mask_and_show_progress(self, mock_stderr) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[20.0, 50.0, 30.0]], requires_grad=True)
-        self._shapley_test_assert(
-            net,
-            inp,
-            [275.0, 275.0, 115.0],
-            feature_mask=torch.tensor([[0, 0, 1]]),
-            perturbations_per_eval=(1, 2, 3),
-            show_progress=True,
-        )
-        output = mock_stderr.getvalue()
-        assert "Shapley Value Sampling attribution:" in output
-        assert "Shapley Values attribution:" in output
 
-        # to test if progress calculation aligns with the actual iteration
-        # all perturbations_per_eval should reach progress of 100%
-        assert output.count("100%") == 3 * 2
+        # test progress output for each batch size
+        for bsz in (1, 2, 3):
+            self._shapley_test_assert(
+                net,
+                inp,
+                [275.0, 275.0, 115.0],
+                feature_mask=torch.tensor([[0, 0, 1]]),
+                perturbations_per_eval=(bsz,),
+                show_progress=True,
+            )
+            output = mock_stderr.getvalue()
+
+            # to test if progress calculation aligns with the actual iteration
+            # all perturbations_per_eval should reach progress of 100%
+            assert (
+                "Shapley Value Sampling attribution: 100%" in output
+            ), f"Error progress output: {repr(output)}"
+            assert (
+                "Shapley Values attribution: 100%" in output
+            ), f"Error progress output: {repr(output)}"
+
+            mock_stderr.seek(0)
+            mock_stderr.truncate(0)
 
     def _single_input_one_sample_batch_scalar_shapley_assert(
         self, func: Callable


### PR DESCRIPTION
Summary: tqdm 's printing behavior is indeterministic, it may repetitively refresh the progress on the same amount. This change improve the related tests by explicitly checking if the progress can reach 100% for each batch size. It also improves the assertion failure message with the detailed progress output.

Differential Revision: D27122687

