### PR TITLE
group tutorials into subsections

### DIFF
--- a/website/core/TutorialSidebar.js
+++ b/website/core/TutorialSidebar.js
@@ -36,7 +36,7 @@ class TutorialSidebar extends React.Component {
     const toc = [
       {
         type: 'CATEGORY',
-        title: 'Tutorials',
+        title: 'Captum Tutorials',
         children: [
           {
             type: 'LINK',
@@ -56,16 +56,34 @@ class TutorialSidebar extends React.Component {
 
     Object.keys(json).forEach(category => {
       const categoryItems = json[category];
-      const items = [];
-      categoryItems.map(item => {
-        items.push({
-          type: 'LINK',
-          item: {
-            permalink: `tutorials/${item.id}`,
-            id: item.id,
-            title: item.title,
-          },
-        });
+      const items = categoryItems.map(item => {
+        console.log('$$$')
+        console.log(item.id)
+        if (item.id !== undefined) {
+          return {
+            type: 'LINK',
+            item: {
+              permalink: `tutorials/${item.id}`,
+              id: item.id,
+              title: item.title,
+            },
+          }
+        }
+
+        return {
+          type: 'SUBCATEGORY',
+          title: item.title,
+          children: item.children.map(iitem => {
+            return {
+              type: 'Link',
+              item: {
+                permalink: `tutorials/${iitem.id}`,
+                id: iitem.id,
+                title: iitem.title,
+              }
+            };
+          }),
+        }
       });
 
       toc.push({

--- a/website/core/TutorialSidebar.js
+++ b/website/core/TutorialSidebar.js
@@ -57,8 +57,6 @@ class TutorialSidebar extends React.Component {
     Object.keys(json).forEach(category => {
       const categoryItems = json[category];
       const items = categoryItems.map(item => {
-        console.log('$$$')
-        console.log(item.id)
         if (item.id !== undefined) {
           return {
             type: 'LINK',

--- a/website/pages/tutorials/index.js
+++ b/website/pages/tutorials/index.js
@@ -55,6 +55,8 @@ class TutorialHome extends React.Component {
                 using conductance.  Finally, we analyze a specific
                 neuron to understand feature importance for that specific neuron.  Find the tutorial <a href="Titanic_Basic_Interpret">here</a>.
 
+                <h3>Attribution</h3>
+
                 <h4>Interpreting text models:</h4>
                 In this tutorial we use a pre-trained CNN model for sentiment analysis on an IMDB dataset.
                 We use Captum and Integrated Gradients to interpret model predictions by show which specific
@@ -111,17 +113,6 @@ class TutorialHome extends React.Component {
                 allowing attributions to be computed in a distributed manner across processors, machines or GPUs.
                 Find the tutorial <a href="Distributed_Attribution">here</a>.
 
-
-                <h4>Getting Started with Captum Insights:</h4>
-                This tutorial demonstrates how to use Captum Insights for a vision model in a notebook setting.  A simple pretrained torchvision
-                CNN model is loaded and then used on the CIFAR dataset.  Captum Insights is then loaded to visualize the interpretation of specific examples.
-                Find the tutorial <a href="CIFAR_TorchVision_Captum_Insights">here</a>.
-
-                <h4>Using Captum Insights with multimodal models (VQA):</h4>
-                This tutorial demonstrates how to use Captum Insights for visualizing attributions of a multimodal model, particularly an open
-                source Visual Question Answer (VQA) model.
-                Find the tutorial <a href="Multimodal_VQA_Captum_Insights">here</a>.
-
                 <h4>Intepreting DLRM models with Captum:</h4>
                 This tutorial demonstrates how we use Captum for Deep Learning Recommender Models using
                  <a href="https://github.com/facebookresearch/dlrm">dlrm</a> model published from facebook research and integrated gradients algorithm.
@@ -136,11 +127,15 @@ class TutorialHome extends React.Component {
                 on the word tokens in the input text.
                 Find the tutorial <a href="Image_and_Text_Classification_LIME">here</a>.
 
+                <h3>Robustness</h3>
+
                 <h4>Applying robustness attacks and metrics to CIFAR model and dataset:</h4>
                 This tutorial demonstrates how to apply robustness attacks such as FGSM and PGD as well as robustness metrics such as
                 MinParamPerturbation and AttackComparator to a model trained on CIFAR dataset. Apart from that it also demonstrates how
                 robustness techniques can be used in conjunction with attribution algorithms.
                 Find the tutorial <a href="CIFAR_Captum_Robustness">here</a>.
+
+                <h3>Concept</h3>
 
                 <h4>TCAV for image classification for googlenet model:</h4>
                 This tutorial demonstrates how to apply Testing with Concept Activation Vectors (TCAV) algorithm on image classification problem.
@@ -153,6 +148,18 @@ class TutorialHome extends React.Component {
                 sentiment classification model. It showcases that `positive adjectives` concept plays a significant role in predicting
                 positive sentiment.
                 Find the tutorial <a href="TCAV_NLP">here</a>.
+
+                <h3>Captum Insight</h3>
+
+                <h4>Getting Started with Captum Insights:</h4>
+                This tutorial demonstrates how to use Captum Insights for a vision model in a notebook setting.  A simple pretrained torchvision
+                CNN model is loaded and then used on the CIFAR dataset.  Captum Insights is then loaded to visualize the interpretation of specific examples.
+                Find the tutorial <a href="CIFAR_TorchVision_Captum_Insights">here</a>.
+
+                <h4>Using Captum Insights with multimodal models (VQA):</h4>
+                This tutorial demonstrates how to use Captum Insights for visualizing attributions of a multimodal model, particularly an open
+                source Visual Question Answer (VQA) model.
+                Find the tutorial <a href="Multimodal_VQA_Captum_Insights">here</a>.
               </p>
             </body>
           </div>

--- a/website/tutorials.json
+++ b/website/tutorials.json
@@ -1,9 +1,11 @@
 {
-  "Using Captum": [
+  "Introduction to Captum": [
      {
       "id": "Titanic_Basic_Interpret",
       "title": "Getting started with Captum"
-    },
+    }
+  ],
+  "Attribution": [
     {
       "id": "IMDB_TorchText_Interpret",
       "title": "Interpreting text models"
@@ -25,14 +27,6 @@
       "title": "Interpreting multimodal models"
     },
     {
-      "id": "Bert_SQUAD_Interpret",
-      "title": "Interpreting question answering with BERT Part 1"
-    },
-    {
-      "id": "Bert_SQUAD_Interpret2",
-      "title": "Interpreting question answering with BERT Part 2"
-    },
-    {
       "id": "House_Prices_Regression_Interpret",
       "title": "Interpreting a regression model of Boston house prices"
     },
@@ -45,14 +39,6 @@
       "title": "Using Captum with torch.distributed"
     },
     {
-      "id": "CIFAR_TorchVision_Captum_Insights",
-      "title": "Getting started with Captum Insights"
-    },
-    {
-      "id": "Multimodal_VQA_Captum_Insights",
-      "title": "Using Captum Insights with multimodal models (VQA)"
-    },
-    {
       "id": "DLRM_Tutorial",
       "title": "Interpreting Deep Learning Recommender Models"
     },
@@ -61,9 +47,26 @@
       "title": "Interpreting vision and text models with LIME"
     },
     {
+      "title": "Interpreting BERT",
+      "children": [
+        {
+          "id": "Bert_SQUAD_Interpret",
+          "title": "Interpreting question answering with BERT Part 1"
+        },
+        {
+          "id": "Bert_SQUAD_Interpret2",
+          "title": "Interpreting question answering with BERT Part 2"
+        }
+      ]
+    }
+  ],
+  "Robustness": [
+    {
       "id": "CIFAR_Captum_Robustness",
       "title": "Applying robustness attacks and metrics to CIFAR model and dataset"
-    },
+    }
+  ],
+  "Concept": [
     {
       "id": "TCAV_Image",
       "title": "TCAV for image classification for googlenet model"
@@ -71,6 +74,16 @@
     {
       "id": "TCAV_NLP",
       "title": "TCAV for NLP sentiment analysis model"
+    }
+  ],
+  "Captum Insight": [
+    {
+      "id": "CIFAR_TorchVision_Captum_Insights",
+      "title": "Getting started with Captum Insights"
+    },
+    {
+      "id": "Multimodal_VQA_Captum_Insights",
+      "title": "Using Captum Insights with multimodal models (VQA)"
     }
   ]
 }


### PR DESCRIPTION
Captum is now more than just a lib of attribution. Reorganize the tutorials in the public site:
- Separate tutorials into subsections
- Support subcategory in the tutorial sidebar

New look
![Screen Shot 2021-09-09 at 4 33 58 PM](https://user-images.githubusercontent.com/5113450/132759570-1bf44c9f-f278-4ddb-bfc8-a6054a669d3a.png)
