### PR TITLE
rm unused np in stats for flake & concise it

### DIFF
--- a/captum/attr/_utils/stat.py
+++ b/captum/attr/_utils/stat.py
@@ -117,10 +117,7 @@ class Mean(Stat):
 
         if self.rolling_mean is None:
             # Ensures rolling_mean is a float tensor
-            if x.is_floating_point():
-                self.rolling_mean = torch.clone(x)
-            else:
-                self.rolling_mean = torch.clone(x.to(torch.float64))
+            self.rolling_mean = x.clone() if x.is_floating_point() else x.double()
         else:
             delta = x - self.rolling_mean
             self.rolling_mean += delta / n

--- a/tests/attr/test_stat.py
+++ b/tests/attr/test_stat.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import random
 
-import numpy as np
 import torch
 from captum.attr import MSE, Max, Mean, Min, StdDev, Sum, Summarizer, Var
 from tests.helpers.basic import (
@@ -61,9 +60,7 @@ class Test(BaseTest):
                 values.append(BIG_VAL)
                 summ.update(torch.tensor(BIG_VAL, dtype=torch.float64))
 
-            actual_var = torch.var(
-                torch.tensor(values).type(torch.double), unbiased=False
-            )
+            actual_var = torch.var(torch.tensor(values).double(), unbiased=False)
 
             var = summ.summary["variance"]
 


### PR DESCRIPTION
remove used numpy due to failed flake8 check