### PR TITLE
Fix Conda Matplotlib Dependency

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -17,7 +17,7 @@ requirements:
   run:
     - numpy
     - pytorch>=1.2
-    - matplotlib
+    - matplotlib-base
 
 test:
   imports:


### PR DESCRIPTION
This addresses #644 , switching the Conda dependency from matplotlib to matplotlib-base, since pyqt is not used in Captum.