### PR TITLE
build sphinx from src code

### DIFF
--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -28,6 +28,7 @@ author = "The PyTorch Team"
 # but the version is no longer used
 # since version is trimmed in sphinx pages to embed into docusaurus
 import captum  # noqa: E402
+
 version = captum.__version__
 
 

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -13,14 +13,11 @@ import os
 import re
 import sys
 
-# base_path = os.path.abspath("../captum"))
-base_path = os.path.abspath(os.path.join(__file__, "..", "..", "..", "captum"))
+base_path = os.path.abspath(os.path.join(__file__, "..", "..", ".."))
+# read module from src instead of installation
+sys.path.insert(0, base_path)
 
-sys.path.append(base_path)
-
-sys.path.insert(0, os.path.abspath("../..captum/attr"))
-
-print(base_path)
+print("base path for Captum module:", base_path)
 
 # -- Project information -----------------------------------------------------
 
@@ -28,16 +25,9 @@ project = "Captum"
 copyright = "2019, Facebook, Inc."
 author = "The PyTorch Team"
 
-
-# get version string from setup.py
-with open(os.path.join(base_path, "__init__.py"), "r") as f:
-    match = re.search(r"__version__ = ['\"]([^'\"]*)['\"]", f.read(), re.M)
-
-# The full version (of the form X.Y.ZaW or X.Y.Z.pW)
-release = match.group(1)
-# The short X.Y.Z version
-splits = release.split(".")
-version = ".".join(splits[:2] + [splits[2][:1]])  # TODO: be smarter here
+# import captum from base_path
+import captum
+version = captum.__version__
 
 
 # -- General configuration ---------------------------------------------------

--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -10,7 +10,6 @@
 # -- Path setup --------------------------------------------------------------
 
 import os
-import re
 import sys
 
 base_path = os.path.abspath(os.path.join(__file__, "..", "..", ".."))
@@ -25,8 +24,10 @@ project = "Captum"
 copyright = "2019, Facebook, Inc."
 author = "The PyTorch Team"
 
-# import captum from base_path
-import captum
+# import captum from base_path to get the version
+# but the version is no longer used
+# since version is trimmed in sphinx pages to embed into docusaurus
+import captum  # noqa: E402
 version = captum.__version__
 
 


### PR DESCRIPTION
The module path in sphinx config is wrong. It is set to `~/captum/captum` but it should be `~/captum/` so all `.rst` files can correctly access the class through full module path, e.g., `.. autoclass:: captum.concept.TCAV`.

The site can be successfully built so far was because the src code was installed as a module in ci https://github.com/pytorch/captum/blob/master/scripts/install_via_pip.sh#L46 So sphinx actually use `captum` from installed module instead of the src code. This is very inconvenient for local development of docs and may potentially go wrong as another captum is installed in the current env.

The fix force the sphinx to use captum from src code.