### PR TITLE
Fixing flaky test

### DIFF
--- a/tests/attr/test_shapley.py
+++ b/tests/attr/test_shapley.py
@@ -348,6 +348,7 @@ class Test(BaseTest):
             feature_mask=mask,
             perturbations_per_eval=(1,),
             target=None,
+            n_samples=2500
         )
 
     def _multi_input_batch_scalar_shapley_assert(self, func: Callable) -> None:

--- a/tests/attr/test_shapley.py
+++ b/tests/attr/test_shapley.py
@@ -348,7 +348,7 @@ class Test(BaseTest):
             feature_mask=mask,
             perturbations_per_eval=(1,),
             target=None,
-            n_samples=2500
+            n_samples=2500,
         )
 
     def _multi_input_batch_scalar_shapley_assert(self, func: Callable) -> None:


### PR DESCRIPTION
Running some tests by removing seeds revealed that tests such as `test_single_shapley_int_batch_scalar_float`, `test_single_shapley_int_batch_scalar_tensor_0d`, `test_single_shapley_int_batch_scalar_tensor_1d`, and `test_single_shapley_int_batch_scalar_tensor_int` are flaky. They almost fail 40-50% of the times.

To fix these tests, I updated the `n_samples` to 2500 to fix the flakiness. The tests now pass consistently. This only affects the execution time of the test by ~1s.

Please let me know if this change seems reasonable. Similar to #775.




