### PR TITLE
fix the usage of 2 baseline components

### DIFF
--- a/tutorials/Bert_SQUAD_Interpret.ipynb
+++ b/tutorials/Bert_SQUAD_Interpret.ipynb
@@ -194,7 +194,7 @@
     "                                    token_type_ids=None, ref_token_type_ids=None, \\\n",
     "                                    position_ids=None, ref_position_ids=None):\n",
     "    input_embeddings = model.bert.embeddings(input_ids, token_type_ids=token_type_ids, position_ids=position_ids)\n",
-    "    ref_input_embeddings = model.bert.embeddings(ref_input_ids, token_type_ids=token_type_ids, position_ids=position_ids)\n",
+    "    ref_input_embeddings = model.bert.embeddings(ref_input_ids, token_type_ids=ref_token_type_ids, position_ids=ref_position_ids)\n",
     "    \n",
     "    return input_embeddings, ref_input_embeddings\n"
    ]


### PR DESCRIPTION
In construct_whole_bert_embeddings() we should be using:
- ref_token_type_ids instead of  token_type_ids
- ref_position_ids and position_ids