### PR TITLE
Make the 'eps' parameter user-adjustable in the .attribute() method.

### DIFF
--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -103,11 +103,12 @@ class DeepLift(GradientAttribution):
     https://pytorch.org/blog/optimizing-cuda-rnn-with-torchscript/
     """
 
-    def __init__(self,
-                 model: Module,
-                 multiply_by_inputs: bool = True,
-                 eps: float = 1e-10,
-                 ) -> None:
+    def __init__(
+        self,
+        model: Module,
+        multiply_by_inputs: bool = True,
+        eps: float = 1e-10,
+    ) -> None:
         r"""
         Args:
 

--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -505,8 +505,12 @@ class DeepLift(GradientAttribution):
             )
         multipliers = tuple(
             SUPPORTED_NON_LINEAR[type(module)](
-                module, module.input, module.output, grad_input, grad_output,
-                eps=self.eps
+                module,
+                module.input,
+                module.output,
+                grad_input,
+                grad_output,
+                eps=self.eps,
             )
         )
         # remove all the properies that we set for the inputs and output

--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -107,7 +107,7 @@ class DeepLift(GradientAttribution):
                  model: Module,
                  multiply_by_inputs: bool = True,
                  eps: float = 1e-10,
-    ) -> None:
+                 ) -> None:
         r"""
         Args:
 

--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -164,7 +164,7 @@ class DeepLift(GradientAttribution):
         additional_forward_args: Any = None,
         return_convergence_delta: bool = False,
         custom_attribution_func: Union[None, Callable[..., Tuple[Tensor, ...]]] = None,
-        eps: float = 1e-10,        
+        eps: float = 1e-10,
     ) -> Union[
         TensorOrTupleOfTensorsGeneric, Tuple[TensorOrTupleOfTensorsGeneric, Tensor]
     ]:
@@ -500,7 +500,8 @@ class DeepLift(GradientAttribution):
             )
         multipliers = tuple(
             SUPPORTED_NON_LINEAR[type(module)](
-                module, module.input, module.output, grad_input, grad_output, eps=self.eps
+                module, module.input, module.output, grad_input, grad_output,
+                eps=self.eps
             )
         )
         # remove all the properies that we set for the inputs and output

--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -107,7 +107,7 @@ class DeepLift(GradientAttribution):
                  model: Module,
                  multiply_by_inputs: bool = True,
                  eps: float = 1e-10,
-                ) -> None:
+    ) -> None:
         r"""
         Args:
 
@@ -127,7 +127,7 @@ class DeepLift(GradientAttribution):
                         are being multiplied by (inputs - baselines).
                         This flag applies only if `custom_attribution_func` is
                         set to None.
-                        
+
             eps (float, optional): A value at which to consider output/input change
                         significant when computing the gradients for non-linear layers.
                         This is useful to adjust, depending on your model's bit depth,


### PR DESCRIPTION
Important to fix numerical stability issues as in #835