### PR TITLE
support empty inputs in Lime & KernelShap

### DIFF
--- a/captum/attr/_core/lime.py
+++ b/captum/attr/_core/lime.py
@@ -654,7 +654,11 @@ def construct_feature_mask(feature_mask, formatted_inputs):
     else:
         feature_mask = _format_input(feature_mask)
         min_interp_features = int(
-            min(torch.min(single_inp).item() for single_inp in feature_mask)
+            min(
+                torch.min(single_mask).item()
+                for single_mask in feature_mask
+                if single_mask.numel()
+            )
         )
         if min_interp_features != 0:
             warnings.warn(
@@ -662,11 +666,16 @@ def construct_feature_mask(feature_mask, formatted_inputs):
                 " start at 0."
             )
             feature_mask = tuple(
-                single_inp - min_interp_features for single_inp in feature_mask
+                single_mask - min_interp_features for single_mask in feature_mask
             )
 
         num_interp_features = int(
-            max(torch.max(single_inp).item() for single_inp in feature_mask) + 1
+            max(
+                torch.max(single_mask).item()
+                for single_mask in feature_mask
+                if single_mask.numel()
+            )
+            + 1
         )
     return feature_mask, num_interp_features
 

--- a/tests/attr/test_kernel_shap.py
+++ b/tests/attr/test_kernel_shap.py
@@ -16,6 +16,7 @@ from tests.helpers.basic import (
 from tests.helpers.basic_models import (
     BasicModel_MultiLayer,
     BasicModel_MultiLayer_MultiInput,
+    BasicLinearModel,
 )
 
 
@@ -181,6 +182,34 @@ class Test(BaseTest):
             feature_mask=(mask1, mask2, mask3),
             baselines=(2, 3.0, 4),
             perturbations_per_eval=(1, 2, 3),
+        )
+
+    def test_multi_input_kernel_shap_with_empty_input(self) -> None:
+        net = BasicLinearModel()
+        inp1 = torch.tensor([[23.0, 0.0, 0.0, 23.0, 0.0, 0.0, 23.0]])
+        inp2 = torch.tensor([[]])  # empty input
+        mask1 = torch.tensor([[0, 1, 2, 3, 4, 5, 6]])
+        mask2 = torch.tensor([[]], dtype=torch.long)  # empty mask
+        expected: Tuple[List[List[float]], ...] = (
+            [[-8.0, 0, 0, -2.0, 0, 0, -8.0]],
+            [[]],
+        )
+        # no mask
+        self._kernel_shap_test_assert(
+            net,
+            (inp1, inp2),
+            expected,
+            n_samples=2000,
+            expected_coefs=[-8.0, 0, 0, -2.0, 0, 0, -8.0],
+        )
+        # with mask
+        self._kernel_shap_test_assert(
+            net,
+            (inp1, inp2),
+            expected,
+            n_samples=2000,
+            expected_coefs=[-8.0, 0, 0, -2.0, 0, 0, -8.0],
+            feature_mask=(mask1, mask2),
         )
 
     def test_multi_input_batch_kernel_shap_without_mask(self) -> None:

--- a/tests/attr/test_lime.py
+++ b/tests/attr/test_lime.py
@@ -3,7 +3,7 @@
 import io
 import unittest
 import unittest.mock
-from typing import Any, Callable, Generator, Tuple, Union
+from typing import Any, Callable, Generator, Tuple, Union, List
 
 import torch
 from captum._utils.models.linear_model import SkLearnLasso
@@ -24,6 +24,7 @@ from tests.helpers.basic_models import (
     BasicModel_MultiLayer,
     BasicModel_MultiLayer_MultiInput,
     BasicModelBoolInput,
+    BasicLinearModel,
 )
 from torch import Tensor
 
@@ -283,6 +284,32 @@ class Test(BaseTest):
             test_generator=True,
         )
 
+    def test_multi_input_lime_with_empty_input(self) -> None:
+        net = BasicLinearModel()
+        inp1 = torch.tensor([[23.0, 0.0, 0.0, 23.0, 0.0, 0.0, 23.0]])
+        inp2 = torch.tensor([[]])  # empty input
+        mask1 = torch.tensor([[0, 1, 2, 3, 4, 5, 6]])
+        mask2 = torch.tensor([[]], dtype=torch.long)  # empty mask
+        expected: Tuple[List[List[float]], ...] = (
+            [[-4.0, 0, 0, 0, 0, 0, -4.0]],
+            [[]],
+        )
+        self._lime_test_assert(
+            net,
+            (inp1, inp2),
+            expected,
+            n_samples=2000,
+            expected_coefs_only=[-4.0, 0, 0, 0, 0, 0, -4.0],
+        )
+        self._lime_test_assert(
+            net,
+            (inp1, inp2),
+            expected,
+            n_samples=2000,
+            expected_coefs_only=[-4.0, 0, 0, 0, 0, 0, -4.0],
+            feature_mask=(mask1, mask2),
+        )
+
     def test_multi_input_batch_lime_without_mask(self) -> None:
         net = BasicModel_MultiLayer_MultiInput()
         inp1 = torch.tensor([[23.0, 0.0, 0.0], [20.0, 50.0, 30.0]])
@@ -517,7 +544,11 @@ class Test(BaseTest):
                 else:
                     formatted_feature_mask = _format_input(feature_mask)
                     num_interp_features = int(
-                        max(torch.max(single_inp).item() for single_inp in feature_mask)
+                        max(
+                            torch.max(single_mask).item()
+                            for single_mask in feature_mask
+                            if single_mask.numel()
+                        )
                         + 1
                     )
                 if batch_attr:

--- a/tests/attr/test_lime.py
+++ b/tests/attr/test_lime.py
@@ -294,6 +294,7 @@ class Test(BaseTest):
             [[-4.0, 0, 0, 0, 0, 0, -4.0]],
             [[]],
         )
+        # no mask
         self._lime_test_assert(
             net,
             (inp1, inp2),
@@ -301,6 +302,7 @@ class Test(BaseTest):
             n_samples=2000,
             expected_coefs_only=[-4.0, 0, 0, 0, 0, 0, -4.0],
         )
+        # with mask
         self._lime_test_assert(
             net,
             (inp1, inp2),

--- a/tests/helpers/basic.py
+++ b/tests/helpers/basic.py
@@ -13,7 +13,7 @@ def deep_copy_args(func: Callable):
     def copy_args(*args, **kwargs):
         return func(
             *(copy.deepcopy(x) for x in args),
-            **{k: copy.deepcopy(v) for k, v in kwargs.items()}
+            **{k: copy.deepcopy(v) for k, v in kwargs.items()},
         )
 
     return copy_args
@@ -45,6 +45,9 @@ def assertTensorAlmostEqual(test, actual, expected, delta=0.0001, mode="sum"):
             torch.sum(torch.abs(actual - expected)).item(), 0.0, delta=delta
         )
     elif mode == "max":
+        # if both tensors are empty, they are equal but there is no max
+        if actual.numel() == expected.numel() == 0:
+            return
         test.assertAlmostEqual(
             torch.max(torch.abs(actual - expected)).item(), 0.0, delta=delta
         )


### PR DESCRIPTION
Empty inputs work in methods like `FeatureAblation` & `ShapleyValueSampling`, but not in `Lime` and `KernelShap`.
This update correctly handles empty tensors like `tensor([[],[],[]])` whose shape is (3,0) in `Lime` and `KernelShap`.
Added corresponding tests.