### PR TITLE
Require inputs to `assertTensorAlmostEqual` to have the same shape.

### DIFF
--- a/captum/_utils/typing.py
+++ b/captum/_utils/typing.py
@@ -22,3 +22,16 @@ TupleOrTensorOrBoolGeneric = TypeVar("TupleOrTensorOrBoolGeneric", Tuple, Tensor
 ModuleOrModuleList = TypeVar("ModuleOrModuleList", Module, List[Module])
 TargetType = Union[None, int, Tuple[int, ...], Tensor, List[Tuple[int, ...]], List[int]]
 BaselineType = Union[None, Tensor, int, float, Tuple[Union[Tensor, int, float], ...]]
+
+TensorLikeList1D = List[float]
+TensorLikeList2D = List[TensorLikeList1D]
+TensorLikeList3D = List[TensorLikeList2D]
+TensorLikeList4D = List[TensorLikeList3D]
+TensorLikeList5D = List[TensorLikeList4D]
+TensorLikeList = Union[
+    TensorLikeList1D,
+    TensorLikeList2D,
+    TensorLikeList3D,
+    TensorLikeList4D,
+    TensorLikeList5D,
+]

--- a/tests/attr/layer/test_grad_cam.py
+++ b/tests/attr/layer/test_grad_cam.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
 import unittest
-from typing import Any, List, Tuple, Union
+from typing import Any, Tuple, Union
 
 import torch
+from captum._utils.typing import TensorLikeList
 from captum.attr._core.layer.grad_cam import LayerGradCam
 from tests.helpers.basic import BaseTest, assertTensorTuplesAlmostEqual
 from tests.helpers.basic_models import (
@@ -18,17 +19,19 @@ class Test(BaseTest):
     def test_simple_input_non_conv(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
-        self._grad_cam_test_assert(net, net.linear0, inp, [400.0])
+        self._grad_cam_test_assert(net, net.linear0, inp, [[400.0]])
 
     def test_simple_multi_input_non_conv(self) -> None:
         net = BasicModel_MultiLayer(multi_input_module=True)
         inp = torch.tensor([[0.0, 6.0, 0.0]], requires_grad=True)
-        self._grad_cam_test_assert(net, net.multi_relu, inp, ([21.0], [21.0]))
+        self._grad_cam_test_assert(net, net.multi_relu, inp, ([[21.0]], [[21.0]]))
 
     def test_simple_input_conv(self) -> None:
         net = BasicModel_ConvNet_One_Conv()
         inp = torch.arange(16).view(1, 1, 4, 4).float()
-        self._grad_cam_test_assert(net, net.conv1, inp, [[11.25, 13.5], [20.25, 22.5]])
+        self._grad_cam_test_assert(
+            net, net.conv1, inp, [[[[11.25, 13.5], [20.25, 22.5]]]]
+        )
 
     def test_simple_input_conv_no_grad(self) -> None:
         net = BasicModel_ConvNet_One_Conv()
@@ -39,12 +42,14 @@ class Test(BaseTest):
             param.requires_grad = False
 
         inp = torch.arange(16).view(1, 1, 4, 4).float()
-        self._grad_cam_test_assert(net, net.conv1, inp, [[11.25, 13.5], [20.25, 22.5]])
+        self._grad_cam_test_assert(
+            net, net.conv1, inp, [[[[11.25, 13.5], [20.25, 22.5]]]]
+        )
 
     def test_simple_input_conv_relu(self) -> None:
         net = BasicModel_ConvNet_One_Conv()
         inp = torch.arange(16).view(1, 1, 4, 4).float()
-        self._grad_cam_test_assert(net, net.relu1, inp, [[0.0, 4.0], [28.0, 32.5]])
+        self._grad_cam_test_assert(net, net.relu1, inp, [[[[0.0, 4.0], [28.0, 32.5]]]])
 
     def test_simple_input_conv_without_final_relu(self) -> None:
         net = BasicModel_ConvNet_One_Conv()
@@ -53,7 +58,7 @@ class Test(BaseTest):
         inp[0, 0, 1, 1] = -4.0
         inp.requires_grad_()
         self._grad_cam_test_assert(
-            net, net.conv1, inp, (0.5625 * inp,), attribute_to_layer_input=True
+            net, net.conv1, inp, 0.5625 * inp, attribute_to_layer_input=True
         )
 
     def test_simple_input_conv_fc_with_final_relu(self) -> None:
@@ -68,7 +73,7 @@ class Test(BaseTest):
             net,
             net.conv1,
             inp,
-            (exp,),
+            exp,
             attribute_to_layer_input=True,
             relu_attributions=True,
         )
@@ -78,7 +83,7 @@ class Test(BaseTest):
         inp = torch.arange(16).view(1, 1, 4, 4).float()
         inp2 = torch.ones((1, 1, 4, 4))
         self._grad_cam_test_assert(
-            net, net.conv1, (inp, inp2), [[14.5, 19.0], [32.5, 37.0]]
+            net, net.conv1, (inp, inp2), [[[[14.5, 19.0], [32.5, 37.0]]]]
         )
 
     def _grad_cam_test_assert(
@@ -87,7 +92,10 @@ class Test(BaseTest):
         target_layer: Module,
         test_input: Union[Tensor, Tuple[Tensor, ...]],
         expected_activation: Union[
-            List[float], Tuple[List[float], ...], List[List[float]], Tuple[Tensor, ...]
+            TensorLikeList,
+            Tuple[TensorLikeList, ...],
+            Tensor,
+            Tuple[Tensor, ...],
         ],
         additional_input: Any = None,
         attribute_to_layer_input: bool = False,

--- a/tests/attr/layer/test_internal_influence.py
+++ b/tests/attr/layer/test_internal_influence.py
@@ -42,7 +42,7 @@ class Test(BaseTest):
         net = BasicModel_MultiLayer(inplace=True)
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         self._internal_influence_test_assert(
-            net, net.relu, inp, ([[0.9, 1.0, 1.0, 1.0]],), attribute_to_layer_input=True
+            net, net.relu, inp, ([0.9, 1.0, 1.0, 1.0],), attribute_to_layer_input=True
         )
 
     def test_simple_linear_internal_inf_inplace(self) -> None:
@@ -148,7 +148,10 @@ class Test(BaseTest):
         target_layer: Module,
         test_input: Union[Tensor, Tuple[Tensor, ...]],
         expected_activation: Union[
-            float, List[List[float]], Tuple[List[List[float]], ...]
+            float,
+            List[List[float]],
+            Tuple[List[float], ...],
+            Tuple[List[List[float]], ...],
         ],
         baseline: BaselineType = None,
         additional_args: Any = None,

--- a/tests/attr/layer/test_layer_ablation.py
+++ b/tests/attr/layer/test_layer_ablation.py
@@ -94,7 +94,7 @@ class Test(BaseTest):
             net,
             net.relu1,
             (inp, inp2),
-            [[[4.0, 13.0], [40.0, 49.0]], [[0, 0], [-15.0, -24.0]]],
+            [[[[4.0, 13.0], [40.0, 49.0]], [[0, 0], [-15.0, -24.0]]]],
             perturbations_per_eval=(1, 2, 4, 8, 12, 16),
         )
         self._ablation_test_assert(
@@ -112,7 +112,7 @@ class Test(BaseTest):
             net,
             net.relu1,
             (inp, inp2),
-            [[[17.0, 17.0], [67.0, 67.0]], [[0, 0], [-39.0, -39.0]]],
+            [[[[17.0, 17.0], [67.0, 67.0]], [[0, 0], [-39.0, -39.0]]]],
             perturbations_per_eval=(1, 2, 4),
             layer_mask=torch.tensor([[[[0, 0], [1, 1]], [[2, 2], [3, 3]]]]),
         )
@@ -121,7 +121,7 @@ class Test(BaseTest):
         net = BasicModel_MultiLayer(multi_input_module=True)
         inp = torch.tensor([[0.0, 6.0, 0.0]])
         self._ablation_test_assert(
-            net, net.multi_relu, inp, ([0.0, 7.0, 7.0, 7.0], [0.0, 7.0, 7.0, 7.0])
+            net, net.multi_relu, inp, ([[0.0, 7.0, 7.0, 7.0]], [[0.0, 7.0, 7.0, 7.0]])
         )
 
     def test_simple_multi_output_input_ablation(self) -> None:
@@ -131,7 +131,7 @@ class Test(BaseTest):
             net,
             net.multi_relu,
             inp,
-            ([0.0, 7.0, 7.0, 7.0], [0.0, 7.0, 7.0, 7.0]),
+            ([[0.0, 7.0, 7.0, 7.0]], [[0.0, 7.0, 7.0, 7.0]]),
             attribute_to_layer_input=True,
         )
 

--- a/tests/attr/layer/test_layer_activation.py
+++ b/tests/attr/layer/test_layer_activation.py
@@ -24,13 +24,13 @@ class Test(BaseTest):
     def test_simple_input_activation(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
-        self._layer_activation_test_assert(net, net.linear0, inp, [0.0, 100.0, 0.0])
+        self._layer_activation_test_assert(net, net.linear0, inp, [[0.0, 100.0, 0.0]])
 
     def test_simple_linear_activation(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         self._layer_activation_test_assert(
-            net, net.linear1, inp, [90.0, 101.0, 101.0, 101.0]
+            net, net.linear1, inp, [[90.0, 101.0, 101.0, 101.0]]
         )
 
     def test_simple_multi_linear_activation(self) -> None:
@@ -40,7 +40,7 @@ class Test(BaseTest):
             net,
             [net.linear1, net.linear0],
             inp,
-            ([90.0, 101.0, 101.0, 101.0], [0.0, 100.0, 0.0]),
+            ([[90.0, 101.0, 101.0, 101.0]], [[0.0, 100.0, 0.0]]),
         )
 
     def test_simple_relu_activation_input_inplace(self) -> None:
@@ -53,23 +53,25 @@ class Test(BaseTest):
     def test_simple_linear_activation_inplace(self) -> None:
         net = BasicModel_MultiLayer(inplace=True)
         inp = torch.tensor([[2.0, -5.0, 4.0]])
-        self._layer_activation_test_assert(net, net.linear1, inp, [-9.0, 2.0, 2.0, 2.0])
+        self._layer_activation_test_assert(
+            net, net.linear1, inp, [[-9.0, 2.0, 2.0, 2.0]]
+        )
 
     def test_simple_relu_activation(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[3.0, 4.0, 0.0]], requires_grad=True)
-        self._layer_activation_test_assert(net, net.relu, inp, [0.0, 8.0, 8.0, 8.0])
+        self._layer_activation_test_assert(net, net.relu, inp, [[0.0, 8.0, 8.0, 8.0]])
 
     def test_simple_output_activation(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
-        self._layer_activation_test_assert(net, net.linear2, inp, [392.0, 394.0])
+        self._layer_activation_test_assert(net, net.linear2, inp, [[392.0, 394.0]])
 
     def test_simple_multi_output_activation(self) -> None:
         net = BasicModel_MultiLayer(multi_input_module=True)
         inp = torch.tensor([[0.0, 6.0, 0.0]])
         self._layer_activation_test_assert(
-            net, net.multi_relu, inp, ([0.0, 7.0, 7.0, 7.0], [0.0, 7.0, 7.0, 7.0])
+            net, net.multi_relu, inp, ([[0.0, 7.0, 7.0, 7.0]], [[0.0, 7.0, 7.0, 7.0]])
         )
 
     def test_simple_multi_layer_multi_output_activation(self) -> None:
@@ -80,7 +82,7 @@ class Test(BaseTest):
             [net.multi_relu, net.linear0, net.linear1],
             inp,
             [
-                ([0.0, 7.0, 7.0, 7.0], [0.0, 7.0, 7.0, 7.0]),
+                ([[0.0, 7.0, 7.0, 7.0]], [[0.0, 7.0, 7.0, 7.0]]),
                 [[0.0, 6.0, 0.0]],
                 [[-4.0, 7.0, 7.0, 7.0]],
             ],
@@ -93,7 +95,7 @@ class Test(BaseTest):
             net,
             net.multi_relu,
             inp,
-            ([-4.0, 7.0, 7.0, 7.0], [-4.0, 7.0, 7.0, 7.0]),
+            ([[-4.0, 7.0, 7.0, 7.0]], [[-4.0, 7.0, 7.0, 7.0]]),
             attribute_to_layer_input=True,
         )
 
@@ -103,7 +105,7 @@ class Test(BaseTest):
         inp2 = torch.tensor([[0.0, 10.0, 0.0]])
         inp3 = torch.tensor([[0.0, 5.0, 0.0]])
         self._layer_activation_test_assert(
-            net, net.model.linear2, (inp1, inp2, inp3), [392.0, 394.0], (4,)
+            net, net.model.linear2, (inp1, inp2, inp3), [[392.0, 394.0]], (4,)
         )
 
     def test_simple_multi_input_relu_activation(self) -> None:
@@ -112,7 +114,7 @@ class Test(BaseTest):
         inp2 = torch.tensor([[0.0, 4.0, 5.0]])
         inp3 = torch.tensor([[0.0, 0.0, 0.0]])
         self._layer_activation_test_assert(
-            net, net.model.relu, (inp1, inp2), [90.0, 101.0, 101.0, 101.0], (inp3, 5)
+            net, net.model.relu, (inp1, inp2), [[90.0, 101.0, 101.0, 101.0]], (inp3, 5)
         )
 
     def test_sequential_in_place(self) -> None:
@@ -133,7 +135,9 @@ class Test(BaseTest):
         model: Module,
         target_layer: Module,
         test_input: Union[Tensor, Tuple[Tensor, ...]],
-        expected_activation: Union[List[float], Tuple[List[float], ...]],
+        expected_activation: Union[
+            List[List[float]], Tuple[List[float], ...], Tuple[List[List[float]], ...]
+        ],
         additional_input: Any = None,
         attribute_to_layer_input: bool = False,
     ):
@@ -153,7 +157,9 @@ class Test(BaseTest):
         model: Module,
         target_layers: List[Module],
         test_input: Union[Tensor, Tuple[Tensor, ...]],
-        expected_activation: Union[List, Tuple[List[float], ...]],
+        expected_activation: Union[
+            List, Tuple[List[float], ...], Tuple[List[List[float]], ...]
+        ],
         additional_input: Any = None,
         attribute_to_layer_input: bool = False,
     ):

--- a/tests/attr/layer/test_layer_deeplift.py
+++ b/tests/attr/layer/test_layer_deeplift.py
@@ -35,7 +35,7 @@ class TestDeepLift(BaseTest):
             attribute_to_layer_input=True,
             return_convergence_delta=True,
         )
-        assertTensorAlmostEqual(self, attributions[0], [[0.0, 15.0]])
+        assertTensorAlmostEqual(self, attributions[0], [0.0, 15.0])
         assert_delta(self, delta)
 
     def test_relu_layer_deeplift_wo_mutliplying_by_inputs(self) -> None:
@@ -48,7 +48,7 @@ class TestDeepLift(BaseTest):
             baselines,
             attribute_to_layer_input=True,
         )
-        assertTensorAlmostEqual(self, attributions[0], [[0.0, 1.0]])
+        assertTensorAlmostEqual(self, attributions[0], [0.0, 1.0])
 
     def test_relu_layer_deeplift_multiple_output(self) -> None:
         model = BasicModel_MultiLayer(multi_input_module=True)
@@ -79,7 +79,7 @@ class TestDeepLift(BaseTest):
             attribute_to_layer_input=True,
             return_convergence_delta=True,
         )
-        assertTensorAlmostEqual(self, attributions[0], [[0.0, 45.0]])
+        assertTensorAlmostEqual(self, attributions[0], [0.0, 45.0])
         assert_delta(self, delta)
 
     def test_linear_layer_deeplift(self) -> None:
@@ -93,7 +93,7 @@ class TestDeepLift(BaseTest):
             attribute_to_layer_input=True,
             return_convergence_delta=True,
         )
-        assertTensorAlmostEqual(self, attributions[0], [[0.0, 15.0]])
+        assertTensorAlmostEqual(self, attributions[0], [0.0, 15.0])
         assert_delta(self, delta)
 
     def test_relu_deeplift_with_custom_attr_func(self) -> None:
@@ -108,9 +108,9 @@ class TestDeepLift(BaseTest):
         dl = LayerDeepLift(model, model.maxpool)
 
         def custom_att_func(mult, inp, baseline):
-            assertTensorAlmostEqual(self, mult[0], [[1.0, 0.0]])
-            assertTensorAlmostEqual(self, inp[0], [[2.0, -1.0]])
-            assertTensorAlmostEqual(self, baseline[0], [[0.0, 0.0]])
+            assertTensorAlmostEqual(self, mult[0], [[[1.0], [0.0]]])
+            assertTensorAlmostEqual(self, inp[0], [[[2.0], [-1.0]]])
+            assertTensorAlmostEqual(self, baseline[0], [[[0.0], [0.0]]])
             return mult
 
         dl.attribute(inp, custom_attribution_func=custom_att_func)
@@ -134,7 +134,7 @@ class TestDeepLift(BaseTest):
             attribute_to_layer_input=True,
             return_convergence_delta=True,
         )
-        assertTensorAlmostEqual(self, attributions[0], [[0.0, 15.0]])
+        assertTensorAlmostEqual(self, attributions[0], [0.0, 15.0])
         assert_delta(self, delta)
 
         attributions, delta = layer_dl.attribute(
@@ -143,7 +143,7 @@ class TestDeepLift(BaseTest):
             attribute_to_layer_input=False,
             return_convergence_delta=True,
         )
-        assertTensorAlmostEqual(self, attributions, [[15.0]])
+        assertTensorAlmostEqual(self, attributions, [[15.0], [15.0], [15.0]])
         assert_delta(self, delta)
 
     def test_relu_layer_deepliftshap(self) -> None:
@@ -159,7 +159,7 @@ class TestDeepLift(BaseTest):
             attribute_to_layer_input=True,
             return_convergence_delta=True,
         )
-        assertTensorAlmostEqual(self, attributions[0], [[0.0, 15.0]])
+        assertTensorAlmostEqual(self, attributions[0], [0.0, 15.0])
         assert_delta(self, delta)
 
     def test_relu_layer_deepliftshap_wo_mutliplying_by_inputs(self) -> None:
@@ -174,7 +174,7 @@ class TestDeepLift(BaseTest):
             baselines,
             attribute_to_layer_input=True,
         )
-        assertTensorAlmostEqual(self, attributions[0], [[0.0, 1.0]])
+        assertTensorAlmostEqual(self, attributions[0], [0.0, 1.0])
 
     def test_relu_layer_deepliftshap_multiple_output(self) -> None:
         model = BasicModel_MultiLayer(multi_input_module=True)
@@ -209,7 +209,7 @@ class TestDeepLift(BaseTest):
             attribute_to_layer_input=True,
             return_convergence_delta=True,
         )
-        assertTensorAlmostEqual(self, attributions[0], [[0.0, 15.0]])
+        assertTensorAlmostEqual(self, attributions[0], [0.0, 15.0])
         assert_delta(self, delta)
         attributions, delta = layer_dl_shap.attribute(
             inputs,
@@ -227,9 +227,7 @@ class TestDeepLift(BaseTest):
             baselines,
         ) = _create_inps_and_base_for_deepliftshap_neuron_layer_testing()
         attr_method = LayerDeepLiftShap(model, model.l3)
-        self._relu_custom_attr_func_assert(
-            attr_method, inputs, baselines, [[2.0], [2.0]]
-        )
+        self._relu_custom_attr_func_assert(attr_method, inputs, baselines, [[2.0]])
 
     def test_lin_maxpool_lin_classification(self) -> None:
         inputs = torch.ones(2, 4)

--- a/tests/attr/layer/test_layer_gradient_shap.py
+++ b/tests/attr/layer/test_layer_gradient_shap.py
@@ -51,7 +51,7 @@ class Test(BaseTest):
         model.eval()
 
         inputs = torch.tensor([[0.0, 100.0, 0.0]])
-        expected = ([90.0, 100.0, 100.0, 100.0], [90.0, 100.0, 100.0, 100.0])
+        expected = ([[90.0, 100.0, 100.0, 100.0]], [[90.0, 100.0, 100.0, 100.0]])
         self._assert_attributions(
             model,
             model.multi_relu,
@@ -93,7 +93,7 @@ class Test(BaseTest):
             inputs,
             baselines,
             0,
-            (expected,),
+            expected,
             expected_delta=delta,
             attribute_to_layer_input=True,
         )

--- a/tests/attr/layer/test_layer_gradient_x_activation.py
+++ b/tests/attr/layer/test_layer_gradient_x_activation.py
@@ -20,19 +20,21 @@ class Test(BaseTest):
     def test_simple_input_gradient_activation(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
-        self._layer_activation_test_assert(net, net.linear0, inp, [0.0, 400.0, 0.0])
+        self._layer_activation_test_assert(net, net.linear0, inp, [[0.0, 400.0, 0.0]])
 
     def test_simple_input_gradient_activation_no_grad(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
         with torch.no_grad():
-            self._layer_activation_test_assert(net, net.linear0, inp, [0.0, 400.0, 0.0])
+            self._layer_activation_test_assert(
+                net, net.linear0, inp, [[0.0, 400.0, 0.0]]
+            )
 
     def test_simple_linear_gradient_activation(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
         self._layer_activation_test_assert(
-            net, net.linear1, inp, [90.0, 101.0, 101.0, 101.0]
+            net, net.linear1, inp, [[90.0, 101.0, 101.0, 101.0]]
         )
 
     def test_multi_layer_linear_gradient_activation(self) -> None:
@@ -43,7 +45,7 @@ class Test(BaseTest):
             net,
             module_list,
             inp,
-            ([0.0, 400.0, 0.0], [90.0, 101.0, 101.0, 101.0]),
+            ([[0.0, 400.0, 0.0]], [[90.0, 101.0, 101.0, 101.0]]),
         )
 
     def test_simple_linear_gradient_activation_no_grad(self) -> None:
@@ -56,20 +58,20 @@ class Test(BaseTest):
             param.requires_grad = False
 
         self._layer_activation_test_assert(
-            net, net.linear1, inp, [90.0, 101.0, 101.0, 101.0]
+            net, net.linear1, inp, [[90.0, 101.0, 101.0, 101.0]]
         )
 
     def test_simple_multi_gradient_activation(self) -> None:
         net = BasicModel_MultiLayer(multi_input_module=True)
         inp = torch.tensor([[3.0, 4.0, 0.0]])
         self._layer_activation_test_assert(
-            net, net.multi_relu, inp, ([0.0, 8.0, 8.0, 8.0], [0.0, 8.0, 8.0, 8.0])
+            net, net.multi_relu, inp, ([[0.0, 8.0, 8.0, 8.0]], [[0.0, 8.0, 8.0, 8.0]])
         )
 
     def test_simple_relu_gradient_activation(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[3.0, 4.0, 0.0]], requires_grad=True)
-        self._layer_activation_test_assert(net, net.relu, inp, [0.0, 8.0, 8.0, 8.0])
+        self._layer_activation_test_assert(net, net.relu, inp, [[0.0, 8.0, 8.0, 8.0]])
 
     def test_multi_layer_multi_gradient_activation(self) -> None:
         net = BasicModel_MultiLayer(multi_input_module=True)
@@ -79,13 +81,13 @@ class Test(BaseTest):
             net,
             module_list,
             inp,
-            [([0.0, 8.0, 8.0, 8.0], [0.0, 8.0, 8.0, 8.0]), [9.0, 12.0, 0.0]],
+            [([[0.0, 8.0, 8.0, 8.0]], [[0.0, 8.0, 8.0, 8.0]]), [[9.0, 12.0, 0.0]]],
         )
 
     def test_simple_output_gradient_activation(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
-        self._layer_activation_test_assert(net, net.linear2, inp, [392.0, 0.0])
+        self._layer_activation_test_assert(net, net.linear2, inp, [[392.0, 0.0]])
 
     def test_simple_gradient_activation_multi_input_linear2(self) -> None:
         net = BasicModel_MultiLayer_MultiInput()
@@ -93,7 +95,7 @@ class Test(BaseTest):
         inp2 = torch.tensor([[0.0, 10.0, 0.0]])
         inp3 = torch.tensor([[0.0, 5.0, 0.0]])
         self._layer_activation_test_assert(
-            net, net.model.linear2, (inp1, inp2, inp3), [392.0, 0.0], (4,)
+            net, net.model.linear2, (inp1, inp2, inp3), [[392.0, 0.0]], (4,)
         )
 
     def test_simple_gradient_activation_multi_input_relu(self) -> None:
@@ -102,7 +104,7 @@ class Test(BaseTest):
         inp2 = torch.tensor([[0.0, 4.0, 5.0]])
         inp3 = torch.tensor([[0.0, 0.0, 0.0]])
         self._layer_activation_test_assert(
-            net, net.model.relu, (inp1, inp2), [90.0, 101.0, 101.0, 101.0], (inp3, 5)
+            net, net.model.relu, (inp1, inp2), [[90.0, 101.0, 101.0, 101.0]], (inp3, 5)
         )
 
     def test_gradient_activation_embedding(self) -> None:
@@ -132,7 +134,7 @@ class Test(BaseTest):
         model: Module,
         target_layer: ModuleOrModuleList,
         test_input: Union[Tensor, Tuple[Tensor, ...]],
-        expected_activation: Union[List, Tuple[List[float], ...]],
+        expected_activation: Union[List, Tuple[List[List[float]], ...]],
         additional_input: Any = None,
     ) -> None:
         layer_act = LayerGradientXActivation(model, target_layer)

--- a/tests/attr/layer/test_layer_integrated_gradients.py
+++ b/tests/attr/layer/test_layer_integrated_gradients.py
@@ -326,7 +326,7 @@ class Test(BaseTest):
             attributions = tuple(attributions)
 
         for attr_lig, attr_ig in zip(attributions, attributions_with_ig):
-            self.assertEqual(attr_lig.shape, attr_ig.shape)
+            self.assertEqual(cast(Tensor, attr_lig).shape, cast(Tensor, attr_ig).shape)
             assertArraysAlmostEqual(attributions, attributions_with_ig)
 
         if multiply_by_inputs:

--- a/tests/attr/layer/test_layer_lrp.py
+++ b/tests/attr/layer/test_layer_lrp.py
@@ -119,7 +119,7 @@ class Test(BaseTest):
         lrp = LayerLRP(model, model.linear)
         relevance = lrp.attribute(inputs)
         assertTensorAlmostEqual(
-            self, relevance[0], torch.Tensor([[0.0537, 0.0537, 0.0537]])
+            self, relevance[0], torch.Tensor([0.0537, 0.0537, 0.0537])
         )  # Result if tanh is skipped for propagation
 
     def test_lrp_simple_attributions_GammaRule(self):
@@ -153,9 +153,7 @@ class Test(BaseTest):
         lrp = LayerLRP(model, layers)
         relevance = lrp.attribute(inputs, attribute_to_layer_input=True)
         self.assertEqual(len(relevance), 2)
-        assertTensorAlmostEqual(
-            self, relevance[0][0], torch.tensor([[[18.0, 36.0, 54.0]]])
-        )
+        assertTensorAlmostEqual(self, relevance[0][0], torch.tensor([18.0, 36.0, 54.0]))
 
     def test_lrp_simple_attributions_all_layers_delta(self):
         model, inputs = _get_simple_model(inplace=False)

--- a/tests/attr/neuron/test_neuron_ablation.py
+++ b/tests/attr/neuron/test_neuron_ablation.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
 
 import unittest
-from typing import Any, Callable, List, Tuple, Union
+from typing import Any, Callable, Tuple, Union
 
 import torch
-from captum._utils.typing import BaselineType, TensorOrTupleOfTensorsGeneric
+from captum._utils.typing import (
+    BaselineType,
+    TensorOrTupleOfTensorsGeneric,
+    TensorLikeList,
+)
 from captum.attr._core.neuron.neuron_feature_ablation import NeuronFeatureAblation
 from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
 from tests.helpers.basic_models import (
@@ -24,7 +28,7 @@ class Test(BaseTest):
             net,
             net.linear2,
             inp,
-            [280.0, 280.0, 120.0],
+            [[280.0, 280.0, 120.0]],
             feature_mask=torch.tensor([[0, 0, 1]]),
             perturbations_per_eval=(1, 2, 3),
         )
@@ -172,16 +176,24 @@ class Test(BaseTest):
             (inp, inp2),
             (
                 [
-                    [0.0, 2.0, 4.0, 3.0],
-                    [4.0, 9.0, 10.0, 7.0],
-                    [4.0, 13.0, 14.0, 11.0],
-                    [0.0, 0.0, 0.0, 0.0],
+                    [
+                        [
+                            [0.0, 2.0, 4.0, 3.0],
+                            [4.0, 9.0, 10.0, 7.0],
+                            [4.0, 13.0, 14.0, 11.0],
+                            [0.0, 0.0, 0.0, 0.0],
+                        ]
+                    ]
                 ],
                 [
-                    [1.0, 2.0, 2.0, 1.0],
-                    [1.0, 2.0, 2.0, 1.0],
-                    [1.0, 2.0, 2.0, 1.0],
-                    [0.0, 0.0, 0.0, 0.0],
+                    [
+                        [
+                            [1.0, 2.0, 2.0, 1.0],
+                            [1.0, 2.0, 2.0, 1.0],
+                            [1.0, 2.0, 2.0, 1.0],
+                            [0.0, 0.0, 0.0, 0.0],
+                        ]
+                    ]
                 ],
             ),
             perturbations_per_eval=(1, 3, 7, 14),
@@ -216,16 +228,24 @@ class Test(BaseTest):
             (inp, inp2),
             (
                 [
-                    [0.0, 1.0, 2.0, 0.0],
-                    [4.0, 5.0, 6.0, 0.0],
-                    [8.0, 9.0, 10.0, 0.0],
-                    [0.0, 0.0, 0.0, 0.0],
+                    [
+                        [
+                            [0.0, 1.0, 2.0, 0.0],
+                            [4.0, 5.0, 6.0, 0.0],
+                            [8.0, 9.0, 10.0, 0.0],
+                            [0.0, 0.0, 0.0, 0.0],
+                        ]
+                    ]
                 ],
                 [
-                    [1.0, 1.0, 1.0, 0.0],
-                    [1.0, 1.0, 1.0, 0.0],
-                    [1.0, 1.0, 1.0, 0.0],
-                    [0.0, 0.0, 0.0, 0.0],
+                    [
+                        [
+                            [1.0, 1.0, 1.0, 0.0],
+                            [1.0, 1.0, 1.0, 0.0],
+                            [1.0, 1.0, 1.0, 0.0],
+                            [0.0, 0.0, 0.0, 0.0],
+                        ]
+                    ]
                 ],
             ),
             perturbations_per_eval=(1, 3, 7, 14),
@@ -239,10 +259,9 @@ class Test(BaseTest):
         layer: Module,
         test_input: TensorOrTupleOfTensorsGeneric,
         expected_ablation: Union[
-            List[float],
-            List[List[float]],
+            TensorLikeList,
+            Tuple[TensorLikeList, ...],
             Tuple[Tensor, ...],
-            Tuple[List[List[float]], ...],
         ],
         feature_mask: Union[None, TensorOrTupleOfTensorsGeneric] = None,
         additional_input: Any = None,

--- a/tests/attr/neuron/test_neuron_deeplift.py
+++ b/tests/attr/neuron/test_neuron_deeplift.py
@@ -83,7 +83,7 @@ class Test(BaseTest):
         model = ReLULinearModel()
         inputs, baselines = _create_inps_and_base_for_deeplift_neuron_layer_testing()
         neuron_dl = NeuronDeepLift(model, model.l3)
-        expected = ([0.0, 0.0, 0.0], [0.0, 0.0, 0.0])
+        expected = ([[0.0, 0.0, 0.0]], [[0.0, 0.0, 0.0]])
         self._relu_custom_attr_func_assert(neuron_dl, inputs, baselines, expected)
 
     def test_relu_neuron_deeplift_shap(self) -> None:
@@ -152,7 +152,7 @@ class Test(BaseTest):
             baselines,
         ) = _create_inps_and_base_for_deepliftshap_neuron_layer_testing()
         neuron_dl = NeuronDeepLiftShap(model, model.l3)
-        expected = (torch.zeros(3, 3), torch.zeros(3, 3))
+        expected = (torch.zeros(1, 3), torch.zeros(1, 3))
         self._relu_custom_attr_func_assert(neuron_dl, inputs, baselines, expected)
 
     def _relu_custom_attr_func_assert(

--- a/tests/attr/neuron/test_neuron_gradient.py
+++ b/tests/attr/neuron/test_neuron_gradient.py
@@ -26,47 +26,47 @@ class Test(BaseTest):
     def test_simple_gradient_input_linear2(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
-        self._gradient_input_test_assert(net, net.linear2, inp, (0,), [4.0, 4.0, 4.0])
+        self._gradient_input_test_assert(net, net.linear2, inp, (0,), [[4.0, 4.0, 4.0]])
 
     def test_simple_gradient_input_linear1(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
-        self._gradient_input_test_assert(net, net.linear1, inp, (0,), [1.0, 1.0, 1.0])
+        self._gradient_input_test_assert(net, net.linear1, inp, (0,), [[1.0, 1.0, 1.0]])
 
     def test_simple_gradient_input_relu_inplace(self) -> None:
         net = BasicModel_MultiLayer(inplace=True)
         inp = torch.tensor([[0.0, 5.0, 4.0]])
         self._gradient_input_test_assert(
-            net, net.relu, inp, (0,), [1.0, 1.0, 1.0], attribute_to_neuron_input=True
+            net, net.relu, inp, (0,), [[1.0, 1.0, 1.0]], attribute_to_neuron_input=True
         )
 
     def test_simple_gradient_input_linear1_inplace(self) -> None:
         net = BasicModel_MultiLayer(inplace=True)
         inp = torch.tensor([[0.0, 5.0, 4.0]])
-        self._gradient_input_test_assert(net, net.linear1, inp, (0,), [1.0, 1.0, 1.0])
+        self._gradient_input_test_assert(net, net.linear1, inp, (0,), [[1.0, 1.0, 1.0]])
 
     def test_simple_gradient_input_relu(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 5.0, 4.0]], requires_grad=True)
-        self._gradient_input_test_assert(net, net.relu, inp, 0, [0.0, 0.0, 0.0])
+        self._gradient_input_test_assert(net, net.relu, inp, 0, [[0.0, 0.0, 0.0]])
 
     def test_simple_gradient_input_relu2(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 5.0, 4.0]])
-        self._gradient_input_test_assert(net, net.relu, inp, 1, [1.0, 1.0, 1.0])
+        self._gradient_input_test_assert(net, net.relu, inp, 1, [[1.0, 1.0, 1.0]])
 
     def test_simple_gradient_input_relu_selector_fn(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 5.0, 4.0]])
         self._gradient_input_test_assert(
-            net, net.relu, inp, lambda x: torch.sum(x), [3.0, 3.0, 3.0]
+            net, net.relu, inp, lambda x: torch.sum(x), [[3.0, 3.0, 3.0]]
         )
 
     def test_simple_gradient_input_relu2_agg_neurons(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 5.0, 4.0]])
         self._gradient_input_test_assert(
-            net, net.relu, inp, (slice(0, 2, 1),), [1.0, 1.0, 1.0]
+            net, net.relu, inp, (slice(0, 2, 1),), [[1.0, 1.0, 1.0]]
         )
 
     def test_simple_gradient_multi_input_linear2(self) -> None:
@@ -79,7 +79,7 @@ class Test(BaseTest):
             net.model.linear2,
             (inp1, inp2, inp3),
             (0,),
-            ([12.0, 12.0, 12.0], [12.0, 12.0, 12.0], [12.0, 12.0, 12.0]),
+            ([[12.0, 12.0, 12.0]], [[12.0, 12.0, 12.0]], [[12.0, 12.0, 12.0]]),
             (3,),
         )
 
@@ -93,7 +93,7 @@ class Test(BaseTest):
             net.model.linear1,
             (inp1, inp2),
             (0,),
-            ([5.0, 5.0, 5.0], [5.0, 5.0, 5.0]),
+            ([[5.0, 5.0, 5.0]], [[5.0, 5.0, 5.0]]),
             (inp3, 5),
         )
 
@@ -113,7 +113,9 @@ class Test(BaseTest):
         target_layer: Module,
         test_input: TensorOrTupleOfTensorsGeneric,
         test_neuron_selector: Union[int, Tuple[Union[int, slice], ...], Callable],
-        expected_input_gradient: Union[List[float], Tuple[List[float], ...]],
+        expected_input_gradient: Union[
+            List[List[float]], Tuple[List[List[float]], ...]
+        ],
         additional_input: Any = None,
         attribute_to_neuron_input: bool = False,
     ) -> None:

--- a/tests/attr/neuron/test_neuron_gradient_shap.py
+++ b/tests/attr/neuron/test_neuron_gradient_shap.py
@@ -23,7 +23,7 @@ class Test(BaseTest):
         ngs = NeuronGradientShap(model, model.linear1, multiply_by_inputs=False)
         attr = ngs.attribute(inputs, 0, baselines=baselines, stdevs=0.0)
         self.assertFalse(ngs.multiplies_by_inputs)
-        assertTensorAlmostEqual(self, attr, [1.0, 1.0, 1.0])
+        assertTensorAlmostEqual(self, attr, [[1.0, 1.0, 1.0]])
 
     def test_basic_multilayer_wo_mult_by_inputs(self) -> None:
         model = BasicModel_MultiLayer(inplace=True)

--- a/tests/attr/neuron/test_neuron_integrated_gradients.py
+++ b/tests/attr/neuron/test_neuron_integrated_gradients.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 
 import unittest
-from typing import Any, Callable, List, Tuple, Union
+from typing import Any, Callable, Tuple, Union
 
 import torch
-from captum._utils.typing import TensorOrTupleOfTensorsGeneric
+from captum._utils.typing import TensorOrTupleOfTensorsGeneric, TensorLikeList
 from captum.attr._core.integrated_gradients import IntegratedGradients
 from captum.attr._core.neuron.neuron_integrated_gradients import (
     NeuronIntegratedGradients,
@@ -27,42 +27,42 @@ class Test(BaseTest):
     def test_simple_ig_input_linear2(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]])
-        self._ig_input_test_assert(net, net.linear2, inp, 0, [0.0, 390.0, 0.0])
+        self._ig_input_test_assert(net, net.linear2, inp, 0, [[0.0, 390.0, 0.0]])
 
     def test_simple_ig_input_linear2_wo_mult_by_inputs(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[100.0, 100.0, 100.0]])
         self._ig_input_test_assert(
-            net, net.linear2, inp, 0, [3.96, 3.96, 3.96], multiply_by_inputs=False
+            net, net.linear2, inp, 0, [[3.96, 3.96, 3.96]], multiply_by_inputs=False
         )
 
     def test_simple_ig_input_linear1(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 100.0, 0.0]], requires_grad=True)
-        self._ig_input_test_assert(net, net.linear1, inp, (0,), [0.0, 100.0, 0.0])
+        self._ig_input_test_assert(net, net.linear1, inp, (0,), [[0.0, 100.0, 0.0]])
 
     def test_simple_ig_input_relu(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 6.0, 14.0]], requires_grad=True)
-        self._ig_input_test_assert(net, net.relu, inp, (0,), [0.0, 3.0, 7.0])
+        self._ig_input_test_assert(net, net.relu, inp, (0,), [[0.0, 3.0, 7.0]])
 
     def test_simple_ig_input_relu2(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 5.0, 4.0]])
-        self._ig_input_test_assert(net, net.relu, inp, 1, [0.0, 5.0, 4.0])
+        self._ig_input_test_assert(net, net.relu, inp, 1, [[0.0, 5.0, 4.0]])
 
     def test_simple_ig_input_relu_selector_fn(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 5.0, 4.0]])
         self._ig_input_test_assert(
-            net, net.relu, inp, lambda x: torch.sum(x[:, 2:]), [0.0, 10.0, 8.0]
+            net, net.relu, inp, lambda x: torch.sum(x[:, 2:]), [[0.0, 10.0, 8.0]]
         )
 
     def test_simple_ig_input_relu2_agg_neurons(self) -> None:
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[0.0, 5.0, 4.0]])
         self._ig_input_test_assert(
-            net, net.relu, inp, (slice(0, 2, 1),), [0.0, 5.0, 4.0]
+            net, net.relu, inp, (slice(0, 2, 1),), [[0.0, 5.0, 4.0]]
         )
 
     def test_simple_ig_multi_input_linear2(self) -> None:
@@ -136,7 +136,7 @@ class Test(BaseTest):
         target_layer: Module,
         test_input: TensorOrTupleOfTensorsGeneric,
         test_neuron: Union[int, Tuple[Union[int, slice], ...], Callable],
-        expected_input_ig: Union[List[float], Tuple[List[List[float]], ...]],
+        expected_input_ig: Union[TensorLikeList, Tuple[TensorLikeList, ...]],
         additional_input: Any = None,
         multiply_by_inputs: bool = True,
     ) -> None:

--- a/tests/attr/test_deconvolution.py
+++ b/tests/attr/test_deconvolution.py
@@ -3,7 +3,7 @@
 from __future__ import print_function
 
 import unittest
-from typing import Any, List, Tuple, Union
+from typing import Any, Tuple, Union
 
 import torch
 from captum._utils.typing import TensorOrTupleOfTensorsGeneric
@@ -26,6 +26,7 @@ class Test(BaseTest):
             [3.0, 5.0, 5.0, 2.0],
             [1.0, 2.0, 2.0, 1.0],
         ]
+        exp = torch.tensor(exp).view(1, 1, 4, 4)
         self._deconv_test_assert(net, (inp,), (exp,))
 
     def test_simple_input_conv_neuron_deconv(self) -> None:
@@ -37,6 +38,7 @@ class Test(BaseTest):
             [3.0, 5.0, 5.0, 2.0],
             [1.0, 2.0, 2.0, 1.0],
         ]
+        exp = torch.tensor(exp).view(1, 1, 4, 4)
         self._neuron_deconv_test_assert(net, net.fc1, (0,), (inp,), (exp,))
 
     def test_simple_input_conv_neuron_deconv_agg_neurons(self) -> None:
@@ -48,6 +50,7 @@ class Test(BaseTest):
             [3.0, 5.0, 5.0, 2.0],
             [1.0, 2.0, 2.0, 1.0],
         ]
+        exp = torch.tensor(exp).view(1, 1, 4, 4)
         self._neuron_deconv_test_assert(net, net.fc1, (slice(0, 1, 1),), (inp,), (exp,))
 
     def test_simple_multi_input_conv_deconv(self) -> None:
@@ -60,6 +63,7 @@ class Test(BaseTest):
             [3.0, 5.0, 5.0, 2.0],
             [1.0, 2.0, 2.0, 1.0],
         ]
+        ex_attr = torch.tensor(ex_attr).view(1, 1, 4, 4)
         self._deconv_test_assert(net, (inp, inp2), (ex_attr, ex_attr))
 
     def test_simple_multi_input_conv_neuron_deconv(self) -> None:
@@ -72,6 +76,7 @@ class Test(BaseTest):
             [3.0, 5.0, 5.0, 2.0],
             [1.0, 2.0, 2.0, 1.0],
         ]
+        ex_attr = torch.tensor(ex_attr).view(1, 1, 4, 4)
         self._neuron_deconv_test_assert(
             net, net.fc1, (3,), (inp, inp2), (ex_attr, ex_attr)
         )
@@ -85,7 +90,7 @@ class Test(BaseTest):
         self,
         model: Module,
         test_input: TensorOrTupleOfTensorsGeneric,
-        expected: Tuple[List[List[float]], ...],
+        expected: Tuple[torch.Tensor, ...],
         additional_input: Any = None,
     ) -> None:
         deconv = Deconvolution(model)
@@ -101,7 +106,7 @@ class Test(BaseTest):
         layer: Module,
         neuron_selector: Union[int, Tuple[Union[int, slice], ...]],
         test_input: TensorOrTupleOfTensorsGeneric,
-        expected: Tuple[List[List[float]], ...],
+        expected: Tuple[torch.Tensor, ...],
         additional_input: Any = None,
     ) -> None:
         deconv = NeuronDeconvolution(model, layer)

--- a/tests/attr/test_deeplift_basic.py
+++ b/tests/attr/test_deeplift_basic.py
@@ -182,8 +182,8 @@ class Test(BaseTest):
         attr = DeepLiftShap(model, multiply_by_inputs=False).attribute(
             inputs, baselines
         )
-        assertTensorAlmostEqual(self, attr[0], 2 * torch.ones(4, 1))
-        assertTensorAlmostEqual(self, attr[1], 0.5 * torch.ones(4, 1))
+        assertTensorAlmostEqual(self, attr[0], 2 * torch.ones(4, 1, 1, 1))
+        assertTensorAlmostEqual(self, attr[1], 0.5 * torch.ones(4, 1, 1, 1))
 
     def test_relu_deepliftshap_multi_ref(self) -> None:
         x1 = torch.tensor([[1.0]], requires_grad=True)

--- a/tests/attr/test_feature_permutation.py
+++ b/tests/attr/test_feature_permutation.py
@@ -163,7 +163,9 @@ class Test(BaseTest):
         for i in range(inp.size(1)):
             if i == target:
                 continue
-            assertTensorAlmostEqual(self, attribs[:, i], 0)
+            assertTensorAlmostEqual(
+                self, attribs[:, i], torch.zeros_like(attribs[:, i])
+            )
 
         y = forward_func(inp)
         actual_diff = torch.stack([(y[0] - y[1])[target], (y[1] - y[0])[target]])
@@ -227,5 +229,5 @@ class Test(BaseTest):
         total_attr1 /= 50
         total_attr2 /= 50
         self.assertEqual(total_attr2.shape, (1,))
-        assertTensorAlmostEqual(self, total_attr1, [0.0, 0.0, 0.0])
+        assertTensorAlmostEqual(self, total_attr1, torch.zeros_like(total_attr1))
         assertTensorAlmostEqual(self, total_attr2, [-6.0], delta=0.2)

--- a/tests/attr/test_guided_backprop.py
+++ b/tests/attr/test_guided_backprop.py
@@ -4,7 +4,7 @@ import unittest
 from typing import Any, List, Tuple, Union
 
 import torch
-from captum._utils.typing import TensorOrTupleOfTensorsGeneric
+from captum._utils.typing import TensorOrTupleOfTensorsGeneric, TensorLikeList
 from captum.attr._core.guided_backprop_deconvnet import GuidedBackprop
 from captum.attr._core.neuron.neuron_guided_backprop_deconvnet import (
     NeuronGuidedBackprop,
@@ -19,10 +19,14 @@ class Test(BaseTest):
         net = BasicModel_ConvNet_One_Conv()
         inp = 1.0 * torch.arange(16, dtype=torch.float).view(1, 1, 4, 4)
         exp = [
-            [0.0, 1.0, 1.0, 1.0],
-            [1.0, 3.0, 3.0, 2.0],
-            [1.0, 3.0, 3.0, 2.0],
-            [1.0, 2.0, 2.0, 1.0],
+            [
+                [
+                    [0.0, 1.0, 1.0, 1.0],
+                    [1.0, 3.0, 3.0, 2.0],
+                    [1.0, 3.0, 3.0, 2.0],
+                    [1.0, 2.0, 2.0, 1.0],
+                ]
+            ]
         ]
         self._guided_backprop_test_assert(net, (inp,), (exp,))
 
@@ -30,10 +34,14 @@ class Test(BaseTest):
         net = BasicModel_ConvNet_One_Conv()
         inp = 1.0 * torch.arange(16, dtype=torch.float).view(1, 1, 4, 4)
         exp = [
-            [0.0, 1.0, 1.0, 1.0],
-            [1.0, 3.0, 3.0, 2.0],
-            [1.0, 3.0, 3.0, 2.0],
-            [1.0, 2.0, 2.0, 1.0],
+            [
+                [
+                    [0.0, 1.0, 1.0, 1.0],
+                    [1.0, 3.0, 3.0, 2.0],
+                    [1.0, 3.0, 3.0, 2.0],
+                    [1.0, 2.0, 2.0, 1.0],
+                ]
+            ]
         ]
         self._neuron_guided_backprop_test_assert(net, net.fc1, (0,), (inp,), (exp,))
 
@@ -41,10 +49,14 @@ class Test(BaseTest):
         net = BasicModel_ConvNet_One_Conv()
         inp = 1.0 * torch.arange(16, dtype=torch.float).view(1, 1, 4, 4)
         exp = [
-            [0.0, 1.0, 1.0, 1.0],
-            [1.0, 3.0, 3.0, 2.0],
-            [1.0, 3.0, 3.0, 2.0],
-            [1.0, 2.0, 2.0, 1.0],
+            [
+                [
+                    [0.0, 1.0, 1.0, 1.0],
+                    [1.0, 3.0, 3.0, 2.0],
+                    [1.0, 3.0, 3.0, 2.0],
+                    [1.0, 2.0, 2.0, 1.0],
+                ]
+            ]
         ]
         self._neuron_guided_backprop_test_assert(
             net, net.fc1, (slice(0, 1, 1),), (inp,), (exp,)
@@ -55,10 +67,14 @@ class Test(BaseTest):
         inp = torch.arange(16, dtype=torch.float).view(1, 1, 4, 4)
         inp2 = torch.ones((1, 1, 4, 4))
         ex_attr = [
-            [1.0, 2.0, 2.0, 1.0],
-            [2.0, 4.0, 4.0, 2.0],
-            [2.0, 4.0, 4.0, 2.0],
-            [1.0, 2.0, 2.0, 1.0],
+            [
+                [
+                    [1.0, 2.0, 2.0, 1.0],
+                    [2.0, 4.0, 4.0, 2.0],
+                    [2.0, 4.0, 4.0, 2.0],
+                    [1.0, 2.0, 2.0, 1.0],
+                ]
+            ]
         ]
         self._guided_backprop_test_assert(net, (inp, inp2), (ex_attr, ex_attr))
 
@@ -67,10 +83,14 @@ class Test(BaseTest):
         inp = torch.arange(16, dtype=torch.float).view(1, 1, 4, 4)
         inp2 = torch.ones((1, 1, 4, 4))
         ex_attr = [
-            [1.0, 2.0, 2.0, 1.0],
-            [2.0, 4.0, 4.0, 2.0],
-            [2.0, 4.0, 4.0, 2.0],
-            [1.0, 2.0, 2.0, 1.0],
+            [
+                [
+                    [1.0, 2.0, 2.0, 1.0],
+                    [2.0, 4.0, 4.0, 2.0],
+                    [2.0, 4.0, 4.0, 2.0],
+                    [1.0, 2.0, 2.0, 1.0],
+                ]
+            ]
         ]
         self._neuron_guided_backprop_test_assert(
             net, net.fc1, (3,), (inp, inp2), (ex_attr, ex_attr)
@@ -85,7 +105,7 @@ class Test(BaseTest):
         self,
         model: Module,
         test_input: TensorOrTupleOfTensorsGeneric,
-        expected: Tuple[List[List[float]], ...],
+        expected: Tuple[TensorLikeList, ...],
         additional_input: Any = None,
     ) -> None:
         guided_backprop = GuidedBackprop(model)
@@ -93,7 +113,12 @@ class Test(BaseTest):
             test_input, target=0, additional_forward_args=additional_input
         )
         for i in range(len(test_input)):
-            assertTensorAlmostEqual(self, attributions[i], expected[i], delta=0.01)
+            assertTensorAlmostEqual(
+                self,
+                attributions[i],
+                expected[i],
+                delta=0.01,
+            )
 
     def _neuron_guided_backprop_test_assert(
         self,
@@ -101,7 +126,7 @@ class Test(BaseTest):
         layer: Module,
         neuron_selector: Union[int, Tuple[Union[int, slice], ...]],
         test_input: TensorOrTupleOfTensorsGeneric,
-        expected: Tuple[List[List[float]], ...],
+        expected: Tuple[List[List[List[List[float]]]], ...],
         additional_input: Any = None,
     ) -> None:
         guided_backprop = NeuronGuidedBackprop(model, layer)
@@ -111,7 +136,12 @@ class Test(BaseTest):
             additional_forward_args=additional_input,
         )
         for i in range(len(test_input)):
-            assertTensorAlmostEqual(self, attributions[i], expected[i], delta=0.01)
+            assertTensorAlmostEqual(
+                self,
+                attributions[i],
+                expected[i],
+                delta=0.01,
+            )
 
     def _guided_backprop_matching_assert(
         self,

--- a/tests/attr/test_guided_grad_cam.py
+++ b/tests/attr/test_guided_grad_cam.py
@@ -16,10 +16,14 @@ class Test(BaseTest):
         net = BasicModel_ConvNet_One_Conv()
         inp = 1.0 * torch.arange(16, dtype=torch.float).view(1, 1, 4, 4)
         ex = [
-            [0.0, 0.0, 4.0, 4.0],
-            [0.0, 0.0, 12.0, 8.0],
-            [28.0, 84.0, 97.5, 65.0],
-            [28.0, 56.0, 65.0, 32.5],
+            [
+                [
+                    [0.0, 0.0, 4.0, 4.0],
+                    [0.0, 0.0, 12.0, 8.0],
+                    [28.0, 84.0, 97.5, 65.0],
+                    [28.0, 56.0, 65.0, 32.5],
+                ]
+            ]
         ]
         self._guided_grad_cam_test_assert(net, net.relu1, inp, ex)
 
@@ -28,10 +32,14 @@ class Test(BaseTest):
         inp = torch.arange(16, dtype=torch.float).view(1, 1, 4, 4)
         inp2 = torch.ones((1, 1, 4, 4))
         ex = [
-            [14.5, 29.0, 38.0, 19.0],
-            [29.0, 58.0, 76.0, 38.0],
-            [65.0, 130.0, 148.0, 74.0],
-            [32.5, 65.0, 74.0, 37.0],
+            [
+                [
+                    [14.5, 29.0, 38.0, 19.0],
+                    [29.0, 58.0, 76.0, 38.0],
+                    [65.0, 130.0, 148.0, 74.0],
+                    [32.5, 65.0, 74.0, 37.0],
+                ]
+            ]
         ]
         self._guided_grad_cam_test_assert(net, net.conv1, (inp, inp2), (ex, ex))
 
@@ -40,10 +48,14 @@ class Test(BaseTest):
         inp = torch.arange(16, dtype=torch.float).view(1, 1, 4, 4)
         inp2 = torch.ones((1, 1, 4, 4))
         ex = [
-            [14.5, 29.0, 38.0, 19.0],
-            [29.0, 58.0, 76.0, 38.0],
-            [65.0, 130.0, 148.0, 74.0],
-            [32.5, 65.0, 74.0, 37.0],
+            [
+                [
+                    [14.5, 29.0, 38.0, 19.0],
+                    [29.0, 58.0, 76.0, 38.0],
+                    [65.0, 130.0, 148.0, 74.0],
+                    [32.5, 65.0, 74.0, 37.0],
+                ]
+            ]
         ]
         self._guided_grad_cam_test_assert(
             net, net.relu1, (inp, inp2), (ex, ex), attribute_to_layer_input=True
@@ -54,10 +66,14 @@ class Test(BaseTest):
         inp = torch.arange(16, dtype=torch.float).view(1, 1, 4, 4)
         inp2 = torch.ones((1, 1, 4, 4))
         ex = [
-            [14.5, 29.0, 38.0, 19.0],
-            [29.0, 58.0, 76.0, 38.0],
-            [65.0, 130.0, 148.0, 74.0],
-            [32.5, 65.0, 74.0, 37.0],
+            [
+                [
+                    [14.5, 29.0, 38.0, 19.0],
+                    [29.0, 58.0, 76.0, 38.0],
+                    [65.0, 130.0, 148.0, 74.0],
+                    [32.5, 65.0, 74.0, 37.0],
+                ]
+            ]
         ]
         self._guided_grad_cam_test_assert(net, net.conv1, (inp, inp2), (ex, ex))
 
@@ -66,10 +82,14 @@ class Test(BaseTest):
         inp = torch.arange(16, dtype=torch.float).view(1, 1, 4, 4)
         inp2 = torch.ones(1)
         ex = [
-            [14.5, 29.0, 38.0, 19.0],
-            [29.0, 58.0, 76.0, 38.0],
-            [65.0, 130.0, 148.0, 74.0],
-            [32.5, 65.0, 74.0, 37.0],
+            [
+                [
+                    [14.5, 29.0, 38.0, 19.0],
+                    [29.0, 58.0, 76.0, 38.0],
+                    [65.0, 130.0, 148.0, 74.0],
+                    [32.5, 65.0, 74.0, 37.0],
+                ]
+            ]
         ]
         self._guided_grad_cam_test_assert(net, net.conv1, (inp, inp2), (ex, []))
 
@@ -102,9 +122,19 @@ class Test(BaseTest):
         )
         if isinstance(test_input, tuple):
             for i in range(len(test_input)):
-                assertTensorAlmostEqual(self, attributions[i], expected[i], delta=0.01)
+                assertTensorAlmostEqual(
+                    self,
+                    attributions[i],
+                    expected[i],
+                    delta=0.01,
+                )
         else:
-            assertTensorAlmostEqual(self, attributions, expected, delta=0.01)
+            assertTensorAlmostEqual(
+                self,
+                attributions,
+                expected,
+                delta=0.01,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/attr/test_input_x_gradient.py
+++ b/tests/attr/test_input_x_gradient.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from typing import Any
+from typing import Any, cast
 
 import torch
 from captum._utils.typing import TensorOrTupleOfTensorsGeneric
@@ -84,7 +84,9 @@ class Test(BaseTest):
         elif isinstance(attributions, Tensor):
             if nt_type == "vanilla":
                 self._assert_attribution(expected_grads, inputs, attributions)
-            self.assertEqual(inputs.shape, attributions.shape)
+            self.assertEqual(
+                cast(Tensor, inputs).shape, cast(Tensor, attributions).shape
+            )
 
     def _assert_attribution(self, expected_grad, input, attribution):
         assertArraysAlmostEqual(

--- a/tests/attr/test_kernel_shap.py
+++ b/tests/attr/test_kernel_shap.py
@@ -40,10 +40,10 @@ class Test(BaseTest):
         self._kernel_shap_test_assert(
             net,
             inp,
-            [40.0, 120.0, 80.0],
+            [[40.0, 120.0, 80.0]],
             n_samples=500,
             baselines=baseline,
-            expected_coefs=[40.0, 120.0, 80.0],
+            expected_coefs=[[40.0, 120.0, 80.0]],
         )
 
     def test_simple_kernel_shap(self) -> None:
@@ -52,7 +52,7 @@ class Test(BaseTest):
         self._kernel_shap_test_assert(
             net,
             inp,
-            [76.66666, 196.66666, 116.66666],
+            [[76.66666, 196.66666, 116.66666]],
             perturbations_per_eval=(1, 2, 3),
             n_samples=500,
         )
@@ -63,10 +63,10 @@ class Test(BaseTest):
         self._kernel_shap_test_assert(
             net,
             inp,
-            [275.0, 275.0, 115.0],
+            [[275.0, 275.0, 115.0]],
             feature_mask=torch.tensor([[0, 0, 1]]),
             perturbations_per_eval=(1, 2, 3),
-            expected_coefs=[275.0, 115.0],
+            expected_coefs=[[275.0, 115.0]],
         )
 
     @unittest.mock.patch("sys.stderr", new_callable=io.StringIO)
@@ -79,7 +79,7 @@ class Test(BaseTest):
             self._kernel_shap_test_assert(
                 net,
                 inp,
-                [76.66666, 196.66666, 116.66666],
+                [[76.66666, 196.66666, 116.66666]],
                 perturbations_per_eval=(bsz,),
                 n_samples=500,
                 show_progress=True,
@@ -101,7 +101,7 @@ class Test(BaseTest):
         self._kernel_shap_test_assert(
             net,
             inp,
-            [248.0, 248.0, 104.0],
+            [[248.0, 248.0, 104.0]],
             feature_mask=torch.tensor([[0, 0, 1]]),
             baselines=4,
             perturbations_per_eval=(1, 2, 3),
@@ -200,7 +200,7 @@ class Test(BaseTest):
             (inp1, inp2),
             expected,
             n_samples=2000,
-            expected_coefs=[-8.0, 0, 0, -2.0, 0, 0, -8.0],
+            expected_coefs=[[-8.0, 0, 0, -2.0, 0, 0, -8.0]],
         )
         # with mask
         self._kernel_shap_test_assert(
@@ -208,7 +208,7 @@ class Test(BaseTest):
             (inp1, inp2),
             expected,
             n_samples=2000,
-            expected_coefs=[-8.0, 0, 0, -2.0, 0, 0, -8.0],
+            expected_coefs=[[-8.0, 0, 0, -2.0, 0, 0, -8.0]],
             feature_mask=(mask1, mask2),
         )
 
@@ -337,9 +337,9 @@ class Test(BaseTest):
         mask2 = torch.tensor([[0, 1, 2]])
         mask3 = torch.tensor([[0, 1, 2]])
         expected = (
-            [[3850.6666, 3850.6666, 3850.6666]],
-            [[306.6666, 3850.6666, 410.6666]],
-            [[306.6666, 3850.6666, 410.6666]],
+            [[3850.6666, 3850.6666, 3850.6666]] * 2,
+            [[306.6666, 3850.6666, 410.6666]] * 2,
+            [[306.6666, 3850.6666, 410.6666]] * 2,
         )
 
         self._kernel_shap_test_assert(
@@ -380,6 +380,7 @@ class Test(BaseTest):
                 n_samples=n_samples,
                 show_progress=show_progress,
             )
+
             assertTensorTuplesAlmostEqual(
                 self, attributions, expected_attr, delta=delta, mode="max"
             )

--- a/tests/attr/test_lime.py
+++ b/tests/attr/test_lime.py
@@ -113,10 +113,10 @@ class Test(BaseTest):
         self._lime_test_assert(
             net,
             inp,
-            [73.3716, 193.3349, 113.3349],
+            [[73.3716, 193.3349, 113.3349]],
             perturbations_per_eval=(1, 2, 3),
             n_samples=500,
-            expected_coefs_only=[73.3716, 193.3349, 113.3349],
+            expected_coefs_only=[[73.3716, 193.3349, 113.3349]],
             test_generator=True,
         )
 
@@ -126,11 +126,11 @@ class Test(BaseTest):
         self._lime_test_assert(
             net,
             inp,
-            [271.0, 271.0, 111.0],
+            [[271.0, 271.0, 111.0]],
             feature_mask=torch.tensor([[0, 0, 1]]),
             perturbations_per_eval=(1, 2, 3),
             n_samples=500,
-            expected_coefs_only=[271.0, 111.0],
+            expected_coefs_only=[[271.0, 111.0]],
         )
 
     def test_simple_lime_with_baselines(self) -> None:
@@ -139,11 +139,11 @@ class Test(BaseTest):
         self._lime_test_assert(
             net,
             inp,
-            [244.0, 244.0, 100.0],
+            [[244.0, 244.0, 100.0]],
             feature_mask=torch.tensor([[0, 0, 1]]),
             baselines=4,
             perturbations_per_eval=(1, 2, 3),
-            expected_coefs_only=[244.0, 100.0],
+            expected_coefs_only=[[244.0, 100.0]],
             test_generator=True,
         )
 
@@ -153,7 +153,7 @@ class Test(BaseTest):
         self._lime_test_assert(
             net,
             inp,
-            [31.42, 31.42, 30.90],
+            [[31.42, 31.42, 30.90]],
             feature_mask=torch.tensor([[0, 0, 1]]),
             perturbations_per_eval=(1, 2, 3),
             test_generator=True,
@@ -165,7 +165,7 @@ class Test(BaseTest):
         self._lime_test_assert(
             net,
             inp,
-            [-36.0, -36.0, 0.0],
+            [[-36.0, -36.0, 0.0]],
             feature_mask=torch.tensor([[0, 0, 1]]),
             baselines=True,
             perturbations_per_eval=(1, 2, 3),
@@ -182,7 +182,7 @@ class Test(BaseTest):
             self._lime_test_assert(
                 net,
                 inp,
-                [73.3716, 193.3349, 113.3349],
+                [[73.3716, 193.3349, 113.3349]],
                 perturbations_per_eval=(bsz,),
                 n_samples=500,
                 test_generator=True,
@@ -241,7 +241,7 @@ class Test(BaseTest):
             expected,
             additional_input=(1,),
             n_samples=2000,
-            expected_coefs_only=[87, 0, 0, 75, 0, 195, 0, 395, 35],
+            expected_coefs_only=[[87, 0, 0, 75, 0, 195, 0, 395, 35]],
         )
 
     def test_multi_input_lime_with_mask(self) -> None:
@@ -264,7 +264,7 @@ class Test(BaseTest):
             additional_input=(1,),
             feature_mask=(mask1, mask2, mask3),
             n_samples=500,
-            expected_coefs_only=[251.0, 591.0, 0.0],
+            expected_coefs_only=[[251.0, 591.0, 0.0]],
         )
         expected_with_baseline = (
             [[180, 576.0, 180]],
@@ -280,7 +280,7 @@ class Test(BaseTest):
             baselines=(2, 3.0, 4),
             perturbations_per_eval=(1, 2, 3),
             n_samples=500,
-            expected_coefs_only=[180, 576.0, -8.0],
+            expected_coefs_only=[[180, 576.0, -8.0]],
             test_generator=True,
         )
 
@@ -300,7 +300,7 @@ class Test(BaseTest):
             (inp1, inp2),
             expected,
             n_samples=2000,
-            expected_coefs_only=[-4.0, 0, 0, 0, 0, 0, -4.0],
+            expected_coefs_only=[[-4.0, 0, 0, 0, 0, 0, -4.0]],
         )
         # with mask
         self._lime_test_assert(
@@ -308,7 +308,7 @@ class Test(BaseTest):
             (inp1, inp2),
             expected,
             n_samples=2000,
-            expected_coefs_only=[-4.0, 0, 0, 0, 0, 0, -4.0],
+            expected_coefs_only=[[-4.0, 0, 0, 0, 0, 0, -4.0]],
             feature_mask=(mask1, mask2),
         )
 
@@ -419,7 +419,7 @@ class Test(BaseTest):
             feature_mask=mask,
             perturbations_per_eval=(1,),
             target=None,
-            expected_coefs_only=[75.0, 17.0],
+            expected_coefs_only=[[75.0, 17.0]],
             n_samples=700,
         )
 
@@ -451,9 +451,9 @@ class Test(BaseTest):
         mask2 = torch.tensor([[0, 1, 2]])
         mask3 = torch.tensor([[0, 1, 2]])
         expected = (
-            [[3850.6666, 3850.6666, 3850.6666]],
-            [[305.5, 3850.6666, 410.1]],
-            [[305.5, 3850.6666, 410.1]],
+            [[3850.6666, 3850.6666, 3850.6666]] * 2,
+            [[305.5, 3850.6666, 410.1]] * 2,
+            [[305.5, 3850.6666, 410.1]] * 2,
         )
 
         self._lime_test_assert(
@@ -465,7 +465,7 @@ class Test(BaseTest):
             perturbations_per_eval=(1,),
             target=None,
             n_samples=1500,
-            expected_coefs_only=[305.5, 3850.6666, 410.1],
+            expected_coefs_only=[[305.5, 3850.6666, 410.1]],
             delta=1.5,
             batch_attr=True,
             test_generator=True,

--- a/tests/attr/test_lrp.py
+++ b/tests/attr/test_lrp.py
@@ -95,7 +95,7 @@ class Test(BaseTest):
         model.linear2.rule = EpsilonRule()  # type: ignore
         lrp = LRP(model)
         relevance = lrp.attribute(inputs)
-        assertTensorAlmostEqual(self, relevance, torch.tensor([18.0, 36.0, 54.0]))
+        assertTensorAlmostEqual(self, relevance, torch.tensor([[18.0, 36.0, 54.0]]))
 
     def test_lrp_simple_attributions_batch(self) -> None:
         model, inputs = _get_simple_model()
@@ -192,7 +192,7 @@ class Test(BaseTest):
         model.linear2.rule = EpsilonRule()  # type: ignore
         lrp = LRP(model)
         relevance = lrp.attribute(inputs)
-        assertTensorAlmostEqual(self, relevance, torch.tensor([24.0, 36.0, 36.0]))
+        assertTensorAlmostEqual(self, relevance, torch.tensor([[24.0, 36.0, 36.0]]))
 
     def test_lrp_simple2_attributions(self) -> None:
         model, input = _get_simple_model2()
@@ -307,7 +307,7 @@ class Test(BaseTest):
         )
         self.assertEqual(len(input), 2)
         assertTensorAlmostEqual(self, attributions[0], torch.Tensor([[16, 32, 48]]))
-        assertTensorAlmostEqual(self, delta, torch.Tensor(0))
+        assertTensorAlmostEqual(self, delta, torch.Tensor([-104.0]))
 
     def test_lrp_ixg_equivalency(self) -> None:
         model, inputs = _get_simple_model()

--- a/tests/attr/test_occlusion.py
+++ b/tests/attr/test_occlusion.py
@@ -2,10 +2,15 @@
 import io
 import unittest
 import unittest.mock
-from typing import Any, Callable, List, Tuple, Union
+from typing import Any, Callable, Tuple, Union
 
 import torch
-from captum._utils.typing import BaselineType, TargetType, TensorOrTupleOfTensorsGeneric
+from captum._utils.typing import (
+    BaselineType,
+    TargetType,
+    TensorOrTupleOfTensorsGeneric,
+    TensorLikeList,
+)
 from captum.attr._core.occlusion import Occlusion
 from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
 from tests.helpers.basic_models import (
@@ -94,7 +99,7 @@ class Test(BaseTest):
         self._occlusion_test_assert(
             net,
             inp,
-            [80.0, 200.0, 120.0],
+            [[80.0, 200.0, 120.0]],
             perturbations_per_eval=(1, 2, 3),
             sliding_window_shapes=((1,)),
         )
@@ -106,7 +111,7 @@ class Test(BaseTest):
         self._occlusion_test_assert(
             net,
             (inp1, inp2),
-            ([0.0, 1.0], [0.0, -1.0]),
+            ([[0.0], [1.0]], [[0.0], [-1.0]]),
             sliding_window_shapes=((1,), (1,)),
         )
 
@@ -121,7 +126,7 @@ class Test(BaseTest):
         self._occlusion_test_assert(
             wrapper_func,
             (inp1, inp2),
-            ([0.0, 1.0], [0.0, -1.0]),
+            ([[0.0], [1.0]], [[0.0], [-1.0]]),
             sliding_window_shapes=((1,), (1,)),
         )
 
@@ -132,7 +137,7 @@ class Test(BaseTest):
         self._occlusion_test_assert(
             net,
             (inp1, inp2),
-            ([0.0, 1.0], [0.0, -1.0]),
+            ([[0.0], [1.0]], [[0.0], [-1.0]]),
             sliding_window_shapes=((1,), (1,)),
         )
 
@@ -154,7 +159,7 @@ class Test(BaseTest):
         self._occlusion_test_assert(
             net,
             inp,
-            [200.0, 220.0, 240.0],
+            [[200.0, 220.0, 240.0]],
             perturbations_per_eval=(1, 2, 3),
             sliding_window_shapes=((2,)),
             baselines=torch.tensor([10.0, 10.0, 10.0]),
@@ -166,7 +171,7 @@ class Test(BaseTest):
         self._occlusion_test_assert(
             net,
             inp,
-            [280.0, 280.0, 120.0],
+            [[280.0, 280.0, 120.0]],
             perturbations_per_eval=(1, 2, 3),
             sliding_window_shapes=((2,)),
             strides=2,
@@ -249,16 +254,24 @@ class Test(BaseTest):
             (inp, inp2),
             (
                 [
-                    [17.0, 17.0, 17.0, 17.0],
-                    [17.0, 17.0, 17.0, 17.0],
-                    [64.0, 65.5, 65.5, 67.0],
-                    [64.0, 65.5, 65.5, 67.0],
+                    [
+                        [
+                            [17.0, 17.0, 17.0, 17.0],
+                            [17.0, 17.0, 17.0, 17.0],
+                            [64.0, 65.5, 65.5, 67.0],
+                            [64.0, 65.5, 65.5, 67.0],
+                        ]
+                    ]
                 ],
                 [
-                    [3.0, 3.0, 3.0, 3.0],
-                    [3.0, 3.0, 3.0, 3.0],
-                    [3.0, 3.0, 3.0, 3.0],
-                    [0.0, 0.0, 0.0, 0.0],
+                    [
+                        [
+                            [3.0, 3.0, 3.0, 3.0],
+                            [3.0, 3.0, 3.0, 3.0],
+                            [3.0, 3.0, 3.0, 3.0],
+                            [0.0, 0.0, 0.0, 0.0],
+                        ]
+                    ]
                 ],
             ),
             perturbations_per_eval=(1, 3, 7, 14),
@@ -276,7 +289,7 @@ class Test(BaseTest):
             self._occlusion_test_assert(
                 net,
                 inp,
-                [80.0, 200.0, 120.0],
+                [[80.0, 200.0, 120.0]],
                 perturbations_per_eval=(bsz,),
                 sliding_window_shapes=((1,)),
                 show_progress=True,
@@ -299,9 +312,9 @@ class Test(BaseTest):
         test_input: TensorOrTupleOfTensorsGeneric,
         expected_ablation: Union[
             float,
-            List[float],
-            List[List[float]],
-            Tuple[Union[Tensor, List[float], List[List[float]]], ...],
+            TensorLikeList,
+            Tuple[TensorLikeList, ...],
+            Tuple[Tensor, ...],
         ],
         sliding_window_shapes: Union[Tuple[int, ...], Tuple[Tuple[int, ...], ...]],
         target: TargetType = 0,
@@ -325,9 +338,17 @@ class Test(BaseTest):
             )
             if isinstance(expected_ablation, tuple):
                 for i in range(len(expected_ablation)):
-                    assertTensorAlmostEqual(self, attributions[i], expected_ablation[i])
+                    assertTensorAlmostEqual(
+                        self,
+                        attributions[i],
+                        expected_ablation[i],
+                    )
             else:
-                assertTensorAlmostEqual(self, attributions, expected_ablation)
+                assertTensorAlmostEqual(
+                    self,
+                    attributions,
+                    expected_ablation,
+                )
 
 
 if __name__ == "__main__":

--- a/tests/attr/test_shapley.py
+++ b/tests/attr/test_shapley.py
@@ -23,7 +23,7 @@ class Test(BaseTest):
         self._shapley_test_assert(
             net,
             inp,
-            [76.66666, 196.66666, 116.66666],
+            [[76.66666, 196.66666, 116.66666]],
             perturbations_per_eval=(1, 2, 3),
             n_samples=250,
         )
@@ -34,7 +34,7 @@ class Test(BaseTest):
         self._shapley_test_assert(
             net,
             inp,
-            [275.0, 275.0, 115.0],
+            [[275.0, 275.0, 115.0]],
             feature_mask=torch.tensor([[0, 0, 1]]),
             perturbations_per_eval=(1, 2, 3),
         )
@@ -45,7 +45,7 @@ class Test(BaseTest):
         self._shapley_test_assert(
             net,
             inp,
-            [35.0, 35.0, 35.0],
+            [[35.0, 35.0, 35.0]],
             feature_mask=torch.tensor([[0, 0, 1]]),
             perturbations_per_eval=(1, 2, 3),
         )
@@ -56,7 +56,7 @@ class Test(BaseTest):
         self._shapley_test_assert(
             net,
             inp,
-            [-40.0, -40.0, 0.0],
+            [[-40.0, -40.0, 0.0]],
             feature_mask=torch.tensor([[0, 0, 1]]),
             baselines=True,
             perturbations_per_eval=(1, 2, 3),
@@ -68,7 +68,7 @@ class Test(BaseTest):
         self._shapley_test_assert(
             net,
             inp,
-            [248.0, 248.0, 104.0],
+            [[248.0, 248.0, 104.0]],
             feature_mask=torch.tensor([[0, 0, 1]]),
             baselines=4,
             perturbations_per_eval=(1, 2, 3),
@@ -257,7 +257,7 @@ class Test(BaseTest):
             self._shapley_test_assert(
                 net,
                 inp,
-                [76.66666, 196.66666, 116.66666],
+                [[76.66666, 196.66666, 116.66666]],
                 perturbations_per_eval=(bsz,),
                 n_samples=250,
                 show_progress=True,
@@ -286,7 +286,7 @@ class Test(BaseTest):
             self._shapley_test_assert(
                 net,
                 inp,
-                [275.0, 275.0, 115.0],
+                [[275.0, 275.0, 115.0]],
                 feature_mask=torch.tensor([[0, 0, 1]]),
                 perturbations_per_eval=(bsz,),
                 show_progress=True,

--- a/tests/attr/test_utils_batching.py
+++ b/tests/attr/test_utils_batching.py
@@ -49,9 +49,9 @@ class Test(BaseTest):
         for index, (inp, add, targ) in enumerate(
             _batched_generator((inp1, inp2), (inp3, 5), 7, 1)
         ):
-            assertTensorAlmostEqual(self, inp[0], array1[index])
-            assertTensorAlmostEqual(self, inp[1], array2[index])
-            assertTensorAlmostEqual(self, add[0], array3[index])
+            assertTensorAlmostEqual(self, inp[0], [array1[index]])
+            assertTensorAlmostEqual(self, inp[1], [array2[index]])
+            assertTensorAlmostEqual(self, add[0], [array3[index]])
             self.assertEqual(add[1], 5)
             self.assertEqual(targ, 7)
 

--- a/tests/helpers/basic.py
+++ b/tests/helpers/basic.py
@@ -36,10 +36,13 @@ def assertTensorAlmostEqual(test, actual, expected, delta=0.0001, mode="sum"):
     assert isinstance(actual, torch.Tensor), (
         "Actual parameter given for " "comparison must be a tensor."
     )
-    actual = actual.squeeze().cpu()
     if not isinstance(expected, torch.Tensor):
         expected = torch.tensor(expected, dtype=actual.dtype)
-    expected = expected.squeeze().cpu()
+    assert (
+        actual.shape == expected.shape
+    ), f"Expected tensor with shape: {expected.shape}. Actual shape {actual.shape}."
+    actual = actual.cpu()
+    expected = expected.cpu()
     if mode == "sum":
         test.assertAlmostEqual(
             torch.sum(torch.abs(actual - expected)).item(), 0.0, delta=delta

--- a/tests/utils/test_av.py
+++ b/tests/utils/test_av.py
@@ -240,7 +240,7 @@ class Test(BaseTest):
             dataset = AV.load(tmpdir, model_id, identifier=DEFAULT_IDENTIFIER)
 
             for i, av in enumerate(DataLoader(cast(Dataset, dataset))):
-                assertTensorAlmostEqual(self, av, avs[i])
+                assertTensorAlmostEqual(self, av, avs[i].unsqueeze(0))
 
             # add av_1 to the list of activations
             dataloader_2 = DataLoader(
@@ -257,7 +257,7 @@ class Test(BaseTest):
             dataloader = DataLoader(cast(Dataset, dataset))
             self.assertEqual(len(dataloader), 2)
             for i, av in enumerate(dataloader):
-                assertTensorAlmostEqual(self, av, avs[i])
+                assertTensorAlmostEqual(self, av, avs[i].unsqueeze(0))
 
     def test_av_load_all_identifiers_one_layer(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -292,7 +292,7 @@ class Test(BaseTest):
 
             self.assertEqual(len(dataloader_layer), 3)
             for i, av in enumerate(dataloader_layer):
-                assertTensorAlmostEqual(self, av, avs[i])
+                assertTensorAlmostEqual(self, av, avs[i].unsqueeze(0))
 
             dataloader = DataLoader(cast(Dataset, AV.load(tmpdir, "dummy")))
             self.assertEqual(len(dataloader), 4)
@@ -340,7 +340,7 @@ class Test(BaseTest):
             self.assertEqual(len(dataloader_layer), 3)
 
             for i, av in enumerate(dataloader_layer):
-                assertTensorAlmostEqual(self, av, avs_0[i])
+                assertTensorAlmostEqual(self, av, avs_0[i].unsqueeze(0))
 
             # check activations for idf2
             dataloader_layer = DataLoader(
@@ -348,7 +348,7 @@ class Test(BaseTest):
             )
             self.assertEqual(len(dataloader_layer), 3)
             for i, av in enumerate(dataloader_layer):
-                assertTensorAlmostEqual(self, av, avs_1[i])
+                assertTensorAlmostEqual(self, av, avs_1[i].unsqueeze(0))
 
     def test_av_sort_files(self) -> None:
         files = ["resnet50-cifar-3000", "resnet50-cifar-1000", "resnet50-cifar-2000"]

--- a/tests/utils/test_common.py
+++ b/tests/utils/test_common.py
@@ -75,10 +75,12 @@ class Test(BaseTest):
             self, _select_targets(output_tensor, torch.tensor(0)), [1, 4, 7]
         )
         assertTensorAlmostEqual(
-            self, _select_targets(output_tensor, torch.tensor([1, 2, 0])), [2, 6, 7]
+            self,
+            _select_targets(output_tensor, torch.tensor([1, 2, 0])),
+            [[2], [6], [7]],
         )
         assertTensorAlmostEqual(
-            self, _select_targets(output_tensor, [1, 2, 0]), [2, 6, 7]
+            self, _select_targets(output_tensor, [1, 2, 0]), [[2], [6], [7]]
         )
 
         # Verify error is raised if too many dimensions are provided.

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+import torch
+from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
+
+
+class HelpersTest(BaseTest):
+    def test_assert_tensor_almost_equal(self) -> None:
+        with self.assertRaises(AssertionError):
+            assertTensorAlmostEqual(self, torch.tensor([[]]), torch.tensor([[1.0]]))
+
+        assertTensorAlmostEqual(self, torch.tensor([[1.0]]), [[1.0]])
+        with self.assertRaises(AssertionError):
+            assertTensorAlmostEqual(self, torch.tensor([[1.0]]), [1.0])


### PR DESCRIPTION
Summary: Before this change `assertTensorAlmostEqual` could perform broadcasting that could lead to unexpected results. This change requires the input tensors to have the same shape to remove broadcasting.

Differential Revision: D33661499

