### PR TITLE
Fix LRP Support for Dropout Modules

### DIFF
--- a/captum/attr/_core/feature_ablation.py
+++ b/captum/attr/_core/feature_ablation.py
@@ -554,7 +554,7 @@ class FeatureAblation(PerturbationAttribution):
         )
 
     def _get_feature_counts(self, inputs, feature_mask, **kwargs):
-        """ return the numbers of input features """
+        """return the numbers of input features"""
         if not feature_mask:
             return tuple(inp[0].numel() if inp.numel() else 0 for inp in inputs)
 

--- a/captum/attr/_core/occlusion.py
+++ b/captum/attr/_core/occlusion.py
@@ -375,5 +375,5 @@ class Occlusion(FeatureAblation):
         return 0, feature_max, None
 
     def _get_feature_counts(self, inputs, feature_mask, **kwargs):
-        """ return the numbers of possible input features """
+        """return the numbers of possible input features"""
         return tuple(np.prod(counts).astype(int) for counts in kwargs["shift_counts"])

--- a/captum/attr/_core/shapley_value.py
+++ b/captum/attr/_core/shapley_value.py
@@ -478,7 +478,7 @@ class ShapleyValueSampling(PerturbationAttribution):
             )
 
     def _get_n_evaluations(self, total_features, n_samples, perturbations_per_eval):
-        """ return the total number of forward evaluations needed """
+        """return the total number of forward evaluations needed"""
         return math.ceil(total_features / perturbations_per_eval) * n_samples
 
 
@@ -740,7 +740,7 @@ class ShapleyValues(ShapleyValueSampling):
         )
 
     def _get_n_evaluations(self, total_features, n_samples, perturbations_per_eval):
-        """ return the total number of forward evaluations needed """
+        """return the total number of forward evaluations needed"""
         return math.ceil(total_features / perturbations_per_eval) * math.factorial(
             total_features
         )

--- a/captum/attr/_utils/lrp_rules.py
+++ b/captum/attr/_utils/lrp_rules.py
@@ -34,6 +34,16 @@ class PropagationRule(ABC):
     @staticmethod
     def backward_hook_activation(module, grad_input, grad_output):
         """Backward hook to propagate relevance over non-linear activations."""
+        if (
+            isinstance(grad_input, tuple)
+            and isinstance(grad_output, tuple)
+            and len(grad_input) > len(grad_output)
+        ):
+            # Adds any additional elements of grad_input is applicable
+            # This occurs when registering a backward hook on nn.Dropout
+            # modules, which has an additional element of None in
+            # grad_input
+            return grad_output + grad_input[len(grad_output) :]
         return grad_output
 
     def _create_backward_hook_input(self, inputs):

--- a/captum/metrics/_core/infidelity.py
+++ b/captum/metrics/_core/infidelity.py
@@ -69,7 +69,7 @@ def infidelity_perturb_func_decorator(multipy_by_inputs: bool = True) -> Callabl
         def default_perturb_func(
             inputs: TensorOrTupleOfTensorsGeneric, baselines: BaselineType = None
         ):
-            r""""""
+            r""" """
             inputs_perturbed = (
                 pertub_func(inputs, baselines)
                 if baselines is not None
@@ -398,7 +398,7 @@ def infidelity(
         """
 
         def call_perturb_func():
-            r""""""
+            r""" """
             baselines_pert = None
             inputs_pert: Union[Tensor, Tuple[Tensor, ...]]
             if len(inputs_expanded) == 1:

--- a/tests/helpers/basic_models.py
+++ b/tests/helpers/basic_models.py
@@ -227,9 +227,10 @@ class SimpleLRPModel(nn.Module):
         self.relu = torch.nn.ReLU(inplace=inplace)
         self.linear2 = nn.Linear(3, 1, bias=False)
         self.linear2.weight.data.fill_(3.0)
+        self.dropout = torch.nn.Dropout(p=0.01)
 
     def forward(self, x):
-        return self.linear2(self.relu(self.linear(x)))
+        return self.dropout(self.linear2(self.relu(self.linear(x))))
 
 
 class Conv1dSeqModel(nn.Module):


### PR DESCRIPTION
This fixes LRP to work appropriately with nn.Dropout modules, since dropout backward hooks add an additional grad_input element of None which is not supported with the current backward_hook_activation. 