### PR TITLE
Adding Minimal Perturbation Metric

### DIFF
--- a/captum/attr/_utils/summarizer.py
+++ b/captum/attr/_utils/summarizer.py
@@ -2,6 +2,7 @@
 
 from typing import Dict, List, Optional, Tuple, Type, Union
 
+import torch
 from torch import Tensor
 
 from captum.attr._utils.stat import MSE, Count, Max, Mean, Min, Stat, StdDev, Sum, Var
@@ -76,6 +77,8 @@ class Summarizer:
                         stats=stats, summary_stats_indices=self._summary_stats_indicies
                     )
                 )
+            if not isinstance(inp, torch.Tensor):
+                inp = torch.tensor(inp, dtype=torch.float)
             self._summarizers[i].update(inp)
 
     @property

--- a/captum/robust/__init__.py
+++ b/captum/robust/__init__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
 from captum.robust._core.fgsm import FGSM  # noqa
+from captum.robust._core.metrics.attack_comparator import AttackComparator  # noqa
 from captum.robust._core.perturbation import Perturbation  # noqa
 from captum.robust._core.pgd import PGD  # noqa

--- a/captum/robust/__init__.py
+++ b/captum/robust/__init__.py
@@ -2,5 +2,8 @@
 
 from captum.robust._core.fgsm import FGSM  # noqa
 from captum.robust._core.metrics.attack_comparator import AttackComparator  # noqa
+from captum.robust._core.metrics.min_param_perturbation import (  # noqa
+    MinParamPerturbation,
+)
 from captum.robust._core.perturbation import Perturbation  # noqa
 from captum.robust._core.pgd import PGD  # noqa

--- a/captum/robust/_core/metrics/attack_comparator.py
+++ b/captum/robust/_core/metrics/attack_comparator.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+import warnings
+from collections import namedtuple
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Union
+
+from torch import Tensor
+
+from captum._utils.common import (
+    _expand_additional_forward_args,
+    _format_additional_forward_args,
+    _reduce_list,
+)
+from captum.attr import Max, Mean, Min, Summarizer
+from captum.robust._core.perturbation import Perturbation
+
+ORIGINAL_KEY = "Original"
+
+
+class AttackInfo(NamedTuple):
+    attack_fn: Union[Perturbation, Callable]
+    name: str
+    num_attempts: int
+    apply_before_preproc: bool
+    attack_kwargs: Dict[str, Any]
+    additional_args: List[str]
+
+
+def agg_metric(inp):
+    if isinstance(inp, Tensor):
+        return inp.mean(dim=0)
+    elif isinstance(inp, tuple):
+        return tuple(agg_metric(elem) for elem in inp)
+    return inp
+
+
+class AttackComparator:
+    r"""
+    Allows measuring model robustness for a given attack or set of attacks. This class
+    can be used with any metric(s) as well as any set of attacks, either based on
+    attacks / perturbations from captum.robust such as FGSM or PGD or external
+    augmentation methods or perturbations such as torchvision transforms.
+    """
+
+    def __init__(
+        self,
+        forward_func: Callable,
+        metric: Callable[..., Union[float, Tensor, Tuple[Union[float, Tensor], ...]]],
+        preproc_fn: Callable = None,
+    ) -> None:
+        r"""
+        Args:
+            forward_func (callable or torch.nn.Module): This can either be an instance
+                of pytorch model or any modification of a model's forward
+                function.
+
+            metric (callable): This function is applied to the model output in
+                order to compute the desired performance metric or metrics.
+                This function should have the following signature:
+                    def model_metric(model_out: Tensor, **kwargs: Any)
+                            -> Union[float, Tensor, Tuple[Union[float, Tensor], ...]
+
+                All kwargs provided to evaluate are provided to the metric function,
+                following the model output. A single metric can be returned as
+                a float or tensor, and multiple metrics should be returned as either
+                a tuple or named tuple of floats or tensors. For a tensor metric,
+                the first dimension should match the batch size, corresponding to
+                metrics for each example. Tensor metrics are averaged over the first
+                dimension when aggregating multiple batch results.
+                If tensor metrics represent results for the full batch, the size of the
+                first dimension should be 1.
+
+            preproc_fn (callable, optional): Optional method applied to inputs. Output
+                of preproc_fn is then provided as input to model, in addition to
+                additional_forward_args provided to evaluate.
+        """
+        self.forward_func = forward_func
+        self.metric = metric
+        self.preproc_fn = preproc_fn
+        self.attacks = {}
+        self.summary_results = {}
+        self.metric_aggregator = agg_metric
+        self.batch_stats = [Mean, Min, Max]
+        self.aggregate_stats = [Mean]
+        self.summary_results = {}
+        self.out_format = None
+
+    def add_attack(
+        self,
+        attack: Union[Perturbation, Callable],
+        name: Optional[str] = None,
+        num_attempts: int = 1,
+        apply_before_preproc: bool = True,
+        attack_kwargs: Optional[Dict[str, Any]] = None,
+        additional_attack_arg_names: Optional[List[str]] = None,
+    ) -> None:
+        r"""
+        Adds attack to be evaluated when calling evaluate.
+
+        Args:
+            attack (perturbation or callable): This can either be an instance
+                of a Captum Perturbation / Attack
+                or any other perturbation or attack function such
+                as a torchvision transform.
+
+            name (optional, str): Name or identifier for attack, used as key for
+                attack results. This defaults to attack.__class__.__name__
+                if not provided and must be unique for all added attacks.
+
+            num_attempts (int): Number of attempts that attack should be
+                repeated. This should only be set to > 1 for non-deterministic
+                attacks. The minimum, maximum, and average (best, worst, and
+                average case) are tracked for attack attempts.
+
+            apply_before_preproc (bool): Defines whether attack should be applied
+                before or after preproc function.
+
+            attack_kwargs (dict): Additional arguments to be provided to given attack.
+                This should be provided as a dictionary of keyword arguments.
+
+            additional_attack_arg_names (list[str]): Any additional arguments for the
+                attack which are specific to the particular input example or batch.
+                An example of this is target, which is necessary for some attacks such
+                as FGSM or PGD. These arguments are included if provided as a kwarg
+                to evaluate.
+        """
+        if name is None:
+            name = attack.__class__.__name__
+
+        if attack_kwargs is None:
+            attack_kwargs = {}
+
+        if additional_attack_arg_names is None:
+            additional_attack_arg_names = []
+
+        if name in self.attacks:
+            raise RuntimeError(
+                "Cannot add attack with same name as existing attack {}".format(name)
+            )
+
+        self.attacks[name] = AttackInfo(
+            attack_fn=attack,
+            name=name,
+            num_attempts=num_attempts,
+            apply_before_preproc=apply_before_preproc,
+            attack_kwargs=attack_kwargs,
+            additional_args=additional_attack_arg_names,
+        )
+
+    def _format_summary(
+        self, summary: Union[Dict, List[Dict]]
+    ) -> Dict[str, Union[float, Tuple[float, ...]]]:
+        r"""
+        This method reformats a given summary; particularly for tuples,
+        the Summarizer's summary format is a list of dictionaries,
+        each containing the summary for the corresponding elements.
+        We reformat this to return a dictionary with tuples containing
+        the summary results.
+        """
+        if isinstance(summary, dict):
+            return summary
+        else:
+            summary_dict = {}
+            for key in summary[0]:
+                summary_dict[key] = tuple(s[key] for s in summary)
+                if self.out_format:
+                    summary_dict[key] = self.out_format(*summary_dict[key])
+            return summary_dict
+
+    def _update_out_format(
+        self, out_metric: Union[float, Tensor, Tuple[Union[float, Tensor], ...]]
+    ) -> None:
+        if (
+            not self.out_format
+            and isinstance(out_metric, tuple)
+            and hasattr(out_metric, "_fields")
+        ):
+            self.out_format = namedtuple(type(out_metric).__name__, out_metric._fields)
+
+    def _evaluate_batch(
+        self,
+        input_list: List[Any],
+        additional_forward_args: Optional[Tuple],
+        key_list: List[str],
+        batch_summarizers: Dict[str, Summarizer],
+        metric_kwargs: Dict[str, Any],
+    ) -> None:
+        if additional_forward_args is None:
+            additional_forward_args = ()
+        if len(input_list) == 1:
+            model_out = self.forward_func(input_list[0], *additional_forward_args)
+            out_metric = self.metric(model_out, **metric_kwargs)
+            self._update_out_format(out_metric)
+            batch_summarizers[key_list[0]].update(out_metric)
+        else:
+            batched_inps = _reduce_list(input_list)
+            model_out = self.forward_func(batched_inps, *additional_forward_args)
+            current_count = 0
+            for i in range(len(input_list)):
+                batch_size = (
+                    input_list[i].shape[0]
+                    if isinstance(input_list[i], Tensor)
+                    else input_list[i][0].shape[0]
+                )
+                out_metric = self.metric(
+                    model_out[current_count : current_count + batch_size],
+                    **metric_kwargs,
+                )
+                self._update_out_format(out_metric)
+                batch_summarizers[key_list[i]].update(out_metric)
+                current_count += batch_size
+
+    def evaluate(
+        self,
+        inputs: Any,
+        additional_forward_args: Optional[Tuple] = None,
+        perturbations_per_eval: int = 1,
+        **kwargs,
+    ) -> Dict[
+        str,
+        Union[Tensor, Tuple[Tensor, ...], Dict[str, Union[Tensor, Tuple[Tensor, ...]]]],
+    ]:
+        r"""
+        Evaluate model and attack performance on provided inputs
+
+        Args:
+
+        inputs (any): Input for which attack metrics
+                are computed. It can be provided as a tensor, tuple of tensors,
+                or any raw input type (e.g. PIL image or text string).
+                This input is provided directly as input to preproc function as well
+                as any attack applied before preprocessing. If no pre-processing
+                function is provided, this input is provided directly to the main
+                model and all attacks.
+
+        additional_forward_args (any, optional): If the forward function
+                requires additional arguments other than the preprocessing
+                outputs (or inputs if preproc_fn is None), this argument
+                can be provided. It must be either a single additional
+                argument of a Tensor or arbitrary (non-tuple) type or a
+                tuple containing multiple additional arguments including
+                tensors or any arbitrary python types. These arguments
+                are provided to forward_func in order following the
+                arguments in inputs.
+                For a tensor, the first dimension of the tensor must
+                correspond to the number of examples. For all other types,
+                the given argument is used for all forward evaluations.
+                Default: None
+        perturbations_per_eval (int, optional): Allows perturbations of multiple
+                attacks to be grouped and evaluated in one call of forward_fn
+                Each forward pass will contain a maximum of
+                perturbations_per_eval * #examples samples.
+                For DataParallel models, each batch is split among the
+                available devices, so evaluations on each available
+                device contain at most
+                (perturbations_per_eval * #examples) / num_devices
+                samples.
+                In order to apply this functionality, the output of preproc_fn
+                (or inputs itself if no preproc_fn is provided) must be a tensor
+                or tuple of tensors.
+                Default: 1
+        kwargs (any, optional): Additional keyword arguments provided to metric function
+                as well as selected attacks based on chosen additional_args
+
+        Returns:
+
+        - **attack results** Dict: str -> Dict[str, Union[Tensor, Tuple[Tensor, ...]]]:
+                Dictionary containing attack results for provided batch.
+                Maps attack name to dictionary,
+                containing best-case, worst-case and average-case results for attack.
+                Dictionary contains keys "mean", "max" and "min" when num_attempts > 1
+                and only "mean" for num_attempts = 1, which contains the (single) metric
+                result for the attack attempt.
+                An additional key of 'Original' is included with metric results
+                without any perturbations.
+
+
+        Examples::
+
+        >>> def accuracy_metric(model_out: Tensor, targets: Tensor):
+        >>>     return torch.argmax(model_out, dim=1) == targets).float()
+
+        >>> attack_metric = AttackComparator(model=resnet18,
+                                             metric=accuracy_metric,
+                                             preproc_fn=normalize)
+
+        >>> random_rotation = transforms.RandomRotation()
+        >>> jitter = transforms.ColorJitter()
+
+        >>> attack_metric.add_attack(random_rotation, "Random Rotation",
+        >>>                          num_attempts = 5)
+        >>> attack_metric.add_attack((jitter, "Jitter", num_attempts = 1)
+        >>> attack_metric.add_attack(FGSM(resnet18), "FGSM 0.1", num_attempts = 1,
+        >>>                          apply_before_preproc=False,
+        >>>                          attack_kwargs={epsilon: 0.1},
+        >>>                          additional_args=["targets"])
+
+        >>> for images, labels in dataloader:
+        >>>     batch_results = attack_metric.evaluate(inputs=images, targets=labels)
+        """
+        additional_forward_args = _format_additional_forward_args(
+            additional_forward_args
+        )
+        expanded_additional_args = (
+            _expand_additional_forward_args(
+                additional_forward_args, perturbations_per_eval
+            )
+            if perturbations_per_eval > 1
+            else additional_forward_args
+        )
+
+        preproc_input = None
+        if self.preproc_fn is not None:
+            preproc_input = self.preproc_fn(inputs)
+        else:
+            preproc_input = inputs
+
+        input_list = [preproc_input]
+        key_list = [ORIGINAL_KEY]
+
+        batch_summarizers = {ORIGINAL_KEY: Summarizer([Mean()])}
+        if ORIGINAL_KEY not in self.summary_results:
+            self.summary_results[ORIGINAL_KEY] = Summarizer(
+                [stat() for stat in self.aggregate_stats]
+            )
+
+        def _check_and_evaluate(input_list, key_list):
+            if len(input_list) == perturbations_per_eval:
+                self._evaluate_batch(
+                    input_list,
+                    expanded_additional_args,
+                    key_list,
+                    batch_summarizers,
+                    kwargs,
+                )
+                return [], []
+            return input_list, key_list
+
+        input_list, key_list = _check_and_evaluate(input_list, key_list)
+
+        for attack_key in self.attacks:
+            attack = self.attacks[attack_key]
+            if attack.num_attempts > 1:
+                stats = [stat() for stat in self.batch_stats]
+            else:
+                stats = [Mean()]
+            batch_summarizers[attack.name] = Summarizer(stats)
+            additional_attack_args = {}
+            for key in attack.additional_args:
+                if key not in kwargs:
+                    warnings.warn(
+                        f"Additional sample arg {key} not provided for {attack_key}"
+                    )
+                else:
+                    additional_attack_args[key] = kwargs[key]
+
+            for _ in range(attack.num_attempts):
+                if attack.apply_before_preproc:
+                    attacked_inp = attack.attack_fn(
+                        inputs, **additional_attack_args, **attack.attack_kwargs
+                    )
+                    preproc_attacked_inp = (
+                        self.preproc_fn(attacked_inp)
+                        if self.preproc_fn
+                        else attacked_inp
+                    )
+                else:
+                    preproc_attacked_inp = attack.attack_fn(
+                        preproc_input, **additional_attack_args, **attack.attack_kwargs
+                    )
+
+                input_list.append(preproc_attacked_inp)
+                key_list.append(attack.name)
+
+                input_list, key_list = _check_and_evaluate(input_list, key_list)
+
+        if len(input_list) > 0:
+            final_add_args = _expand_additional_forward_args(
+                additional_forward_args, len(input_list)
+            )
+            self._evaluate_batch(
+                input_list, final_add_args, key_list, batch_summarizers, kwargs
+            )
+
+        return self._parse_and_update_results(batch_summarizers)
+
+    def _parse_and_update_results(
+        self, batch_summarizers: Dict[str, Summarizer]
+    ) -> Dict[
+        str, Union[float, Tuple[float, ...], Dict[str, Union[float, Tuple[float, ...]]]]
+    ]:
+        results = {
+            ORIGINAL_KEY: self._format_summary(batch_summarizers[ORIGINAL_KEY].summary)[
+                "mean"
+            ]
+        }
+        self.summary_results[ORIGINAL_KEY].update(
+            self.metric_aggregator(results[ORIGINAL_KEY])
+        )
+        for attack_key in self.attacks:
+            attack = self.attacks[attack_key]
+            results[attack.name] = self._format_summary(
+                batch_summarizers[attack.name].summary
+            )
+
+            if len(results[attack.name]) == 1:
+                key = next(iter(results[attack.name]))
+                if attack.name not in self.summary_results:
+                    self.summary_results[attack.name] = Summarizer(
+                        [stat() for stat in self.aggregate_stats]
+                    )
+                self.summary_results[attack.name].update(
+                    self.metric_aggregator(results[attack.name][key])
+                )
+            else:
+                for key in results[attack.name]:
+                    summary_key = f"{attack.name} {key.title()} Attempt"
+                    if summary_key not in self.summary_results:
+                        self.summary_results[summary_key] = Summarizer(
+                            [stat() for stat in self.aggregate_stats]
+                        )
+                    self.summary_results[summary_key].update(
+                        self.metric_aggregator(results[attack.name][key])
+                    )
+        return results
+
+    def summary(self) -> Dict[str, Dict[str, Union[Tensor, Tuple[Tensor, ...]]]]:
+        r"""
+        Returns average results over all previous batches evaluated.
+
+        Returns:
+
+            - **summary** Dict: str -> Dict[str, Union[Tensor, Tuple[Tensor, ...]]]:
+                Dictionary containing summarized average attack results.
+                Maps attack name (with "Mean Attempt", "Max Attempt" and "Min Attempt"
+                suffixes if num_attempts > 1) to dictionary containing a key of "mean"
+                maintaining summarized results,
+                which is the running mean of results over all batches
+                since construction or previous reset call. Tensor metrics are averaged
+                over dimension 0 for each batch, in order to aggregte metrics collected
+                per batch.
+        """
+        return {
+            key: self._format_summary(self.summary_results[key].summary)
+            for key in self.summary_results
+        }
+
+    def reset(self) -> None:
+        r"""
+        Reset stored average summary results for previous batches
+        """
+        self.summary_results = {}

--- a/captum/robust/_core/metrics/min_param_perturbation.py
+++ b/captum/robust/_core/metrics/min_param_perturbation.py
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3
+import math
+from enum import Enum
+from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
+
+import torch
+from torch import Tensor
+
+from captum._utils.common import (
+    _expand_additional_forward_args,
+    _format_additional_forward_args,
+    _reduce_list,
+)
+from captum._utils.typing import TargetType
+from captum.robust._core.perturbation import Perturbation
+
+
+def drange(
+    min_val: Union[int, float], max_val: Union[int, float], step_val: Union[int, float]
+) -> Generator[Union[int, float], None, None]:
+    curr = min_val
+    while curr < max_val:
+        yield curr
+        curr += step_val
+
+
+def default_correct_fn(model_out: Tensor, target: TargetType) -> bool:
+    assert (
+        isinstance(model_out, Tensor) and model_out.ndim == 2
+    ), "Model output must be a 2D tensor to use default correct function;"
+    " otherwise custom correct function must be provided"
+    target_tensor = torch.tensor(target) if not isinstance(target, Tensor) else target
+    return all(torch.argmax(model_out, dim=1) == target_tensor)
+
+
+class MinParamPerturbationMode(Enum):
+    LINEAR = 0
+    BINARY = 1
+
+
+class MinParamPerturbation:
+    def __init__(
+        self,
+        forward_func: Callable,
+        attack: Union[Callable, Perturbation],
+        arg_name: str,
+        arg_min: Union[int, float],
+        arg_max: Union[int, float],
+        arg_step: Union[int, float],
+        mode: str = "linear",
+        num_attempts: int = 1,
+        preproc_fn: Optional[Callable] = None,
+        apply_before_preproc: bool = False,
+        correct_fn: Optional[Callable] = None,
+    ):
+        r"""
+        Identifies minimal perturbation based on target variable which causes
+        misclassification (or other incorrect prediction) of target input.
+
+        More specifically, given a perturbation parametrized by a single value
+        (e.g. rotation by angle or mask percentage of top features based on
+        attribution results), MinParamPerturbation helps identify the minimum value
+        which leads to misclassification (or other model output change) with the
+        corresponding perturbed input.
+
+        Args:
+            forward_func (callable or torch.nn.Module): This can either be an instance
+                of pytorch model or any modification of a model's forward
+                function.
+
+            attack (Perturbation or Callable): This can either be an instance
+                of a Captum Perturbation / Attack
+                or any other perturbation or attack function such
+                as a torchvision transform.
+                Perturb function must take additional argument (var_name) used for
+                minimal perturbation search.
+
+            arg_name (str): Name of argument / variable paramterizing attack, must be
+                kwarg of attack. Examples are num_dropout or stdevs
+
+            arg_min (int, float): Minimum value of target variable
+
+            arg_max (int, float): Maximum value of target variable
+                (not included in range)
+
+            arg_step (int, float): Minimum interval for increase of target variable.
+
+            mode (str, optional): Mode for search of minimum attack value;
+                either 'linear' for linear search on variable, or 'binary' for
+                binary search of variable
+                Default: 'linear'
+
+            num_attempts (int, optional): Number of attempts or trials with
+                given variable. This should only be set to > 1 for non-deterministic
+                perturbation / attack functions
+                Default: 1
+
+            preproc_fn (callable, optional): Optional method applied to inputs. Output
+                of preproc_fn is then provided as input to model, in addition to
+                additional_forward_args provided to evaluate.
+                Default: None
+
+            apply_before_preproc (bool, optional): Defines whether attack should be
+                applied before or after preproc function.
+                Default: False
+
+            correct_fn (Callable, optional): This determines whether the perturbed input
+                leads to a correct or incorrect prediction. By default, this function
+                is set to the standard classification test for correctness
+                (comparing argmax of output with target), which requires model output to
+                be a 2D tensor, returning True if all batch examples are correct and
+                false otherwise. Setting this method allows
+                any custom behavior defining whether the perturbation is successful
+                at fooling the model. For non-classification use cases, a custom
+                function must be provided which determines correctness.
+
+                The first argument to this function must be the model out;
+                any additional arguments should be provided through correct_fn_kwargs.
+
+                This function should have the following signature:
+                    def correct_fn(model_out: Tensor, **kwargs: Any) -> bool
+
+                Method should return a boolean if correct (True) and incorrect (False).
+                Default: None (applies standard correct_fn for classification)
+        """
+        self.forward_func = forward_func
+        self.attack = attack
+        self.arg_name = arg_name
+        self.arg_min = arg_min
+        self.arg_max = arg_max
+        self.arg_step = arg_step
+        assert self.arg_max > (
+            self.arg_min + self.arg_step
+        ), "Step size cannot be smaller than range between min and max"
+
+        self.num_attempts = num_attempts
+        self.preproc_fn = preproc_fn
+        self.apply_before_preproc = apply_before_preproc
+        self.correct_fn = correct_fn if correct_fn is not None else default_correct_fn
+
+        assert (
+            mode.upper() in MinParamPerturbationMode.__members__
+        ), f"Provided perturb mode {mode} is not valid - must be linear or binary"
+        self.mode = MinParamPerturbationMode[mode.upper()]
+
+    def _evaluate_batch(
+        self,
+        input_list: List,
+        additional_forward_args: Any,
+        correct_fn_kwargs: Dict[str, Any],
+        target: TargetType,
+    ) -> None:
+        if additional_forward_args is None:
+            additional_forward_args = ()
+
+        all_kwargs = {}
+        if target is not None:
+            all_kwargs["target"] = target
+        if correct_fn_kwargs is not None:
+            all_kwargs.update(correct_fn_kwargs)
+
+        if len(input_list) == 1:
+            model_out = self.forward_func(input_list[0], *additional_forward_args)
+            out_metric = self.correct_fn(model_out, **all_kwargs)
+            return 0 if not out_metric else None
+        else:
+            batched_inps = _reduce_list(input_list)
+            model_out = self.forward_func(batched_inps, *additional_forward_args)
+            current_count = 0
+            for i in range(len(input_list)):
+                batch_size = (
+                    input_list[i].shape[0]
+                    if isinstance(input_list[i], Tensor)
+                    else input_list[i][0].shape[0]
+                )
+                out_metric = self.correct_fn(
+                    model_out[current_count : current_count + batch_size], **all_kwargs
+                )
+                if not out_metric:
+                    return i
+                current_count += batch_size
+            return None
+
+    def _apply_attack(
+        self,
+        inputs: Any,
+        preproc_input: Any,
+        attack_kwargs: Optional[Dict[str, Any]],
+        param: Union[int, float],
+    ) -> Tuple[Any, Any]:
+        if attack_kwargs is None:
+            attack_kwargs = {}
+        if self.apply_before_preproc:
+            attacked_inp = self.attack(
+                inputs, **attack_kwargs, **{self.arg_name: param}
+            )
+            preproc_attacked_inp = (
+                self.preproc_fn(attacked_inp) if self.preproc_fn else attacked_inp
+            )
+        else:
+            attacked_inp = self.attack(
+                preproc_input, **attack_kwargs, **{self.arg_name: param}
+            )
+            preproc_attacked_inp = attacked_inp
+        return preproc_attacked_inp, attacked_inp
+
+    def _linear_search(
+        self,
+        inputs: Any,
+        preproc_input: Any,
+        attack_kwargs: Optional[Dict[str, Any]],
+        additional_forward_args: Any,
+        expanded_additional_args: Any,
+        correct_fn_kwargs: Optional[Dict[str, Any]],
+        target: TargetType,
+        perturbations_per_eval: int,
+    ) -> Tuple[Any, Optional[Union[int, float]]]:
+        input_list = []
+        attack_inp_list = []
+        param_list = []
+
+        for param in drange(self.arg_min, self.arg_max, self.arg_step):
+            for _ in range(self.num_attempts):
+                preproc_attacked_inp, attacked_inp = self._apply_attack(
+                    inputs, preproc_input, attack_kwargs, param
+                )
+
+                input_list.append(preproc_attacked_inp)
+                param_list.append(param)
+                attack_inp_list.append(attacked_inp)
+
+                if len(input_list) == perturbations_per_eval:
+                    successful_ind = self._evaluate_batch(
+                        input_list,
+                        expanded_additional_args,
+                        correct_fn_kwargs,
+                        target,
+                    )
+                    if successful_ind is not None:
+                        return (
+                            attack_inp_list[successful_ind],
+                            param_list[successful_ind],
+                        )
+                    input_list = []
+                    param_list = []
+                    attack_inp_list = []
+        if len(input_list) > 0:
+            final_add_args = _expand_additional_forward_args(
+                additional_forward_args, len(input_list)
+            )
+            successful_ind = self._evaluate_batch(
+                input_list,
+                final_add_args,
+                correct_fn_kwargs,
+                target,
+            )
+            if successful_ind is not None:
+                return (
+                    attack_inp_list[successful_ind],
+                    param_list[successful_ind],
+                )
+        return None, None
+
+    def _binary_search(
+        self,
+        inputs: Any,
+        preproc_input: Any,
+        attack_kwargs: Optional[Dict[str, Any]],
+        additional_forward_args: Any,
+        expanded_additional_args: Any,
+        correct_fn_kwargs: Optional[Dict[str, Any]],
+        target: TargetType,
+        perturbations_per_eval: int,
+    ) -> Tuple[Any, Optional[Union[int, float]]]:
+        min_range = self.arg_min
+        max_range = self.arg_max
+        min_so_far = None
+        min_input = None
+        while max_range > min_range:
+            mid_step = ((max_range - min_range) // self.arg_step) // 2
+
+            if mid_step == 0 and min_range + self.arg_step < max_range:
+                mid_step = 1
+            mid = min_range + (mid_step * self.arg_step)
+
+            input_list = []
+            param_list = []
+            attack_inp_list = []
+            attack_success = False
+
+            for i in range(self.num_attempts):
+                preproc_attacked_inp, attacked_inp = self._apply_attack(
+                    inputs, preproc_input, attack_kwargs, mid
+                )
+
+                input_list.append(preproc_attacked_inp)
+                param_list.append(mid)
+                attack_inp_list.append(attacked_inp)
+
+                if len(input_list) == perturbations_per_eval or i == (
+                    self.num_attempts - 1
+                ):
+                    additional_args = expanded_additional_args
+                    if len(input_list) != perturbations_per_eval:
+                        additional_args = _expand_additional_forward_args(
+                            additional_forward_args, len(input_list)
+                        )
+
+                    successful_ind = self._evaluate_batch(
+                        input_list,
+                        additional_args,
+                        correct_fn_kwargs,
+                        target,
+                    )
+                    if successful_ind is not None:
+                        attack_success = True
+                        max_range = mid
+                        if min_so_far is None or min_so_far > mid:
+                            min_so_far = mid
+                            min_input = attack_inp_list[successful_ind]
+                        break
+
+                    input_list = []
+                    param_list = []
+                    attack_inp_list = []
+
+            if math.isclose(min_range, mid):
+                break
+
+            if not attack_success:
+                min_range = mid
+
+        return min_input, min_so_far
+
+    def evaluate(
+        self,
+        inputs: Any,
+        additional_forward_args: Optional[Tuple] = None,
+        target: TargetType = None,
+        perturbations_per_eval: int = 1,
+        attack_kwargs: Optional[Dict[str, Any]] = None,
+        correct_fn_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[Any, Optional[Union[int, float]]]:
+        r"""
+        This method evaluates the model at each perturbed input and identifies
+        the minimum perturbation that leads to an incorrect model prediction.
+
+        It is recommended to provide a single input (batch size = 1) when using
+        this to identify a minimal perturbation for the chosen example. If a
+        batch of examples is provided, the default correct function identifies
+        the minimal perturbation for at least 1 example in the batch to be
+        misclassified. A custom correct_fn can be provided to customize
+        this behavior and define correctness for the batch.
+
+        Args:
+
+            inputs (Any): Input for which minimal perturbation
+                    is computed. It can be provided as a tensor, tuple of tensors,
+                    or any raw input type (e.g. PIL image or text string).
+                    This input is provided directly as input to preproc function
+                    as well as any attack applied before preprocessing. If no
+                    pre-processing function is provided,
+                    this input is provided directly to the main model and all attacks.
+
+            additional_forward_args (any, optional): If the forward function
+                    requires additional arguments other than the preprocessing
+                    outputs (or inputs if preproc_fn is None), this argument
+                    can be provided. It must be either a single additional
+                    argument of a Tensor or arbitrary (non-tuple) type or a
+                    tuple containing multiple additional arguments including
+                    tensors or any arbitrary python types. These arguments
+                    are provided to forward_func in order following the
+                    arguments in inputs.
+                    For a tensor, the first dimension of the tensor must
+                    correspond to the number of examples. For all other types,
+                    the given argument is used for all forward evaluations.
+                    Default: None
+            target (TargetType): Target class for classification. This is required if
+                using the default correct_fn
+
+            perturbations_per_eval (int, optional): Allows perturbations of multiple
+                    attacks to be grouped and evaluated in one call of forward_fn
+                    Each forward pass will contain a maximum of
+                    perturbations_per_eval * #examples samples.
+                    For DataParallel models, each batch is split among the
+                    available devices, so evaluations on each available
+                    device contain at most
+                    (perturbations_per_eval * #examples) / num_devices
+                    samples.
+                    In order to apply this functionality, the output of preproc_fn
+                    (or inputs itself if no preproc_fn is provided) must be a tensor
+                    or tuple of tensors.
+                    Default: 1
+            attack_kwargs (dictionary, optional): Optional dictionary of keyword
+                    arguments provided to attack function
+            correct_fn_kwargs (dictionary, optional): Optional dictionary of keyword
+                    arguments provided to correct function
+
+        Returns:
+
+            Tuple of (perturbed_inputs, param_val) if successful
+            else Tuple of (None, None)
+
+            - **perturbed inputs** (Any):
+                   Perturbed input (output of attack) which results in incorrect
+                   prediction.
+            - param_val (int, float)
+                    Param value leading to perturbed inputs causing misclassification
+
+        Examples::
+
+        >>> def gaussian_noise(inp: Tensor, std: float) -> Tensor:
+        >>>     return inp + std*torch.randn_like(inp)
+
+        >>> min_pert = MinParamPerturbation(forward_func=resnet18,
+                                           attack=gaussian_noise,
+                                           arg_name="std",
+                                           arg_min=0.0,
+                                           arg_max=2.0,
+                                           arg_step=0.01,
+                                        )
+        >>> for images, labels in dataloader:
+        >>>     noised_image, min_std = min_pert.evaluate(inputs=images, target=labels)
+
+        """
+        additional_forward_args = _format_additional_forward_args(
+            additional_forward_args
+        )
+        expanded_additional_args = (
+            _expand_additional_forward_args(
+                additional_forward_args, perturbations_per_eval
+            )
+            if perturbations_per_eval > 1
+            else additional_forward_args
+        )
+        preproc_input = inputs if not self.preproc_fn else self.preproc_fn(inputs)
+
+        if self.mode is MinParamPerturbationMode.LINEAR:
+            search_fn = self._linear_search
+        elif self.mode is MinParamPerturbationMode.BINARY:
+            search_fn = self._binary_search
+        else:
+            raise NotImplementedError(
+                "Chosen MinParamPerturbationMode is not supported!"
+            )
+
+        return search_fn(
+            inputs,
+            preproc_input,
+            attack_kwargs,
+            additional_forward_args,
+            expanded_additional_args,
+            correct_fn_kwargs,
+            target,
+            perturbations_per_eval,
+        )

--- a/captum/robust/_core/perturbation.py
+++ b/captum/robust/_core/perturbation.py
@@ -34,3 +34,6 @@ class Perturbation:
                     is returned. If a tuple is provided for inputs, a tuple of
                     corresponding sized tensors is returned.
     """
+
+    def __call__(self, *args, **kwargs):
+        return self.perturb(*args, **kwargs)

--- a/sphinx/source/robust.rst
+++ b/sphinx/source/robust.rst
@@ -13,3 +13,17 @@ PGD
 
 .. autoclass:: captum.robust.PGD
     :members:
+
+
+Attack Comparator
+^^^^^^^^^^^^^^^^^
+
+.. autoclass:: captum.robust.AttackComparator
+    :members:
+
+
+Min Param Perturbation
+^^^^^^^^^^^^^^^^
+
+.. autoclass:: captum.robust.MinParamPerturbation
+    :members:

--- a/tests/robust/test_attack_comparator.py
+++ b/tests/robust/test_attack_comparator.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+import collections
+from typing import List
+
+import torch
+from torch import Tensor
+
+from captum.robust import FGSM, AttackComparator
+from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
+from tests.helpers.basic_models import BasicModel, BasicModel_MultiLayer
+
+
+def float_metric(model_out: Tensor, target: int):
+    return model_out[:, target]
+
+
+ModelResult = collections.namedtuple("ModelResult", "accuracy output")
+
+
+def tuple_metric(model_out: Tensor, target: int, named_tuple=False):
+    _, pred = torch.max(model_out, dim=1)
+    acc = (pred == target).float()
+    output = model_out[:, target]
+    if named_tuple:
+        return ModelResult(
+            accuracy=acc.item() if acc.numel() == 1 else acc,
+            output=output.item() if output.numel() == 1 else output,
+        )
+    return (acc, output)
+
+
+def drop_column_perturb(inp: Tensor, column: int) -> Tensor:
+    mask = torch.ones_like(inp)
+    mask[:, column] = 0.0
+    return mask * inp
+
+
+def text_preproc_fn(inp: List[str]) -> Tensor:
+    return torch.tensor([float(ord(elem[0])) for elem in inp]).unsqueeze(0)
+
+
+def batch_text_preproc_fn(inp: List[List[str]]) -> Tensor:
+    return torch.cat([text_preproc_fn(elem) for elem in inp])
+
+
+def string_perturb(inp: List[str]) -> List[str]:
+    return ["a" + elem for elem in inp]
+
+
+def string_batch_perturb(inp: List[List[str]]) -> List[List[str]]:
+    return [string_perturb(elem) for elem in inp]
+
+
+class SamplePerturb:
+    def __init__(self):
+        self.count = 0
+
+    def perturb(self, inp: Tensor) -> Tensor:
+        mask = torch.ones_like(inp)
+        mask[:, self.count % mask.shape[1]] = 0.0
+        self.count += 1
+        return mask * inp
+
+
+class Test(BaseTest):
+    def test_attack_comparator_basic(self) -> None:
+        model = BasicModel()
+        inp = torch.tensor([[2.0, -9.0, 9.0, 1.0, -3.0]])
+        attack_comp = AttackComparator(
+            forward_func=lambda x: model(x)
+            + torch.tensor([[0.000001, 0.0, 0.0, 0.0, 0.0]]),
+            metric=tuple_metric,
+        )
+        attack_comp.add_attack(
+            drop_column_perturb,
+            name="first_column_perturb",
+            attack_kwargs={"column": 0},
+        )
+        attack_comp.add_attack(
+            drop_column_perturb,
+            name="last_column_perturb",
+            attack_kwargs={"column": -1},
+        )
+        attack_comp.add_attack(
+            FGSM(model),
+            attack_kwargs={"epsilon": 0.5},
+            additional_attack_arg_names=["target"],
+        )
+        batch_results = attack_comp.evaluate(inp, target=0, named_tuple=True)
+        expected_first_results = {
+            "Original": (1.0, 1.0),
+            "first_column_perturb": {"mean": (0.0, 0.0)},
+            "last_column_perturb": {"mean": (1.0, 1.0)},
+            "FGSM": {"mean": (1.0, 1.0)},
+        }
+        self._compare_results(batch_results, expected_first_results)
+
+        alt_inp = torch.tensor([[1.0, 2.0, -3.0, 4.0, -5.0]])
+
+        second_batch_results = attack_comp.evaluate(alt_inp, target=4, named_tuple=True)
+        expected_second_results = {
+            "Original": (0.0, -5.0),
+            "first_column_perturb": {"mean": (0.0, -5.0)},
+            "last_column_perturb": {"mean": (0.0, 0.0)},
+            "FGSM": {"mean": (0.0, -4.5)},
+        }
+        self._compare_results(second_batch_results, expected_second_results)
+
+        expected_summary_results = {
+            "Original": {"mean": (0.5, -2.0)},
+            "first_column_perturb": {"mean": (0.0, -2.5)},
+            "last_column_perturb": {"mean": (0.5, 0.5)},
+            "FGSM": {"mean": (0.5, -1.75)},
+        }
+        self._compare_results(attack_comp.summary(), expected_summary_results)
+
+    def test_attack_comparator_with_preproc(self) -> None:
+        model = BasicModel_MultiLayer()
+        text_inp = ["abc", "zyd", "ghi"]
+        attack_comp = AttackComparator(
+            forward_func=model, metric=tuple_metric, preproc_fn=text_preproc_fn
+        )
+        attack_comp.add_attack(
+            SamplePerturb().perturb,
+            name="Sequence Column Perturb",
+            num_attempts=5,
+            apply_before_preproc=False,
+        )
+        attack_comp.add_attack(
+            string_perturb,
+            name="StringPerturb",
+            apply_before_preproc=True,
+        )
+        batch_results = attack_comp.evaluate(
+            text_inp, target=0, named_tuple=True, perturbations_per_eval=3
+        )
+        expected_first_results = {
+            "Original": (0.0, 1280.0),
+            "Sequence Column Perturb": {
+                "mean": (0.0, 847.2),
+                "max": (0.0, 892.0),
+                "min": (0.0, 792.0),
+            },
+            "StringPerturb": {"mean": (0.0, 1156.0)},
+        }
+        self._compare_results(batch_results, expected_first_results)
+
+        expected_summary_results = {
+            "Original": {"mean": (0.0, 1280.0)},
+            "Sequence Column Perturb Mean Attempt": {"mean": (0.0, 847.2)},
+            "Sequence Column Perturb Min Attempt": {"mean": (0.0, 792.0)},
+            "Sequence Column Perturb Max Attempt": {"mean": (0.0, 892.0)},
+            "StringPerturb": {"mean": (0.0, 1156.0)},
+        }
+        self._compare_results(attack_comp.summary(), expected_summary_results)
+
+    def test_attack_comparator_with_additional_args(self) -> None:
+        model = BasicModel_MultiLayer()
+        text_inp = [["abc", "zyd", "ghi"], ["mnop", "qrs", "Tuv"]]
+        additional_forward_args = torch.ones((2, 3)) * -97
+        attack_comp = AttackComparator(
+            forward_func=model, metric=tuple_metric, preproc_fn=batch_text_preproc_fn
+        )
+        attack_comp.add_attack(
+            SamplePerturb().perturb,
+            name="Sequence Column Perturb",
+            num_attempts=5,
+            apply_before_preproc=False,
+        )
+        attack_comp.add_attack(
+            string_batch_perturb,
+            name="StringPerturb",
+            apply_before_preproc=True,
+        )
+        batch_results = attack_comp.evaluate(
+            text_inp,
+            additional_forward_args=additional_forward_args,
+            target=0,
+            named_tuple=True,
+            perturbations_per_eval=2,
+        )
+        expected_first_results = {
+            "Original": ([0.0, 0.0], [116.0, 52.0]),
+            "Sequence Column Perturb": {
+                "mean": ([0.0, 0.0], [-1.0, -1.0]),
+                "max": ([0.0, 0.0], [-1.0, -1.0]),
+                "min": ([0.0, 0.0], [-1.0, -1.0]),
+            },
+            "StringPerturb": {"mean": ([0.0, 0.0], [2.0, 2.0])},
+        }
+        self._compare_results(batch_results, expected_first_results)
+        expected_summary_results = {
+            "Original": {
+                "mean": (0.0, 84.0),
+            },
+            "Sequence Column Perturb Mean Attempt": {"mean": (0.0, -1.0)},
+            "Sequence Column Perturb Min Attempt": {"mean": (0.0, -1.0)},
+            "Sequence Column Perturb Max Attempt": {"mean": (0.0, -1.0)},
+            "StringPerturb": {"mean": (0.0, 2.0)},
+        }
+        self._compare_results(attack_comp.summary(), expected_summary_results)
+
+        attack_comp.reset()
+        self.assertEqual(len(attack_comp.summary()), 0)
+
+    def _compare_results(self, obtained, expected) -> None:
+        if isinstance(expected, dict):
+            self.assertIsInstance(obtained, dict)
+            for key in expected:
+                self._compare_results(obtained[key], expected[key])
+        elif isinstance(expected, tuple):
+            self.assertIsInstance(obtained, tuple)
+            for i in range(len(expected)):
+                self._compare_results(obtained[i], expected[i])
+        else:
+            assertTensorAlmostEqual(self, obtained, expected)

--- a/tests/robust/test_min_param_perturbation.py
+++ b/tests/robust/test_min_param_perturbation.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+from typing import List
+
+import torch
+from torch import Tensor
+
+from captum.robust import MinParamPerturbation
+from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
+from tests.helpers.basic_models import BasicModel, BasicModel_MultiLayer
+
+
+def inp_subtract(inp: Tensor, ind: int = 0, add_arg: int = 0) -> Tensor:
+    inp_repeat = 1.0 * inp
+    inp_repeat[0][ind] -= add_arg
+    return inp_repeat
+
+
+def add_char(inp: List[str], ind: int = 0, char_val: int = 0) -> List[str]:
+    list_copy = list(inp)
+    list_copy[ind] = chr(122 - char_val) + list_copy[ind]
+    return list_copy
+
+
+def add_char_batch(inp: List[List[str]], ind: int, char_val: int) -> List[List[str]]:
+    return [add_char(elem, ind, char_val) for elem in inp]
+
+
+def text_preproc_fn(inp: List[str]) -> Tensor:
+    return torch.tensor([float(ord(elem[0])) for elem in inp]).unsqueeze(0)
+
+
+def batch_text_preproc_fn(inp: List[List[str]]) -> Tensor:
+    return torch.cat([text_preproc_fn(elem) for elem in inp])
+
+
+def alt_correct_fn(model_out: Tensor, target: int, threshold: float) -> bool:
+    if all(model_out[:, target] > threshold):
+        return True
+    return False
+
+
+class Test(BaseTest):
+    def test_minimal_pert_basic_linear(self) -> None:
+        model = BasicModel()
+        inp = torch.tensor([[2.0, -9.0, 9.0, 1.0, -3.0]])
+        minimal_pert = MinParamPerturbation(
+            forward_func=lambda x: model(x)
+            + torch.tensor([[0.000001, 0.0, 0.0, 0.0, 0.0]]),
+            attack=inp_subtract,
+            arg_name="add_arg",
+            arg_min=0.0,
+            arg_max=1000.0,
+            arg_step=1.0,
+        )
+        target_inp, pert = minimal_pert.evaluate(
+            inp, target=0, attack_kwargs={"ind": 0}
+        )
+        self.assertAlmostEqual(pert, 2.0)
+        assertTensorAlmostEqual(
+            self, target_inp, torch.tensor([[0.0, -9.0, 9.0, 1.0, -3.0]])
+        )
+
+    def test_minimal_pert_basic_binary(self) -> None:
+        model = BasicModel()
+        inp = torch.tensor([[2.0, -9.0, 9.0, 1.0, -3.0]])
+        minimal_pert = MinParamPerturbation(
+            forward_func=lambda x: model(x)
+            + torch.tensor([[0.000001, 0.0, 0.0, 0.0, 0.0]]),
+            attack=inp_subtract,
+            arg_name="add_arg",
+            arg_min=0.0,
+            arg_max=1000.0,
+            arg_step=1.0,
+            mode="binary",
+        )
+        target_inp, pert = minimal_pert.evaluate(
+            inp,
+            target=0,
+            attack_kwargs={"ind": 0},
+            perturbations_per_eval=10,
+        )
+        self.assertAlmostEqual(pert, 2.0)
+        assertTensorAlmostEqual(
+            self, target_inp, torch.tensor([[0.0, -9.0, 9.0, 1.0, -3.0]])
+        )
+
+    def test_minimal_pert_preproc(self) -> None:
+        model = BasicModel_MultiLayer()
+        text_inp = ["abc", "zyd", "ghi"]
+        minimal_pert = MinParamPerturbation(
+            forward_func=model,
+            attack=add_char,
+            arg_name="char_val",
+            arg_min=0,
+            arg_max=26,
+            arg_step=1,
+            preproc_fn=text_preproc_fn,
+            apply_before_preproc=True,
+        )
+        target_inp, pert = minimal_pert.evaluate(
+            text_inp, target=1, attack_kwargs={"ind": 1}
+        )
+        self.assertEqual(pert, None)
+        self.assertEqual(target_inp, None)
+
+    def test_minimal_pert_alt_correct(self) -> None:
+        model = BasicModel_MultiLayer()
+        text_inp = ["abc", "zyd", "ghi"]
+        minimal_pert = MinParamPerturbation(
+            forward_func=model,
+            attack=add_char,
+            arg_name="char_val",
+            arg_min=0,
+            arg_max=26,
+            arg_step=1,
+            preproc_fn=text_preproc_fn,
+            apply_before_preproc=True,
+            correct_fn=alt_correct_fn,
+            num_attempts=5,
+        )
+        expected_list = ["abc", "ezyd", "ghi"]
+
+        target_inp, pert = minimal_pert.evaluate(
+            text_inp,
+            target=1,
+            attack_kwargs={"ind": 1},
+            correct_fn_kwargs={"threshold": 1200},
+            perturbations_per_eval=5,
+        )
+        self.assertEqual(pert, 21)
+        self.assertListEqual(target_inp, expected_list)
+
+        target_inp_single, pert_single = minimal_pert.evaluate(
+            text_inp,
+            target=1,
+            attack_kwargs={"ind": 1},
+            correct_fn_kwargs={"threshold": 1200},
+        )
+        self.assertEqual(pert_single, 21)
+        self.assertListEqual(target_inp_single, expected_list)
+
+    def test_minimal_pert_additional_forward_args(self) -> None:
+        model = BasicModel_MultiLayer()
+        text_inp = [["abc", "zyd", "ghi"], ["abc", "uyd", "ghi"]]
+        additional_forward_args = torch.ones((2, 3)) * -97
+
+        model = BasicModel_MultiLayer()
+        minimal_pert = MinParamPerturbation(
+            forward_func=model,
+            attack=add_char_batch,
+            arg_name="char_val",
+            arg_min=0,
+            arg_max=26,
+            arg_step=1,
+            preproc_fn=batch_text_preproc_fn,
+            apply_before_preproc=True,
+            correct_fn=alt_correct_fn,
+        )
+        expected_list = [["abc", "uzyd", "ghi"], ["abc", "uuyd", "ghi"]]
+
+        target_inp, pert = minimal_pert.evaluate(
+            text_inp,
+            target=1,
+            attack_kwargs={"ind": 1},
+            correct_fn_kwargs={"threshold": 100},
+            perturbations_per_eval=15,
+            additional_forward_args=(additional_forward_args,),
+        )
+        self.assertEqual(pert, 5)
+        self.assertListEqual(target_inp, expected_list)
+
+        target_inp_single, pert_single = minimal_pert.evaluate(
+            text_inp,
+            target=1,
+            attack_kwargs={"ind": 1},
+            correct_fn_kwargs={"threshold": 100},
+            additional_forward_args=(additional_forward_args,),
+        )
+        self.assertEqual(pert_single, 5)
+        self.assertListEqual(target_inp_single, expected_list)
+
+    def test_minimal_pert_tuple_test(self) -> None:
+        model = BasicModel_MultiLayer()
+        text_inp = (
+            [["abc", "zyd", "ghi"], ["abc", "uyd", "ghi"]],
+            torch.ones((2, 3)) * -97,
+        )
+
+        model = BasicModel_MultiLayer()
+        minimal_pert = MinParamPerturbation(
+            forward_func=lambda x: model(*x),
+            attack=lambda x, ind, char_val: (add_char_batch(x[0], ind, char_val), x[1]),
+            arg_name="char_val",
+            arg_min=0,
+            arg_max=26,
+            arg_step=1,
+            preproc_fn=lambda x: (batch_text_preproc_fn(x[0]), x[1]),
+            apply_before_preproc=True,
+            correct_fn=alt_correct_fn,
+        )
+        expected_list = [["abc", "uzyd", "ghi"], ["abc", "uuyd", "ghi"]]
+
+        target_inp, pert = minimal_pert.evaluate(
+            text_inp,
+            target=1,
+            attack_kwargs={"ind": 1},
+            correct_fn_kwargs={"threshold": 100},
+            perturbations_per_eval=15,
+        )
+        self.assertEqual(pert, 5)
+        self.assertListEqual(target_inp[0], expected_list)


### PR DESCRIPTION
Summary: Add Minimal Perturbation metric as a robustness metrics to work with Captum perturbations as well as arbitrary transformations such as torchvision transforms.

Reviewed By: aobo-y

Differential Revision: D29123001

