### PR TITLE
Fixing flaky tests

### DIFF
--- a/tests/attr/test_shapley.py
+++ b/tests/attr/test_shapley.py
@@ -371,7 +371,8 @@ class Test(BaseTest):
             feature_mask=(mask1, mask2, mask3),
             perturbations_per_eval=(1,),
             target=None,
-            n_samples=800,
+            n_samples=3500,
+            delta=1.2,
         )
 
     def _shapley_test_assert(


### PR DESCRIPTION
This is a fix for another set of flaky tests: `test_multi_inp_shapley_batch_scalar_tensor_0d`, `test_multi_inp_shapley_batch_scalar_float` and `test_multi_inp_shapley_batch_scalar_tensor_1d` in `test_shapley.py`.  Not that `test_multi_inp_shapley_batch_scalar_int` was not flaky to begin with

I observed that increasing `n_samples` up to 3500 reduces flakiness by a lot.  This increases the runtime from about 1.7s to 4.5s though. The tests only failed about 6/7 times out of 1000 runs with only the `n_samples` change. Hence, I also increased the `delta` to 1.2 based on the observed failures to bring that to ~0%. Let me know in case you would prefer lower `n_samples` but higher `delta` to reduce the runtime.

Thanks!

cc @vivekmig 