### PR TITLE
Consolidate assertTensorAlmostEqual and assertArraysAlmostEqual functions.

### DIFF
--- a/tests/attr/layer/test_layer_conductance.py
+++ b/tests/attr/layer/test_layer_conductance.py
@@ -9,7 +9,7 @@ from captum.attr._core.layer.layer_conductance import LayerConductance
 from tests.attr.helpers.conductance_reference import ConductanceReference
 from tests.helpers.basic import (
     BaseTest,
-    assertArraysAlmostEqual,
+    assertTensorAlmostEqual,
     assertTensorTuplesAlmostEqual,
 )
 from tests.helpers.basic_models import (
@@ -213,10 +213,12 @@ class Test(BaseTest):
         # Check that layer output size matches conductance size.
         self.assertEqual(layer_output.shape, attributions.shape)
         # Check that reference implementation output matches standard implementation.
-        assertArraysAlmostEqual(
-            attributions.reshape(-1).tolist(),
-            attributions_reference.reshape(-1).tolist(),
+        assertTensorAlmostEqual(
+            self,
+            attributions,
+            attributions_reference,
             delta=0.07,
+            mode="max",
         )
 
         # Test if batching is working correctly for inputs with multiple examples
@@ -236,10 +238,12 @@ class Test(BaseTest):
                 )
                 # Verify that attributions when passing example independently
                 # matches corresponding attribution of batched input.
-                assertArraysAlmostEqual(
-                    attributions[i : i + 1].reshape(-1).tolist(),
-                    single_attributions.reshape(-1).tolist(),
+                assertTensorAlmostEqual(
+                    self,
+                    attributions[i : i + 1],
+                    single_attributions,
                     delta=0.01,
+                    mode="max",
                 )
 
 

--- a/tests/attr/layer/test_layer_integrated_gradients.py
+++ b/tests/attr/layer/test_layer_integrated_gradients.py
@@ -13,7 +13,7 @@ from captum.attr._models.base import (
 )
 from tests.helpers.basic import (
     BaseTest,
-    assertArraysAlmostEqual,
+    assertTensorAlmostEqual,
     assertTensorTuplesAlmostEqual,
 )
 from tests.helpers.basic_models import (
@@ -244,8 +244,10 @@ class Test(BaseTest):
             return_convergence_delta=True,
             attribute_to_layer_input=attribute_to_layer_input,
         )
-        assertArraysAlmostEqual(attribution, attributions2, 0.01)
-        assertArraysAlmostEqual(delta, delta2, 0.5)
+        assertTensorAlmostEqual(
+            self, attribution, attributions2, delta=0.01, mode="max"
+        )
+        assertTensorAlmostEqual(self, delta, delta2, delta=0.5, mode="max")
 
     def _assert_compare_with_emb_patching(
         self,
@@ -327,10 +329,10 @@ class Test(BaseTest):
 
         for attr_lig, attr_ig in zip(attributions, attributions_with_ig):
             self.assertEqual(cast(Tensor, attr_lig).shape, cast(Tensor, attr_ig).shape)
-            assertArraysAlmostEqual(attributions, attributions_with_ig)
+            assertTensorAlmostEqual(self, attr_lig, attr_ig, delta=0.05, mode="max")
 
         if multiply_by_inputs:
-            assertArraysAlmostEqual(delta, delta_with_ig)
+            assertTensorAlmostEqual(self, delta, delta_with_ig, delta=0.05, mode="max")
 
     def _assert_compare_with_expected(
         self,

--- a/tests/attr/models/test_base.py
+++ b/tests/attr/models/test_base.py
@@ -10,7 +10,7 @@ from captum.attr._models.base import (
     configure_interpretable_embedding_layer,
     remove_interpretable_embedding_layer,
 )
-from tests.helpers.basic import assertArraysAlmostEqual
+from tests.helpers.basic import assertTensorAlmostEqual
 from tests.helpers.basic_models import BasicEmbeddingModel, TextModule
 from torch.nn import Embedding
 
@@ -71,12 +71,11 @@ class Test(unittest.TestCase):
         )
         actual = interpretable_embedding.indices_to_embeddings(input=input2)
         output_interpretable_models = model(input1, actual)
-        assertArraysAlmostEqual(output, output_interpretable_models)
+        assertTensorAlmostEqual(
+            self, output, output_interpretable_models, delta=0.05, mode="max"
+        )
 
-        # using assertArraysAlmostEqual instead of assertTensorAlmostEqual because
-        # it is important and necessary that each element in comparing tensors
-        # match exactly.
-        assertArraysAlmostEqual(expected, actual, 0.0)
+        assertTensorAlmostEqual(self, expected, actual, delta=0.0, mode="max")
         self.assertTrue(model.embedding2.__class__ is InterpretableEmbeddingBase)
         remove_interpretable_embedding_layer(model, interpretable_embedding)
         self.assertTrue(model.embedding2.__class__ is TextModule)
@@ -97,12 +96,11 @@ class Test(unittest.TestCase):
             input=input2, another_input=input3
         )
         output_interpretable_models = model(input1, actual)
-        assertArraysAlmostEqual(output, output_interpretable_models)
+        assertTensorAlmostEqual(
+            self, output, output_interpretable_models, delta=0.05, mode="max"
+        )
 
-        # using assertArraysAlmostEqual instead of assertTensorAlmostEqual because
-        # it is important and necessary that each element in comparing tensors
-        # match exactly.
-        assertArraysAlmostEqual(expected, actual, 0.0)
+        assertTensorAlmostEqual(self, expected, actual, delta=0.0, mode="max")
         self.assertTrue(model.embedding2.__class__ is InterpretableEmbeddingBase)
         remove_interpretable_embedding_layer(model, interpretable_embedding2)
         self.assertTrue(model.embedding2.__class__ is TextModule)

--- a/tests/attr/neuron/test_neuron_conductance.py
+++ b/tests/attr/neuron/test_neuron_conductance.py
@@ -7,7 +7,7 @@ import torch
 from captum._utils.typing import BaselineType, TensorOrTupleOfTensorsGeneric
 from captum.attr._core.layer.layer_conductance import LayerConductance
 from captum.attr._core.neuron.neuron_conductance import NeuronConductance
-from tests.helpers.basic import BaseTest, assertArraysAlmostEqual
+from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
 from tests.helpers.basic_models import (
     BasicModel_ConvNet,
     BasicModel_MultiLayer,
@@ -182,17 +182,21 @@ class Test(BaseTest):
             if isinstance(expected_input_conductance, tuple):
                 for i in range(len(expected_input_conductance)):
                     for j in range(len(expected_input_conductance[i])):
-                        assertArraysAlmostEqual(
-                            attributions[i][j : j + 1].squeeze(0).tolist(),
+                        assertTensorAlmostEqual(
+                            self,
+                            attributions[i][j : j + 1].squeeze(0),
                             expected_input_conductance[i][j],
                             delta=0.1,
+                            mode="max",
                         )
             else:
                 if isinstance(attributions, Tensor):
-                    assertArraysAlmostEqual(
-                        attributions.squeeze(0).tolist(),
+                    assertTensorAlmostEqual(
+                        self,
+                        attributions.squeeze(0),
                         expected_input_conductance,
                         delta=0.1,
+                        mode="max",
                     )
                 else:
                     raise AssertionError(

--- a/tests/attr/neuron/test_neuron_gradient.py
+++ b/tests/attr/neuron/test_neuron_gradient.py
@@ -10,7 +10,7 @@ from captum.attr._core.neuron.neuron_gradient import NeuronGradient
 from captum.attr._core.saliency import Saliency
 from tests.helpers.basic import (
     BaseTest,
-    assertArraysAlmostEqual,
+    assertTensorAlmostEqual,
     assertTensorTuplesAlmostEqual,
 )
 from tests.helpers.basic_models import (
@@ -150,11 +150,7 @@ class Test(BaseTest):
             # Verify matching sizes
             self.assertEqual(grad_vals.shape, sal_vals.shape)
             self.assertEqual(grad_vals.shape, test_input.shape)
-            assertArraysAlmostEqual(
-                sal_vals.reshape(-1).tolist(),
-                grad_vals.reshape(-1).tolist(),
-                delta=0.001,
-            )
+            assertTensorAlmostEqual(self, sal_vals, grad_vals, delta=0.001, mode="max")
 
 
 if __name__ == "__main__":

--- a/tests/attr/neuron/test_neuron_integrated_gradients.py
+++ b/tests/attr/neuron/test_neuron_integrated_gradients.py
@@ -11,7 +11,7 @@ from captum.attr._core.neuron.neuron_integrated_gradients import (
 )
 from tests.helpers.basic import (
     BaseTest,
-    assertArraysAlmostEqual,
+    assertTensorAlmostEqual,
     assertTensorTuplesAlmostEqual,
 )
 from tests.helpers.basic_models import (
@@ -170,10 +170,8 @@ class Test(BaseTest):
         for i in range(out.shape[1]):
             ig_vals = input_attrib.attribute(test_input, target=i, baselines=baseline)
             neuron_ig_vals = ig_attrib.attribute(test_input, (i,), baselines=baseline)
-            assertArraysAlmostEqual(
-                ig_vals.reshape(-1).tolist(),
-                neuron_ig_vals.reshape(-1).tolist(),
-                delta=0.001,
+            assertTensorAlmostEqual(
+                self, ig_vals, neuron_ig_vals, delta=0.001, mode="max"
             )
             self.assertEqual(neuron_ig_vals.shape, test_input.shape)
 

--- a/tests/attr/test_approximation_methods.py
+++ b/tests/attr/test_approximation_methods.py
@@ -2,8 +2,9 @@
 
 import unittest
 
+import torch
 from captum.attr._utils.approximation_methods import Riemann, riemann_builders
-from tests.helpers.basic import assertArraysAlmostEqual
+from tests.helpers.basic import assertTensorAlmostEqual
 
 
 class Test(unittest.TestCase):
@@ -81,14 +82,54 @@ class Test(unittest.TestCase):
         step_sizes_right, alphas_right = riemann_builders(Riemann.right)
         step_sizes_middle, alphas_middle = riemann_builders(Riemann.middle)
         step_sizes_trapezoid, alphas_trapezoid = riemann_builders(Riemann.trapezoid)
-        assertArraysAlmostEqual(expected_step_sizes, step_sizes_left(n))
-        assertArraysAlmostEqual(expected_step_sizes, step_sizes_right(n))
-        assertArraysAlmostEqual(expected_step_sizes, step_sizes_middle(n))
-        assertArraysAlmostEqual(expected_step_sizes_trapezoid, step_sizes_trapezoid(n))
-        assertArraysAlmostEqual(expected_left, alphas_left(n))
-        assertArraysAlmostEqual(expected_right, alphas_right(n))
-        assertArraysAlmostEqual(expected_middle, alphas_middle(n))
-        assertArraysAlmostEqual(expected_trapezoid, alphas_trapezoid(n))
+        assertTensorAlmostEqual(
+            self,
+            torch.tensor(expected_step_sizes),
+            step_sizes_left(n),
+            delta=0.05,
+            mode="max",
+        )
+        assertTensorAlmostEqual(
+            self,
+            torch.tensor(expected_step_sizes),
+            step_sizes_right(n),
+            delta=0.05,
+            mode="max",
+        )
+        assertTensorAlmostEqual(
+            self,
+            torch.tensor(expected_step_sizes),
+            step_sizes_middle(n),
+            delta=0.05,
+            mode="max",
+        )
+        assertTensorAlmostEqual(
+            self,
+            torch.tensor(expected_step_sizes_trapezoid),
+            step_sizes_trapezoid(n),
+            delta=0.05,
+            mode="max",
+        )
+        assertTensorAlmostEqual(
+            self, torch.tensor(expected_left), alphas_left(n), delta=0.05, mode="max"
+        )
+        assertTensorAlmostEqual(
+            self, torch.tensor(expected_right), alphas_right(n), delta=0.05, mode="max"
+        )
+        assertTensorAlmostEqual(
+            self,
+            torch.tensor(expected_middle),
+            alphas_middle(n),
+            delta=0.05,
+            mode="max",
+        )
+        assertTensorAlmostEqual(
+            self,
+            torch.tensor(expected_trapezoid),
+            alphas_trapezoid(n),
+            delta=0.05,
+            mode="max",
+        )
 
 
 # TODO write a test case for gauss-legendre

--- a/tests/attr/test_deeplift_basic.py
+++ b/tests/attr/test_deeplift_basic.py
@@ -8,7 +8,6 @@ from captum.attr._core.deep_lift import DeepLift, DeepLiftShap
 from captum.attr._core.integrated_gradients import IntegratedGradients
 from tests.helpers.basic import (
     BaseTest,
-    assertArraysAlmostEqual,
     assertAttributionComparision,
     assertTensorAlmostEqual,
 )
@@ -343,7 +342,9 @@ class Test(BaseTest):
                 delta_external = attr_method.compute_convergence_delta(
                     attributions, baselines, inputs
                 )
-                assertArraysAlmostEqual(delta, delta_external, 0.0)
+                assertTensorAlmostEqual(
+                    self, delta, delta_external, delta=0.0, mode="max"
+                )
 
             delta_condition = (delta.abs() < 0.00001).all()
             self.assertTrue(

--- a/tests/attr/test_feature_permutation.py
+++ b/tests/attr/test_feature_permutation.py
@@ -5,7 +5,6 @@ import torch
 from captum.attr._core.feature_permutation import FeaturePermutation, _permute_feature
 from tests.helpers.basic import (
     BaseTest,
-    assertArraysAlmostEqual,
     assertTensorAlmostEqual,
 )
 from tests.helpers.basic_models import BasicModelWithSparseInputs
@@ -97,7 +96,7 @@ class Test(BaseTest):
         attribs = feature_importance.attribute(inp)
 
         self.assertTrue(attribs.squeeze(0).size() == (batch_size,) + input_size)
-        assertArraysAlmostEqual(attribs[:, 0], zeros)
+        assertTensorAlmostEqual(self, attribs[:, 0], zeros, delta=0.05, mode="max")
         self.assertTrue((attribs[:, 1 : input_size[0]].abs() > 0).all())
 
     def test_multi_input(self) -> None:
@@ -200,7 +199,13 @@ class Test(BaseTest):
             for feature in features:
                 m = (fm == feature).bool()
                 attribs_for_feature = attribs[:, m]
-                assertArraysAlmostEqual(attribs_for_feature[0], -attribs_for_feature[1])
+                assertTensorAlmostEqual(
+                    self,
+                    attribs_for_feature[0],
+                    -attribs_for_feature[1],
+                    delta=0.05,
+                    mode="max",
+                )
 
     def test_empty_sparse_features(self) -> None:
         model = BasicModelWithSparseInputs()

--- a/tests/attr/test_input_x_gradient.py
+++ b/tests/attr/test_input_x_gradient.py
@@ -8,7 +8,6 @@ from captum.attr._core.noise_tunnel import NoiseTunnel
 from tests.attr.test_saliency import _get_basic_config, _get_multiargs_basic_config
 from tests.helpers.basic import (
     BaseTest,
-    assertArraysAlmostEqual,
     assertTensorAlmostEqual,
 )
 from tests.helpers.classification_models import SoftmaxModel
@@ -89,9 +88,12 @@ class Test(BaseTest):
             )
 
     def _assert_attribution(self, expected_grad, input, attribution):
-        assertArraysAlmostEqual(
-            attribution.reshape(-1),
-            (expected_grad * input).reshape(-1),
+        assertTensorAlmostEqual(
+            self,
+            attribution,
+            (expected_grad * input),
+            delta=0.05,
+            mode="max",
         )
 
     def _input_x_gradient_classification_assert(self, nt_type: str = "vanilla") -> None:

--- a/tests/attr/test_integrated_gradients_basic.py
+++ b/tests/attr/test_integrated_gradients_basic.py
@@ -11,7 +11,6 @@ from captum.attr._core.noise_tunnel import NoiseTunnel
 from captum.attr._utils.common import _tensorize_baseline
 from tests.helpers.basic import (
     BaseTest,
-    assertArraysAlmostEqual,
     assertTensorAlmostEqual,
 )
 from tests.helpers.basic_models import (
@@ -180,15 +179,19 @@ class Test(BaseTest):
             multiply_by_inputs=multiply_by_inputs,
         )
         if type == "vanilla":
-            assertArraysAlmostEqual(
-                attributions1[0].tolist(),
+            assertTensorAlmostEqual(
+                self,
+                attributions1[0],
                 [1.5] if multiply_by_inputs else [0.5],
                 delta=0.05,
+                mode="max",
             )
-            assertArraysAlmostEqual(
-                attributions1[1].tolist(),
+            assertTensorAlmostEqual(
+                self,
+                attributions1[1],
                 [-0.5] if multiply_by_inputs else [-0.5],
                 delta=0.05,
+                mode="max",
             )
         model = BasicModel3()
         attributions2 = self._compute_attribution_and_evaluate(
@@ -200,15 +203,19 @@ class Test(BaseTest):
             multiply_by_inputs=multiply_by_inputs,
         )
         if type == "vanilla":
-            assertArraysAlmostEqual(
-                attributions2[0].tolist(),
+            assertTensorAlmostEqual(
+                self,
+                attributions2[0],
                 [1.5] if multiply_by_inputs else [0.5],
                 delta=0.05,
+                mode="max",
             )
-            assertArraysAlmostEqual(
-                attributions2[1].tolist(),
+            assertTensorAlmostEqual(
+                self,
+                attributions2[1],
                 [-0.5] if multiply_by_inputs else [-0.5],
                 delta=0.05,
+                mode="max",
             )
             # Verifies implementation invariance
             self.assertEqual(
@@ -429,7 +436,7 @@ class Test(BaseTest):
                 target=target,
                 additional_forward_args=additional_forward_args,
             )
-            assertArraysAlmostEqual(delta, delta_external, 0.0)
+            assertTensorAlmostEqual(self, delta, delta_external, delta=0.0, mode="max")
         else:
             nt = NoiseTunnel(ig)
             n_samples = 5
@@ -523,9 +530,12 @@ class Test(BaseTest):
                 )
                 total_delta += abs(delta_indiv).sum().item()
                 for j in range(len(attributions)):
-                    assertArraysAlmostEqual(
-                        attributions[j][i : i + 1].squeeze(0).tolist(),
-                        attributions_indiv[j].squeeze(0).tolist(),
+                    assertTensorAlmostEqual(
+                        self,
+                        attributions[j][i : i + 1].squeeze(0),
+                        attributions_indiv[j].squeeze(0),
+                        delta=0.05,
+                        mode="max",
                     )
             self.assertAlmostEqual(abs(delta).sum().item(), total_delta, delta=0.005)
 

--- a/tests/attr/test_saliency.py
+++ b/tests/attr/test_saliency.py
@@ -8,7 +8,6 @@ from captum.attr._core.noise_tunnel import NoiseTunnel
 from captum.attr._core.saliency import Saliency
 from tests.helpers.basic import (
     BaseTest,
-    assertArraysAlmostEqual,
     assertTensorTuplesAlmostEqual,
     assertTensorAlmostEqual,
 )
@@ -183,11 +182,7 @@ class Test(BaseTest):
         if len(attribution.shape) == 0:
             assert (attribution - expected).abs() < 0.001
         else:
-            assertArraysAlmostEqual(
-                expected.flatten(),
-                attribution.flatten(),
-                delta=0.5,
-            )
+            assertTensorAlmostEqual(self, expected, attribution, delta=0.5, mode="max")
 
     def _saliency_classification_assert(self, nt_type: str = "vanilla") -> None:
         num_in = 5

--- a/tests/attr/test_stat.py
+++ b/tests/attr/test_stat.py
@@ -5,7 +5,6 @@ import torch
 from captum.attr import MSE, Max, Mean, Min, StdDev, Sum, Summarizer, Var
 from tests.helpers.basic import (
     BaseTest,
-    assertArraysAlmostEqual,
     assertTensorAlmostEqual,
 )
 
@@ -74,22 +73,47 @@ class Test(BaseTest):
 
         summarizer = Summarizer([Mean(), Var()])
         summarizer.update(x1)
-        assertArraysAlmostEqual(summarizer.summary["mean"], x1)
-        assertArraysAlmostEqual(summarizer.summary["variance"], torch.zeros_like(x1))
+        assertTensorAlmostEqual(
+            self, summarizer.summary["mean"], x1, delta=0.05, mode="max"
+        )
+        assertTensorAlmostEqual(
+            self,
+            summarizer.summary["variance"],
+            torch.zeros_like(x1),
+            delta=0.05,
+            mode="max",
+        )
 
         summarizer.update(x2)
-        assertArraysAlmostEqual(
-            summarizer.summary["mean"], torch.tensor([1.5, 1.5, 2.5, 4])
+        assertTensorAlmostEqual(
+            self,
+            summarizer.summary["mean"],
+            torch.tensor([1.5, 1.5, 2.5, 4]),
+            delta=0.05,
+            mode="max",
         )
-        assertArraysAlmostEqual(
-            summarizer.summary["variance"], torch.tensor([0.25, 0.25, 0.25, 0])
+        assertTensorAlmostEqual(
+            self,
+            summarizer.summary["variance"],
+            torch.tensor([0.25, 0.25, 0.25, 0]),
+            delta=0.05,
+            mode="max",
         )
 
         summarizer.update(x3)
-        assertArraysAlmostEqual(summarizer.summary["mean"], torch.tensor([2, 2, 2, 4]))
-        assertArraysAlmostEqual(
+        assertTensorAlmostEqual(
+            self,
+            summarizer.summary["mean"],
+            torch.tensor([2, 2, 2, 4]),
+            delta=0.05,
+            mode="max",
+        )
+        assertTensorAlmostEqual(
+            self,
             summarizer.summary["variance"],
             torch.tensor([2.0 / 3.0, 2.0 / 3.0, 2.0 / 3.0, 0]),
+            delta=0.05,
+            mode="max",
         )
 
     def test_stats_random_data(self):

--- a/tests/helpers/basic.py
+++ b/tests/helpers/basic.py
@@ -19,19 +19,6 @@ def deep_copy_args(func: Callable):
     return copy_args
 
 
-def assertArraysAlmostEqual(inputArr, refArr, delta=0.05):
-    for index, (input, ref) in enumerate(zip(inputArr, refArr)):
-        almost_equal = abs(input - ref) <= delta
-        if hasattr(almost_equal, "__iter__"):
-            almost_equal = almost_equal.all()
-        assert (
-            almost_equal
-        ), "Values at index {}, {} and {}, \
-            differ more than by {}".format(
-            index, input, ref, delta
-        )
-
-
 def assertTensorAlmostEqual(test, actual, expected, delta=0.0001, mode="sum"):
     assert isinstance(actual, torch.Tensor), (
         "Actual parameter given for " "comparison must be a tensor."
@@ -51,9 +38,21 @@ def assertTensorAlmostEqual(test, actual, expected, delta=0.0001, mode="sum"):
         # if both tensors are empty, they are equal but there is no max
         if actual.numel() == expected.numel() == 0:
             return
-        test.assertAlmostEqual(
-            torch.max(torch.abs(actual - expected)).item(), 0.0, delta=delta
-        )
+
+        if actual.size() == torch.Size([]):
+            test.assertAlmostEqual(
+                torch.max(torch.abs(actual - expected)).item(), 0.0, delta=delta
+            )
+        else:
+            for index, (input, ref) in enumerate(zip(actual, expected)):
+                almost_equal = abs(input - ref) <= delta
+                if hasattr(almost_equal, "__iter__"):
+                    almost_equal = almost_equal.all()
+                assert (
+                    almost_equal
+                ), "Values at index {}, {} and {}, differ more than by {}".format(
+                    index, input, ref, delta
+                )
     else:
         raise ValueError("Mode for assertion comparison must be one of `max` or `sum`.")
 

--- a/tests/metrics/test_infidelity.py
+++ b/tests/metrics/test_infidelity.py
@@ -14,7 +14,6 @@ from captum.attr import (
 from captum.metrics import infidelity, infidelity_perturb_func_decorator
 from tests.helpers.basic import (
     BaseTest,
-    assertArraysAlmostEqual,
     assertTensorAlmostEqual,
 )
 from tests.helpers.basic_models import (
@@ -145,7 +144,7 @@ class Test(BaseTest):
             n_perturb_samples=5,
             max_batch_size=60,
         )
-        assertArraysAlmostEqual(infid1, infid2, 0.01)
+        assertTensorAlmostEqual(self, infid1, infid2, delta=0.01, mode="max")
 
     def test_basic_infidelity_additional_forward_args1(self) -> None:
         model = BasicModel4_MultiArgs()
@@ -239,7 +238,7 @@ class Test(BaseTest):
             max_batch_size=2,
             multi_input=False,
         )
-        assertArraysAlmostEqual(infid1, infid2, 1e-05)
+        assertTensorAlmostEqual(self, infid1, infid2, delta=1e-05, mode="max")
 
     def test_classification_infidelity_tpl_target_w_baseline(self) -> None:
         model = BasicModel_MultiLayer()

--- a/tests/utils/test_gradient.py
+++ b/tests/utils/test_gradient.py
@@ -9,7 +9,7 @@ from captum._utils.gradient import (
     compute_layer_gradients_and_eval,
     undo_gradient_requirements,
 )
-from tests.helpers.basic import BaseTest, assertArraysAlmostEqual
+from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
 from tests.helpers.basic_models import (
     BasicModel,
     BasicModel2,
@@ -49,34 +49,34 @@ class Test(BaseTest):
         input = torch.tensor([[5.0]], requires_grad=True)
         input.grad = torch.tensor([[9.0]])
         grads = compute_gradients(model, input)[0]
-        assertArraysAlmostEqual(grads.squeeze(0).tolist(), [0.0], delta=0.01)
+        assertTensorAlmostEqual(self, grads, [[0.0]], delta=0.01, mode="max")
         # Verify grad attribute is not altered
-        assertArraysAlmostEqual(input.grad.squeeze(0).tolist(), [9.0], delta=0.0)
+        assertTensorAlmostEqual(self, input.grad, [[9.0]], delta=0.0, mode="max")
 
     def test_gradient_basic_2(self) -> None:
         model = BasicModel()
         input = torch.tensor([[-3.0]], requires_grad=True)
         input.grad = torch.tensor([[14.0]])
         grads = compute_gradients(model, input)[0]
-        assertArraysAlmostEqual(grads.squeeze(0).tolist(), [1.0], delta=0.01)
+        assertTensorAlmostEqual(self, grads, [[1.0]], delta=0.01, mode="max")
         # Verify grad attribute is not altered
-        assertArraysAlmostEqual(input.grad.squeeze(0).tolist(), [14.0], delta=0.0)
+        assertTensorAlmostEqual(self, input.grad, [[14.0]], delta=0.0, mode="max")
 
     def test_gradient_multiinput(self) -> None:
         model = BasicModel6_MultiTensor()
         input1 = torch.tensor([[-3.0, -5.0]], requires_grad=True)
         input2 = torch.tensor([[-5.0, 2.0]], requires_grad=True)
         grads = compute_gradients(model, (input1, input2))
-        assertArraysAlmostEqual(grads[0].squeeze(0).tolist(), [0.0, 1.0], delta=0.01)
-        assertArraysAlmostEqual(grads[1].squeeze(0).tolist(), [0.0, 1.0], delta=0.01)
+        assertTensorAlmostEqual(self, grads[0], [[0.0, 1.0]], delta=0.01, mode="max")
+        assertTensorAlmostEqual(self, grads[1], [[0.0, 1.0]], delta=0.01, mode="max")
 
     def test_gradient_additional_args(self) -> None:
         model = BasicModel4_MultiArgs()
         input1 = torch.tensor([[10.0]], requires_grad=True)
         input2 = torch.tensor([[8.0]], requires_grad=True)
         grads = compute_gradients(model, (input1, input2), additional_forward_args=(2,))
-        assertArraysAlmostEqual(grads[0].squeeze(0).tolist(), [1.0], delta=0.01)
-        assertArraysAlmostEqual(grads[1].squeeze(0).tolist(), [-0.5], delta=0.01)
+        assertTensorAlmostEqual(self, grads[0], [[1.0]], delta=0.01, mode="max")
+        assertTensorAlmostEqual(self, grads[1], [[-0.5]], delta=0.01, mode="max")
 
     def test_gradient_additional_args_2(self) -> None:
         model = BasicModel5_MultiArgs()
@@ -85,8 +85,8 @@ class Test(BaseTest):
         grads = compute_gradients(
             model, (input1, input2), additional_forward_args=([3, -4],)
         )
-        assertArraysAlmostEqual(grads[0].squeeze(0).tolist(), [0.0], delta=0.01)
-        assertArraysAlmostEqual(grads[1].squeeze(0).tolist(), [4.0], delta=0.01)
+        assertTensorAlmostEqual(self, grads[0], [[0.0]], delta=0.01, mode="max")
+        assertTensorAlmostEqual(self, grads[1], [[4.0]], delta=0.01, mode="max")
 
     def test_gradient_target_int(self) -> None:
         model = BasicModel2()
@@ -94,21 +94,29 @@ class Test(BaseTest):
         input2 = torch.tensor([[2.0, 5.0]], requires_grad=True)
         grads0 = compute_gradients(model, (input1, input2), target_ind=0)
         grads1 = compute_gradients(model, (input1, input2), target_ind=1)
-        assertArraysAlmostEqual(grads0[0].squeeze(0).tolist(), [1.0, 0.0], delta=0.01)
-        assertArraysAlmostEqual(grads0[1].squeeze(0).tolist(), [-1.0, 0.0], delta=0.01)
-        assertArraysAlmostEqual(grads1[0].squeeze(0).tolist(), [0.0, 0.0], delta=0.01)
-        assertArraysAlmostEqual(grads1[1].squeeze(0).tolist(), [0.0, 0.0], delta=0.01)
+        assertTensorAlmostEqual(self, grads0[0], [[1.0, 0.0]], delta=0.01, mode="max")
+        assertTensorAlmostEqual(self, grads0[1], [[-1.0, 0.0]], delta=0.01, mode="max")
+        assertTensorAlmostEqual(self, grads1[0], [[0.0, 0.0]], delta=0.01, mode="max")
+        assertTensorAlmostEqual(self, grads1[1], [[0.0, 0.0]], delta=0.01, mode="max")
 
     def test_gradient_target_list(self) -> None:
         model = BasicModel2()
         input1 = torch.tensor([[4.0, -1.0], [3.0, 10.0]], requires_grad=True)
         input2 = torch.tensor([[2.0, -5.0], [-2.0, 1.0]], requires_grad=True)
         grads = compute_gradients(model, (input1, input2), target_ind=[0, 1])
-        assertArraysAlmostEqual(
-            torch.flatten(grads[0]).tolist(), [1.0, 0.0, 0.0, 1.0], delta=0.01
+        assertTensorAlmostEqual(
+            self,
+            grads[0],
+            [[1.0, 0.0], [0.0, 1.0]],
+            delta=0.01,
+            mode="max",
         )
-        assertArraysAlmostEqual(
-            torch.flatten(grads[1]).tolist(), [-1.0, 0.0, 0.0, -1.0], delta=0.01
+        assertTensorAlmostEqual(
+            self,
+            grads[1],
+            [[-1.0, 0.0], [0.0, -1.0]],
+            delta=0.01,
+            mode="max",
         )
 
     def test_gradient_target_tuple(self) -> None:
@@ -117,10 +125,12 @@ class Test(BaseTest):
             [[[4.0, 2.0], [-1.0, -2.0]], [[3.0, -4.0], [10.0, 5.0]]], requires_grad=True
         )
         grads = compute_gradients(model, input, target_ind=(0, 1))[0]
-        assertArraysAlmostEqual(
-            torch.flatten(grads).tolist(),
-            [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+        assertTensorAlmostEqual(
+            self,
+            grads,
+            [[[0.0, 0.0], [0.0, 0.0]], [[0.0, 1.0], [0.0, 0.0]]],
             delta=0.01,
+            mode="max",
         )
 
     def test_gradient_target_listtuple(self) -> None:
@@ -130,17 +140,19 @@ class Test(BaseTest):
         )
         target: List[Tuple[int, ...]] = [(1, 1), (0, 1)]
         grads = compute_gradients(model, input, target_ind=target)[0]
-        assertArraysAlmostEqual(
-            torch.flatten(grads).tolist(),
-            [0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0],
+        assertTensorAlmostEqual(
+            self,
+            grads,
+            [[[0.0, 0.0], [0.0, 1.0]], [[0.0, 1.0], [0.0, 0.0]]],
             delta=0.01,
+            mode="max",
         )
 
     def test_gradient_inplace(self) -> None:
         model = BasicModel_MultiLayer(inplace=True)
         input = torch.tensor([[1.0, 6.0, -3.0]], requires_grad=True)
         grads = compute_gradients(model, input, target_ind=0)[0]
-        assertArraysAlmostEqual(grads.squeeze(0).tolist(), [3.0, 3.0, 3.0], delta=0.01)
+        assertTensorAlmostEqual(self, grads, [[3.0, 3.0, 3.0]], delta=0.01, mode="max")
 
     def test_layer_gradient_linear0(self) -> None:
         model = BasicModel_MultiLayer()
@@ -148,11 +160,15 @@ class Test(BaseTest):
         grads, eval = compute_layer_gradients_and_eval(
             model, model.linear0, input, target_ind=0
         )
-        assertArraysAlmostEqual(
-            grads[0].squeeze(0).tolist(), [4.0, 4.0, 4.0], delta=0.01
+        assertTensorAlmostEqual(
+            self, grads[0], [[4.0, 4.0, 4.0]], delta=0.01, mode="max"
         )
-        assertArraysAlmostEqual(
-            eval[0].squeeze(0).tolist(), [5.0, -11.0, 23.0], delta=0.01
+        assertTensorAlmostEqual(
+            self,
+            eval[0],
+            [[5.0, -11.0, 23.0]],
+            delta=0.01,
+            mode="max",
         )
 
     def test_layer_gradient_linear1(self) -> None:
@@ -161,11 +177,19 @@ class Test(BaseTest):
         grads, eval = compute_layer_gradients_and_eval(
             model, model.linear1, input, target_ind=1
         )
-        assertArraysAlmostEqual(
-            grads[0].squeeze(0).tolist(), [0.0, 1.0, 1.0, 1.0], delta=0.01
+        assertTensorAlmostEqual(
+            self,
+            grads[0],
+            [[0.0, 1.0, 1.0, 1.0]],
+            delta=0.01,
+            mode="max",
         )
-        assertArraysAlmostEqual(
-            eval[0].squeeze(0).tolist(), [-2.0, 9.0, 9.0, 9.0], delta=0.01
+        assertTensorAlmostEqual(
+            self,
+            eval[0],
+            [[-2.0, 9.0, 9.0, 9.0]],
+            delta=0.01,
+            mode="max",
         )
 
     def test_layer_gradient_linear1_inplace(self) -> None:
@@ -174,11 +198,19 @@ class Test(BaseTest):
         grads, eval = compute_layer_gradients_and_eval(
             model, model.linear1, input, target_ind=1
         )
-        assertArraysAlmostEqual(
-            grads[0].squeeze(0).tolist(), [0.0, 1.0, 1.0, 1.0], delta=0.01
+        assertTensorAlmostEqual(
+            self,
+            grads[0],
+            [[0.0, 1.0, 1.0, 1.0]],
+            delta=0.01,
+            mode="max",
         )
-        assertArraysAlmostEqual(
-            eval[0].squeeze(0).tolist(), [-2.0, 9.0, 9.0, 9.0], delta=0.01
+        assertTensorAlmostEqual(
+            self,
+            eval[0],
+            [[-2.0, 9.0, 9.0, 9.0]],
+            delta=0.01,
+            mode="max",
         )
 
     def test_layer_gradient_relu_input_inplace(self) -> None:
@@ -187,11 +219,19 @@ class Test(BaseTest):
         grads, eval = compute_layer_gradients_and_eval(
             model, model.relu, input, target_ind=1, attribute_to_layer_input=True
         )
-        assertArraysAlmostEqual(
-            grads[0].squeeze(0).tolist(), [0.0, 1.0, 1.0, 1.0], delta=0.01
+        assertTensorAlmostEqual(
+            self,
+            grads[0],
+            [[0.0, 1.0, 1.0, 1.0]],
+            delta=0.01,
+            mode="max",
         )
-        assertArraysAlmostEqual(
-            eval[0].squeeze(0).tolist(), [-2.0, 9.0, 9.0, 9.0], delta=0.01
+        assertTensorAlmostEqual(
+            self,
+            eval[0],
+            [[-2.0, 9.0, 9.0, 9.0]],
+            delta=0.01,
+            mode="max",
         )
 
     def test_layer_gradient_output(self) -> None:
@@ -200,5 +240,5 @@ class Test(BaseTest):
         grads, eval = compute_layer_gradients_and_eval(
             model, model.linear2, input, target_ind=1
         )
-        assertArraysAlmostEqual(grads[0].squeeze(0).tolist(), [0.0, 1.0], delta=0.01)
-        assertArraysAlmostEqual(eval[0].squeeze(0).tolist(), [26.0, 28.0], delta=0.01)
+        assertTensorAlmostEqual(self, grads[0], [[0.0, 1.0]], delta=0.01, mode="max")
+        assertTensorAlmostEqual(self, eval[0], [[26.0, 28.0]], delta=0.01, mode="max")

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -6,9 +6,51 @@ from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
 
 class HelpersTest(BaseTest):
     def test_assert_tensor_almost_equal(self) -> None:
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(AssertionError) as cm:
+            assertTensorAlmostEqual(self, [[1.0]], [[1.0]])
+        self.assertEqual(
+            cm.exception.args,
+            ("Actual parameter given for comparison must be a tensor.",),
+        )
+
+        with self.assertRaises(AssertionError) as cm:
             assertTensorAlmostEqual(self, torch.tensor([[]]), torch.tensor([[1.0]]))
+        self.assertEqual(
+            cm.exception.args,
+            (
+                "Expected tensor with shape: torch.Size([1, 1]). Actual shape torch.Size([1, 0]).",  # noqa: E501
+            ),
+        )
 
         assertTensorAlmostEqual(self, torch.tensor([[1.0]]), [[1.0]])
-        with self.assertRaises(AssertionError):
+
+        with self.assertRaises(AssertionError) as cm:
             assertTensorAlmostEqual(self, torch.tensor([[1.0]]), [1.0])
+        self.assertEqual(
+            cm.exception.args,
+            (
+                "Expected tensor with shape: torch.Size([1]). Actual shape torch.Size([1, 1]).",  # noqa: E501
+            ),
+        )
+
+        assertTensorAlmostEqual(
+            self, torch.tensor([[1.0, 1.0]]), [[1.0, 0.0]], delta=1.0, mode="max"
+        )
+
+        with self.assertRaises(AssertionError) as cm:
+            assertTensorAlmostEqual(
+                self, torch.tensor([[1.0, 1.0]]), [[1.0, 0.0]], mode="max"
+            )
+        self.assertEqual(
+            cm.exception.args,
+            (
+                "Values at index 0, tensor([1., 1.]) and tensor([1., 0.]), differ more than by 0.0001",  # noqa: E501
+            ),
+        )
+
+        assertTensorAlmostEqual(
+            self, torch.tensor([[1.0, 1.0]]), [[1.0, 0.0]], delta=1.0
+        )
+
+        with self.assertRaises(AssertionError):
+            assertTensorAlmostEqual(self, torch.tensor([[1.0, 1.0]]), [[1.0, 0.0]])


### PR DESCRIPTION
Summary: Replaces calls to `assertArraysAlmostEqual` to calls to `assertTensorAlmostEqual` with `mode="max"` because it has the same functionality.

Differential Revision: D33722669

