### PR TITLE
Optim-wip: Fix failing tests, model download link, & more

### DIFF
--- a/captum/attr/_core/feature_ablation.py
+++ b/captum/attr/_core/feature_ablation.py
@@ -62,7 +62,7 @@ class FeatureAblation(PerturbationAttribution):
         additional_forward_args: Any = None,
         feature_mask: Union[None, Tensor, Tuple[Tensor, ...]] = None,
         perturbations_per_eval: int = 1,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> TensorOrTupleOfTensorsGeneric:
         r"""
         Args:
@@ -321,7 +321,7 @@ class FeatureAblation(PerturbationAttribution):
                     baselines,
                     feature_mask,
                     perturbations_per_eval,
-                    **kwargs
+                    **kwargs,
                 ):
                     # modified_eval dimensions: 1D tensor with length
                     # equal to #num_examples * #features in batch
@@ -373,7 +373,7 @@ class FeatureAblation(PerturbationAttribution):
         baselines,
         input_mask,
         perturbations_per_eval,
-        **kwargs
+        **kwargs,
     ):
         """
         This method is a generator which yields each perturbation to be evaluated
@@ -458,7 +458,7 @@ class FeatureAblation(PerturbationAttribution):
                 baseline,
                 num_features_processed,
                 num_features_processed + current_num_ablated_features,
-                **extra_args
+                **extra_args,
             )
 
             # current_features[i] has dimension

--- a/captum/metrics/_core/infidelity.py
+++ b/captum/metrics/_core/infidelity.py
@@ -68,7 +68,7 @@ def infidelity_perturb_func_decorator(multipy_by_inputs: bool = True) -> Callabl
         def default_perturb_func(
             inputs: TensorOrTupleOfTensorsGeneric, baselines: BaselineType = None
         ):
-            r""""""
+            r""" """
             inputs_perturbed = (
                 pertub_func(inputs, baselines)
                 if baselines is not None
@@ -380,7 +380,7 @@ def infidelity(
         """
 
         def call_perturb_func():
-            r""""""
+            r""" """
             baselines_pert = None
             inputs_pert: Union[Tensor, Tuple[Tensor, ...]]
             if len(inputs_expanded) == 1:

--- a/captum/optim/__init__.py
+++ b/captum/optim/__init__.py
@@ -12,7 +12,6 @@ from captum.optim._utils.image.common import (  # noqa: F401
     show,
     weights_to_heatmap_2d,
 )
-from captum.optim._utils.reducer import ChannelReducer, posneg  # noqa: F401
 
 __all__ = [
     "InputOptimization",

--- a/captum/optim/_core/optimization.py
+++ b/captum/optim/_core/optimization.py
@@ -111,7 +111,7 @@ class InputOptimization(Objective, Parameterized):
         self,
         stop_criteria: Optional[StopCriteria] = None,
         optimizer: Optional[optim.Optimizer] = None,
-        loss_summarize_fn: Optional[Callable] = default_loss_summarize,
+        loss_summarize_fn: Optional[Callable] = None,
         lr: float = 0.025,
     ) -> torch.Tensor:
         r"""Optimize input based on loss function and objectives.
@@ -131,6 +131,7 @@ class InputOptimization(Objective, Parameterized):
         stop_criteria = stop_criteria or n_steps(512)
         optimizer = optimizer or optim.Adam(self.parameters(), lr=lr)
         assert isinstance(optimizer, optim.Optimizer)
+        loss_summarize_fn = loss_summarize_fn or default_loss_summarize
 
         history = []
         step = 0

--- a/captum/optim/_core/optimization.py
+++ b/captum/optim/_core/optimization.py
@@ -138,7 +138,7 @@ class InputOptimization(Objective, Parameterized):
             while stop_criteria(step, self, history, optimizer):
                 optimizer.zero_grad()
                 loss_value = loss_summarize_fn(self.loss())
-                history.append(loss_value)
+                history.append(loss_value.clone().detach().cpu())
                 loss_value.backward()
                 optimizer.step()
                 step += 1

--- a/captum/optim/_core/optimization.py
+++ b/captum/optim/_core/optimization.py
@@ -138,7 +138,7 @@ class InputOptimization(Objective, Parameterized):
             while stop_criteria(step, self, history, optimizer):
                 optimizer.zero_grad()
                 loss_value = loss_summarize_fn(self.loss())
-                history.append(loss_value.clone().detach().cpu())
+                history.append(loss_value.clone().detach())
                 loss_value.backward()
                 optimizer.step()
                 step += 1

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -179,7 +179,6 @@ class FFTImage(ImageParameterization):
         return torch_rfft, torch_irfft, torch_fftfreq
 
     def forward(self) -> torch.Tensor:
-        h, w = self.size
         scaled_spectrum = self.fourier_coeffs * self.spectrum_scale
         output = self.torch_irfft(scaled_spectrum)
         return output.refine_names("B", "C", "H", "W")

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -138,9 +138,7 @@ class FFTImage(ImageParameterization):
     def rfft2d_freqs(self, height: int, width: int) -> torch.Tensor:
         """Computes 2D spectrum frequencies."""
         fy = self.torch_fftfreq(height)[:, None]
-        # on odd input dimensions we need to keep one additional frequency
-        wadd = 2 if width % 2 == 1 else 1
-        fx = self.torch_fftfreq(width)[: width // 2 + wadd]
+        fx = self.torch_fftfreq(width)[: width // 2 + 1]
         return torch.sqrt((fx * fx) + (fy * fy))
 
     def get_fft_funcs(self) -> Tuple[Callable, Callable, Callable]:

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -35,13 +35,13 @@ class ImageTensor(torch.Tensor):
             return super().__new__(cls, x, *args, **kwargs)
 
     @classmethod
-    def open(cls, path: str, scale: float = 255.0) -> "ImageTensor":
+    def open(cls, path: str, scale: float = 255.0, mode: str = "RGB") -> "ImageTensor":
         if path.startswith("https://") or path.startswith("http://"):
             response = requests.get(path, stream=True)
             img = Image.open(response.raw)
         else:
             img = Image.open(path)
-        img_np = np.array(img.convert("RGB")).astype(np.float32)
+        img_np = np.array(img.convert(mode)).astype(np.float32)
         return cls(img_np.transpose(2, 0, 1) / scale)
 
     def __repr__(self) -> str:

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -418,17 +418,17 @@ class NaturalImage(ImageParameterization):
 
     def __init__(
         self,
-        size: Tuple[int, int] = [224, 224],
+        size: Tuple[int, int] = (224, 224),
         channels: int = 3,
         batch: int = 1,
         init: Optional[torch.Tensor] = None,
         parameterization: ImageParameterization = FFTImage,
         squash_func: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
-        decorrelation_module: Optional[nn.Module] = ToRGB(transform="klt"),
-        decorrelate_init: bool = True,
+        decorrelation_module: Optional[nn.Module] = None,
+        decorrelate_init: bool = False,
     ) -> None:
         super().__init__()
-        self.decorrelate = decorrelation_module
+        self.decorrelate = decorrelation_module or ToRGB(transform="klt")
         if init is not None:
             assert init.dim() == 3 or init.dim() == 4
             if decorrelate_init:

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -209,6 +209,9 @@ class PixelImage(ImageParameterization):
 
 
 class LaplacianImage(ImageParameterization):
+    """
+    TODO: Fix divison by 6 in setup_input when init is not None.
+    """
     def __init__(
         self,
         size: Tuple[int, int] = None,
@@ -386,7 +389,9 @@ class SharedImage(ImageParameterization):
 
 
 class NaturalImage(ImageParameterization):
-    r"""Outputs an optimizable input image.
+    r"""TODO: Resolve device issues with default ToRGB instance, and init tensors.
+    
+    Outputs an optimizable input image.
 
     By convention, single images are CHW and float32s in [0,1].
     The underlying parameterization can be decorrelated via a ToRGB transform.

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -425,7 +425,7 @@ class NaturalImage(ImageParameterization):
         parameterization: ImageParameterization = FFTImage,
         squash_func: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
         decorrelation_module: Optional[nn.Module] = None,
-        decorrelate_init: bool = False,
+        decorrelate_init: bool = True,
     ) -> None:
         super().__init__()
         self.decorrelate = decorrelation_module or ToRGB(transform="klt")

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -430,12 +430,7 @@ class NaturalImage(ImageParameterization):
         decorrelate_init: bool = True,
     ) -> None:
         super().__init__()
-        # Deep copy to avoid issue with creating class instance in the function
-        # signature
-        if isinstance(decorrelation_module, ToRGB):
-            decorrelation_module = deepcopy(decorrelation_module)
         self.decorrelate = decorrelation_module
-
         if init is not None:
             assert init.dim() == 3 or init.dim() == 4
             if decorrelate_init and self.decorrelate is not None:

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -116,7 +116,6 @@ class FFTImage(ImageParameterization):
         )
         scale = scale * ((self.size[0] * self.size[1]) ** (1 / 2))
         spectrum_scale = scale[None, :, :, None]
-        self.register_buffer("spectrum_scale", spectrum_scale)
 
         if init is None:
             coeffs_shape = (
@@ -131,8 +130,10 @@ class FFTImage(ImageParameterization):
             )  # names=["C", "H_f", "W_f", "complex"]
             fourier_coeffs = random_coeffs / 50
         else:
+            spectrum_scale = spectrum_scale.to(init.device)
             fourier_coeffs = self.torch_rfft(init) / spectrum_scale
 
+        self.register_buffer("spectrum_scale", spectrum_scale)
         self.fourier_coeffs = nn.Parameter(fourier_coeffs)
 
     def rfft2d_freqs(self, height: int, width: int) -> torch.Tensor:
@@ -390,7 +391,7 @@ class SharedImage(ImageParameterization):
 
 class NaturalImage(ImageParameterization):
     r"""TODO: Resolve device issues with default ToRGB instance, and init tensors.
-    
+
     Outputs an optimizable input image.
 
     By convention, single images are CHW and float32s in [0,1].

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -432,11 +432,10 @@ class NaturalImage(ImageParameterization):
         super().__init__()
         # Deep copy to avoid issue with creating class instance in the function
         # signature
-        self.decorrelate = (
-            deepcopy(decorrelation_module)
-            if isinstance(decorrelation_module, ToRGB)
-            else decorrelation_module
-        )
+        if isinstance(decorrelation_module, ToRGB):
+            decorrelation_module = deepcopy(decorrelation_module)
+        self.decorrelate = decorrelation_module
+
         if init is not None:
             assert init.dim() == 3 or init.dim() == 4
             if decorrelate_init and self.decorrelate is not None:

--- a/captum/optim/_param/image/images.py
+++ b/captum/optim/_param/image/images.py
@@ -213,6 +213,7 @@ class LaplacianImage(ImageParameterization):
     """
     TODO: Fix divison by 6 in setup_input when init is not None.
     """
+
     def __init__(
         self,
         size: Tuple[int, int] = None,
@@ -390,9 +391,7 @@ class SharedImage(ImageParameterization):
 
 
 class NaturalImage(ImageParameterization):
-    r"""TODO: Resolve device issues with default ToRGB instance, and init tensors.
-
-    Outputs an optimizable input image.
+    r"""Outputs an optimizable input image.
 
     By convention, single images are CHW and float32s in [0,1].
     The underlying parameterization can be decorrelated via a ToRGB transform.
@@ -431,11 +430,14 @@ class NaturalImage(ImageParameterization):
         decorrelate_init: bool = True,
     ) -> None:
         super().__init__()
+        # Deep copy to avoid issue with creating class instance in the function
+        # signature
         self.decorrelate = (
-            decorrelation_module.cpu() if decorrelation_module is not None else None
+            deepcopy(decorrelation_module)
+            if isinstance(decorrelation_module, ToRGB)
+            else decorrelation_module
         )
         if init is not None:
-            assert not init.is_cuda
             assert init.dim() == 3 or init.dim() == 4
             if decorrelate_init and self.decorrelate is not None:
                 init = (

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -107,9 +107,9 @@ class ToRGB(nn.Module):
         h, w = x.size("H"), x.size("W")
         flat = x.flatten(("H", "W"), "spatials")
         if inverse:
-            correct = torch.inverse(self.transform) @ flat
+            correct = torch.inverse(self.transform.to(x.device)) @ flat
         else:
-            correct = self.transform @ flat
+            correct = self.transform.to(x.device) @ flat
         chw = correct.unflatten("spatials", (("H", h), ("W", w)))
 
         if x.dim() == 3:

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -503,53 +503,6 @@ class RandomCrop(nn.Module):
         )
 
 
-class AlphaChannelLoss(nn.Module):
-    """
-        TODO: Fix AlphaChannelLoss
-        Transform for calculating alpha channel loss, without altering the input tensor.
-        Loss values are calculated in such a way that opaque and transparent regions of
-        the tensor are automatically balanced.
-    ​
-        See: https://distill.pub/2018/differentiable-parameterizations/
-        Mordvintsev, et al., "Differentiable Image Parameterizations", Distill, 2018.
-    ​
-        Args:
-            scale (float, sequence): Tuple of rescaling values to randomly select from.
-            crop_size (int, sequence, int, optional): The desired cropped output size
-                for secondary alpha channel loss.
-            background (tensor, optional):  An NCHW image tensor to be used as the
-                alpha channel's background.
-    """
-
-    def __init__(
-        self,
-        scale: NumSeqOrTensorType,
-        crop_size: Optional[Tuple[int, int]] = None,
-        background: Optional[torch.Tensor] = None,
-    ) -> None:
-        raise NotImplementedError  # We are not ready for this
-        super().__init__()
-        self.random_scale = RandomScale(scale=scale)
-        self.crop_size = crop_size
-        self.random_crop = RandomCrop(crop_size)
-        self.blend_alpha = BlendAlpha(background=background)
-        self.loss = 0
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        assert x.dim() == 4  # Should be of shape (batch, channel, height, width)
-        assert x.size(1) == 4  # Channel dim should be rgba
-
-        x_shifted = torch.cat([self.blend_alpha(x.clone()), x.clone()[:, 3:]], 1)
-
-        x_shifted = self.random_scale(x_shifted)
-        x_shifted_crop = self.random_crop(x_shifted)
-
-        self.loss = (1.0 - x_shifted[:, 3:].mean()) + (
-            (1.0 - x_shifted_crop[:, 3:].mean()) * 0.5
-        )
-        return x
-
-
 __all__ = [
     "BlendAlpha",
     "IgnoreAlpha",

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -217,9 +217,9 @@ def _rand_select(
     transform_values: NumSeqOrTensorType,
 ) -> Union[int, float, torch.Tensor]:
     """
-    Randomly return a value from the provided tuple or list
+    Randomly return a single value from the provided tuple, list, or tensor.
     """
-    n = torch.randint(low=0, high=len(transform_values) - 1, size=[1]).item()
+    n = torch.randint(low=0, high=len(transform_values), size=[1]).item()
     return transform_values[n]
 
 

--- a/captum/optim/models/__init__.py
+++ b/captum/optim/models/__init__.py
@@ -1,5 +1,6 @@
 from ._common import (  # noqa: F401
     RedirectedReluLayer,
+    SkipLayer,
     collect_activations,
     get_model_layers,
     replace_layers,
@@ -10,6 +11,7 @@ from ._image.inception_v1 import InceptionV1, googlenet  # noqa: F401
 
 __all__ = [
     "RedirectedReluLayer",
+    "SkipLayer",
     "collect_activations",
     "get_model_layers",
     "replace_layers",

--- a/captum/optim/models/_common.py
+++ b/captum/optim/models/_common.py
@@ -204,7 +204,8 @@ class SkipLayer(torch.nn.Module):
     like ReLU for circuits research.
 
     This layer works almost exactly the same way that nn.Indentiy does, except it also
-    ignores any additional arguments passed to the forward function.
+    ignores any additional arguments passed to the forward function. Any layer replaced
+    by SkipLayer must have the same input and output shapes.
 
     See nn.Identity for more details:
     https://pytorch.org/docs/stable/generated/torch.nn.Identity.html

--- a/captum/optim/models/_common.py
+++ b/captum/optim/models/_common.py
@@ -199,13 +199,36 @@ def collect_activations(
 
 class SkipLayer(torch.nn.Module):
     """
-    This layer is made to take the place of nonlinear activation layers like ReLU.
+    This layer is made to take the place of any layer that needs to be skipped over
+    during the forward pass. Use cases include removing nonlinear activation layers
+    like ReLU for circuits research.
+
+    This layer works almost exactly the same way that nn.Indentiy does, except it also
+    ignores any additional arguments passed to the forward function.
+
+    See nn.Identity for more details:
+    https://pytorch.org/docs/stable/generated/torch.nn.Identity.html
+
+    Args:
+        args (Any): Any argument. Arguments will be safely ignored.
+        kwargs (Any) Any keyword argument. Arguments will be safely ignored.
     """
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__()
 
-    def forward(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+    def forward(
+        self, x: Union[torch.Tensor, Tuple[torch.Tensor]], *args, **kwargs
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor]]:
+        """
+        Args:
+            x (torch.Tensor or tuple of torch.Tensor): The input tensor or tensors.
+            args (Any): Any argument. Arguments will be safely ignored.
+            kwargs (Any) Any keyword argument. Arguments will be safely ignored.
+        Returns:
+            x (torch.Tensor or tuple of torch.Tensor): The unmodified input tensor or
+                tensors.
+        """
         return x
 
 

--- a/captum/optim/models/_common.py
+++ b/captum/optim/models/_common.py
@@ -202,7 +202,10 @@ class SkipLayer(torch.nn.Module):
     This layer is made to take the place of nonlinear activation layers like ReLU.
     """
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__()
+
+    def forward(self, x: torch.Tensor, *args, **kwargs) -> torch.Tensor:
         return x
 
 

--- a/captum/optim/models/_image/inception_v1.py
+++ b/captum/optim/models/_image/inception_v1.py
@@ -7,7 +7,7 @@ from captum.optim.models._common import Conv2dSame, RedirectedReluLayer, SkipLay
 
 GS_SAVED_WEIGHTS_URL = (
     "https://github.com/pytorch/captum/raw/"
-    + "optim-wip/captum/optim/_models/inception5h.pth"
+    + "optim-wip/captum/optim/models/_image/inception5h.pth"
 )
 
 

--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -40,7 +40,7 @@ conda install -y -c conda-forge black matplotlib pytest-cov sphinx-autodoc-typeh
 # install node/yarn for insights build
 conda install -y -c conda-forge yarn
 # nodejs should be last, otherwise other conda packages will downgrade node
-conda update -y --no-channel-priority -c conda-forge nodejs
+conda install -y --no-channel-priority -c conda-forge nodejs=14
 
 
 # build insights and install captum

--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -34,8 +34,8 @@ else
 fi
 
 # install other deps
-conda install -y numpy sphinx pytest flake8 ipywidgets ipython
-conda install -y -c conda-forge black matplotlib pytest-cov sphinx-autodoc-typehints mypy flask isort
+conda install -y numpy sphinx pytest flake8 ipywidgets ipython scikit-learn
+conda install -y -c conda-forge black matplotlib pytest-cov sphinx-autodoc-typehints mypy flask isort flask-compress
 
 # install node/yarn for insights build
 conda install -y -c conda-forge yarn
@@ -44,5 +44,4 @@ conda update -y --no-channel-priority -c conda-forge nodejs
 
 
 # build insights and install captum
-# TODO: remove CI=false when we want React warnings treated as errors
-CI=false BUILD_INSIGHTS=1 python setup.py develop
+BUILD_INSIGHTS=1 python setup.py develop

--- a/tests/optim/core/test_optimization.py
+++ b/tests/optim/core/test_optimization.py
@@ -9,7 +9,6 @@ from tests.helpers.basic_models import BasicModel_ConvNet_Optim
 
 
 class TestInputOptimization(BaseTest):
-    @unittest.skipIf(torch.__version__ > "1.8.1", "Bug in PyTorch nightly build")
     def test_input_optimization(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(
@@ -23,7 +22,6 @@ class TestInputOptimization(BaseTest):
         self.assertTrue(history[0] > history[-1])
         self.assertTrue(len(history) == n_steps)
 
-    @unittest.skipIf(torch.__version__ > "1.8.1", "Bug in PyTorch nightly build")
     def test_input_optimization_param(self) -> None:
         """Test for optimizing param without model"""
         if torch.__version__ <= "1.2.0":

--- a/tests/optim/core/test_optimization.py
+++ b/tests/optim/core/test_optimization.py
@@ -17,7 +17,7 @@ class TestInputOptimization(BaseTest):
         model = BasicModel_ConvNet_Optim()
         loss_fn = opt.loss.ChannelActivation(model.layer, 0)
         obj = opt.InputOptimization(model, loss_function=loss_fn)
-        n_steps = 5
+        n_steps = 25
         history = obj.optimize(opt.optimization.n_steps(n_steps, show_progress=False))
         self.assertTrue(history[0] > history[-1])
         self.assertTrue(len(history) == n_steps)

--- a/tests/optim/core/test_optimization.py
+++ b/tests/optim/core/test_optimization.py
@@ -9,6 +9,7 @@ from tests.helpers.basic_models import BasicModel_ConvNet_Optim
 
 
 class TestInputOptimization(BaseTest):
+    @unittest.skipIf(torch.__version__ > "1.8.1", "Bug in PyTorch nightly build")
     def test_input_optimization(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(
@@ -22,6 +23,7 @@ class TestInputOptimization(BaseTest):
         self.assertTrue(history[0] > history[-1])
         self.assertTrue(len(history) == n_steps)
 
+    @unittest.skipIf(torch.__version__ > "1.8.1", "Bug in PyTorch nightly build")
     def test_input_optimization_param(self) -> None:
         """Test for optimizing param without model"""
         if torch.__version__ <= "1.2.0":

--- a/tests/optim/helpers/numpy_image.py
+++ b/tests/optim/helpers/numpy_image.py
@@ -3,17 +3,6 @@ from typing import Optional
 import numpy as np
 
 
-def setup_batch(x: np.ndarray, batch: int = 1, dim: int = 3) -> np.ndarray:
-    assert batch > 0
-    x = x[None, :] if x.ndim == dim and batch == 1 else x
-    x = (
-        np.stack([np.copy(x) for b in range(batch)])
-        if x.ndim == dim and batch > 1
-        else x
-    )
-    return x
-
-
 class FFTImage:
     """Parameterize an image using inverse real 2D FFT"""
 
@@ -66,10 +55,6 @@ class FFTImage:
         wadd = 2 if width % 2 == 1 else 1
         fx = np.fft.fftfreq(width)[: width // 2 + wadd]
         return np.sqrt((fx * fx) + (fy * fy))
-
-    def set_image(self, correlated_image: np.ndarray) -> None:
-        coeffs = np.fft.rfftn(correlated_image, s=self.size).view("(2,)float")
-        self.fourier_coeffs = coeffs / self.spectrum_scale
 
     def forward(self) -> np.ndarray:
         h, w = self.size

--- a/tests/optim/helpers/numpy_image.py
+++ b/tests/optim/helpers/numpy_image.py
@@ -51,13 +51,10 @@ class FFTImage:
     def rfft2d_freqs(height: int, width: int) -> np.ndarray:
         """Computes 2D spectrum frequencies."""
         fy = np.fft.fftfreq(height)[:, None]
-        # on odd input dimensions we need to keep one additional frequency
-        wadd = 2 if width % 2 == 1 else 1
-        fx = np.fft.fftfreq(width)[: width // 2 + wadd]
+        fx = np.fft.fftfreq(width)[: width // 2 + 1]
         return np.sqrt((fx * fx) + (fy * fy))
 
     def forward(self) -> np.ndarray:
-        h, w = self.size
         scaled_spectrum = self.fourier_coeffs * self.spectrum_scale
         scaled_spectrum = scaled_spectrum.astype(complex)
         output = np.fft.irfftn(scaled_spectrum, s=self.size)

--- a/tests/optim/models/test_models_common.py
+++ b/tests/optim/models/test_models_common.py
@@ -270,6 +270,18 @@ class TestSkipLayer(BaseTest):
         output_tensor = layer(x)
         assertTensorAlmostEqual(self, x, output_tensor, 0)
 
+    def test_skip_layer_ignore_init_variables(self) -> None:
+        layer = model_utils.SkipLayer(0, inplace=True)
+        x = torch.randn(1, 3, 4, 4)
+        output_tensor = layer(x)
+        assertTensorAlmostEqual(self, x, output_tensor, 0)
+
+    def test_skip_layer_ignore_forward_variables(self) -> None:
+        layer = model_utils.SkipLayer()
+        x = torch.randn(1, 3, 4, 4)
+        output_tensor = layer(x, 1, inverse=True)
+        assertTensorAlmostEqual(self, x, output_tensor, 0)
+
 
 class TestSkipLayersFunction(BaseTest):
     def test_skip_layers(self) -> None:

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -16,6 +16,7 @@ from tests.optim.helpers import numpy_image
 
 
 class TestImageTensor(BaseTest):
+    @unittest.skipIf(torch.__version__ > "1.8.1", "Bug in PyTorch nightly build")
     def test_repr(self) -> None:
         self.assertEqual(str(images.ImageTensor()), "ImageTensor([])")
 
@@ -565,6 +566,7 @@ class TestSharedImage(BaseTest):
 
 
 class TestNaturalImage(BaseTest):
+    @unittest.skipIf(torch.__version__ > "1.8.1", "Bug in PyTorch nightly build")
     def test_natural_image_0(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(
@@ -573,7 +575,7 @@ class TestNaturalImage(BaseTest):
         image_param = images.NaturalImage(size=(1, 1))
         image_np = image_param.forward().detach().numpy()
         assertArraysAlmostEqual(image_np, np.ones_like(image_np) * 0.5)
-
+    @unittest.skipIf(torch.__version__ > "1.8.1", "Bug in PyTorch nightly build")
     def test_natural_image_1(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -662,3 +662,14 @@ class TestNaturalImage(BaseTest):
             )
         image_param = images.NaturalImage().cuda()
         self.assertTrue(image_param().is_cuda)
+
+    def test_natural_image_decorrelation_module_none(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping NaturalImage test due to insufficient Torch version."
+            )
+        image_param = images.NaturalImage(
+            init=torch.ones(1, 3, 4, 4), decorrelation_module=None
+        )
+        image = image_param.forward().detach()
+        assertTensorAlmostEqual(self, image, torch.ones_like(image))

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -150,6 +150,16 @@ class TestFFTImage(BaseTest):
 
         self.assertEqual(fftimage_tensor.detach().numpy().shape, fftimage_array.shape)
 
+    def test_fftimage_forward_randn_init_width_odd(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping FFTImage test due to insufficient Torch version."
+            )
+        fftimage = images.FFTImage(size=(512, 405))
+        self.assertEqual(list(fftimage.spectrum_scale.shape), [1, 512, 203, 1])
+        fftimage_tensor = fftimage().detach()
+        self.assertEqual(list(fftimage_tensor.shape), [1, 3, 512, 405])
+
     def test_fftimage_forward_init_chw(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -98,9 +98,11 @@ class TestFFTImage(BaseTest):
         height = 2
         width = 3
         image = images.FFTImage((1, 1))
-        assertArraysAlmostEqual(
-            image.rfft2d_freqs(height, width).numpy(),
-            numpy_image.FFTImage.rfft2d_freqs(height, width),
+
+        assertTensorAlmostEqual(
+            self,
+            image.rfft2d_freqs(height, width),
+            torch.tensor([[0.0000, 0.3333], [0.5000, 0.6009]]),
         )
 
     def test_fftimage_forward_randn_init(self) -> None:

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -664,7 +664,7 @@ class TestNaturalImage(BaseTest):
         self.assertTrue(image_param().is_cuda)
 
     def test_natural_image_decorrelation_module_none(self) -> None:
-        if torch.__version__ <= "1.2.0":
+        if torch.__version__ <= "1.3.0":
             raise unittest.SkipTest(
                 "Skipping NaturalImage test due to insufficient Torch version."
             )

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -575,6 +575,7 @@ class TestNaturalImage(BaseTest):
         image_param = images.NaturalImage(size=(1, 1))
         image_np = image_param.forward().detach().numpy()
         assertArraysAlmostEqual(image_np, np.ones_like(image_np) * 0.5)
+
     @unittest.skipIf(torch.__version__ > "1.8.1", "Bug in PyTorch nightly build")
     def test_natural_image_1(self) -> None:
         if torch.__version__ <= "1.2.0":

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -32,8 +32,8 @@ class TestImageTensor(BaseTest):
         self.assertEqual(x.shape, test_tensor.shape)
 
     def test_new_list(self) -> None:
-        x = torch.ones(5).tolist()
-        test_tensor = images.ImageTensor(x)
+        x = torch.ones(5)
+        test_tensor = images.ImageTensor(x.tolist())
         self.assertTrue(torch.is_tensor(test_tensor))
         self.assertEqual(x.shape, test_tensor.shape)
 

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -44,6 +44,14 @@ class TestImageTensor(BaseTest):
         self.assertEqual(image_tensor.sum().item(), torch.ones(5).sum().item())
 
     def test_load_image_from_url(self) -> None:
+        try:
+            from PIL import Image  # noqa: F401
+
+        except (ImportError, AssertionError):
+            raise unittest.SkipTest(
+                "Module Pillow / PIL not found, skipping ImageTensor load from url"
+                + " test"
+            )
         img_url = (
             "https://github.com/pytorch/captum"
             + "/raw/master/website/static/img/captum_logo.png"
@@ -53,6 +61,14 @@ class TestImageTensor(BaseTest):
         self.assertEqual(list(new_tensor.shape), [3, 54, 208])
 
     def test_export_and_open_local_image(self) -> None:
+        try:
+            from PIL import Image  # noqa: F401
+
+        except (ImportError, AssertionError):
+            raise unittest.SkipTest(
+                "Module Pillow / PIL not found, skipping ImageTensor export and save"
+                + " local image test"
+            )
         x = torch.ones(1, 3, 5, 5)
         image_tensor = images.ImageTensor(x)
 

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -650,22 +650,3 @@ class TestRandomCrop(BaseTest):
         x_out = crop_transform(x)
 
         self.assertEqual(list(x_out.shape), [1, 4, 160, 160])
-
-
-class TestAlphaChannelLoss(BaseTest):
-    def test_alpha_channel_loss_forward(self) -> None:
-        raise unittest.SkipTest(
-            "Skipping AlphaChannelLoss test until function is ready."
-        )
-        # crop_size = [160, 160]
-        # scale = [0.6, 0.7, 0.8, 0.9, 1.0, 1.1]
-
-        # alpha_loss_transform = transforms.AlphaChannelLoss(
-        #     scale=scale, crop_size=crop_size
-        # )
-        # x = torch.randn(1, 4, 224, 224)
-
-        # x_out = alpha_loss_transform(x)
-
-        # assertTensorAlmostEqual(self, x_out, x, 0)
-        # self.assertNotEqual(alpha_loss_transforms.loss, 0)

--- a/tests/optim/utils/test_reducer.py
+++ b/tests/optim/utils/test_reducer.py
@@ -68,9 +68,8 @@ class TestChannelReducer(BaseTest):
             )
 
         test_input = torch.randn(1, 32, 224, 224).abs()
-        c_reducer = reducer.ChannelReducer(
-            n_components=3, reduction_alg="PCA", max_iter=100
-        )
+        c_reducer = reducer.ChannelReducer(n_components=3, reduction_alg="PCA")
+
         test_output = c_reducer.fit_transform(test_input)
         self.assertEquals(test_output.size(0), 1)
         self.assertEquals(test_output.size(1), 3)


### PR DESCRIPTION
* Quick fix for the model file path as it's breaking all the notebooks & tests.

* It also looks like `black` was updated and now is reporting an issue with `captum/attr/_core/feature_ablation.py` &  `captum/metrics/_core/infidelity.py`, so I've resolved that as well. The files in the master branch may be a bit different, but we need to at least keep the tests passing for the other areas of Captum until we merge into master.

* Added new `ImageTensor` tests.

* Added `detach()` to `InputOptimization` to fix out of memory crashes.

* Made sure that `SkipLayer` can handle any addition arguments to it's init and forward functions. This adds to the usefulness of the layer and improves it beyond just copying `nn.Identity`.

* Fixed various bugs.