### PR TITLE
minor update on lrp rule check

### DIFF
--- a/captum/attr/_core/lrp.py
+++ b/captum/attr/_core/lrp.py
@@ -267,10 +267,15 @@ class LRP(GradientAttribution):
     def _check_and_attach_rules(self) -> None:
         for layer in self.layers:
             if hasattr(layer, "rule"):
-                layer.activations = {}  # type: ignore
-                layer.rule.relevance_input = defaultdict(list)  # type: ignore
-                layer.rule.relevance_output = {}  # type: ignore
-                pass
+                if layer.rule is not None:
+                    layer.activations = {}  # type: ignore
+                    layer.rule.relevance_input = defaultdict(list)  # type: ignore
+                    layer.rule.relevance_output = {}  # type: ignore
+                    pass
+                else:
+                    # we need to check layer.rule is not None
+                    # Otherwise, nn.ReLU() will raise error because it has layer.rule = None 
+                    pass 
             elif type(layer) in SUPPORTED_LAYERS_WITH_RULES.keys():
                 layer.activations = {}  # type: ignore
                 layer.rule = SUPPORTED_LAYERS_WITH_RULES[type(layer)]()  # type: ignore

--- a/captum/attr/_core/lrp.py
+++ b/captum/attr/_core/lrp.py
@@ -273,9 +273,7 @@ class LRP(GradientAttribution):
                     layer.rule.relevance_output = {}  # type: ignore
                     pass
                 else:
-                    # we need to check layer.rule is not None
-                    # Otherwise, nn.ReLU() will raise error because it has layer.rule = None 
-                    pass 
+                    pass
             elif type(layer) in SUPPORTED_LAYERS_WITH_RULES.keys():
                 layer.activations = {}  # type: ignore
                 layer.rule = SUPPORTED_LAYERS_WITH_RULES[type(layer)]()  # type: ignore


### PR DESCRIPTION
Retry pulling request.

Tested on pretrained ResNet50. Without the additional "if layer.rule is not None:", the following error will be raised:

Traceback (most recent call last):
File "/home/<computername>/.local/lib/python3.9/site-packages/captum/attr/_core/lrp.py", line 272, in _check_and_attach_rules
layer.rule.relevance_input = defaultdict(list) # type: ignore
AttributeError: 'NoneType' object has no attribute 'relevance_input'