### PR TITLE
Fix gradient requirements for layer methods

### DIFF
--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -24,7 +24,7 @@ from captum._utils.typing import (
 
 
 def apply_gradient_requirements(
-    inputs: Tuple[Tensor, ...], warn: bool = False
+    inputs: Tuple[Tensor, ...], warn: bool = True
 ) -> List[bool]:
     """
     Iterates through tuple on input tensors and sets requires_grad to be true on

--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -23,7 +23,9 @@ from captum._utils.typing import (
 )
 
 
-def apply_gradient_requirements(inputs: Tuple[Tensor, ...]) -> List[bool]:
+def apply_gradient_requirements(
+    inputs: Tuple[Tensor, ...], warn: bool = False
+) -> List[bool]:
     """
     Iterates through tuple on input tensors and sets requires_grad to be true on
     each Tensor, and ensures all grads are set to zero. To ensure that the input
@@ -43,17 +45,19 @@ def apply_gradient_requirements(inputs: Tuple[Tensor, ...]) -> List[bool]:
         if not inputs_dtype.is_floating_point and not (
             hasattr(inputs_dtype, "is_complex") and inputs_dtype.is_complex
         ):
-            warnings.warn(
-                """Input Tensor %d has a dtype of %s.
-                Gradients cannot be activated
-                for these data types."""
-                % (index, str(inputs_dtype))
-            )
+            if warn:
+                warnings.warn(
+                    """Input Tensor %d has a dtype of %s.
+                    Gradients cannot be activated
+                    for these data types."""
+                    % (index, str(inputs_dtype))
+                )
         elif not input.requires_grad:
-            warnings.warn(
-                "Input Tensor %d did not already require gradients, "
-                "required_grads has been set automatically." % index
-            )
+            if warn:
+                warnings.warn(
+                    "Input Tensor %d did not already require gradients, "
+                    "required_grads has been set automatically." % index
+                )
             input.requires_grad_()
     return grad_required
 
@@ -196,6 +200,7 @@ def _forward_layer_distributed_eval(
     additional_forward_args: Any = None,
     attribute_to_layer_input: bool = False,
     forward_hook_with_return: Literal[False] = False,
+    require_layer_grads: bool = False,
 ) -> Dict[Module, Dict[device, Tuple[Tensor, ...]]]:
     ...
 
@@ -210,6 +215,7 @@ def _forward_layer_distributed_eval(
     attribute_to_layer_input: bool = False,
     *,
     forward_hook_with_return: Literal[True],
+    require_layer_grads: bool = False,
 ) -> Tuple[Dict[Module, Dict[device, Tuple[Tensor, ...]]], Tensor]:
     ...
 
@@ -222,6 +228,7 @@ def _forward_layer_distributed_eval(
     additional_forward_args: Any = None,
     attribute_to_layer_input: bool = False,
     forward_hook_with_return: bool = False,
+    require_layer_grads: bool = False,
 ) -> Union[
     Tuple[Dict[Module, Dict[device, Tuple[Tensor, ...]]], Tensor],
     Dict[Module, Dict[device, Tuple[Tensor, ...]]],
@@ -251,6 +258,8 @@ def _forward_layer_distributed_eval(
 
             if not is_eval_tuple:
                 eval_tsrs = (eval_tsrs,)
+            if require_layer_grads:
+                apply_gradient_requirements(eval_tsrs, warn=False)
             with lock:
                 nonlocal saved_layer
                 # Note that cloning behaviour of `eval_tsr` is different
@@ -588,6 +597,7 @@ def compute_layer_gradients_and_eval(
             additional_forward_args=additional_forward_args,
             attribute_to_layer_input=attribute_to_layer_input,
             forward_hook_with_return=True,
+            require_layer_grads=True,
         )
         assert output[0].numel() == 1, (
             "Target not provided when necessary, cannot"

--- a/captum/attr/__init__.py
+++ b/captum/attr/__init__.py
@@ -51,7 +51,7 @@ from captum.attr._models.base import (
     configure_interpretable_embedding_layer,
     remove_interpretable_embedding_layer,
 )
-from captum.attr._utils import visualization  # noqa
+# from captum.attr._utils import visualization  # noqa
 from captum.attr._utils.attribution import Attribution  # noqa
 from captum.attr._utils.attribution import GradientAttribution  # noqa
 from captum.attr._utils.attribution import LayerAttribution  # noqa

--- a/captum/attr/__init__.py
+++ b/captum/attr/__init__.py
@@ -51,7 +51,7 @@ from captum.attr._models.base import (
     configure_interpretable_embedding_layer,
     remove_interpretable_embedding_layer,
 )
-# from captum.attr._utils import visualization  # noqa
+from captum.attr._utils import visualization  # noqa
 from captum.attr._utils.attribution import Attribution  # noqa
 from captum.attr._utils.attribution import GradientAttribution  # noqa
 from captum.attr._utils.attribution import LayerAttribution  # noqa

--- a/captum/attr/_core/layer/grad_cam.py
+++ b/captum/attr/_core/layer/grad_cam.py
@@ -11,11 +11,7 @@ from captum._utils.common import (
     _format_input,
     _format_output,
 )
-from captum._utils.gradient import (
-    apply_gradient_requirements,
-    compute_layer_gradients_and_eval,
-    undo_gradient_requirements,
-)
+from captum._utils.gradient import compute_layer_gradients_and_eval
 from captum._utils.typing import TargetType
 from captum.attr._utils.attribution import GradientAttribution, LayerAttribution
 from captum.log import log_usage
@@ -190,7 +186,6 @@ class LayerGradCam(LayerAttribution, GradientAttribution):
         additional_forward_args = _format_additional_forward_args(
             additional_forward_args
         )
-        gradient_mask = apply_gradient_requirements(inputs)
         # Returns gradient of output with respect to
         # hidden layer and hidden layer evaluated at each input.
         layer_gradients, layer_evals = compute_layer_gradients_and_eval(
@@ -202,7 +197,6 @@ class LayerGradCam(LayerAttribution, GradientAttribution):
             device_ids=self.device_ids,
             attribute_to_layer_input=attribute_to_layer_input,
         )
-        undo_gradient_requirements(inputs, gradient_mask)
 
         summed_grads = tuple(
             torch.mean(

--- a/captum/attr/_core/layer/layer_deep_lift.py
+++ b/captum/attr/_core/layer/layer_deep_lift.py
@@ -13,11 +13,7 @@ from captum._utils.common import (
     _format_baseline,
     _format_input,
 )
-from captum._utils.gradient import (
-    apply_gradient_requirements,
-    compute_layer_gradients_and_eval,
-    undo_gradient_requirements,
-)
+from captum._utils.gradient import compute_layer_gradients_and_eval
 from captum._utils.typing import (
     BaselineType,
     Literal,
@@ -294,7 +290,6 @@ class LayerDeepLift(LayerAttribution, DeepLift):
         """
         inputs = _format_input(inputs)
         baselines = _format_baseline(baselines, inputs)
-        gradient_mask = apply_gradient_requirements(inputs)
         _validate_input(inputs, baselines)
 
         baselines = _tensorize_baseline(inputs, baselines)
@@ -357,7 +352,6 @@ class LayerDeepLift(LayerAttribution, DeepLift):
             # remove hooks from all activations
             self._remove_hooks(main_model_hooks)
 
-        undo_gradient_requirements(inputs, gradient_mask)
         return _compute_conv_delta_and_format_attrs(
             self,
             return_convergence_delta,

--- a/captum/attr/_core/layer/layer_gradient_x_activation.py
+++ b/captum/attr/_core/layer/layer_gradient_x_activation.py
@@ -9,11 +9,7 @@ from captum._utils.common import (
     _format_input,
     _format_output,
 )
-from captum._utils.gradient import (
-    apply_gradient_requirements,
-    compute_layer_gradients_and_eval,
-    undo_gradient_requirements,
-)
+from captum._utils.gradient import compute_layer_gradients_and_eval
 from captum._utils.typing import ModuleOrModuleList, TargetType
 from captum.attr._utils.attribution import GradientAttribution, LayerAttribution
 from captum.log import log_usage
@@ -170,7 +166,6 @@ class LayerGradientXActivation(LayerAttribution, GradientAttribution):
         additional_forward_args = _format_additional_forward_args(
             additional_forward_args
         )
-        gradient_mask = apply_gradient_requirements(inputs)
         # Returns gradient of output with respect to
         # hidden layer and hidden layer evaluated at each input.
         layer_gradients, layer_evals = compute_layer_gradients_and_eval(
@@ -182,7 +177,6 @@ class LayerGradientXActivation(LayerAttribution, GradientAttribution):
             device_ids=self.device_ids,
             attribute_to_layer_input=attribute_to_layer_input,
         )
-        undo_gradient_requirements(inputs, gradient_mask)
         if isinstance(self.layer, Module):
             return _format_output(
                 len(layer_evals) > 1,

--- a/tests/attr/layer/test_layer_gradient_x_activation.py
+++ b/tests/attr/layer/test_layer_gradient_x_activation.py
@@ -109,6 +109,18 @@ class Test(BaseTest):
             list(layer_act.attribute(inputs=(input1, input2)).shape), [4, 100]
         )
 
+    def test_gradient_activation_embedding_no_grad(self) -> None:
+        input1 = torch.tensor([2, 5, 0, 1])
+        input2 = torch.tensor([3, 0, 0, 2])
+        model = BasicEmbeddingModel()
+        # for param in model.parameters():
+        #    param.requires_grad = False
+        with torch.no_grad():
+            layer_act = LayerGradientXActivation(model, model.embedding1)
+            self.assertEqual(
+                list(layer_act.attribute(inputs=(input1, input2)).shape), [4, 100]
+            )
+
     def _layer_activation_test_assert(
         self,
         model: Module,

--- a/tests/attr/layer/test_layer_gradient_x_activation.py
+++ b/tests/attr/layer/test_layer_gradient_x_activation.py
@@ -113,8 +113,9 @@ class Test(BaseTest):
         input1 = torch.tensor([2, 5, 0, 1])
         input2 = torch.tensor([3, 0, 0, 2])
         model = BasicEmbeddingModel()
-        # for param in model.parameters():
-        #    param.requires_grad = False
+        for param in model.parameters():
+            param.requires_grad = False
+
         with torch.no_grad():
             layer_act = LayerGradientXActivation(model, model.embedding1)
             self.assertEqual(


### PR DESCRIPTION
This updates gradient requirements to be set on layer inputs / outputs rather than original inputs, which ensures that gradient requirements are set when inputs are non-floating point (e.g. token indices). This also avoids unnecessarily requiring gradients between the input and target layer, when only layer gradients are required.