### PR TITLE
adjust api docs style to be consistent

### DIFF
--- a/scripts/parse_sphinx.py
+++ b/scripts/parse_sphinx.py
@@ -31,7 +31,7 @@ def parse_sphinx(input_dir, output_dir):
                 with open(os.path.join(cur, fname), "r") as f:
                     soup = BeautifulSoup(f.read(), "html.parser")
                     doc = soup.find("div", {"class": "document"})
-                    wrapped_doc = doc.wrap(soup.new_tag("div", **{"class": "sphinx"}))
+                    wrapped_doc = doc.wrap(soup.new_tag("div", **{"class": "sphinx wrapper"}))
                 # add js
                 if fname == "search.html":
                     out = js_scripts + search_js_scripts + str(wrapped_doc)

--- a/scripts/parse_sphinx.py
+++ b/scripts/parse_sphinx.py
@@ -31,7 +31,9 @@ def parse_sphinx(input_dir, output_dir):
                 with open(os.path.join(cur, fname), "r") as f:
                     soup = BeautifulSoup(f.read(), "html.parser")
                     doc = soup.find("div", {"class": "document"})
-                    wrapped_doc = doc.wrap(soup.new_tag("div", **{"class": "sphinx wrapper"}))
+                    wrapped_doc = doc.wrap(
+                        soup.new_tag("div", **{"class": "sphinx wrapper"})
+                    )
                 # add js
                 if fname == "search.html":
                     out = js_scripts + search_js_scripts + str(wrapped_doc)

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -287,6 +287,13 @@ a.docs-prev:hover {
   background-color: inherit;
 }
 
+/* Style api refs */
+div.sphinx div.document {
+  margin: 0 0;
+  padding: 40px 0;
+  width: auto;
+}
+
 .wrapper {
   max-width: 1400px;
 }


### PR DESCRIPTION
The API doc page in public website is centered instead of left aligned like all other pages. Padding (or margin) is also slightly different.
![Screen Shot 2021-09-10 at 1 45 36 PM](https://user-images.githubusercontent.com/5113450/132895734-6aa1f9df-2ce0-470f-b9a2-ceb544d8a939.png)

Unify the style to give a consistent experience
![Screen Shot 2021-09-10 at 1 47 57 PM](https://user-images.githubusercontent.com/5113450/132895965-fad3756b-aa43-44b3-a63c-1fcb50340897.png)

