### PR TITLE
Enhance error message for missing rule

### DIFF
--- a/captum/attr/_core/lrp.py
+++ b/captum/attr/_core/lrp.py
@@ -282,8 +282,10 @@ class LRP(GradientAttribution):
             else:
                 raise TypeError(
                     (
-                        f"Module type {type(layer)} is not supported."
-                        "No default rule defined."
+                        f"Module of type {type(layer)} has no rule defined and no"
+                        "default rule exists for this module type. Please, set a rule"
+                        "explicitly for this module and assure that it is appropriate"
+                        "for this type of layer."
                     )
                 )
 


### PR DESCRIPTION
This PR provides additional information to an error message that is triggered when neither an explicit LRP rule is defined nor a default rule exists. The current error message is quite short and does not give enough information to the user on how to solve the problem as discussed in issue #723 .

Feel free to propose a different wording.