### PR TITLE
Moving initial captum.robust to OSS

### DIFF
--- a/captum/robust/__init__.py
+++ b/captum/robust/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+from captum.robust._core.fgsm import FGSM  # noqa
+from captum.robust._core.perturbation import Perturbation  # noqa
+from captum.robust._core.pgd import PGD  # noqa

--- a/captum/robust/_core/fgsm.py
+++ b/captum/robust/_core/fgsm.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+from typing import Any, Callable, Tuple
+
+import torch
+from torch import Tensor
+
+from captum._utils.common import (
+    _format_additional_forward_args,
+    _format_input,
+    _format_output,
+    _is_tuple,
+    _select_targets,
+)
+from captum._utils.gradient import (
+    apply_gradient_requirements,
+    compute_gradients,
+    undo_gradient_requirements,
+)
+from captum._utils.typing import TensorOrTupleOfTensorsGeneric
+from captum.robust._core.perturbation import Perturbation
+
+
+class FGSM(Perturbation):
+    r"""
+    Fast Gradient Sign Method is an one-step method that can generate
+    adversarial examples. For non-targeted attack, the formulation is
+    x' = x + epsilon * sign(gradient of L(theta, x, y)).
+    For targeted attack on t, the formulation is
+    x' = x - epsilon * sign(gradient of L(theta, x, t)).
+    L(theta, x, y) is the model's loss function with respect to model
+    parameters, inputs and labels.
+
+    More details on Fast Gradient Sign Method can be found in the original
+    paper:
+    https://arxiv.org/pdf/1412.6572.pdf
+    """
+
+    def __init__(
+        self,
+        forward_func: Callable,
+        loss_func: Callable = None,
+        lower_bound: float = float("-inf"),
+        upper_bound: float = float("inf"),
+    ) -> None:
+        r"""
+        Args:
+            forward_func (callable): The pytorch model for which the attack is
+                        computed.
+            loss_func (callable, optional): Loss function of which the gradient
+                        computed. The loss function should take in outputs of the
+                        model and labels, and return a loss tensor.
+                        The default loss function is negative log.
+            lower_bound (float, optional): Lower bound of input values.
+            upper_bound (float, optional): Upper bound of input values.
+                        e.g. image pixels must be in the range 0-255
+
+        Attributes:
+            bound (Callable): A function that bounds the input values based on
+                        given lower_bound and upper_bound. Can be overwritten for
+                        custom use cases if necessary.
+            zero_thresh (float): The threshold below which gradient will be treated
+                        as zero. Can be modified for custom use cases if necessary.
+        """
+        super().__init__()
+        self.forward_func = forward_func
+        self.loss_func = loss_func
+        self.bound = lambda x: torch.clamp(x, min=lower_bound, max=upper_bound)
+        self.zero_thresh = 10 ** -6
+
+    def perturb(
+        self,
+        inputs: TensorOrTupleOfTensorsGeneric,
+        epsilon: float,
+        target: Any,
+        additional_forward_args: Any = None,
+        targeted: bool = False,
+    ) -> TensorOrTupleOfTensorsGeneric:
+        r"""
+        This method computes and returns the perturbed input for each input tensor.
+        It supports both targeted and non-targeted attacks.
+
+        Args:
+
+            inputs (tensor or tuple of tensors): Input for which adversarial
+                        attack is computed. It can be provided as a single
+                        tensor or a tuple of multiple tensors. If multiple
+                        input tensors are provided, the batch sizes must be
+                        aligned accross all tensors.
+            epsilon (float): Step size of perturbation.
+            target (any): True labels of inputs if non-targeted attack is
+                        desired. Target class of inputs if targeted attack
+                        is desired. Target will be passed to the loss function
+                        to compute loss, so the type needs to match the
+                        argument type of the loss function.
+
+                        If using the default negative log as loss function,
+                        labels should be of type int, tuple, tensor or list.
+                        For general 2D outputs, labels can be either:
+
+                        - a single integer or a tensor containing a single
+                          integer, which is applied to all input examples
+
+                        - a list of integers or a 1D tensor, with length matching
+                          the number of examples in inputs (dim 0). Each integer
+                          is applied as the label for the corresponding example.
+
+                        For outputs with > 2 dimensions, labels can be either:
+
+                        - A single tuple, which contains #output_dims - 1
+                          elements. This label index is applied to all examples.
+
+                        - A list of tuples with length equal to the number of
+                          examples in inputs (dim 0), and each tuple containing
+                          #output_dims - 1 elements. Each tuple is applied as the
+                          label for the corresponding example.
+            additional_forward_args (any, optional): If the forward function
+                        requires additional arguments other than the inputs for
+                        which attributions should not be computed, this argument
+                        can be provided. These arguments are provided to
+                        forward_func in order following the arguments in inputs.
+                        Default: None.
+            targeted (bool, optional): If attack should be targeted.
+                        Default: False.
+
+
+        Returns:
+
+            - **perturbed inputs** (*tensor* or tuple of *tensors*):
+                        Perturbed input for each
+                        input tensor. The perturbed inputs have the same shape and
+                        dimensionality as the inputs.
+                        If a single tensor is provided as inputs, a single tensor
+                        is returned. If a tuple is provided for inputs, a tuple of
+                        corresponding sized tensors is returned.
+        """
+        is_inputs_tuple = _is_tuple(inputs)
+        inputs: Tuple[Tensor, ...] = _format_input(inputs)
+        gradient_mask = apply_gradient_requirements(inputs)
+
+        def _forward_with_loss() -> Tensor:
+            additional_inputs = _format_additional_forward_args(additional_forward_args)
+            outputs = self.forward_func(  # type: ignore
+                *(*inputs, *additional_inputs)  # type: ignore
+                if additional_inputs is not None
+                else inputs
+            )
+            if self.loss_func is not None:
+                return self.loss_func(outputs, target)
+            else:
+                loss = -torch.log(outputs)
+                return _select_targets(loss, target)
+
+        grads = compute_gradients(_forward_with_loss, inputs)
+        undo_gradient_requirements(inputs, gradient_mask)
+        perturbed_inputs = self._perturb(inputs, grads, epsilon, targeted)
+        perturbed_inputs = tuple(
+            self.bound(perturbed_inputs[i]) for i in range(len(perturbed_inputs))
+        )
+        return _format_output(is_inputs_tuple, perturbed_inputs)
+
+    def _perturb(
+        self,
+        inputs: Tuple,
+        grads: Tuple,
+        epsilon: float,
+        targeted: bool,
+    ) -> Tuple:
+        r"""
+        A helper function to calculate the perturbed inputs given original
+        inputs, gradient of loss function and epsilon. The calculation is
+        different for targetd v.s. non-targeted as described above.
+        """
+        multiplier = -1 if targeted else 1
+        inputs = tuple(
+            torch.where(
+                torch.abs(grad) > self.zero_thresh,
+                inp + multiplier * epsilon * torch.sign(grad),
+                inp,
+            )
+            for grad, inp in zip(grads, inputs)
+        )
+        return inputs

--- a/captum/robust/_core/perturbation.py
+++ b/captum/robust/_core/perturbation.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+from typing import Callable
+
+
+class Perturbation:
+    r"""
+    All perturbation and attack algorithms extend this class. It enforces
+    its child classes to extend and override core `perturb` method.
+    """
+
+    perturb: Callable
+    r"""
+    This method computes and returns the perturbed input for each input tensor.
+    Deriving classes are responsible for implementing its logic accordingly.
+
+    Specific adversarial attack algorithms that extend this class take relevant
+    arguments.
+
+    Args:
+
+        inputs (tensor or tuple of tensors): Input for which adversarial attack
+                    is computed. It can be provided as a single tensor or
+                    a tuple of multiple tensors. If multiple input tensors
+                    are provided, the batch sizes must be aligned accross all
+                    tensors.
+
+    Returns:
+
+        - **perturbed inputs** (*tensor* or tuple of *tensors*):
+                    Perturbed input for each
+                    input tensor. The perturbed inputs have the same shape and
+                    dimensionality as the inputs.
+                    If a single tensor is provided as inputs, a single tensor
+                    is returned. If a tuple is provided for inputs, a tuple of
+                    corresponding sized tensors is returned.
+    """

--- a/captum/robust/_core/pgd.py
+++ b/captum/robust/_core/pgd.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+from typing import Any, Callable
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+from captum._utils.common import _format_input, _format_output, _is_tuple
+from captum._utils.typing import TensorOrTupleOfTensorsGeneric
+from captum.robust._core.fgsm import FGSM
+from captum.robust._core.perturbation import Perturbation
+
+
+class PGD(Perturbation):
+    r"""
+    Projected Gradient Descent is an iterative version of the one-step attack
+    FGSM that can generate adversarial examples. It takes multiple gradient
+    steps to search for an adversarial perturbation within the desired
+    neighbor ball around the original inputs. In a non-targeted attack, the
+    formulation is:
+        x_0 = x
+        x_(t+1) = Clip_r(x_t + alpha * sign(gradient of L(theta, x, t)))
+    where Clip denotes the function that projects its argument to the r-neighbor
+    ball around x so that the perturbation will be bounded. Alpha is the step
+    size. L(theta, x, y) is the model's loss function with respect to model
+    parameters, inputs and targets.
+    In a targeted attack, the formulation is similar:
+        x_0 = x
+        x_(t+1) = Clip_r(x_t - alpha * sign(gradient of L(theta, x, t)))
+
+    More details on Projected Gradient Descent can be found in the original
+    paper:
+    https://arxiv.org/pdf/1706.06083.pdf
+    """
+
+    def __init__(
+        self,
+        forward_func: Callable,
+        loss_func: Callable = None,
+        lower_bound: float = float("-inf"),
+        upper_bound: float = float("inf"),
+    ) -> None:
+        r"""
+        Args:
+            forward_func (callable): The pytorch model for which the attack is
+                        computed.
+            loss_func (callable, optional): Loss function of which the gradient
+                        computed. The loss function should take in outputs of the
+                        model and labels, and return the loss for each input tensor.
+                        The default loss function is negative log.
+            lower_bound (float, optional): Lower bound of input values.
+            upper_bound (float, optional): Upper bound of input values.
+                        e.g. image pixels must be in the range 0-255
+
+        Attributes:
+            bound (Callable): A function that bounds the input values based on
+                        given lower_bound and upper_bound. Can be overwritten for
+                        custom use cases if necessary.
+        """
+        super().__init__()
+        self.forward_func = forward_func
+        self.fgsm = FGSM(forward_func, loss_func)
+        self.bound = lambda x: torch.clamp(x, min=lower_bound, max=upper_bound)
+
+    def perturb(
+        self,
+        inputs: TensorOrTupleOfTensorsGeneric,
+        radius: float,
+        step_size: float,
+        step_num: int,
+        target: Any,
+        additional_forward_args: Any = None,
+        targeted: bool = False,
+        random_start: bool = False,
+        norm: str = "Linf",
+    ) -> TensorOrTupleOfTensorsGeneric:
+        r"""
+        This method computes and returns the perturbed input for each input tensor.
+        It supports both targeted and non-targeted attacks.
+
+        Args:
+
+            inputs (tensor or tuple of tensors): Input for which adversarial
+                        attack is computed. It can be provided as a single
+                        tensor or a tuple of multiple tensors. If multiple
+                        input tensors are provided, the batch sizes must be
+                        aligned accross all tensors.
+            radius (float): Radius of the neighbor ball centered around inputs.
+                        The perturbation should be within this range.
+            step_size (float): Step size of each gradient step.
+            step_num (int): Step numbers. It usually guarantees that the perturbation
+                        can reach the border.
+            target (any): True labels of inputs if non-targeted attack is
+                        desired. Target class of inputs if targeted attack
+                        is desired. Target will be passed to the loss function
+                        to compute loss, so the type needs to match the
+                        argument type of the loss function.
+
+                        If using the default negative log as loss function,
+                        labels should be of type int, tuple, tensor or list.
+                        For general 2D outputs, labels can be either:
+
+                        - a single integer or a tensor containing a single
+                          integer, which is applied to all input examples
+
+                        - a list of integers or a 1D tensor, with length matching
+                          the number of examples in inputs (dim 0). Each integer
+                          is applied as the label for the corresponding example.
+
+                        For outputs with > 2 dimensions, labels can be either:
+
+                        - A single tuple, which contains #output_dims - 1
+                          elements. This label index is applied to all examples.
+
+                        - A list of tuples with length equal to the number of
+                          examples in inputs (dim 0), and each tuple containing
+                          #output_dims - 1 elements. Each tuple is applied as the
+                          label for the corresponding example.
+            additional_forward_args (any, optional): If the forward function
+                        requires additional arguments other than the inputs for
+                        which attributions should not be computed, this argument
+                        can be provided. These arguments are provided to
+                        forward_func in order following the arguments in inputs.
+                        Default: None.
+            targeted (bool, optional): If attack should be targeted.
+                        Default: False.
+            random_start (bool, optional): If a random initialization is added to
+                        inputs. Default: False.
+            norm (str, optional): Specifies the norm to calculate distance from
+                        original inputs: 'Linf'|'L2'.
+                        Default: 'Linf'.
+
+        Returns:
+
+            - **perturbed inputs** (*tensor* or tuple of *tensors*):
+                        Perturbed input for each
+                        input tensor. The perturbed inputs have the same shape and
+                        dimensionality as the inputs.
+                        If a single tensor is provided as inputs, a single tensor
+                        is returned. If a tuple is provided for inputs, a tuple of
+                        corresponding sized tensors is returned.
+        """
+
+        def _clip(inputs: Tensor, outputs: Tensor) -> Tensor:
+            diff = outputs - inputs
+            if norm == "Linf":
+                return inputs + torch.clamp(diff, -radius, radius)
+            elif norm == "L2":
+                return inputs + torch.renorm(diff, 2, 0, radius)
+            else:
+                raise AssertionError("Norm constraint must be L2 or Linf.")
+
+        is_inputs_tuple = _is_tuple(inputs)
+        formatted_inputs = _format_input(inputs)
+        perturbed_inputs = formatted_inputs
+        if random_start:
+            perturbed_inputs = tuple(
+                self.bound(self._random_point(formatted_inputs[i], radius, norm))
+                for i in range(len(formatted_inputs))
+            )
+        for _i in range(step_num):
+            perturbed_inputs = self.fgsm.perturb(
+                perturbed_inputs, step_size, target, additional_forward_args, targeted
+            )
+            perturbed_inputs = tuple(
+                _clip(formatted_inputs[j], perturbed_inputs[j])
+                for j in range(len(perturbed_inputs))
+            )
+            # Detaching inputs to avoid dependency of gradient between steps
+            perturbed_inputs = tuple(
+                self.bound(perturbed_inputs[j]).detach()
+                for j in range(len(perturbed_inputs))
+            )
+        return _format_output(is_inputs_tuple, perturbed_inputs)
+
+    def _random_point(self, center: Tensor, radius: float, norm: str) -> Tensor:
+        r"""
+        A helper function that returns a uniform random point within the ball
+        with the given center and radius. Norm should be either L2 or Linf.
+        """
+        if norm == "L2":
+            u = torch.randn_like(center)
+            unit_u = F.normalize(u.view(u.size(0), -1)).view(u.size())
+            d = torch.numel(center[0])
+            r = (torch.rand(u.size(0)) ** (1.0 / d)) * radius
+            r = r[(...,) + (None,) * (r.dim() - 1)]
+            x = r * unit_u
+            return center + x
+        elif norm == "Linf":
+            x = torch.rand_like(center) * radius * 2 - radius
+            return center + x
+        else:
+            raise AssertionError("Norm constraint must be L2 or Linf.")

--- a/scripts/run_mypy.sh
+++ b/scripts/run_mypy.sh
@@ -7,5 +7,6 @@ set -e
 mypy -p captum.attr --ignore-missing-imports --allow-redefinition
 mypy -p captum.insights --ignore-missing-imports --allow-redefinition
 mypy -p captum.metrics --ignore-missing-imports --allow-redefinition
+mypy -p captum.robust --ignore-missing-imports --allow-redefinition
 mypy -p tests --ignore-missing-imports --allow-redefinition
 mypy -p captum._utils --ignore-missing-imports --allow-redefinition

--- a/sphinx/source/index.rst
+++ b/sphinx/source/index.rst
@@ -16,6 +16,7 @@ Captum API Reference
    layer
    neuron
    metrics
+   robust
    utilities
    base_classes
 

--- a/sphinx/source/robust.rst
+++ b/sphinx/source/robust.rst
@@ -1,0 +1,15 @@
+Robustness
+======
+
+FGSM
+^^^^^^^^^^^^^^^^^
+
+.. autoclass:: captum.robust.FGSM
+    :members:
+
+
+PGD
+^^^^^^^^^^^^^^^^
+
+.. autoclass:: captum.robust.PGD
+    :members:

--- a/tests/robust/test_FGSM.py
+++ b/tests/robust/test_FGSM.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+from typing import Any, Callable, List, Tuple, Union
+
+import torch
+from torch import Tensor
+from torch.nn import CrossEntropyLoss
+
+from captum._utils.typing import TensorOrTupleOfTensorsGeneric
+from captum.robust import FGSM
+from tests.helpers.basic import BaseTest, assertArraysAlmostEqual
+from tests.helpers.basic_models import BasicModel, BasicModel2, BasicModel_MultiLayer
+
+
+class Test(BaseTest):
+    def test_attack_nontargeted(self) -> None:
+        model = BasicModel()
+        input = torch.tensor([[2.0, -9.0, 9.0, 1.0, -3.0]])
+        self._FGSM_assert(model, input, 1, 0.1, [2.0, -8.9, 9.0, 1.0, -3.0])
+
+    def test_attack_targeted(self) -> None:
+        model = BasicModel()
+        input = torch.tensor([[9.0, 10.0, -6.0, -1.0]])
+        self._FGSM_assert(model, input, 3, 0.2, [9.0, 10.0, -6.0, -1.2], targeted=True)
+
+    def test_attack_multiinput(self) -> None:
+        model = BasicModel2()
+        input1 = torch.tensor([[4.0, -1.0], [3.0, 10.0]], requires_grad=True)
+        input2 = torch.tensor([[2.0, -5.0], [-2.0, 1.0]], requires_grad=True)
+        self._FGSM_assert(
+            model,
+            (input1, input2),
+            0,
+            0.25,
+            ([3.75, -1.0, 2.75, 10.0], [2.25, -5.0, -2.0, 1.0]),
+        )
+
+    def test_attack_label_list(self) -> None:
+        model = BasicModel2()
+        input1 = torch.tensor([[4.0, -1.0], [3.0, 10.0]], requires_grad=True)
+        input2 = torch.tensor([[2.0, -5.0], [-2.0, 1.0]], requires_grad=True)
+        self._FGSM_assert(
+            model,
+            (input1, input2),
+            [0, 1],
+            0.1,
+            ([3.9, -1.0, 3.0, 9.9], [2.1, -5.0, -2.0, 1.1]),
+        )
+
+    def test_attack_label_tensor(self) -> None:
+        model = BasicModel2()
+        input1 = torch.tensor([[4.0, -1.0], [3.0, 10.0]], requires_grad=True)
+        input2 = torch.tensor([[2.0, -5.0], [-2.0, 1.0]], requires_grad=True)
+        labels = torch.tensor([0, 1])
+        self._FGSM_assert(
+            model,
+            (input1, input2),
+            labels,
+            0.1,
+            ([4.1, -1.0, 3.0, 10.1], [1.9, -5.0, -2.0, 0.9]),
+            targeted=True,
+        )
+
+    def test_attack_label_tuple(self) -> None:
+        model = BasicModel()
+        input = torch.tensor(
+            [[[4.0, 2.0], [-1.0, -2.0]], [[3.0, -4.0], [10.0, 5.0]]], requires_grad=True
+        )
+        labels = (0, 1)
+        self._FGSM_assert(
+            model, input, labels, 0.1, [4.0, 2.0, -1.0, -2.0, 3.0, -3.9, 10.0, 5.0]
+        )
+
+    def test_attack_label_listtuple(self) -> None:
+        model = BasicModel()
+        input = torch.tensor(
+            [[[4.0, 2.0], [-1.0, -2.0]], [[3.0, -4.0], [10.0, 5.0]]], requires_grad=True
+        )
+        labels: List[Tuple[int, ...]] = [(1, 1), (0, 1)]
+        self._FGSM_assert(
+            model, input, labels, 0.1, [4.0, 2.0, -1.0, -1.9, 3.0, -3.9, 10.0, 5.0]
+        )
+
+    def test_attack_additional_inputs(self) -> None:
+        model = BasicModel_MultiLayer()
+        add_input = torch.tensor([[-1.0, 2.0, 2.0]], requires_grad=True)
+        input = torch.tensor([[1.0, 6.0, -3.0]], requires_grad=True)
+        self._FGSM_assert(
+            model, input, 0, 0.2, [0.8, 5.8, -3.2], additional_inputs=(add_input,)
+        )
+        self._FGSM_assert(
+            model, input, 0, 0.2, [0.8, 5.8, -3.2], additional_inputs=add_input
+        )
+
+    def test_attack_loss_defined(self) -> None:
+        model = BasicModel_MultiLayer()
+        add_input = torch.tensor([[-1.0, 2.0, 2.0]])
+        input = torch.tensor([[1.0, 6.0, -3.0]])
+        labels = torch.tensor([0])
+        loss_func = CrossEntropyLoss(reduction="none")
+        adv = FGSM(model, loss_func)
+        perturbed_input = adv.perturb(
+            input, 0.2, labels, additional_forward_args=(add_input,)
+        )
+        assertArraysAlmostEqual(
+            perturbed_input.squeeze(0).tolist(), [1.0, 6.0, -3.0], delta=0.01
+        )
+
+    def test_attack_bound(self) -> None:
+        model = BasicModel()
+        input = torch.tensor([[9.0, 10.0, -6.0, -1.0]])
+        self._FGSM_assert(
+            model,
+            input,
+            3,
+            0.2,
+            [5.0, 5.0, -5.0, -1.2],
+            targeted=True,
+            lower_bound=-5.0,
+            upper_bound=5.0,
+        )
+
+    def _FGSM_assert(
+        self,
+        model: Callable,
+        inputs: TensorOrTupleOfTensorsGeneric,
+        target: Any,
+        epsilon: float,
+        answer: Union[List[float], Tuple[List[float], ...]],
+        targeted=False,
+        additional_inputs: Any = None,
+        lower_bound: float = float("-inf"),
+        upper_bound: float = float("inf"),
+    ) -> None:
+        adv = FGSM(model, lower_bound=lower_bound, upper_bound=upper_bound)
+        perturbed_input = adv.perturb(
+            inputs, epsilon, target, additional_inputs, targeted
+        )
+        if isinstance(perturbed_input, Tensor):
+            assertArraysAlmostEqual(
+                torch.flatten(perturbed_input).tolist(), answer, delta=0.01
+            )
+        else:
+            for i in range(len(perturbed_input)):
+                assertArraysAlmostEqual(
+                    torch.flatten(perturbed_input[i]).tolist(), answer[i], delta=0.01
+                )

--- a/tests/robust/test_PGD.py
+++ b/tests/robust/test_PGD.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+import torch
+from torch.nn import CrossEntropyLoss
+
+from captum.robust import PGD
+from tests.helpers.basic import BaseTest, assertArraysAlmostEqual
+from tests.helpers.basic_models import BasicModel, BasicModel2, BasicModel_MultiLayer
+
+
+class Test(BaseTest):
+    def test_attack_nontargeted(self) -> None:
+        model = BasicModel()
+        input = torch.tensor([[2.0, -9.0, 9.0, 1.0, -3.0]])
+        adv = PGD(model)
+        perturbed_input = adv.perturb(input, 0.25, 0.1, 2, 4)
+        assertArraysAlmostEqual(
+            torch.flatten(perturbed_input).tolist(),
+            [2.0, -9.0, 9.0, 1.0, -2.8],
+            delta=0.01,
+        )
+
+    def test_attack_targeted(self) -> None:
+        model = BasicModel()
+        input = torch.tensor([[9.0, 10.0, -6.0, -1.0]], requires_grad=True)
+        adv = PGD(model)
+        perturbed_input = adv.perturb(input, 0.2, 0.1, 3, 3, targeted=True)
+        assertArraysAlmostEqual(
+            torch.flatten(perturbed_input).tolist(), [9.0, 10.0, -6.0, -1.2], delta=0.01
+        )
+
+    def test_attack_l2norm(self) -> None:
+        model = BasicModel()
+        input = torch.tensor([[9.0, 10.0, -6.0, -1.0]], requires_grad=True)
+        adv = PGD(model)
+        perturbed_input = adv.perturb(input, 0.2, 0.1, 3, 2, targeted=True, norm="L2")
+        assertArraysAlmostEqual(
+            torch.flatten(perturbed_input).tolist(), [9.0, 10.0, -6.2, -1.0], delta=0.01
+        )
+
+    def test_attack_multiinput(self) -> None:
+        model = BasicModel2()
+        input1 = torch.tensor([[4.0, -1.0], [3.0, 10.0]], requires_grad=True)
+        input2 = torch.tensor([[2.0, -5.0], [-2.0, 1.0]], requires_grad=True)
+        adv = PGD(model)
+        perturbed_input = adv.perturb((input1, input2), 0.25, 0.1, 3, 0, norm="L2")
+        answer = ([3.75, -1.0, 2.75, 10.0], [2.25, -5.0, -2.0, 1.0])
+        for i in range(len(perturbed_input)):
+            assertArraysAlmostEqual(
+                torch.flatten(perturbed_input[i]).tolist(), answer[i], delta=0.01
+            )
+
+    def test_attack_3dimensional_input(self) -> None:
+        model = BasicModel()
+        input = torch.tensor(
+            [[[4.0, 2.0], [-1.0, -2.0]], [[3.0, -4.0], [10.0, 5.0]]], requires_grad=True
+        )
+        adv = PGD(model)
+        perturbed_input = adv.perturb(input, 0.25, 0.1, 3, (0, 1))
+        assertArraysAlmostEqual(
+            torch.flatten(perturbed_input).tolist(),
+            [4.0, 2.0, -1.0, -2.0, 3.0, -3.75, 10.0, 5.0],
+            delta=0.01,
+        )
+
+    def test_attack_loss_defined(self) -> None:
+        model = BasicModel_MultiLayer()
+        add_input = torch.tensor([[-1.0, 2.0, 2.0]])
+        input = torch.tensor([[1.0, 6.0, -3.0]])
+        labels = torch.tensor([0])
+        loss_func = CrossEntropyLoss(reduction="none")
+        adv = PGD(model, loss_func)
+        perturbed_input = adv.perturb(
+            input, 0.25, 0.1, 3, labels, additional_forward_args=(add_input,)
+        )
+        assertArraysAlmostEqual(
+            perturbed_input.squeeze(0).tolist(), [1.0, 6.0, -3.0], delta=0.01
+        )
+
+    def test_attack_random_start(self) -> None:
+        model = BasicModel()
+        input = torch.tensor([[2.0, -9.0, 9.0, 1.0, -3.0]])
+        adv = PGD(model)
+        perturbed_input = adv.perturb(input, 0.25, 0.1, 0, 4, random_start=True)
+        assertArraysAlmostEqual(
+            torch.flatten(perturbed_input).tolist(),
+            [2.0, -9.0, 9.0, 1.0, -3.0],
+            delta=0.25,
+        )
+        perturbed_input = adv.perturb(
+            input, 0.25, 0.1, 0, 4, norm="L2", random_start=True
+        )
+        norm = torch.norm((perturbed_input - input).squeeze()).numpy()
+        self.assertLessEqual(norm, 0.25)


### PR DESCRIPTION
Summary: Move initial captum.robust attacks (FGSM, PGD, base classes) to open source folder

Reviewed By: aobo-y

Differential Revision: D29353978

