### PR TITLE
Optim-wip: Composable loss improvements

### DIFF
--- a/tests/optim/core/test_loss.py
+++ b/tests/optim/core/test_loss.py
@@ -168,6 +168,20 @@ class TestCompositeLoss(BaseTest):
             get_loss_value(model, loss), -CHANNEL_ACTIVATION_0_LOSS, places=6
         )
 
+    def test_positive(self) -> None:
+        model = BasicModel_ConvNet_Optim()
+        loss = +opt_loss.ChannelActivation(model.layer, 0)
+        self.assertAlmostEqual(
+            get_loss_value(model, loss), CHANNEL_ACTIVATION_0_LOSS, places=6
+        )
+
+    def test_abs(self) -> None:
+        model = BasicModel_ConvNet_Optim()
+        loss = abs(-opt_loss.ChannelActivation(model.layer, 0))
+        self.assertAlmostEqual(
+            get_loss_value(model, loss), CHANNEL_ACTIVATION_0_LOSS, places=6
+        )
+
     def test_addition(self) -> None:
         model = BasicModel_ConvNet_Optim()
         loss = (
@@ -242,3 +256,20 @@ class TestCompositeLoss(BaseTest):
     #         opt_loss.ChannelActivation(model.layer, 0) ** opt_loss.ChannelActivation(
     #             model.layer, 1
     #         )
+
+    def test_sum(self) -> None:
+        model = torch.nn.Identity()
+        loss = opt_loss.LayerActivation(model).sum()
+
+        self.assertAlmostEqual(get_loss_value(model, loss), 3.0, places=1)
+
+    def test_mean(self) -> None:
+        model = torch.nn.Identity()
+        loss = opt_loss.LayerActivation(model).mean()
+
+        self.assertAlmostEqual(get_loss_value(model, loss), 1.0, places=1)
+
+
+class TestCompositeLossReductionOP(BaseTest):
+    def test_reduction_op(self) -> None:
+        self.assertEqual(opt_loss.REDUCTION_OP, torch.mean)

--- a/tests/optim/helpers/numpy_transforms.py
+++ b/tests/optim/helpers/numpy_transforms.py
@@ -1,5 +1,5 @@
 import math
-from typing import List, Optional, Tuple, Union, cast
+from typing import List, Optional, Tuple, Union, cast, no_type_check
 
 import numpy as np
 
@@ -112,6 +112,7 @@ class CenterCrop:
         )
 
 
+@no_type_check
 def center_crop(
     input: np.ndarray,
     crop_vals: IntSeqOrIntType,


### PR DESCRIPTION
This PR adds a few simple improvements to the `CompositeLoss` class and it's features.

* Added support for `__pos__` and `__abs__` unary operators to `CompositeLoss`. These appear to be the only other basic operators that make sense to add support for.
* Made `CompositeLoss`'s reduction operation a global variable that can be changed by users. This should improve the generality of the optim module, and it makes it possible to disable this aspect of `CompositeLoss`.
* Added composable `torch.mean` and `torch.sum` reduction operations to `CompositeLoss`. These are common operations, so there are likely use cases that can benefit from them. Example usage: `loss_fn.mean()` & `loss_fn.sum()`.
* Added tests for the changes listed above.


I'm also working on ways for users to create their own custom composite loss operations, similar to the `sum_loss_list` function, for future PRs.