### PR TITLE
change AV.load to not return None

### DIFF
--- a/captum/_utils/av.py
+++ b/captum/_utils/av.py
@@ -245,7 +245,7 @@ class AV:
         identifier: Optional[str] = None,
         layer: Optional[str] = None,
         num_id: Optional[str] = None,
-    ) -> Union[None, AVDataset]:
+    ) -> AVDataset:
         r"""
         Loads lazily the activation vectors for given `model_id` and
         `layer` saved under the `path`.
@@ -275,8 +275,10 @@ class AV:
         if os.path.exists(av_save_dir):
             avdataset = AV.AVDataset(path, model_id, identifier, layer, num_id)
             return avdataset
-
-        return None
+        else:
+            raise RuntimeError(
+                f"Activation vectors for model {model_id} was not found at path {path}"
+            )
 
     @staticmethod
     def _manage_loading_layers(
@@ -401,7 +403,6 @@ class AV:
                 raise RuntimeError(f"Layer {layer} was not found in manifold")
             else:
                 act_dataset = AV.load(path, model_id, identifier, layer, num_id)
-                assert not (act_dataset is None)
                 _layer_act = [act.squeeze(0) for act in DataLoader(act_dataset)]
                 __layer_act = torch.cat(_layer_act)
                 activations.append(__layer_act)

--- a/captum/concept/_core/tcav.py
+++ b/captum/concept/_core/tcav.py
@@ -151,9 +151,6 @@ def train_cav(
         )
 
         labels = [concept.id for concept in concepts]
-        assert None not in datasets, "Cannot load concepts for given layer: {}".format(
-            layer
-        )
 
         labelled_dataset = LabelledDataset(cast(List[AV.AVDataset], datasets), labels)
 

--- a/tests/utils/test_av.py
+++ b/tests/utils/test_av.py
@@ -172,7 +172,7 @@ class Test(BaseTest):
             loaded_dataset = AV.load(
                 tmpdir, model_id, DEFAULT_IDENTIFIER, "layer1.0.conv1", n_batch_name
             )
-            self.assertIsNotNone(loaded_dataset)
+
             assertTensorAlmostEqual(self, next(iter(loaded_dataset)), batch, 0.0)
 
             loaded_dataset_for_layer = AV.load(
@@ -206,8 +206,16 @@ class Test(BaseTest):
 
     def test_av_load_non_saved_layer(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
-            dataset = AV.load(tmpdir, "dummy")
-            self.assertIsNone(dataset)
+            model_id = "dummy"
+            with self.assertRaises(RuntimeError) as context:
+                AV.load(tmpdir, model_id)
+            self.assertTrue(
+                (
+                    f"Activation vectors for model {model_id} "
+                    f"was not found at path {tmpdir}"
+                )
+                == str(context.exception)
+            )
 
     def test_av_load_one_batch(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -216,12 +224,20 @@ class Test(BaseTest):
             avs = [av_0, av_1]
 
             # add av_0 to the list of activations
-            dataset = AV.load(tmpdir, "dummy")
-            self.assertIsNone(dataset)
+            model_id = "dummy"
+            with self.assertRaises(RuntimeError) as context:
+                AV.load(tmpdir, model_id)
+            self.assertTrue(
+                (
+                    f"Activation vectors for model {model_id} "
+                    f"was not found at path {tmpdir}"
+                )
+                == str(context.exception)
+            )
 
             AV.save(tmpdir, "dummy", DEFAULT_IDENTIFIER, "layer1.0.conv1", av_0, "0")
             dataset = AV.load(tmpdir, "dummy", identifier=DEFAULT_IDENTIFIER)
-            self.assertIsNotNone(dataset)
+
             for i, av in enumerate(DataLoader(cast(Dataset, dataset))):
                 assertTensorAlmostEqual(self, av, avs[i])
 
@@ -236,7 +252,7 @@ class Test(BaseTest):
 
             AV.save(tmpdir, "dummy", DEFAULT_IDENTIFIER, "layer1.0.conv2", av_1, "0")
             dataset = AV.load(tmpdir, "dummy", identifier=DEFAULT_IDENTIFIER)
-            self.assertIsNotNone(dataset)
+
             dataloader = DataLoader(cast(Dataset, dataset))
             self.assertEqual(len(dataloader), 2)
             for i, av in enumerate(dataloader):


### PR DESCRIPTION
Summary:
`captum/_utils/av.AV.load` previous returned `None` when AV was not found.  This made type checking difficult.

This diff changes so that a `RuntimeError` is raised if the AV is not found.

tests.utils.fb._core.test_av is changed to reflect this new convention

The only file that directly calls `AV.load` is `tcav.py` - all other files only call `AV.generate_dataset_activations`, which then calls `AV.load`.

Reviewed By: NarineK

Differential Revision: D32102878

