### PR TITLE
Optim-wip: Add JIT support to all transforms & some image parameterizations

### DIFF
--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from captum.optim._utils.image.common import nchannels_to_rgb
-from captum.optim._utils.typing import IntSeqOrIntType, NumSeqOrTensorType
+from captum.optim._utils.typing import IntSeqOrIntType, NumSeqOrTensorOrProbDistType
 
 
 class BlendAlpha(nn.Module):
@@ -364,7 +364,7 @@ class RandomScale(nn.Module):
 
     def __init__(
         self,
-        scale: NumSeqOrTensorType,
+        scale: NumSeqOrTensorOrProbDistType,
         mode: str = "bilinear",
         align_corners: Optional[bool] = False,
         recompute_scale_factor: bool = False,
@@ -512,7 +512,7 @@ class RandomScaleAffine(nn.Module):
 
     def __init__(
         self,
-        scale: NumSeqOrTensorType,
+        scale: NumSeqOrTensorOrProbDistType,
         mode: str = "bilinear",
         padding_mode: str = "zeros",
         align_corners: bool = False,

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -768,7 +768,7 @@ class RandomRotation(nn.Module):
 
     def __init__(
         self,
-        degrees: NumSeqOrTensorType,
+        degrees: NumSeqOrTensorOrProbDistType,
         mode: str = "bilinear",
         padding_mode: str = "zeros",
         align_corners: bool = False,
@@ -1283,7 +1283,7 @@ class TransformationRobustness(nn.Module):
         else:
             self.jitter_transforms = translate
         self.random_scale = None if scale is None else RandomScale(scale)
-        self.random_rotation = None  # if degrees is None else RandomRotation(degrees)
+        self.random_rotation = None if degrees is None else RandomRotation(degrees)
         self.final_jitter = (
             None if final_translate is None else RandomSpatialJitter(final_translate)
         )

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -159,7 +159,7 @@ class ToRGB(nn.Module):
         )
 
         # alpha channel is taken off...
-        has_alpha = x.size("C") == 4
+        has_alpha = x.size("C") >= 4
         if has_alpha:
             if x.dim() == 3:
                 x, alpha_channel = x[:3], x[3:]
@@ -208,7 +208,7 @@ class ToRGB(nn.Module):
         assert x.shape[-3] >= 3
 
         # alpha channel is taken off...
-        has_alpha = x.shape[-3] == 4
+        has_alpha = x.shape[-3] >= 4
         if has_alpha:
             if x.dim() == 3:
                 x, alpha_channel = x[:3], x[3:]

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -470,6 +470,7 @@ class RandomScale(nn.Module):
                 Default: False
         """
         super().__init__()
+        assert mode in ["nearest", "bilinear", "bicubic", "area"]
         if isinstance(scale, torch.distributions.distribution.Distribution):
             # Distributions are not supported by TorchScript / JIT yet
             assert scale.batch_shape == torch.Size([])

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -470,7 +470,7 @@ class RandomScale(nn.Module):
                 Default: False
         """
         super().__init__()
-        assert mode in ["nearest", "bilinear", "bicubic", "area"]
+        assert mode not in ["linear", "trilinear"]
         if isinstance(scale, torch.distributions.distribution.Distribution):
             # Distributions are not supported by TorchScript / JIT yet
             assert scale.batch_shape == torch.Size([])

--- a/captum/optim/_param/image/transforms.py
+++ b/captum/optim/_param/image/transforms.py
@@ -181,6 +181,8 @@ class CenterCrop(torch.nn.Module):
     Center crop a specified amount from a tensor.
     """
 
+    __constants__ = ["crop_vals", "pixels_from_edges", "offset_left"]
+
     def __init__(
         self,
         size: IntSeqOrIntType = 0,
@@ -220,6 +222,7 @@ class CenterCrop(torch.nn.Module):
         )
 
 
+@torch.jit.ignore
 def center_crop(
     input: torch.Tensor,
     crop_vals: IntSeqOrIntType,
@@ -273,79 +276,140 @@ def center_crop(
     return x
 
 
-def _rand_select(
-    transform_values: NumSeqOrTensorType,
-) -> Union[int, float, torch.Tensor]:
-    """
-    Randomly return a single value from the provided tuple, list, or tensor.
-
-    Args:
-
-        transform_values (sequence):  A sequence of values to randomly select from.
-
-    Returns:
-        **value**:  A single value from the specified sequence.
-    """
-    n = torch.randint(low=0, high=len(transform_values), size=[1]).item()
-    return transform_values[n]
-
-
 class RandomScale(nn.Module):
     """
     Apply random rescaling on a NCHW tensor.
     """
 
-    def __init__(self, scale: NumSeqOrTensorType) -> None:
+    __constants__ = [
+        "scale",
+        "mode",
+        "padding_mode",
+        "align_corners",
+        "has_align_corners",
+    ]
+
+    def __init__(
+        self,
+        scale: NumSeqOrTensorType,
+        mode: str = "bilinear",
+        padding_mode: str = "zeros",
+        align_corners: bool = False,
+    ) -> None:
         """
         Args:
 
             scale (float, sequence): Tuple of rescaling values to randomly select from.
+            mode (str, optional): Interpolation mode to use. See documentation of
+                F.grid_sample for more details. One of; "bilinear", "nearest", or
+                "bicubic".
+                Default: "bilinear"
+            padding_mode (str, optional): Padding mode for values that fall outside of
+                the grid. See documentation of F.grid_sample for more details. One of;
+                "zeros", "border", or "reflection".
+                Default: "zeros"
+            align_corners (bool, optional): Whether or not to align corners. See
+                documentation of F.affine_grid & F.grid_sample for more details.
+                Default: False
         """
         super().__init__()
-        self.scale = scale
+        assert hasattr(scale, "__iter__")
+        if torch.is_tensor(scale):
+            assert cast(torch.Tensor, scale).dim() == 1
+            scale = scale.tolist()
+        assert len(scale) > 0
+        self.scale = [float(s) for s in scale]
+        self.mode = mode
+        self.padding_mode = padding_mode
+        self.align_corners = align_corners
+        self.has_align_corners = torch.__version__ >= "1.3.0"
 
-    def get_scale_mat(
-        self, m: IntSeqOrIntType, device: torch.device, dtype: torch.dtype
+    def _get_scale_mat(
+        self,
+        m: float,
+        device: torch.device,
+        dtype: torch.dtype,
     ) -> torch.Tensor:
+        """
+        Create a rotation matrix tensor.
+
+        Args:
+
+            m (float): The scale value to use.
+
+        Returns:
+            **scale_mat** (torch.Tensor): A scale matrix.
+        """
         scale_mat = torch.tensor(
             [[m, 0.0, 0.0], [0.0, m, 0.0]], device=device, dtype=dtype
         )
         return scale_mat
 
-    def scale_tensor(
-        self, x: torch.Tensor, scale: Union[int, float, torch.Tensor]
-    ) -> torch.Tensor:
-        scale_matrix = self.get_scale_mat(scale, x.device, x.dtype)[None, ...].repeat(
+    def _scale_tensor(self, x: torch.Tensor, scale: float) -> torch.Tensor:
+        """
+        Scale an NCHW image tensor based on a specified scale value.
+
+        Args:
+
+            x (torch.Tensor): The NCHW image tensor to scale.
+            scale (float): The amount to scale the NCHW image by.
+
+        Returns:
+            **x** (torch.Tensor): A scaled NCHW image tensor.
+        """
+        scale_matrix = self._get_scale_mat(scale, x.device, x.dtype)[None, ...].repeat(
             x.shape[0], 1, 1
         )
-        if torch.__version__ >= "1.3.0":
+        if self.has_align_corners:
             # Pass align_corners explicitly for torch >= 1.3.0
-            grid = F.affine_grid(scale_matrix, x.size(), align_corners=False)
-            x = F.grid_sample(x, grid, align_corners=False)
+            grid = F.affine_grid(
+                scale_matrix, x.size(), align_corners=self.align_corners
+            )
+            x = F.grid_sample(
+                x,
+                grid,
+                mode=self.mode,
+                padding_mode=self.padding_mode,
+                align_corners=self.align_corners,
+            )
         else:
             grid = F.affine_grid(scale_matrix, x.size())
-            x = F.grid_sample(x, grid)
+            x = F.grid_sample(x, grid, mode=self.mode, padding_mode=self.padding_mode)
         return x
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         """
-        Randomly scale / zoom in or out of a tensor.
+        Randomly scale / zoom in or out of an NCHW image tensor.
 
         Args:
 
-            input (torch.Tensor): Input to randomly scale.
+            input (torch.Tensor): NCHW image tensor to randomly scale.
 
         Returns:
-            **tensor** (torch.Tensor): Scaled *tensor*.
+            **tensor** (torch.Tensor): A randomly scaled NCHW image *tensor*.
         """
-        scale = _rand_select(self.scale)
-        return self.scale_tensor(input, scale=scale)
+        assert input.dim() == 4
+
+        n = int(
+            torch.randint(
+                low=0,
+                high=len(self.scale),
+                size=[1],
+                dtype=torch.int64,
+                layout=torch.strided,
+                device=input.device,
+            ).item()
+        )
+        scale = self.scale[n]
+        return self._scale_tensor(input, scale=scale)
 
 
 class RandomSpatialJitter(torch.nn.Module):
     """
     Apply random spatial translations on a NCHW tensor.
     """
+
+    __constants__ = ["pad_range"]
 
     def __init__(self, translate: int) -> None:
         """
@@ -380,7 +444,13 @@ class RandomSpatialJitter(torch.nn.Module):
         Returns:
             **tensor** (torch.Tensor): A randomly translated *tensor*.
         """
-        insets = torch.randint(high=self.pad_range, size=(2,))
+        insets = torch.randint(
+            high=self.pad_range,
+            size=(2,),
+            dtype=input.dtype,
+            layout=input.layout,
+            device=input.device,
+        )
         return self.translate_tensor(input, insets)
 
 
@@ -389,6 +459,8 @@ class ScaleInputRange(nn.Module):
     Multiplies the input by a specified multiplier for models with input ranges other
     than [0,1].
     """
+
+    __constants__ = ["multiplier"]
 
     def __init__(self, multiplier: float = 1.0) -> None:
         """
@@ -473,6 +545,8 @@ class GaussianSmoothing(nn.Module):
     1d, 2d or 3d tensor. Filtering is performed seperately for each channel
     in the input using a depthwise convolution.
     """
+
+    __constants__ = ["groups"]
 
     def __init__(
         self,
@@ -603,6 +677,8 @@ class NChannelsToRGB(nn.Module):
     Convert an NCHW image with n channels into a 3 channel RGB image.
     """
 
+    __constants__ = ["warp"]
+
     def __init__(self, warp: bool = False) -> None:
         """
         Args:
@@ -633,6 +709,8 @@ class RandomCrop(nn.Module):
     Randomly crop out a specific size from an NCHW image tensor.
     """
 
+    __constants__ = ["crop_size"]
+
     def __init__(
         self,
         crop_size: IntSeqOrIntType,
@@ -649,20 +727,50 @@ class RandomCrop(nn.Module):
         assert len(crop_size) == 2
         self.crop_size = crop_size
 
+    def _center_crop(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Center crop an NCHW image tensor based on self.crop_size.
+
+        Args:
+
+            x (torch.Tensor): The NCHW image tensor to center crop.
+
+        Returns
+            x (torch.Tensor): The center cropped NCHW image tensor.
+        """
+        h, w = x.shape[2:]
+        h_crop = h - int(math.ceil((h - self.crop_size[0]) / 2.0))
+        w_crop = w - int(math.ceil((w - self.crop_size[1]) / 2.0))
+        return x[
+            ...,
+            h_crop - self.crop_size[0] : h_crop,
+            w_crop - self.crop_size[1] : w_crop,
+        ]
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         assert x.dim() == 4
         hs = x.shape[2] - self.crop_size[0]
         ws = x.shape[3] - self.crop_size[1]
         shifts = [
-            torch.randint(low=-hs, high=hs, size=[1]),
-            torch.randint(low=-ws, high=ws, size=[1]),
+            torch.randint(
+                low=-hs,
+                high=hs,
+                size=[1],
+                dtype=torch.int64,
+                layout=torch.strided,
+                device=x.device,
+            ),
+            torch.randint(
+                low=-ws,
+                high=ws,
+                size=[1],
+                dtype=torch.int64,
+                layout=torch.strided,
+                device=x.device,
+            ),
         ]
-        x = torch.roll(x, shifts, dims=(2, 3))
-        return center_crop(
-            x,
-            crop_vals=self.crop_size,
-            pixels_from_edges=False,
-        )
+        x = torch.roll(x, [int(s) for s in shifts], dims=(2, 3))
+        return self._center_crop(x)
 
 
 __all__ = [

--- a/captum/optim/_utils/image/common.py
+++ b/captum/optim/_utils/image/common.py
@@ -110,6 +110,7 @@ def _dot_cossim(
     return dot * torch.clamp(torch.cosine_similarity(x, y, eps=eps), 0.1) ** cossim_pow
 
 
+@torch.jit.ignore
 def nchannels_to_rgb(x: torch.Tensor, warp: bool = True) -> torch.Tensor:
     """
     Convert an NCHW image with n channels into a 3 channel RGB image.

--- a/captum/optim/_utils/typing.py
+++ b/captum/optim/_utils/typing.py
@@ -1,7 +1,7 @@
 import sys
 from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
-from torch import Tensor
+from torch import Tensor, __version__
 from torch.nn import Module
 from torch.optim import Optimizer
 
@@ -33,6 +33,16 @@ StopCriteria = Callable[[int, Objective, Iterable[Tensor], Optimizer], bool]
 LossFunction = Callable[[ModuleOutputMapping], Tensor]
 SingleTargetLossFunction = Callable[[Tensor], Tensor]
 
-NumSeqOrTensorType = Union[Sequence[int], Sequence[float], Tensor]
+if __version__ < "1.4.0":
+    NumSeqOrTensorOrProbDistType = Union[Sequence[int], Sequence[float], Tensor]
+else:
+    from torch import distributions
+
+    NumSeqOrTensorOrProbDistType = Union[
+        Sequence[int],
+        Sequence[float],
+        Tensor,
+        distributions.distribution.Distribution,
+    ]
 IntSeqOrIntType = Union[List[int], Tuple[int], Tuple[int, int], int]
 TupleOfTensorsOrTensorType = Union[Tuple[Tensor, ...], Tensor]

--- a/tests/optim/helpers/numpy_transforms.py
+++ b/tests/optim/helpers/numpy_transforms.py
@@ -1,5 +1,5 @@
 import math
-from typing import List, Optional, Tuple, Union, cast
+from typing import List, Optional, Tuple, Union, cast, no_type_check
 
 import numpy as np
 
@@ -112,6 +112,7 @@ class CenterCrop:
         )
 
 
+@no_type_check
 def center_crop(
     input: np.ndarray,
     crop_vals: IntSeqOrIntType,

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -796,7 +796,7 @@ class TestNaturalImage(BaseTest):
         self.assertIsInstance(image_param.decorrelate, ToRGB)
         self.assertEqual(image_param.squash_func, torch.sigmoid)
 
-    def test_natural_image_init_func_fft_image(self) -> None:
+    def test_natural_image_init_func_fftimage(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(
                 "Skipping NaturalImage FFTImage init func test due to insufficient"
@@ -807,7 +807,20 @@ class TestNaturalImage(BaseTest):
         self.assertIsInstance(image_param.decorrelate, ToRGB)
         self.assertEqual(image_param.squash_func, torch.sigmoid)
 
-    def test_natural_image_init_func_pixel_image(self) -> None:
+    def test_natural_image_init_func_fftimage_instance(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping NaturalImage FFTImage init func FFTImage instance test due"
+                + " to insufficient Torch version."
+            )
+
+        fft_param = images.FFTImage(size=(4, 4))
+        image_param = images.NaturalImage(parameterization=fft_param)
+        self.assertIsInstance(image_param.parameterization, images.FFTImage)
+        self.assertIsInstance(image_param.decorrelate, ToRGB)
+        self.assertEqual(image_param.squash_func, torch.sigmoid)
+
+    def test_natural_image_init_func_pixelimage(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(
                 "Skipping NaturalImage PixelImage init func test due to insufficient"
@@ -831,7 +844,7 @@ class TestNaturalImage(BaseTest):
         self.assertIsInstance(image_param.decorrelate, ToRGB)
         self.assertEqual(image_param.squash_func, image_param._clamp_image)
 
-    def test_natural_image_init_tensor_pixel_image_sf_sigmoid(self) -> None:
+    def test_natural_image_init_tensor_pixelimage_sf_sigmoid(self) -> None:
         if torch.__version__ <= "1.8.0":
             raise unittest.SkipTest(
                 "Skipping NaturalImage PixelImage init tensor with sigmoid"
@@ -897,7 +910,7 @@ class TestNaturalImage(BaseTest):
         output_tensor = jit_image_param()
         assertTensorAlmostEqual(self, output_tensor, torch.ones_like(output_tensor))
 
-    def test_natural_image_jit_module_init_tensor_pixel_image(self) -> None:
+    def test_natural_image_jit_module_init_tensor_pixelimage(self) -> None:
         if torch.__version__ <= "1.8.0":
             raise unittest.SkipTest(
                 "Skipping NaturalImage PixelImage init tensor JIT module"

--- a/tests/optim/param/test_images.py
+++ b/tests/optim/param/test_images.py
@@ -6,7 +6,7 @@ import numpy as np
 import torch
 
 from captum.optim._param.image import images
-from captum.optim._param.image.transforms import SymmetricPadding
+from captum.optim._param.image.transforms import SymmetricPadding, ToRGB
 from tests.helpers.basic import (
     BaseTest,
     assertArraysAlmostEqual,
@@ -105,6 +105,127 @@ class TestFFTImage(BaseTest):
             torch.tensor([[0.0000, 0.3333], [0.5000, 0.6009]]),
         )
 
+    def test_irfftn(self) -> None:
+        size = (4, 4)
+        image = images.FFTImage(size)
+        test_fft_tensor = (
+            torch.arange(0, 1 * 1 * size[1] * size[0] * 2)
+            .view(1, 1, size[1], size[0], 2)
+            .float()
+        )
+
+        test_output = image.torch_irfft(test_fft_tensor)
+
+        if torch.__version__ >= "1.7.0":
+            # torch.fft.irfftn output
+            expected_tensor = torch.tensor(
+                [
+                    [
+                        [
+                            [14.0000, -8.5000, 0.0000, 6.5000],
+                            [0.0000, 4.0000, 0.0000, -4.0000],
+                            [-4.0000, 2.0000, 0.0000, -2.0000],
+                            [-8.0000, 0.0000, 0.0000, 0.0000],
+                        ]
+                    ]
+                ]
+            )
+            delta = 0.0001
+
+        else:
+            # torch.irfft output
+            expected_tensor = torch.tensor(
+                [
+                    [
+                        [
+                            [14.8571, -12.4554, 1.5140, -4.1097],
+                            [-1.2143, 3.7929, -1.7647, 0.2188],
+                            [-3.4286, 3.0750, 0.2962, 1.2880],
+                            [-6.7857, 1.2143, 1.2143, 1.2143],
+                        ]
+                    ]
+                ]
+            )
+            delta = 0.0004
+        assertTensorAlmostEqual(self, test_output, expected_tensor, delta=delta)
+
+    def test_init_spectrum_scale_init_tensor(self) -> None:
+        size = (4, 4)
+        image_param = images.FFTImage(init=torch.ones(1, 3, size[0], size[1]))
+        scale = torch.tensor(
+            [
+                [4.0000, 4.0000, 2.0000],
+                [4.0000, 2.8284, 1.7889],
+                [2.0000, 1.7889, 1.4142],
+                [4.0000, 2.8284, 1.7889],
+            ]
+        )
+        scale = scale * ((size[0] * size[1]) ** (1 / 2))
+        spectrum_scale = scale[None, :, :, None]
+        assertTensorAlmostEqual(
+            self, image_param.spectrum_scale, spectrum_scale, delta=0.0009
+        )
+
+    @unittest.skipIf(
+        torch.__version__ < "1.8.0",
+        "Skipping FFTImage fourier_coeffs with init"
+        + " tensor test due to newer Torch version.",
+    )
+    def test_init_fourier_coeffs_init_tensor_after_v1_7_0(self) -> None:
+        size = (4, 4)
+        init_tensor = torch.ones(1, 3, size[0], size[1])
+        image_param = images.FFTImage(init=init_tensor.clone())
+
+        torch_rfft_init = torch.view_as_real(torch.fft.rfftn(init_tensor, s=size))
+
+        scale = torch.tensor(
+            [
+                [4.0000, 4.0000, 2.0000],
+                [4.0000, 2.8284, 1.7889],
+                [2.0000, 1.7889, 1.4142],
+                [4.0000, 2.8284, 1.7889],
+            ]
+        )
+        scale = scale * ((size[0] * size[1]) ** (1 / 2))
+        spectrum_scale = scale[None, :, :, None]
+
+        fourier_coeffs = torch_rfft_init / spectrum_scale
+        assertTensorAlmostEqual(self, image_param.fourier_coeffs, fourier_coeffs)
+        self.assertTrue(image_param.fourier_coeffs.requires_grad)
+
+    @unittest.skipUnless(
+        torch.__version__ < "1.7.0",
+        "Skipping FFTImage fourier_coeffs with init"
+        + " tensor test due to newer Torch version.",
+    )
+    def test_init_fourier_coeffs_init_tensor_before_v1_7_0(self) -> None:
+        if torch.__version__ < "1.7.0":
+            raise unittest.SkipTest(
+                "Skipping FFTImage fourier_coeffs with init tensor test due to newer"
+                + " Torch version."
+            )
+
+        size = (4, 4)
+        init_tensor = torch.ones(1, 3, size[0], size[1])
+        image_param = images.FFTImage(init=init_tensor.clone())
+
+        torch_rfft_init = torch.rfft(init_tensor, signal_ndim=2)  # type: ignore
+
+        scale = torch.tensor(
+            [
+                [4.0000, 4.0000, 2.0000],
+                [4.0000, 2.8284, 1.7889],
+                [2.0000, 1.7889, 1.4142],
+                [4.0000, 2.8284, 1.7889],
+            ]
+        )
+        scale = scale * ((size[0] * size[1]) ** (1 / 2))
+        spectrum_scale = scale[None, :, :, None]
+
+        fourier_coeffs = torch_rfft_init * spectrum_scale
+        assertTensorAlmostEqual(self, image_param.fourier_coeffs, fourier_coeffs)
+        self.assertTrue(image_param.fourier_coeffs.requires_grad)
+
     def test_fftimage_forward_randn_init(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(
@@ -117,8 +238,19 @@ class TestFFTImage(BaseTest):
 
         fftimage_tensor = fftimage.forward()
         fftimage_array = fftimage_np.forward()
-
+        self.assertEqual(fftimage.size, (224, 224))
         self.assertEqual(fftimage_tensor.detach().numpy().shape, fftimage_array.shape)
+        self.assertTrue(fftimage.fourier_coeffs.requires_grad)
+
+    def test_fftimage_forward_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping FFTImage JIT module test due to insufficient Torch version."
+            )
+        fftimage = images.FFTImage(size=(224, 224))
+        jit_fftimage = torch.jit.script(fftimage)
+        fftimage_tensor = jit_fftimage()
+        self.assertTrue(torch.is_tensor(fftimage_tensor))
 
     def test_fftimage_forward_init_randn_batch(self) -> None:
         if torch.__version__ <= "1.2.0":
@@ -177,6 +309,7 @@ class TestFFTImage(BaseTest):
         fftimage_tensor = fftimage.forward()
         fftimage_array = fftimage_np.forward()
 
+        self.assertEqual(fftimage.size, (224, 224))
         self.assertEqual(fftimage_tensor.detach().numpy().shape, fftimage_array.shape)
         assertArraysAlmostEqual(fftimage_tensor.detach().numpy(), fftimage_array, 25.0)
 
@@ -195,6 +328,7 @@ class TestFFTImage(BaseTest):
         fftimage_tensor = fftimage.forward()
         fftimage_array = fftimage_np.forward()
 
+        self.assertEqual(fftimage.size, (224, 224))
         self.assertEqual(fftimage_tensor.detach().numpy().shape, fftimage_array.shape)
         assertArraysAlmostEqual(fftimage_tensor.detach().numpy(), fftimage_array, 25.0)
 
@@ -214,6 +348,7 @@ class TestFFTImage(BaseTest):
         fftimage_tensor = fftimage.forward()
         fftimage_array = fftimage_np.forward()
 
+        self.assertEqual(fftimage.size, (224, 224))
         self.assertEqual(fftimage_tensor.detach().numpy().shape, fftimage_array.shape)
         assertArraysAlmostEqual(fftimage_tensor.detach().numpy(), fftimage_array, 25.0)
 
@@ -233,6 +368,7 @@ class TestPixelImage(BaseTest):
         self.assertEqual(image_param.image.size(1), channels)
         self.assertEqual(image_param.image.size(2), size[0])
         self.assertEqual(image_param.image.size(3), size[1])
+        self.assertTrue(image_param.image.requires_grad)
 
     def test_pixelimage_init(self) -> None:
         if torch.__version__ <= "1.2.0":
@@ -250,6 +386,7 @@ class TestPixelImage(BaseTest):
         self.assertEqual(image_param.image.size(2), size[0])
         self.assertEqual(image_param.image.size(3), size[1])
         assertTensorAlmostEqual(self, image_param.image, init_tensor, 0)
+        self.assertTrue(image_param.image.requires_grad)
 
     def test_pixelimage_init_error(self) -> None:
         if torch.__version__ <= "1.2.0":
@@ -277,6 +414,17 @@ class TestPixelImage(BaseTest):
         self.assertEqual(test_tensor.size(1), channels)
         self.assertEqual(test_tensor.size(2), size[0])
         self.assertEqual(test_tensor.size(3), size[1])
+
+    def test_pixelimage_forward_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping PixelImage JIT module test due to insufficient Torch"
+                + " version."
+            )
+        image_param = images.PixelImage(size=(224, 224), channels=3)
+        jit_image_param = torch.jit.script(image_param)
+        output_tensor = jit_image_param()
+        self.assertTrue(torch.is_tensor(output_tensor))
 
     def test_pixelimage_init_forward(self) -> None:
         if torch.__version__ <= "1.2.0":
@@ -637,6 +785,70 @@ class TestSharedImage(BaseTest):
 
 
 class TestNaturalImage(BaseTest):
+    def test_natural_image_init_func_default(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping NaturalImage FFTImage init func test due to insufficient"
+                + " Torch version."
+            )
+        image_param = images.NaturalImage(size=(4, 4))
+        self.assertIsInstance(image_param.parameterization, images.FFTImage)
+        self.assertIsInstance(image_param.decorrelate, ToRGB)
+        self.assertEqual(image_param.squash_func, torch.sigmoid)
+
+    def test_natural_image_init_func_fft_image(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping NaturalImage FFTImage init func test due to insufficient"
+                + " Torch version."
+            )
+        image_param = images.NaturalImage(size=(4, 4), parameterization=images.FFTImage)
+        self.assertIsInstance(image_param.parameterization, images.FFTImage)
+        self.assertIsInstance(image_param.decorrelate, ToRGB)
+        self.assertEqual(image_param.squash_func, torch.sigmoid)
+
+    def test_natural_image_init_func_pixel_image(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping NaturalImage PixelImage init func test due to insufficient"
+                + " Torch version."
+            )
+        image_param = images.NaturalImage(
+            size=(4, 4), parameterization=images.PixelImage
+        )
+        self.assertIsInstance(image_param.parameterization, images.PixelImage)
+        self.assertIsInstance(image_param.decorrelate, ToRGB)
+        self.assertEqual(image_param.squash_func, torch.sigmoid)
+
+    def test_natural_image_init_func_default_init_tensor(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping NaturalImage FFTImage init func test due to insufficient"
+                + " Torch version."
+            )
+        image_param = images.NaturalImage(init=torch.ones(1, 3, 1, 1))
+        self.assertIsInstance(image_param.parameterization, images.FFTImage)
+        self.assertIsInstance(image_param.decorrelate, ToRGB)
+        self.assertEqual(image_param.squash_func, image_param._clamp_image)
+
+    def test_natural_image_init_tensor_pixel_image_sf_sigmoid(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping NaturalImage PixelImage init tensor with sigmoid"
+                + " test due to insufficient Torch version."
+            )
+        image_param = images.NaturalImage(
+            init=torch.ones(1, 3, 1, 1),
+            parameterization=images.PixelImage,
+            squash_func=torch.sigmoid,
+        )
+        output_tensor = image_param()
+
+        self.assertEqual(image_param.squash_func, torch.sigmoid)
+        assertTensorAlmostEqual(
+            self, output_tensor, torch.ones_like(output_tensor) * 0.7310586
+        )
+
     def test_natural_image_0(self) -> None:
         if torch.__version__ <= "1.2.0":
             raise unittest.SkipTest(
@@ -663,6 +875,41 @@ class TestNaturalImage(BaseTest):
         image_param = images.NaturalImage().cuda()
         self.assertTrue(image_param().is_cuda)
 
+    def test_natural_image_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping NaturalImage JIT module test due to"
+                + " insufficient Torch version."
+            )
+        image_param = images.NaturalImage()
+        jit_image_param = torch.jit.script(image_param)
+        output_tensor = jit_image_param()
+        self.assertTrue(torch.is_tensor(output_tensor))
+
+    def test_natural_image_jit_module_init_tensor(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping NaturalImage init tensor JIT module test due to"
+                + " insufficient Torch version."
+            )
+        image_param = images.NaturalImage(init=torch.ones(1, 3, 1, 1))
+        jit_image_param = torch.jit.script(image_param)
+        output_tensor = jit_image_param()
+        assertTensorAlmostEqual(self, output_tensor, torch.ones_like(output_tensor))
+
+    def test_natural_image_jit_module_init_tensor_pixel_image(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping NaturalImage PixelImage init tensor JIT module"
+                + " test due to insufficient Torch version."
+            )
+        image_param = images.NaturalImage(
+            init=torch.ones(1, 3, 1, 1), parameterization=images.PixelImage
+        )
+        jit_image_param = torch.jit.script(image_param)
+        output_tensor = jit_image_param()
+        assertTensorAlmostEqual(self, output_tensor, torch.ones_like(output_tensor))
+
     def test_natural_image_decorrelation_module_none(self) -> None:
         if torch.__version__ <= "1.3.0":
             raise unittest.SkipTest(
@@ -672,4 +919,5 @@ class TestNaturalImage(BaseTest):
             init=torch.ones(1, 3, 4, 4), decorrelation_module=None
         )
         image = image_param.forward().detach()
+        self.assertIsNone(image_param.decorrelate)
         assertTensorAlmostEqual(self, image, torch.ones_like(image))

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1173,7 +1173,7 @@ class TestToRGB(BaseTest):
                 "Skipping ToRGB forward due to insufficient Torch version."
             )
         to_rgb = transforms.ToRGB(transform="klt")
-        test_tensor = torch.ones(3, 4, 4).unsqueeze(0).refine_names("B", "C", "H", "W")
+        test_tensor = torch.ones(1, 3, 4, 4).refine_names("B", "C", "H", "W")
         rgb_tensor = to_rgb(test_tensor)
 
         r = torch.ones(4, 4) * 0.8009
@@ -1182,6 +1182,7 @@ class TestToRGB(BaseTest):
         expected_rgb_tensor = torch.stack([r, g, b]).unsqueeze(0)
 
         assertTensorAlmostEqual(self, rgb_tensor, expected_rgb_tensor, 0.002)
+        self.assertEqual(list(rgb_tensor.names), ["B", "C", "H", "W"])
 
         inverse_tensor = to_rgb(rgb_tensor.clone(), inverse=True)
         assertTensorAlmostEqual(
@@ -1194,7 +1195,7 @@ class TestToRGB(BaseTest):
                 "Skipping ToRGB with Alpha forward due to insufficient Torch version."
             )
         to_rgb = transforms.ToRGB(transform="klt")
-        test_tensor = torch.ones(4, 4, 4).unsqueeze(0).refine_names("B", "C", "H", "W")
+        test_tensor = torch.ones(1, 4, 4, 4).refine_names("B", "C", "H", "W")
         rgb_tensor = to_rgb(test_tensor)
 
         r = torch.ones(4, 4) * 0.8009
@@ -1204,6 +1205,7 @@ class TestToRGB(BaseTest):
         expected_rgb_tensor = torch.stack([r, g, b, a]).unsqueeze(0)
 
         assertTensorAlmostEqual(self, rgb_tensor, expected_rgb_tensor, 0.002)
+        self.assertEqual(list(rgb_tensor.names), ["B", "C", "H", "W"])
 
         inverse_tensor = to_rgb(rgb_tensor.clone(), inverse=True)
         assertTensorAlmostEqual(
@@ -1227,6 +1229,52 @@ class TestToRGB(BaseTest):
         expected_rgb_tensor = torch.stack([r, g, b, a])
 
         assertTensorAlmostEqual(self, rgb_tensor, expected_rgb_tensor, 0.002)
+        self.assertEqual(list(rgb_tensor.names), ["C", "H", "W"])
+
+        inverse_tensor = to_rgb(rgb_tensor.clone(), inverse=True)
+        assertTensorAlmostEqual(
+            self, inverse_tensor, torch.ones_like(inverse_tensor.rename(None))
+        )
+
+    def test_to_rgb_klt_forward_no_named_dims(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping ToRGB forward due to insufficient Torch version."
+            )
+        to_rgb = transforms.ToRGB(transform="klt")
+        test_tensor = torch.ones(1, 3, 4, 4)
+        rgb_tensor = to_rgb(test_tensor)
+
+        r = torch.ones(4, 4) * 0.8009
+        g = torch.ones(4, 4) * 0.4762
+        b = torch.ones(4, 4) * 0.4546
+        expected_rgb_tensor = torch.stack([r, g, b]).unsqueeze(0)
+
+        assertTensorAlmostEqual(self, rgb_tensor, expected_rgb_tensor, 0.002)
+        self.assertEqual(list(rgb_tensor.names), [None] * 4)
+
+        inverse_tensor = to_rgb(rgb_tensor.clone(), inverse=True)
+        assertTensorAlmostEqual(
+            self, inverse_tensor, torch.ones_like(inverse_tensor.rename(None))
+        )
+
+    def test_to_rgb_alpha_klt_forward_no_named_dims(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping ToRGB with Alpha forward due to insufficient Torch version."
+            )
+        to_rgb = transforms.ToRGB(transform="klt")
+        test_tensor = torch.ones(1, 4, 4, 4)
+        rgb_tensor = to_rgb(test_tensor)
+
+        r = torch.ones(4, 4) * 0.8009
+        g = torch.ones(4, 4) * 0.4762
+        b = torch.ones(4, 4) * 0.4546
+        a = torch.ones(4, 4)
+        expected_rgb_tensor = torch.stack([r, g, b, a]).unsqueeze(0)
+
+        assertTensorAlmostEqual(self, rgb_tensor, expected_rgb_tensor, 0.002)
+        self.assertEqual(list(rgb_tensor.names), [None] * 4)
 
         inverse_tensor = to_rgb(rgb_tensor.clone(), inverse=True)
         assertTensorAlmostEqual(
@@ -1239,7 +1287,7 @@ class TestToRGB(BaseTest):
                 "Skipping ToRGB forward due to insufficient Torch version."
             )
         to_rgb = transforms.ToRGB(transform="i1i2i3")
-        test_tensor = torch.ones(3, 4, 4).unsqueeze(0).refine_names("B", "C", "H", "W")
+        test_tensor = torch.ones(1, 3, 4, 4).refine_names("B", "C", "H", "W")
         rgb_tensor = to_rgb(test_tensor)
 
         r = torch.ones(4, 4)
@@ -1260,7 +1308,7 @@ class TestToRGB(BaseTest):
                 "Skipping ToRGB with Alpha forward due to insufficient Torch version."
             )
         to_rgb = transforms.ToRGB(transform="i1i2i3")
-        test_tensor = torch.ones(4, 4, 4).unsqueeze(0).refine_names("B", "C", "H", "W")
+        test_tensor = torch.ones(1, 4, 4, 4).refine_names("B", "C", "H", "W")
         rgb_tensor = to_rgb(test_tensor)
 
         r = torch.ones(4, 4)
@@ -1283,7 +1331,7 @@ class TestToRGB(BaseTest):
             )
         matrix = torch.eye(3, 3)
         to_rgb = transforms.ToRGB(transform=matrix)
-        test_tensor = torch.ones(3, 4, 4).unsqueeze(0).refine_names("B", "C", "H", "W")
+        test_tensor = torch.ones(1, 3, 4, 4).refine_names("B", "C", "H", "W")
         rgb_tensor = to_rgb(test_tensor)
 
         to_rgb_np = numpy_transforms.ToRGB(transform=matrix.numpy())
@@ -1305,7 +1353,7 @@ class TestToRGB(BaseTest):
             )
         to_rgb = transforms.ToRGB(transform="klt")
         jit_to_rgb = torch.jit.script(to_rgb)
-        test_tensor = torch.ones(3, 4, 4).unsqueeze(0)
+        test_tensor = torch.ones(1, 3, 4, 4)
         rgb_tensor = jit_to_rgb(test_tensor)
 
         r = torch.ones(4, 4) * 0.8009

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -1898,9 +1898,9 @@ class TestTransformationRobustness(BaseTest):
         for module in transform_robustness.jitter_transforms:
             self.assertIsInstance(module, transforms.RandomSpatialJitter)
         self.assertIsInstance(transform_robustness.random_scale, transforms.RandomScale)
-        # self.assertIsInstance(
-        #    transform_robustness.random_rotation, transforms.RandomRotation
-        # )
+        self.assertIsInstance(
+            transform_robustness.random_rotation, transforms.RandomRotation
+        )
         self.assertIsInstance(
             transform_robustness.final_jitter, transforms.RandomSpatialJitter
         )
@@ -1919,13 +1919,11 @@ class TestTransformationRobustness(BaseTest):
             0.998 ** n for n in 2 * list(range(20, 40))
         ]
         self.assertEqual(transform_robustness.random_scale.scale, expected_scale)
-        # expected_degrees = (
-        #    list(range(-20, 20)) + list(range(-10, 10)) + list(range(-5, 5)) + 5 * [0]
-        # )
-        # expected_degrees = [float(d) for d in expected_degrees]
-        # self.assertEqual(
-        #    transform_robustness.random_rotation.degrees, test_expected_degrees
-        # )
+        expected_degrees = (
+            list(range(-20, 20)) + list(range(-10, 10)) + list(range(-5, 5)) + 5 * [0]
+        )
+        expected_degrees = [float(d) for d in expected_degrees]
+        self.assertEqual(transform_robustness.random_rotation.degrees, expected_degrees)
 
         self.assertEqual(transform_robustness.final_jitter.pad_range, 2 * 2)
 

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -166,6 +166,11 @@ class TestRandomScale(BaseTest):
         )
 
     def test_random_scale_forward_exact_align_corners(self) -> None:
+        if torch.__version__ <= "1.2.0":
+            raise unittest.SkipTest(
+                "Skipping RandomScale exact align corners forward due to"
+                + " insufficient Torch version."
+            )
         scale_module = transforms.RandomScale(scale=[0.5], align_corners=True)
         self.assertTrue(scale_module.align_corners)
 
@@ -1300,7 +1305,7 @@ class TestToRGB(BaseTest):
             )
         to_rgb = transforms.ToRGB(transform="klt")
         jit_to_rgb = torch.jit.script(to_rgb)
-        test_tensor = torch.ones(3, 4, 4).unsqueeze(0).refine_names("B", "C", "H", "W")
+        test_tensor = torch.ones(3, 4, 4).unsqueeze(0)
         rgb_tensor = jit_to_rgb(test_tensor)
 
         r = torch.ones(4, 4) * 0.8009

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -513,6 +513,11 @@ class TestCenterCrop(BaseTest):
         assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
 
     def test_center_crop_padding_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping CenterCrop padding JIT module test due to insufficient"
+                + " Torch version."
+            )
         test_tensor = torch.arange(0, 1 * 1 * 4 * 4).view(1, 1, 4, 4).float()
         crop_vals = [6, 6]
 
@@ -715,6 +720,11 @@ class TestCenterCropFunction(BaseTest):
         assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
 
     def test_center_crop_padding_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping center_crop padding JIT module test due to insufficient"
+                + " Torch version."
+            )
         test_tensor = torch.arange(0, 1 * 1 * 4 * 4).view(1, 1, 4, 4).float()
         crop_vals = [6, 6]
 

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -15,15 +15,6 @@ from tests.helpers.basic import (
 from tests.optim.helpers import numpy_transforms
 
 
-class TestRandSelect(BaseTest):
-    def test_rand_select(self) -> None:
-        a = (1, 2, 3, 4, 5)
-        b = torch.Tensor([0.1, -5, 56.7, 99.0])
-
-        self.assertIn(transforms._rand_select(a), a)
-        self.assertIn(transforms._rand_select(b), b)
-
-
 class TestRandomScale(BaseTest):
     def test_random_scale(self) -> None:
         scale_module = transforms.RandomScale(scale=(1, 0.975, 1.025, 0.95, 1.05))
@@ -32,14 +23,14 @@ class TestRandomScale(BaseTest):
         # Test rescaling
         assertTensorAlmostEqual(
             self,
-            scale_module.scale_tensor(test_tensor, 0.5),
+            scale_module._scale_tensor(test_tensor, 0.5),
             torch.ones(3, 1).repeat(3, 1, 3).unsqueeze(0),
             0,
         )
 
         assertTensorAlmostEqual(
             self,
-            scale_module.scale_tensor(test_tensor, 1.5),
+            scale_module._scale_tensor(test_tensor, 1.5),
             torch.tensor(
                 [
                     [0.2500, 0.5000, 0.2500],
@@ -59,15 +50,40 @@ class TestRandomScale(BaseTest):
 
         assertTensorAlmostEqual(
             self,
-            scale_module.get_scale_mat(0.5, test_tensor.device, test_tensor.dtype),
+            scale_module._get_scale_mat(0.5, test_tensor.device, test_tensor.dtype),
             torch.tensor([[0.5000, 0.0000, 0.0000], [0.0000, 0.5000, 0.0000]]),
             0,
         )
 
         assertTensorAlmostEqual(
             self,
-            scale_module.get_scale_mat(1.24, test_tensor.device, test_tensor.dtype),
+            scale_module._get_scale_mat(1.24, test_tensor.device, test_tensor.dtype),
             torch.tensor([[1.2400, 0.0000, 0.0000], [0.0000, 1.2400, 0.0000]]),
+            0,
+        )
+
+    def test_random_scale_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping RandomScale JIT module test due to insufficient"
+                + " Torch version."
+            )
+        scale_module = transforms.RandomScale(scale=[1.5])
+        jit_scale_module = torch.jit.script(scale_module)
+        test_tensor = torch.ones(1, 3, 3, 3)
+
+        assertTensorAlmostEqual(
+            self,
+            jit_scale_module(test_tensor),
+            torch.tensor(
+                [
+                    [0.2500, 0.5000, 0.2500],
+                    [0.5000, 1.0000, 0.5000],
+                    [0.2500, 0.5000, 0.2500],
+                ]
+            )
+            .repeat(3, 1, 1)
+            .unsqueeze(0),
             0,
         )
 
@@ -123,6 +139,28 @@ class TestRandomSpatialJitter(BaseTest):
         assertArraysAlmostEqual(jittered_tensor[0].numpy(), jittered_array, 0)
         assertArraysAlmostEqual(jittered_tensor[1].numpy(), jittered_array, 0)
         assertArraysAlmostEqual(jittered_tensor[2].numpy(), jittered_array, 0)
+
+    def test_random_spatial_jitter_forward(self) -> None:
+        t_val = 3
+
+        spatialjitter = transforms.RandomSpatialJitter(t_val)
+        test_input = torch.eye(4, 4).repeat(3, 1, 1).unsqueeze(0)
+        jittered_tensor = spatialjitter(test_input)
+        self.assertEqual(list(jittered_tensor.shape), list(test_input.shape))
+
+    def test_random_spatial_jitter_forward_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping RandomSpatialJitter JIT module test due to insufficient"
+                + " Torch version."
+            )
+        t_val = 3
+
+        spatialjitter = transforms.RandomSpatialJitter(t_val)
+        jit_spatialjitter = torch.jit.script(spatialjitter)
+        test_input = torch.eye(4, 4).repeat(3, 1, 1).unsqueeze(0)
+        jittered_tensor = jit_spatialjitter(test_input)
+        self.assertEqual(list(jittered_tensor.shape), list(test_input.shape))
 
 
 class TestCenterCrop(BaseTest):
@@ -242,6 +280,35 @@ class TestCenterCrop(BaseTest):
         cropped_tensor = crop_mod(px)
         assertTensorAlmostEqual(self, x, cropped_tensor)
 
+    def test_center_crop_one_number_exact_jit_module(self) -> None:
+        pad = (1, 1, 1, 1)
+        test_tensor = (
+            F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
+            .repeat(3, 1, 1)
+            .unsqueeze(0)
+        )
+
+        crop_vals = 5
+
+        crop_tensor = transforms.CenterCrop(crop_vals, False)
+        jit_crop_tensor = torch.jit.script(crop_tensor)
+        cropped_tensor = jit_crop_tensor(test_tensor)
+        expected_tensor = torch.stack(
+            [
+                torch.tensor(
+                    [
+                        [1.0, 1.0, 1.0, 1.0, 1.0],
+                        [1.0, 0.0, 0.0, 0.0, 0.0],
+                        [1.0, 0.0, 1.0, 1.0, 0.0],
+                        [1.0, 0.0, 1.0, 1.0, 0.0],
+                        [1.0, 0.0, 0.0, 0.0, 0.0],
+                    ]
+                )
+            ]
+            * 3
+        ).unsqueeze(0)
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
+
 
 class TestCenterCropFunction(BaseTest):
     def test_center_crop_one_number(self) -> None:
@@ -353,6 +420,39 @@ class TestCenterCropFunction(BaseTest):
         )
         assertTensorAlmostEqual(self, x, cropped_tensor)
 
+    def test_center_crop_one_number_exact_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping center_crop JIT module test due to insufficient"
+                + " Torch version."
+            )
+        pad = (1, 1, 1, 1)
+        test_tensor = (
+            F.pad(F.pad(torch.ones(2, 2), pad=pad), pad=pad, value=1)
+            .repeat(3, 1, 1)
+            .unsqueeze(0)
+        )
+
+        crop_vals = 5
+
+        jit_center_crop = transforms.center_crop
+        cropped_tensor = jit_center_crop(test_tensor, crop_vals, False)
+        expected_tensor = torch.stack(
+            [
+                torch.tensor(
+                    [
+                        [1.0, 1.0, 1.0, 1.0, 1.0],
+                        [1.0, 0.0, 0.0, 0.0, 0.0],
+                        [1.0, 0.0, 1.0, 1.0, 0.0],
+                        [1.0, 0.0, 1.0, 1.0, 0.0],
+                        [1.0, 0.0, 0.0, 0.0, 0.0],
+                    ]
+                )
+            ]
+            * 3
+        ).unsqueeze(0)
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
+
 
 class TestBlendAlpha(BaseTest):
     def test_blend_alpha(self) -> None:
@@ -374,12 +474,49 @@ class TestBlendAlpha(BaseTest):
 
         assertArraysAlmostEqual(blended_tensor.numpy(), blended_array, 0)
 
+    def test_blend_alpha_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping BlendAlpha JIT module test due to insufficient"
+                + " Torch version."
+            )
+        rgb_tensor = torch.ones(3, 3, 3)
+        alpha_tensor = ((torch.eye(3, 3) + torch.eye(3, 3).flip(1)) / 2).repeat(1, 1, 1)
+        test_tensor = torch.cat([rgb_tensor, alpha_tensor]).unsqueeze(0)
+
+        background_tensor = torch.ones_like(rgb_tensor) * 5
+        blend_alpha = transforms.BlendAlpha(background=background_tensor)
+        jit_blend_alpha = torch.jit.script(blend_alpha)
+        blended_tensor = jit_blend_alpha(test_tensor)
+
+        rgb_array = np.ones((3, 3, 3))
+        alpha_array = (np.add(np.eye(3, 3), np.flip(np.eye(3, 3), 1)) / 2)[None, :]
+        test_array = np.concatenate([rgb_array, alpha_array])[None, :]
+
+        background_array = np.ones(rgb_array.shape) * 5
+        blend_alpha_np = numpy_transforms.BlendAlpha(background=background_array)
+        blended_array = blend_alpha_np.blend_alpha(test_array)
+
+        assertArraysAlmostEqual(blended_tensor.numpy(), blended_array, 0)
+
 
 class TestIgnoreAlpha(BaseTest):
     def test_ignore_alpha(self) -> None:
         ignore_alpha = transforms.IgnoreAlpha()
         test_input = torch.ones(1, 4, 3, 3)
         rgb_tensor = ignore_alpha(test_input)
+        assert rgb_tensor.size(1) == 3
+
+    def test_ignore_alpha_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping IgnoreAlpha JIT module test due to insufficient"
+                + " Torch version."
+            )
+        ignore_alpha = transforms.IgnoreAlpha()
+        jit_ignore_alpha = torch.jit.script(ignore_alpha)
+        test_input = torch.ones(1, 4, 3, 3)
+        rgb_tensor = jit_ignore_alpha(test_input)
         assert rgb_tensor.size(1) == 3
 
 
@@ -562,6 +699,29 @@ class TestGaussianSmoothing(BaseTest):
         self.assertLessEqual(t_max, 4.8162e-05)
         self.assertGreaterEqual(t_min, 3.3377e-06)
 
+    def test_gaussian_smoothing_2d_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping GaussianSmoothing 2D JIT module test due to insufficient"
+                + " Torch version."
+            )
+        channels = 3
+        kernel_size = 3
+        sigma = 2.0
+        dim = 2
+        smoothening_module = transforms.GaussianSmoothing(
+            channels, kernel_size, sigma, dim
+        )
+        jit_smoothening_module = torch.jit.script(smoothening_module)
+
+        test_tensor = torch.tensor([1.0, 5.0]).repeat(3, 6, 3).unsqueeze(0)
+
+        diff_tensor = jit_smoothening_module(test_tensor) - torch.tensor(
+            [2.4467, 3.5533]
+        ).repeat(3, 4, 2).unsqueeze(0)
+        self.assertLessEqual(diff_tensor.max().item(), 4.5539e-05)
+        self.assertGreaterEqual(diff_tensor.min().item(), -4.5539e-05)
+
 
 class TestScaleInputRange(BaseTest):
     def test_scale_input_range(self) -> None:
@@ -570,12 +730,37 @@ class TestScaleInputRange(BaseTest):
         output_tensor = scale_input(x)
         self.assertEqual(output_tensor.mean(), 255.0)
 
+    def test_scale_input_range_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping ScaleInputRange JIT module test due to insufficient"
+                + " Torch version."
+            )
+        x = torch.ones(1, 3, 4, 4)
+        scale_input = transforms.ScaleInputRange(255)
+        jit_scale_input = torch.jit.script(scale_input)
+        output_tensor = jit_scale_input(x)
+        self.assertEqual(output_tensor.mean(), 255.0)
+
 
 class TestRGBToBGR(BaseTest):
     def test_rgb_to_bgr(self) -> None:
         x = torch.randn(1, 3, 224, 224)
         rgb_to_bgr = transforms.RGBToBGR()
         output_tensor = rgb_to_bgr(x)
+        expected_x = x[:, [2, 1, 0]]
+        assertTensorAlmostEqual(self, output_tensor, expected_x)
+
+    def test_rgb_to_bgr_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping RGBToBGR JIT module test due to insufficient"
+                + " Torch version."
+            )
+        x = torch.randn(1, 3, 224, 224)
+        rgb_to_bgr = transforms.RGBToBGR()
+        jit_rgb_to_bgr = torch.jit.script(rgb_to_bgr)
+        output_tensor = jit_rgb_to_bgr(x)
         expected_x = x[:, [2, 1, 0]]
         assertTensorAlmostEqual(self, output_tensor, expected_x)
 
@@ -640,13 +825,49 @@ class TestNChannelsToRGB(BaseTest):
         test_output = nchannels_to_rgb(test_input)
         self.assertEqual(list(test_output.size()), [1, 3, 224, 224])
 
+    def test_nchannels_to_rgb_collapse_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping NChannelsToRGB collapse JIT module test due to insufficient"
+                + " Torch version."
+            )
+        test_input = torch.randn(1, 6, 224, 224)
+        nchannels_to_rgb = transforms.NChannelsToRGB()
+        jit_nchannels_to_rgb = torch.jit.script(nchannels_to_rgb)
+        test_output = jit_nchannels_to_rgb(test_input)
+        self.assertEqual(list(test_output.size()), [1, 3, 224, 224])
+
 
 class TestRandomCrop(BaseTest):
+    def test_random_crop_center_crop(self) -> None:
+        crop_size = [160, 160]
+        crop_transform = transforms.RandomCrop(crop_size=crop_size)
+        x = torch.ones(1, 4, 224, 224)
+
+        x_out = crop_transform._center_crop(x)
+
+        self.assertEqual(list(x_out.shape), [1, 4, 160, 160])
+
     def test_random_crop(self) -> None:
         crop_size = [160, 160]
         crop_transform = transforms.RandomCrop(crop_size=crop_size)
         x = torch.ones(1, 4, 224, 224)
 
         x_out = crop_transform(x)
+
+        self.assertEqual(list(x_out.shape), [1, 4, 160, 160])
+
+    def test_random_crop_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping RandomCrop JIT module test due to insufficient"
+                + " Torch version."
+            )
+        crop_size = [160, 160]
+        crop_transform = transforms.RandomCrop(crop_size=crop_size)
+        jit_crop_transform = torch.jit.script(crop_transform)
+        x = torch.ones(1, 4, 224, 224)
+
+        x_out = jit_crop_transform(x)
 
         self.assertEqual(list(x_out.shape), [1, 4, 160, 160])

--- a/tests/optim/param/test_transforms.py
+++ b/tests/optim/param/test_transforms.py
@@ -437,6 +437,47 @@ class TestCenterCrop(BaseTest):
         cropped_tensor = crop_mod(px)
         assertTensorAlmostEqual(self, x, cropped_tensor)
 
+    def test_center_crop_padding(self) -> None:
+        test_tensor = torch.arange(0, 1 * 1 * 4 * 4).view(1, 1, 4, 4).float()
+        crop_vals = [6, 6]
+
+        center_crop_module = transforms.CenterCrop(crop_vals, offset_left=False)
+        cropped_tensor = center_crop_module(test_tensor)
+
+        expected_tensor = torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 2.0, 3.0, 0.0],
+                [0.0, 4.0, 5.0, 6.0, 7.0, 0.0],
+                [0.0, 8.0, 9.0, 10.0, 11.0, 0.0],
+                [0.0, 12.0, 13.0, 14.0, 15.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ]
+        )
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
+
+    def test_center_crop_padding_prime_num_pad(self) -> None:
+        test_tensor = torch.arange(0, 1 * 1 * 3 * 3).view(1, 1, 3, 3).float()
+        crop_vals = [6, 6]
+
+        center_crop_module = transforms.CenterCrop(crop_vals, offset_left=False)
+
+        cropped_tensor = center_crop_module(test_tensor)
+
+        expected_tensor = torch.nn.functional.pad(test_tensor, [2, 1, 2, 1])
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
+
+    def test_center_crop_padding_prime_num_pad_offset_left(self) -> None:
+        test_tensor = torch.arange(0, 1 * 1 * 3 * 3).view(1, 1, 3, 3).float()
+        crop_vals = [6, 6]
+
+        center_crop_module = transforms.CenterCrop(crop_vals, offset_left=True)
+
+        cropped_tensor = center_crop_module(test_tensor)
+
+        expected_tensor = torch.nn.functional.pad(test_tensor, [1, 2, 1, 2])
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
+
     def test_center_crop_one_number_exact_jit_module(self) -> None:
         if torch.__version__ <= "1.8.0":
             raise unittest.SkipTest(
@@ -469,6 +510,26 @@ class TestCenterCrop(BaseTest):
             ]
             * 3
         ).unsqueeze(0)
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
+
+    def test_center_crop_padding_jit_module(self) -> None:
+        test_tensor = torch.arange(0, 1 * 1 * 4 * 4).view(1, 1, 4, 4).float()
+        crop_vals = [6, 6]
+
+        center_crop_module = transforms.CenterCrop(crop_vals, offset_left=False)
+        jit_center_crop = torch.jit.script(center_crop_module)
+        cropped_tensor = jit_center_crop(test_tensor)
+
+        expected_tensor = torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 2.0, 3.0, 0.0],
+                [0.0, 4.0, 5.0, 6.0, 7.0, 0.0],
+                [0.0, 8.0, 9.0, 10.0, 11.0, 0.0],
+                [0.0, 12.0, 13.0, 14.0, 15.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ]
+        )
         assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
 
 
@@ -600,6 +661,26 @@ class TestCenterCropFunction(BaseTest):
         )
         assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
 
+    def test_center_crop_padding_prime_num_pad(self) -> None:
+        test_tensor = torch.arange(0, 1 * 1 * 3 * 3).view(1, 1, 3, 3).float()
+        crop_vals = [6, 6]
+
+        cropped_tensor = transforms.center_crop(test_tensor, crop_vals)
+
+        expected_tensor = torch.nn.functional.pad(test_tensor, [2, 1, 2, 1])
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
+
+    def test_center_crop_padding_prime_num_pad_offset_left(self) -> None:
+        test_tensor = torch.arange(0, 1 * 1 * 3 * 3).view(1, 1, 3, 3).float()
+        crop_vals = [6, 6]
+
+        cropped_tensor = transforms.center_crop(
+            test_tensor, crop_vals, offset_left=True
+        )
+
+        expected_tensor = torch.nn.functional.pad(test_tensor, [1, 2, 1, 2])
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
+
     def test_center_crop_one_number_exact_jit_module(self) -> None:
         if torch.__version__ <= "1.8.0":
             raise unittest.SkipTest(
@@ -632,6 +713,25 @@ class TestCenterCropFunction(BaseTest):
             * 3
         ).unsqueeze(0)
         assertTensorAlmostEqual(self, cropped_tensor, expected_tensor)
+
+    def test_center_crop_padding_jit_module(self) -> None:
+        test_tensor = torch.arange(0, 1 * 1 * 4 * 4).view(1, 1, 4, 4).float()
+        crop_vals = [6, 6]
+
+        jit_center_crop = torch.jit.script(transforms.center_crop)
+        cropped_tensor = jit_center_crop(test_tensor, crop_vals)
+
+        expected_tensor = torch.tensor(
+            [
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 2.0, 3.0, 0.0],
+                [0.0, 4.0, 5.0, 6.0, 7.0, 0.0],
+                [0.0, 8.0, 9.0, 10.0, 11.0, 0.0],
+                [0.0, 12.0, 13.0, 14.0, 15.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ]
+        )
+        assertTensorAlmostEqual(self, cropped_tensor, expected_tensor, 0)
 
 
 class TestBlendAlpha(BaseTest):
@@ -1074,3 +1174,99 @@ class TestRandomCrop(BaseTest):
         x_out = jit_crop_transform(x)
 
         self.assertEqual(list(x_out.shape), [1, 4, 160, 160])
+
+
+class TestTransformationRobustness(BaseTest):
+    def test_transform_robustness_init(self) -> None:
+        transform_robustness = transforms.TransformationRobustness()
+        self.assertIsNone(transform_robustness.padding_transform)
+        self.assertIsInstance(
+            transform_robustness.jitter_transforms, torch.nn.Sequential
+        )
+        for module in transform_robustness.jitter_transforms:
+            self.assertIsInstance(module, transforms.RandomSpatialJitter)
+        self.assertIsInstance(transform_robustness.random_scale, transforms.RandomScale)
+        # self.assertIsInstance(
+        #    transform_robustness.random_rotation, transforms.RandomRotation
+        # )
+        self.assertIsInstance(
+            transform_robustness.final_jitter, transforms.RandomSpatialJitter
+        )
+        self.assertFalse(transform_robustness.crop_or_pad_output)
+
+    def test_transform_robustness_init_single_translate(self) -> None:
+        transform_robustness = transforms.TransformationRobustness(translate=4)
+        self.assertIsInstance(
+            transform_robustness.jitter_transforms, transforms.RandomSpatialJitter
+        )
+
+    def test_transform_robustness_forward(self) -> None:
+        transform_robustness = transforms.TransformationRobustness()
+        test_input = torch.ones(1, 3, 224, 224)
+        test_output = transform_robustness(test_input)
+        self.assertTrue(torch.is_tensor(test_output))
+
+    def test_transform_robustness_forward_padding(self) -> None:
+        pad_module = torch.nn.ConstantPad2d(2, value=0.5)
+        transform_robustness = transforms.TransformationRobustness(
+            padding_transform=pad_module
+        )
+        test_input = torch.ones(1, 3, 224, 224)
+        test_output = transform_robustness(test_input)
+        self.assertTrue(torch.is_tensor(test_output))
+
+    def test_transform_robustness_forward_crop_output(self) -> None:
+        transform_robustness = transforms.TransformationRobustness(
+            crop_or_pad_output=True
+        )
+        test_input = torch.ones(1, 3, 224, 224)
+        test_output = transform_robustness(test_input)
+        self.assertEqual(test_output.shape, test_input.shape)
+
+    def test_transform_robustness_forward_padding_crop_output(self) -> None:
+        pad_module = torch.nn.ConstantPad2d(2, value=0.5)
+        transform_robustness = transforms.TransformationRobustness(
+            padding_transform=pad_module, crop_or_pad_output=True
+        )
+        test_input = torch.ones(1, 3, 224, 224)
+        test_output = transform_robustness(test_input)
+        self.assertEqual(test_output.shape, test_input.shape)
+
+    def test_transform_robustness_forward_all_disabled(self) -> None:
+        transform_robustness = transforms.TransformationRobustness(
+            padding_transform=None,
+            translate=None,
+            scale=None,
+            degrees=None,
+            final_translate=None,
+            crop_or_pad_output=False,
+        )
+        test_input = torch.randn(1, 3, 224, 224)
+        test_output = transform_robustness(test_input)
+        assertTensorAlmostEqual(self, test_output, test_input, 0)
+
+    def test_transform_robustness_forward_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping TransformationRobustness JIT module test due"
+                + " to insufficient Torch version."
+            )
+        transform_robustness = transforms.TransformationRobustness()
+        jit_transform_robustness = torch.jit.script(transform_robustness)
+        test_input = torch.ones(1, 3, 224, 224)
+        test_output = jit_transform_robustness(test_input)
+        self.assertTrue(torch.is_tensor(test_output))
+
+    def test_transform_robustness_forward_padding_crop_output_jit_module(self) -> None:
+        if torch.__version__ <= "1.8.0":
+            raise unittest.SkipTest(
+                "Skipping TransformationRobustness with crop or pad output"
+                + " JIT module test due to insufficient Torch version."
+            )
+        pad_module = torch.nn.ConstantPad2d(2, value=0.5)
+        transform_robustness = transforms.TransformationRobustness(
+            padding_transform=pad_module, crop_or_pad_output=True
+        )
+        test_input = torch.ones(1, 3, 224, 224)
+        test_output = transform_robustness(test_input)
+        self.assertEqual(test_output.shape, test_input.shape)


### PR DESCRIPTION
* Added JIT support to all transforms.

* Added JIT tests for all applicable transforms.

* There's currently a bug that prevents `CenterCrop` from working with JIT, so I added the `@torch.jit.ignore` decorator to it's forward function to avoid the bug. This is so that it won't throw an error if someone uses `torch.jit.script` on it. https://github.com/pytorch/pytorch/issues/69938 

* JIT is also told to ignore `NChannelsToRGB` due to it's unsupported inner functions.

* The `ToRGB` didn't support JIT due to the usage of named dimensions, so I implemented a second forward function that is only used when using JIT.

* Add JIT support `NaturalImage`, `FFTImage`, & `PixelImage`.

* Improved `NaturalImage` & `FFTImage` tests, and test coverage.

* Added `ImageParameterization` instance support for `NaturalImage`. This improvement should make it easier to use parameterization enhancements like SharedImage, and will be helpful for custom parameterizations that don't use the standard input variable set (size, channels, batch, & init).

* Added asserts to verify `NaturalImage` parameterization inputs are instances or types of `ImageParameterization`.

* Some transform type hints had to be changed due to a bug in JIT's Union support: https://github.com/pytorch/pytorch/issues/69434

* Fixed bug with `RandomCrop` transform.

* Replaced default `RandomScale` transform with Interpolation based variant. Renamed the old variant to `RandomScaleAffine`.

* `CenterCrop` / `center_crop` now adds padding if the crop size is larger than the input dimensions.

* Add distributions support to both versions of `RandomScale`. Ludwig wanted this based off of his original PR.

* Changed `NumSeqOrTensorType` hint to `NumSeqOrTensorOrProbDistType`.

* Added more comprehensive testing to applicable transforms. Test coverage reported by pytest should now be 100% minus the version specific tests.

* Transform torch version checks required for module forward functions are performed in their  `__init__` function so that they work with JIT.

* Add `TransformationRobustness()` transform.
    * Similar to Lucid's `standard_transforms`, the `TransformationRobustness()` is a convenient helper for applying the standard set of transforms in the correct order. The default values have also been tuned to optimal values.
    * It performs the following transforms: A padding transform, one or more `RandomSpatialJitter` transforms, a `RandomScale` transform, a `RandomRotation` transform, a single `RandomSpatialJitter` transform, and then a final optional CenterCrop or Pad To transform.
    * There's a pretty significant improvement to visualization quality when using `TransformationRobustness()`, and it makes it easier to use transform robustness properly..
    * Links to Lucid's versions: https://github.com/tensorflow/lucid/blob/master/lucid/optvis/transform.py#L164, https://github.com/tensorflow/lucid/blob/master/lucid/recipes/activation_atlas/render.py#L127
    * Ludwig's original Captum PR had the same transform planned: https://github.com/ludwigschubert/captum/blob/f1fd0729dece59564a7c10b7b397617d8a09a247/captum/optim/param/transform.py#L88
    * It was also used for feature visualization with OpenAI's CLIP model: https://github.com/openai/CLIP-featurevis/blob/master/example_facets.py#L61

```
    pad_module = torch.nn.ConstantPad2d(2, value=0.5)
    transforms = opt.transforms.TransformationRobustness(padding_transform=pad_module)
```

JIT support for the InceptionV1 model was added to https://github.com/pytorch/captum/pull/655





This PR only changes / adds around 711 lines of code, with the other 1306 lines being from tests that feature a lot of redundant / simple code.