### PR TITLE
refactor to use `_basic_computation`

### DIFF
--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -711,7 +711,6 @@ def _compute_jacobian_wrt_params(
     inputs: Union[Tuple[Tensor], Tensor],
     labels: Optional[Tensor] = None,
     loss_fn: Optional[Union[Module, Callable]] = None,
-    unpack_inputs: bool = False,
 ) -> Tuple[Tensor, ...]:
     r"""
     Computes the Jacobian of a batch of test examples given a model, and optional
@@ -739,7 +738,7 @@ def _compute_jacobian_wrt_params(
                 parameters of the i-th layer, for the j-th member of the minibatch.
     """
     with torch.autograd.set_grad_enabled(True):
-        out = model(inputs) if not unpack_inputs else model(*inputs)
+        out = model(*inputs)
         assert out.dim() != 0, "Please ensure model output has at least one dimension."
 
         if labels is not None and loss_fn is not None:
@@ -778,7 +777,6 @@ def _compute_jacobian_wrt_params_autograd_hacks(
     labels: Optional[Tensor] = None,
     loss_fn: Optional[Module] = None,
     reduction_type: Optional[str] = "sum",
-    unpack_inputs: bool = False,
 ) -> Tuple[Any, ...]:
     r"""
     NOT SUPPORTED FOR OPEN SOURCE. This method uses an internal 'hack` and is currently
@@ -820,7 +818,7 @@ def _compute_jacobian_wrt_params_autograd_hacks(
     with torch.autograd.set_grad_enabled(True):
         autograd_hacks.add_hooks(model)
 
-        out = model(inputs) if not unpack_inputs else model(*inputs)
+        out = model(*inputs)
         assert out.dim() != 0, "Please ensure model output has at least one dimension."
 
         if labels is not None and loss_fn is not None:


### PR DESCRIPTION
Summary: `TracInCP._influence`, `TracInCPFast._influence`, `TracInCPFastAmortized._get_intermediate_quantities`, `TracInCPFastRandProj.__init__`, and `TracInCPFastRandProj._get_intermediate_quantities` are refactored.  In particular, a computation that is performed on both the input batch and training batches is separated into a `_basic_computation` method.  This computation will also be re-used once `_self_influence` is implemented, so that is why it is good to separate it out to avoid code duplication.  Since no new functionality is added, the tests do not change.

Differential Revision: D33660472

