### PR TITLE
remove numpy from attribution tests

### DIFF
--- a/tests/attr/layer/test_layer_conductance.py
+++ b/tests/attr/layer/test_layer_conductance.py
@@ -153,7 +153,7 @@ class Test(BaseTest):
                 internal_batch_size=internal_batch_size,
                 return_convergence_delta=True,
             )
-            delta_condition = all(abs(delta.numpy().flatten()) < 0.01)
+            delta_condition = (delta.abs() < 0.01).all()
             self.assertTrue(
                 delta_condition,
                 "Sum of attributions does {}"
@@ -195,7 +195,7 @@ class Test(BaseTest):
                 return_convergence_delta=True,
             ),
         )
-        delta_condition = all(abs(delta.numpy().flatten()) < 0.005)
+        delta_condition = (delta.abs() < 0.005).all()
         self.assertTrue(
             delta_condition,
             "Sum of attribution values does {} "

--- a/tests/attr/layer/test_layer_deeplift.py
+++ b/tests/attr/layer/test_layer_deeplift.py
@@ -9,7 +9,6 @@ from captum.attr._core.layer.layer_deep_lift import LayerDeepLift, LayerDeepLift
 from tests.helpers.basic import (
     BaseTest,
     assert_delta,
-    assertArraysAlmostEqual,
     assertTensorAlmostEqual,
     assertTensorTuplesAlmostEqual,
 )
@@ -243,8 +242,8 @@ class TestDeepLift(BaseTest):
         )
         expected = [[[-8.0]], [[-7.0]]]
         expected_delta = [0.0, 0.0]
-        assertArraysAlmostEqual(cast(Tensor, attrs).detach().numpy(), expected)
-        assertArraysAlmostEqual(delta.detach().numpy(), expected_delta)
+        assertTensorAlmostEqual(self, cast(Tensor, attrs), expected, 0.0001, "max")
+        assertTensorAlmostEqual(self, delta, expected_delta, 0.0001, "max")
 
     def test_convnet_maxpool2d_classification(self) -> None:
         inputs = 100 * torch.randn(2, 1, 10, 10)

--- a/tests/attr/test_deeplift_basic.py
+++ b/tests/attr/test_deeplift_basic.py
@@ -291,10 +291,10 @@ class Test(BaseTest):
         attrs, delta = dl.attribute(
             inputs, baselines, target=0, return_convergence_delta=True
         )
-        expected = [[0.0, 0.0, 0.0, -8.0], [0.0, -7.0, 0.0, 0.0]]
-        expected_delta = [0.0, 0.0]
-        assertArraysAlmostEqual(attrs.detach().numpy(), expected)
-        assertArraysAlmostEqual(delta.detach().numpy(), expected_delta)
+        expected = torch.Tensor([[0.0, 0.0, 0.0, -8.0], [0.0, -7.0, 0.0, 0.0]])
+        expected_delta = torch.Tensor([0.0, 0.0])
+        assertTensorAlmostEqual(self, attrs, expected, 0.0001)
+        assertTensorAlmostEqual(self, delta, expected_delta, 0.0001)
 
     def _deeplift_assert(
         self,
@@ -345,7 +345,7 @@ class Test(BaseTest):
                 )
                 assertArraysAlmostEqual(delta, delta_external, 0.0)
 
-            delta_condition = all(abs(delta.numpy().flatten()) < 0.00001)
+            delta_condition = (delta.abs() < 0.00001).all()
             self.assertTrue(
                 delta_condition,
                 "The sum of attribution values {} is not "

--- a/tests/attr/test_deeplift_classification.py
+++ b/tests/attr/test_deeplift_classification.py
@@ -179,7 +179,7 @@ class Test(BaseTest):
     ) -> None:
         self.assertEqual(inputs.shape, attributions.shape)
 
-        delta_condition = all(abs(delta.numpy().flatten()) < 0.003)
+        delta_condition = (delta.abs() < 0.003).all()
         self.assertTrue(
             delta_condition,
             "The sum of attribution values {} is not "

--- a/tests/attr/test_feature_ablation.py
+++ b/tests/attr/test_feature_ablation.py
@@ -457,7 +457,7 @@ class Test(BaseTest):
             target=None,
             feature_mask=mask,
             perturbations_per_eval=(1,),
-            expected_ablation=torch.zeros((5 * 3 * 2,) + inp[0].shape).numpy().tolist(),
+            expected_ablation=torch.zeros((5 * 3 * 2,) + inp[0].shape),
         )
 
     def test_single_inp_ablation_multi_output_aggr(self) -> None:

--- a/tests/attr/test_gradient_shap.py
+++ b/tests/attr/test_gradient_shap.py
@@ -10,7 +10,6 @@ from captum.attr._core.integrated_gradients import IntegratedGradients
 from numpy import ndarray
 from tests.helpers.basic import (
     BaseTest,
-    assertArraysAlmostEqual,
     assertTensorAlmostEqual,
 )
 from tests.helpers.basic_models import BasicLinearModel, BasicModel2
@@ -244,10 +243,8 @@ class Test(BaseTest):
         self, attributions1: Tuple[Tensor, ...], attributions2: Tuple[Tensor, ...]
     ) -> None:
         for attribution1, attribution2 in zip(attributions1, attributions2):
-            for attr_row1, attr_row2 in zip(
-                attribution1.detach().numpy(), attribution2.detach().numpy()
-            ):
-                assertArraysAlmostEqual(attr_row1, attr_row2, delta=0.005)
+            for attr_row1, attr_row2 in zip(attribution1, attribution2):
+                assertTensorAlmostEqual(self, attr_row1, attr_row2, 0.005, "max")
 
 
 def _assert_attribution_delta(
@@ -272,7 +269,7 @@ def _assert_attribution_delta(
 
 
 def _assert_delta(test: BaseTest, delta: Tensor) -> None:
-    delta_condition = all(abs(delta.numpy().flatten()) < 0.0006)
+    delta_condition = (delta.abs() < 0.0006).all()
     test.assertTrue(
         delta_condition,
         "Sum of SHAP values {} does"

--- a/tests/attr/test_input_x_gradient.py
+++ b/tests/attr/test_input_x_gradient.py
@@ -6,7 +6,11 @@ from captum._utils.typing import TensorOrTupleOfTensorsGeneric
 from captum.attr._core.input_x_gradient import InputXGradient
 from captum.attr._core.noise_tunnel import NoiseTunnel
 from tests.attr.test_saliency import _get_basic_config, _get_multiargs_basic_config
-from tests.helpers.basic import BaseTest, assertArraysAlmostEqual
+from tests.helpers.basic import (
+    BaseTest,
+    assertArraysAlmostEqual,
+    assertTensorAlmostEqual,
+)
 from tests.helpers.classification_models import SoftmaxModel
 from torch import Tensor
 from torch.nn import Module
@@ -100,11 +104,8 @@ class Test(BaseTest):
             attributions = input_x_grad.attribute(input, target)
             output = model(input)[:, target]
             output.backward()
-            expercted = input.grad * input
-            self.assertEqual(
-                expercted.detach().numpy().tolist(),
-                attributions.detach().numpy().tolist(),
-            )
+            expected = input.grad * input
+            assertTensorAlmostEqual(self, attributions, expected, 0.00001, "max")
         else:
             nt = NoiseTunnel(input_x_grad)
             attributions = nt.attribute(

--- a/tests/attr/test_integrated_gradients_basic.py
+++ b/tests/attr/test_integrated_gradients_basic.py
@@ -464,7 +464,7 @@ class Test(BaseTest):
         for input, attribution in zip(inputs, attributions):
             self.assertEqual(attribution.shape, input.shape)
         if multiply_by_inputs:
-            self.assertTrue(all(abs(delta.numpy().flatten()) < 0.07))
+            assertTensorAlmostEqual(self, delta, torch.zeros(delta.shape), 0.07, "max")
 
         # compare attributions retrieved with and without
         # `return_convergence_delta` flag

--- a/tests/attr/test_integrated_gradients_classification.py
+++ b/tests/attr/test_integrated_gradients_classification.py
@@ -106,7 +106,7 @@ class Test(BaseTest):
             )
             assertTensorAlmostEqual(self, delta_expected, delta)
 
-            delta_condition = all(abs(delta.numpy().flatten()) < 0.005)
+            delta_condition = (delta.abs() < 0.005).all()
             self.assertTrue(
                 delta_condition,
                 "The sum of attribution values {} is not "
@@ -130,7 +130,7 @@ class Test(BaseTest):
             )
             self.assertEqual([input.shape[0] * n_samples], list(delta.shape))
 
-        self.assertTrue(all(abs(delta.numpy().flatten()) < 0.05))
+        self.assertTrue((delta.abs() < 0.05).all())
         self.assertEqual(attributions.shape, input.shape)
 
 

--- a/tests/helpers/basic.py
+++ b/tests/helpers/basic.py
@@ -62,17 +62,12 @@ def assertTensorTuplesAlmostEqual(test, actual, expected, delta=0.0001, mode="su
 
 def assertAttributionComparision(test, attributions1, attributions2):
     for attribution1, attribution2 in zip(attributions1, attributions2):
-        for attr_row1, attr_row2 in zip(
-            attribution1.detach().numpy(), attribution2.detach().numpy()
-        ):
-            if isinstance(attr_row1, np.ndarray):
-                assertArraysAlmostEqual(attr_row1, attr_row2, delta=0.05)
-            else:
-                test.assertAlmostEqual(attr_row1, attr_row2, delta=0.05)
+        for attr_row1, attr_row2 in zip(attribution1, attribution2):
+            assertTensorAlmostEqual(test, attr_row1, attr_row2, 0.05, "max")
 
 
 def assert_delta(test, delta):
-    delta_condition = all(abs(delta.numpy().flatten()) < 0.00001)
+    delta_condition = (delta.abs() < 0.00001).all()
     test.assertTrue(
         delta_condition,
         "The sum of attribution values {} for relu layer is not "


### PR DESCRIPTION
Summary: minimize conversion from tensor -> numpy array whenever possible

Reviewed By: aobo-y

Differential Revision: D30878898

