### PR TITLE
Fixes for Boolean Input Tensors

### DIFF
--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -106,7 +106,7 @@ def _zeros(inputs: Tuple[Tensor, ...]) -> Tuple[int, ...]:
     Takes a tuple of tensors as input and returns a tuple that has the same
     length as `inputs` with each element as the integer 0.
     """
-    return tuple(0 for input in inputs)
+    return tuple(0 if input.dtype is not torch.bool else False for input in inputs)
 
 
 def _format_baseline(

--- a/captum/attr/_core/feature_ablation.py
+++ b/captum/attr/_core/feature_ablation.py
@@ -554,7 +554,7 @@ class FeatureAblation(PerturbationAttribution):
         )
 
     def _get_feature_counts(self, inputs, feature_mask, **kwargs):
-        """ return the numbers of input features """
+        """return the numbers of input features"""
         if not feature_mask:
             return tuple(inp[0].numel() if inp.numel() else 0 for inp in inputs)
 

--- a/captum/attr/_core/lime.py
+++ b/captum/attr/_core/lime.py
@@ -571,15 +571,18 @@ def default_from_interp_rep_transform(curr_sample, original_inputs, **kwargs):
     ), "Must provide baselines to use default interpretable representation transfrom"
     feature_mask = kwargs["feature_mask"]
     if isinstance(feature_mask, Tensor):
-        binary_mask = curr_sample[0][feature_mask].to(original_inputs.dtype)
-        return binary_mask * original_inputs + (1 - binary_mask) * kwargs["baselines"]
+        binary_mask = curr_sample[0][feature_mask].bool()
+        return (
+            binary_mask.to(original_inputs.dtype) * original_inputs
+            + (~binary_mask).to(original_inputs.dtype) * kwargs["baselines"]
+        )
     else:
         binary_mask = tuple(
-            curr_sample[0][feature_mask[j]] for j in range(len(feature_mask))
+            curr_sample[0][feature_mask[j]].bool() for j in range(len(feature_mask))
         )
         return tuple(
             binary_mask[j].to(original_inputs[j].dtype) * original_inputs[j]
-            + (1 - binary_mask[j].to(original_inputs[j].dtype)) * kwargs["baselines"][j]
+            + (~binary_mask[j]).to(original_inputs[j].dtype) * kwargs["baselines"][j]
             for j in range(len(feature_mask))
         )
 

--- a/captum/attr/_core/occlusion.py
+++ b/captum/attr/_core/occlusion.py
@@ -375,5 +375,5 @@ class Occlusion(FeatureAblation):
         return 0, feature_max, None
 
     def _get_feature_counts(self, inputs, feature_mask, **kwargs):
-        """ return the numbers of possible input features """
+        """return the numbers of possible input features"""
         return tuple(np.prod(counts).astype(int) for counts in kwargs["shift_counts"])

--- a/captum/attr/_core/shapley_value.py
+++ b/captum/attr/_core/shapley_value.py
@@ -424,8 +424,7 @@ class ShapleyValueSampling(PerturbationAttribution):
         target_repeated = _expand_target(target, perturbations_per_eval)
         for i in range(len(feature_permutation)):
             current_tensors = tuple(
-                current
-                * (torch.tensor(1) - (mask == feature_permutation[i]).to(current.dtype))
+                current * (~(mask == feature_permutation[i])).to(current.dtype)
                 + input * (mask == feature_permutation[i]).to(input.dtype)
                 for input, current, mask in zip(inputs, current_tensors, input_masks)
             )
@@ -478,7 +477,7 @@ class ShapleyValueSampling(PerturbationAttribution):
             )
 
     def _get_n_evaluations(self, total_features, n_samples, perturbations_per_eval):
-        """ return the total number of forward evaluations needed """
+        """return the total number of forward evaluations needed"""
         return math.ceil(total_features / perturbations_per_eval) * n_samples
 
 
@@ -740,7 +739,7 @@ class ShapleyValues(ShapleyValueSampling):
         )
 
     def _get_n_evaluations(self, total_features, n_samples, perturbations_per_eval):
-        """ return the total number of forward evaluations needed """
+        """return the total number of forward evaluations needed"""
         return math.ceil(total_features / perturbations_per_eval) * math.factorial(
             total_features
         )

--- a/captum/metrics/_core/infidelity.py
+++ b/captum/metrics/_core/infidelity.py
@@ -69,7 +69,7 @@ def infidelity_perturb_func_decorator(multipy_by_inputs: bool = True) -> Callabl
         def default_perturb_func(
             inputs: TensorOrTupleOfTensorsGeneric, baselines: BaselineType = None
         ):
-            r""""""
+            r""" """
             inputs_perturbed = (
                 pertub_func(inputs, baselines)
                 if baselines is not None
@@ -398,7 +398,7 @@ def infidelity(
         """
 
         def call_perturb_func():
-            r""""""
+            r""" """
             baselines_pert = None
             inputs_pert: Union[Tensor, Tuple[Tensor, ...]]
             if len(inputs_expanded) == 1:

--- a/tests/attr/test_feature_ablation.py
+++ b/tests/attr/test_feature_ablation.py
@@ -18,6 +18,7 @@ from tests.helpers.basic_models import (
     BasicModel_ConvNet_One_Conv,
     BasicModel_MultiLayer,
     BasicModel_MultiLayer_MultiInput,
+    BasicModelBoolInput,
     BasicModelWithSparseInputs,
 )
 
@@ -110,6 +111,29 @@ class Test(BaseTest):
             [[248.0, 248.0, 104.0]],
             feature_mask=torch.tensor([[0, 0, 1]]),
             baselines=4,
+            perturbations_per_eval=(1, 2, 3),
+        )
+
+    def test_simple_ablation_boolean(self) -> None:
+        ablation_algo = FeatureAblation(BasicModelBoolInput())
+        inp = torch.tensor([[True, False, True]])
+        self._ablation_test_assert(
+            ablation_algo,
+            inp,
+            [[40.0, 40.0, 40.0]],
+            feature_mask=torch.tensor([[0, 0, 1]]),
+            perturbations_per_eval=(1, 2, 3),
+        )
+
+    def test_simple_ablation_boolean_with_baselines(self) -> None:
+        ablation_algo = FeatureAblation(BasicModelBoolInput())
+        inp = torch.tensor([[True, False, True]])
+        self._ablation_test_assert(
+            ablation_algo,
+            inp,
+            [[-40.0, -40.0, 0.0]],
+            feature_mask=torch.tensor([[0, 0, 1]]),
+            baselines=True,
             perturbations_per_eval=(1, 2, 3),
         )
 

--- a/tests/attr/test_lime.py
+++ b/tests/attr/test_lime.py
@@ -25,6 +25,7 @@ from tests.helpers.basic import (
 from tests.helpers.basic_models import (
     BasicModel_MultiLayer,
     BasicModel_MultiLayer_MultiInput,
+    BasicModelBoolInput,
 )
 
 
@@ -143,6 +144,31 @@ class Test(BaseTest):
             baselines=4,
             perturbations_per_eval=(1, 2, 3),
             expected_coefs_only=[244.0, 100.0],
+            test_generator=True,
+        )
+
+    def test_simple_lime_boolean(self) -> None:
+        net = BasicModelBoolInput()
+        inp = torch.tensor([[True, False, True]])
+        self._lime_test_assert(
+            net,
+            inp,
+            [31.42, 31.42, 30.90],
+            feature_mask=torch.tensor([[0, 0, 1]]),
+            perturbations_per_eval=(1, 2, 3),
+            test_generator=True,
+        )
+
+    def test_simple_lime_boolean_with_baselines(self) -> None:
+        net = BasicModelBoolInput()
+        inp = torch.tensor([[True, False, True]])
+        self._lime_test_assert(
+            net,
+            inp,
+            [-36.0, -36.0, 0.0],
+            feature_mask=torch.tensor([[0, 0, 1]]),
+            baselines=True,
+            perturbations_per_eval=(1, 2, 3),
             test_generator=True,
         )
 

--- a/tests/attr/test_shapley.py
+++ b/tests/attr/test_shapley.py
@@ -13,6 +13,7 @@ from tests.helpers.basic import BaseTest, assertTensorTuplesAlmostEqual
 from tests.helpers.basic_models import (
     BasicModel_MultiLayer,
     BasicModel_MultiLayer_MultiInput,
+    BasicModelBoolInput,
 )
 
 
@@ -36,6 +37,29 @@ class Test(BaseTest):
             inp,
             [275.0, 275.0, 115.0],
             feature_mask=torch.tensor([[0, 0, 1]]),
+            perturbations_per_eval=(1, 2, 3),
+        )
+
+    def test_simple_shapley_sampling_boolean(self) -> None:
+        net = BasicModelBoolInput()
+        inp = torch.tensor([[True, False, True]])
+        self._shapley_test_assert(
+            net,
+            inp,
+            [35.0, 35.0, 35.0],
+            feature_mask=torch.tensor([[0, 0, 1]]),
+            perturbations_per_eval=(1, 2, 3),
+        )
+
+    def test_simple_shapley_sampling_boolean_with_baseline(self) -> None:
+        net = BasicModelBoolInput()
+        inp = torch.tensor([[True, False, True]])
+        self._shapley_test_assert(
+            net,
+            inp,
+            [-40.0, -40.0, 0.0],
+            feature_mask=torch.tensor([[0, 0, 1]]),
+            baselines=True,
             perturbations_per_eval=(1, 2, 3),
         )
 

--- a/tests/helpers/basic_models.py
+++ b/tests/helpers/basic_models.py
@@ -362,6 +362,21 @@ class BasicModel_MultiLayer(nn.Module):
             return lin2_out
 
 
+class BasicModelBoolInput(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.mod = BasicModel_MultiLayer()
+
+    def forward(
+        self,
+        x: Tensor,
+        add_input: Optional[Tensor] = None,
+        mult: float = 10.0,
+    ):
+        assert x.dtype is torch.bool, "Input must be boolean"
+        return self.mod(x.float() * mult, add_input)
+
+
 class BasicModel_MultiLayer_MultiInput(nn.Module):
     def __init__(self) -> None:
         super().__init__()


### PR DESCRIPTION
This adds support for boolean input tensors to perturbation-based methods (Shapley Value Sampling and Lime) with corresponding unit tests.