### PR TITLE
Fix LRP Class Names for Documentation

### DIFF
--- a/sphinx/source/layer.rst
+++ b/sphinx/source/layer.rst
@@ -66,5 +66,5 @@ Layer Feature Ablation
 Layer LRP
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. autoclass:: captum.attr.layer_lrp
+.. autoclass:: captum.attr.LayerLRP
     :members:

--- a/sphinx/source/lrp.rst
+++ b/sphinx/source/lrp.rst
@@ -1,5 +1,5 @@
 LRP
 ====================
 
-.. autoclass:: captum.attr.lrp
+.. autoclass:: captum.attr.LRP
     :members:


### PR DESCRIPTION
Fixes LRP class name casing for documentation generation