### PR TITLE
Reduce Default Lime Lasso Regularization

### DIFF
--- a/captum/attr/_core/lime.py
+++ b/captum/attr/_core/lime.py
@@ -727,7 +727,7 @@ class Lime(LimeBase):
             interpretable_model (optional, Model): Model object to train
                     interpretable model.
 
-                    This argument is optional and defaults to SkLearnLasso(alpha=1.0),
+                    This argument is optional and defaults to SkLearnLasso(alpha=0.01),
                     which is a wrapper around the Lasso linear model in SkLearn.
                     This requires having sklearn version >= 0.23 available.
 
@@ -805,7 +805,7 @@ class Lime(LimeBase):
 
         """
         if interpretable_model is None:
-            interpretable_model = SkLearnLasso(alpha=1.0)
+            interpretable_model = SkLearnLasso(alpha=0.01)
 
         if similarity_func is None:
             similarity_func = get_exp_kernel_similarity_function()

--- a/tests/attr/test_lime.py
+++ b/tests/attr/test_lime.py
@@ -464,6 +464,7 @@ class Test(BaseTest):
             lime = Lime(
                 model,
                 similarity_func=get_exp_kernel_similarity_function("cosine", 10.0),
+                interpretable_model=SkLearnLasso(alpha=1.0),
             )
             with self.assertWarns(DeprecationWarning):
                 attributions = lime.attribute(


### PR DESCRIPTION
The default regularization coefficient of alpha=1.0 has been too high in many use-cases, causing attributions to become 0. This reduces the default regularization to 0.01 to reduce such issues (e.g. #679 ).