### PR TITLE
WIP: Migrate to register_full_backward_hook

### DIFF
--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -85,6 +85,17 @@ def undo_gradient_requirements(
             input.requires_grad_(False)
 
 
+def register_backward_hook(
+    module: Module, hook: Callable
+) -> torch.utils.hooks.RemovableHandle:
+    try:
+        # Only support for torch >= 1.8
+        return module.register_full_backward_hook(hook)
+    except AttributeError:
+        # Fallback for previous versions of PyTorch
+        return module.register_backward_hook(hook)
+
+
 def compute_gradients(
     forward_fn: Callable,
     inputs: Union[Tensor, Tuple[Tensor, ...]],

--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -26,6 +26,7 @@ from captum._utils.common import (
 )
 from captum._utils.gradient import (
     apply_gradient_requirements,
+    register_backward_hook,
     undo_gradient_requirements,
 )
 from captum._utils.typing import (
@@ -529,7 +530,7 @@ class DeepLift(GradientAttribution):
         # adds forward hook to leaf nodes that are non-linear
         forward_handle = module.register_forward_hook(self._forward_hook)
         pre_forward_handle = module.register_forward_pre_hook(self._forward_pre_hook)
-        backward_handle = module.register_backward_hook(self._backward_hook)
+        backward_handle = register_backward_hook(module, self._backward_hook)
         self.forward_handles.append(forward_handle)
         self.forward_handles.append(pre_forward_handle)
         self.backward_handles.append(backward_handle)

--- a/captum/attr/_core/feature_ablation.py
+++ b/captum/attr/_core/feature_ablation.py
@@ -554,7 +554,7 @@ class FeatureAblation(PerturbationAttribution):
         )
 
     def _get_feature_counts(self, inputs, feature_mask, **kwargs):
-        """ return the numbers of input features """
+        """return the numbers of input features"""
         if not feature_mask:
             return tuple(inp[0].numel() if inp.numel() else 0 for inp in inputs)
 

--- a/captum/attr/_core/guided_backprop_deconvnet.py
+++ b/captum/attr/_core/guided_backprop_deconvnet.py
@@ -11,6 +11,7 @@ from torch.utils.hooks import RemovableHandle
 from captum._utils.common import _format_input, _format_output, _is_tuple
 from captum._utils.gradient import (
     apply_gradient_requirements,
+    register_backward_hook,
     undo_gradient_requirements,
 )
 from captum._utils.typing import TargetType, TensorOrTupleOfTensorsGeneric
@@ -75,7 +76,7 @@ class ModifiedReluGradientAttribution(GradientAttribution):
 
     def _register_hooks(self, module: Module):
         if isinstance(module, torch.nn.ReLU):
-            hook = module.register_backward_hook(self._backward_hook)
+            hook = register_backward_hook(module, self._backward_hook)
             self.backward_hooks.append(hook)
 
     def _backward_hook(

--- a/captum/attr/_core/lrp.py
+++ b/captum/attr/_core/lrp.py
@@ -6,7 +6,11 @@ import torch
 import torch.nn as nn
 
 from ..._utils.common import _format_input, _format_output, _run_forward
-from ..._utils.gradient import apply_gradient_requirements, undo_gradient_requirements
+from ..._utils.gradient import (
+    apply_gradient_requirements,
+    register_backward_hook,
+    undo_gradient_requirements,
+)
 from .._utils.attribution import GradientAttribution
 from .._utils.custom_modules import Addition_Module
 from .._utils.lrp_rules import EpsilonRule, PropagationRule
@@ -276,8 +280,8 @@ class LRP(GradientAttribution):
     def _register_forward_hooks(self):
         for layer in self.layers:
             if type(layer) in SUPPORTED_NON_LINEAR_LAYERS:
-                backward_handle = layer.register_backward_hook(
-                    PropagationRule.backward_hook_activation
+                backward_handle = register_backward_hook(
+                    layer, PropagationRule.backward_hook_activation
                 )
                 self.backward_handles.append(backward_handle)
             else:

--- a/captum/attr/_core/occlusion.py
+++ b/captum/attr/_core/occlusion.py
@@ -375,5 +375,5 @@ class Occlusion(FeatureAblation):
         return 0, feature_max, None
 
     def _get_feature_counts(self, inputs, feature_mask, **kwargs):
-        """ return the numbers of possible input features """
+        """return the numbers of possible input features"""
         return tuple(np.prod(counts).astype(int) for counts in kwargs["shift_counts"])

--- a/captum/attr/_core/shapley_value.py
+++ b/captum/attr/_core/shapley_value.py
@@ -478,7 +478,7 @@ class ShapleyValueSampling(PerturbationAttribution):
             )
 
     def _get_n_evaluations(self, total_features, n_samples, perturbations_per_eval):
-        """ return the total number of forward evaluations needed """
+        """return the total number of forward evaluations needed"""
         return math.ceil(total_features / perturbations_per_eval) * n_samples
 
 
@@ -740,7 +740,7 @@ class ShapleyValues(ShapleyValueSampling):
         )
 
     def _get_n_evaluations(self, total_features, n_samples, perturbations_per_eval):
-        """ return the total number of forward evaluations needed """
+        """return the total number of forward evaluations needed"""
         return math.ceil(total_features / perturbations_per_eval) * math.factorial(
             total_features
         )

--- a/captum/metrics/_core/infidelity.py
+++ b/captum/metrics/_core/infidelity.py
@@ -69,7 +69,7 @@ def infidelity_perturb_func_decorator(multipy_by_inputs: bool = True) -> Callabl
         def default_perturb_func(
             inputs: TensorOrTupleOfTensorsGeneric, baselines: BaselineType = None
         ):
-            r""""""
+            r""" """
             inputs_perturbed = (
                 pertub_func(inputs, baselines)
                 if baselines is not None
@@ -398,7 +398,7 @@ def infidelity(
         """
 
         def call_perturb_func():
-            r""""""
+            r""" """
             baselines_pert = None
             inputs_pert: Union[Tensor, Tuple[Tensor, ...]]
             if len(inputs_expanded) == 1:


### PR DESCRIPTION
Modifying all module backward hooks to utilize the new register_full_backward hook API documented [here](register_full_backward_hook). This new API resolves many issues we previously encountered with backward module hooks.

Since this API is available only in torch 1.8, allowing a fall-back option to the original backward hook approach.