### PR TITLE
fix error quote block in docstring

### DIFF
--- a/captum/concept/_core/tcav.py
+++ b/captum/concept/_core/tcav.py
@@ -454,18 +454,22 @@ class TCAV(ConceptInterpreter):
                     If the network returns a scalar value per example,
                     no target index is necessary.
                     For general 2D outputs, targets can be either:
-                        - a single integer or a tensor containing a single
-                          integer, which is applied to all input examples
-                        - a list of integers or a 1D tensor, with length matching
-                          the number of examples in inputs (dim 0). Each integer
-                          is applied as the target for the corresponding example.
-                        For outputs with > 2 dimensions, targets can be either:
-                        - A single tuple, which contains #output_dims - 1
-                          elements. This target index is applied to all examples.
-                        - A list of tuples with length equal to the number of
-                          examples in inputs (dim 0), and each tuple containing
-                          #output_dims - 1 elements. Each tuple is applied as the
-                          target for the corresponding example.
+
+                    - a single integer or a tensor containing a single
+                        integer, which is applied to all input examples
+                    - a list of integers or a 1D tensor, with length matching
+                        the number of examples in inputs (dim 0). Each integer
+                        is applied as the target for the corresponding example.
+
+                    For outputs with > 2 dimensions, targets can be either:
+
+                    - A single tuple, which contains #output_dims - 1
+                        elements. This target index is applied to all examples.
+                    - A list of tuples with length equal to the number of
+                        examples in inputs (dim 0), and each tuple containing
+                        #output_dims - 1 elements. Each tuple is applied as the
+                        target for the corresponding example.
+
             additional_forward_args (Any, optional): Extra arguments that are passed to
                      model when computing the attributions for `inputs`
                      w.r.t. layer output.

--- a/captum/metrics/_core/infidelity.py
+++ b/captum/metrics/_core/infidelity.py
@@ -350,12 +350,14 @@ def infidelity(
         normalize (bool, optional): Normalize the dot product of the input
                 perturbation and the attribution so the infidelity value is invariant
                 to constant scaling of the attribution values. The normalization factor
-                beta is defined as the ratio of two mean values:
-                $$ \beta = \frac{
-                    \mathbb{E}_{I \sim \mu_I} [ I^T \Phi(f, x) (f(x) - f(x - I)) ]
-                }{
-                    \mathbb{E}_{I \sim \mu_I} [ (I^T \Phi(f, x))^2 ]
-                } $$.
+                beta is defined as the ratio of two mean values::
+
+                    \beta = \frac{
+                        \mathbb{E}_{I \sim \mu_I} [ I^T \Phi(f, x) (f(x) - f(x - I)) ]
+                    }{
+                        \mathbb{E}_{I \sim \mu_I} [ (I^T \Phi(f, x))^2 ]
+                    }
+
                 Please refer the original paper for the meaning of the symbols. Same
                 normalization can be found in the paper's official implementation
                 https://github.com/chihkuanyeh/saliency_evaluation

--- a/captum/robust/_core/metrics/attack_comparator.py
+++ b/captum/robust/_core/metrics/attack_comparator.py
@@ -70,9 +70,10 @@ class AttackComparator(Generic[MetricResultType]):
 
             metric (callable): This function is applied to the model output in
                 order to compute the desired performance metric or metrics.
-                This function should have the following signature:
-                    def model_metric(model_out: Tensor, **kwargs: Any)
-                            -> Union[float, Tensor, Tuple[Union[float, Tensor], ...]
+                This function should have the following signature::
+
+                    >>> def model_metric(model_out: Tensor, **kwargs: Any)
+                    >>>     -> Union[float, Tensor, Tuple[Union[float, Tensor], ...]:
 
                 All kwargs provided to evaluate are provided to the metric function,
                 following the model output. A single metric can be returned as

--- a/captum/robust/_core/pgd.py
+++ b/captum/robust/_core/pgd.py
@@ -16,14 +16,17 @@ class PGD(Perturbation):
     FGSM that can generate adversarial examples. It takes multiple gradient
     steps to search for an adversarial perturbation within the desired
     neighbor ball around the original inputs. In a non-targeted attack, the
-    formulation is:
+    formulation is::
+
         x_0 = x
         x_(t+1) = Clip_r(x_t + alpha * sign(gradient of L(theta, x, t)))
+
     where Clip denotes the function that projects its argument to the r-neighbor
     ball around x so that the perturbation will be bounded. Alpha is the step
     size. L(theta, x, y) is the model's loss function with respect to model
     parameters, inputs and targets.
-    In a targeted attack, the formulation is similar:
+    In a targeted attack, the formulation is similar::
+
         x_0 = x
         x_(t+1) = Clip_r(x_t - alpha * sign(gradient of L(theta, x, t)))
 


### PR DESCRIPTION
Some indentation in our docstring leads to unexpected `Block Quote` https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#block-quotes

![Screen Shot 2021-09-07 at 7 19 21 PM](https://user-images.githubusercontent.com/5113450/132422257-cc6ea410-a6f6-4269-acae-cb5c770a4d5c.png)

This pr fixed them by either remove the unnecessary indentations or use `Literal Block` to replace them