### PR TITLE
fix broken links in the doc of GradientShap

### DIFF
--- a/captum/attr/_core/gradient_shap.py
+++ b/captum/attr/_core/gradient_shap.py
@@ -25,14 +25,11 @@ from captum.log import log_usage
 class GradientShap(GradientAttribution):
     r"""
     Implements gradient SHAP based on the implementation from SHAP's primary
-    author. For reference, please, view:
-
-    https://github.com/slundberg/shap\
-    #deep-learning-example-with-gradientexplainer-tensorflowkeraspytorch-models
-
-    A Unified Approach to Interpreting Model Predictions
-    http://papers.nips.cc/paper\
-    7062-a-unified-approach-to-interpreting-model-predictions
+    author. For reference, please view the original
+    `implementation
+    <https://github.com/slundberg/shap#deep-learning-example-with-gradientexplainer-tensorflowkeraspytorch-models>`_
+    and the paper: `A Unified Approach to Interpreting Model Predictions
+    <https://arxiv.org/abs/1705.07874>`_
 
     GradientShap approximates SHAP values by computing the expectations of
     gradients by randomly sampling from the distribution of baselines/references.

--- a/captum/attr/_core/gradient_shap.py
+++ b/captum/attr/_core/gradient_shap.py
@@ -29,7 +29,7 @@ class GradientShap(GradientAttribution):
     `implementation
     <https://github.com/slundberg/shap#deep-learning-example-with-gradientexplainer-tensorflowkeraspytorch-models>`_
     and the paper: `A Unified Approach to Interpreting Model Predictions
-    <https://arxiv.org/abs/1705.07874>`_
+    <https://papers.nips.cc/paper/7062-a-unified-approach-to-interpreting-model-predictions>`_
 
     GradientShap approximates SHAP values by computing the expectations of
     gradients by randomly sampling from the distribution of baselines/references.


### PR DESCRIPTION
sphinx does not allow breaking url into multiple lines. This pr simply fixes the broken links