### PR TITLE
Fix layer_gradient_x_activation and add logging for metrics

### DIFF
--- a/captum/attr/_core/layer/layer_gradient_x_activation.py
+++ b/captum/attr/_core/layer/layer_gradient_x_activation.py
@@ -170,9 +170,7 @@ class LayerGradientXActivation(LayerAttribution, GradientAttribution):
         additional_forward_args = _format_additional_forward_args(
             additional_forward_args
         )
-
         gradient_mask = apply_gradient_requirements(inputs)
-
         # Returns gradient of output with respect to
         # hidden layer and hidden layer evaluated at each input.
         layer_gradients, layer_evals = compute_layer_gradients_and_eval(
@@ -184,9 +182,7 @@ class LayerGradientXActivation(LayerAttribution, GradientAttribution):
             device_ids=self.device_ids,
             attribute_to_layer_input=attribute_to_layer_input,
         )
-
         undo_gradient_requirements(inputs, gradient_mask)
-
         if isinstance(self.layer, Module):
             return _format_output(
                 len(layer_evals) > 1,

--- a/captum/attr/_core/layer/layer_gradient_x_activation.py
+++ b/captum/attr/_core/layer/layer_gradient_x_activation.py
@@ -170,7 +170,10 @@ class LayerGradientXActivation(LayerAttribution, GradientAttribution):
         additional_forward_args = _format_additional_forward_args(
             additional_forward_args
         )
-        gradient_mask = apply_gradient_requirements(inputs)
+
+        if inputs[0].is_floating_point() or inputs[0].is_complex():
+            gradient_mask = apply_gradient_requirements(inputs)
+
         # Returns gradient of output with respect to
         # hidden layer and hidden layer evaluated at each input.
         layer_gradients, layer_evals = compute_layer_gradients_and_eval(
@@ -182,7 +185,10 @@ class LayerGradientXActivation(LayerAttribution, GradientAttribution):
             device_ids=self.device_ids,
             attribute_to_layer_input=attribute_to_layer_input,
         )
-        undo_gradient_requirements(inputs, gradient_mask)
+
+        if inputs[0].is_floating_point() or inputs[0].is_complex():
+            undo_gradient_requirements(inputs, gradient_mask)
+
         if isinstance(self.layer, Module):
             return _format_output(
                 len(layer_evals) > 1,

--- a/captum/attr/_core/layer/layer_gradient_x_activation.py
+++ b/captum/attr/_core/layer/layer_gradient_x_activation.py
@@ -171,8 +171,7 @@ class LayerGradientXActivation(LayerAttribution, GradientAttribution):
             additional_forward_args
         )
 
-        if inputs[0].is_floating_point() or inputs[0].is_complex():
-            gradient_mask = apply_gradient_requirements(inputs)
+        gradient_mask = apply_gradient_requirements(inputs)
 
         # Returns gradient of output with respect to
         # hidden layer and hidden layer evaluated at each input.
@@ -186,8 +185,7 @@ class LayerGradientXActivation(LayerAttribution, GradientAttribution):
             attribute_to_layer_input=attribute_to_layer_input,
         )
 
-        if inputs[0].is_floating_point() or inputs[0].is_complex():
-            undo_gradient_requirements(inputs, gradient_mask)
+        undo_gradient_requirements(inputs, gradient_mask)
 
         if isinstance(self.layer, Module):
             return _format_output(

--- a/captum/metrics/_core/infidelity.py
+++ b/captum/metrics/_core/infidelity.py
@@ -17,6 +17,7 @@ from captum._utils.common import (
     safe_div,
 )
 from captum._utils.typing import BaselineType, TargetType, TensorOrTupleOfTensorsGeneric
+from captum.log import log_usage
 from captum.metrics._utils.batching import _divide_and_aggregate_metrics
 
 
@@ -108,6 +109,7 @@ def infidelity_perturb_func_decorator(multipy_by_inputs: bool = True) -> Callabl
     return sub_infidelity_perturb_func_decorator
 
 
+@log_usage()
 def infidelity(
     forward_func: Callable,
     perturb_func: Callable,

--- a/captum/metrics/_core/sensitivity.py
+++ b/captum/metrics/_core/sensitivity.py
@@ -16,6 +16,7 @@ from captum._utils.common import (
     _format_tensor_into_tuples,
 )
 from captum._utils.typing import TensorOrTupleOfTensorsGeneric
+from captum.log import log_usage
 from captum.metrics._utils.batching import _divide_and_aggregate_metrics
 
 
@@ -57,6 +58,7 @@ def default_perturb_func(
     return perturbed_input
 
 
+@log_usage()
 def sensitivity_max(
     explanation_func: Callable,
     inputs: TensorOrTupleOfTensorsGeneric,

--- a/tests/attr/layer/test_layer_gradient_x_activation.py
+++ b/tests/attr/layer/test_layer_gradient_x_activation.py
@@ -23,6 +23,16 @@ class Test(BaseTest):
         inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
         self._layer_activation_test_assert(net, net.linear0, inp, [0.0, 400.0, 0.0])
 
+    def test_simple_input_gradient_activation_no_grad(self) -> None:
+        net = BasicModel_MultiLayer()
+        inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
+        with torch.no_grad():
+            self._layer_activation_test_assert(net,
+                                               net.linear0,
+                                               inp,
+                                               [0.0, 400.0, 0.0])
+
+
     def test_simple_linear_gradient_activation(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
@@ -35,7 +45,10 @@ class Test(BaseTest):
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         module_list: List[Module] = [net.linear0, net.linear1]
         self._layer_activation_test_assert(
-            net, module_list, inp, ([0.0, 400.0, 0.0], [90.0, 101.0, 101.0, 101.0]),
+            net,
+            module_list,
+            inp,
+            ([0.0, 400.0, 0.0], [90.0, 101.0, 101.0, 101.0]),
         )
 
     def test_simple_linear_gradient_activation_no_grad(self) -> None:

--- a/tests/attr/layer/test_layer_gradient_x_activation.py
+++ b/tests/attr/layer/test_layer_gradient_x_activation.py
@@ -27,11 +27,7 @@ class Test(BaseTest):
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
         with torch.no_grad():
-            self._layer_activation_test_assert(net,
-                                               net.linear0,
-                                               inp,
-                                               [0.0, 400.0, 0.0])
-
+            self._layer_activation_test_assert(net, net.linear0, inp, [0.0, 400.0, 0.0])
 
     def test_simple_linear_gradient_activation(self) -> None:
         net = BasicModel_MultiLayer()
@@ -45,10 +41,7 @@ class Test(BaseTest):
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         module_list: List[Module] = [net.linear0, net.linear1]
         self._layer_activation_test_assert(
-            net,
-            module_list,
-            inp,
-            ([0.0, 400.0, 0.0], [90.0, 101.0, 101.0, 101.0]),
+            net, module_list, inp, ([0.0, 400.0, 0.0], [90.0, 101.0, 101.0, 101.0]),
         )
 
     def test_simple_linear_gradient_activation_no_grad(self) -> None:

--- a/tests/attr/layer/test_layer_gradient_x_activation.py
+++ b/tests/attr/layer/test_layer_gradient_x_activation.py
@@ -41,7 +41,10 @@ class Test(BaseTest):
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         module_list: List[Module] = [net.linear0, net.linear1]
         self._layer_activation_test_assert(
-            net, module_list, inp, ([0.0, 400.0, 0.0], [90.0, 101.0, 101.0, 101.0]),
+            net,
+            module_list,
+            inp,
+            ([0.0, 400.0, 0.0], [90.0, 101.0, 101.0, 101.0]),
         )
 
     def test_simple_linear_gradient_activation_no_grad(self) -> None:

--- a/tests/attr/layer/test_layer_gradient_x_activation.py
+++ b/tests/attr/layer/test_layer_gradient_x_activation.py
@@ -35,10 +35,7 @@ class Test(BaseTest):
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         module_list: List[Module] = [net.linear0, net.linear1]
         self._layer_activation_test_assert(
-            net,
-            module_list,
-            inp,
-            ([0.0, 400.0, 0.0], [90.0, 101.0, 101.0, 101.0]),
+            net, module_list, inp, ([0.0, 400.0, 0.0], [90.0, 101.0, 101.0, 101.0]),
         )
 
     def test_simple_linear_gradient_activation_no_grad(self) -> None:


### PR DESCRIPTION
+ Adding logging for captum.metrics
+ currently layer_gradient_x_activation is failing for integer inputs. Adding datatype check before calling `apply_gradient_requirements` otherwise if attribute is called in `torch.no_grad()` context then it fails.