### PR TITLE
Optim-wip: Fix bug with nn.Sequential targets

### DIFF
--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -127,16 +127,8 @@ def module_op(
             return math_op(torch.mean(self(module)), torch.mean(other(module)))
 
         name = f"Compose({', '.join([self.__name__, other.__name__])})"
-        target = (
-            self.target
-            if hasattr(self.target, "__iter__")
-            and not isinstance(self.target, nn.Module)
-            else [self.target]
-        ) + (
-            other.target
-            if hasattr(other.target, "__iter__")
-            and not isinstance(other.target, nn.Module)
-            else [other.target]
+        target = (self.target if isinstance(self.target, list) else [self.target]) + (
+            other.target if isinstance(other.target, list) else [other.target]
         )
     else:
         raise TypeError(
@@ -724,12 +716,7 @@ def sum_loss_list(
     target = [
         target
         for targets in [
-            [loss.target]
-            if not (
-                hasattr(loss.target, "__iter__")
-                and not isinstance(loss.target, nn.Module)
-            )
-            else loss.target
+            [loss.target] if not isinstance(loss.target, list) else loss.target
             for loss in loss_list
         ]
         for target in targets

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -724,7 +724,12 @@ def sum_loss_list(
     target = [
         target
         for targets in [
-            [loss.target] if not hasattr(loss.target, "__iter__") else loss.target
+            [loss.target]
+            if not (
+                hasattr(loss.target, "__iter__")
+                and not isinstance(loss.target, nn.Module)
+            )
+            else loss.target
             for loss in loss_list
         ]
         for target in targets

--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -128,8 +128,16 @@ def module_op(
 
         name = f"Compose({', '.join([self.__name__, other.__name__])})"
         target = (
-            self.target if hasattr(self.target, "__iter__") else [self.target]
-        ) + (other.target if hasattr(other.target, "__iter__") else [other.target])
+            self.target
+            if hasattr(self.target, "__iter__")
+            and not isinstance(self.target, nn.Module)
+            else [self.target]
+        ) + (
+            other.target
+            if hasattr(other.target, "__iter__")
+            and not isinstance(other.target, nn.Module)
+            else [other.target]
+        )
     else:
         raise TypeError(
             "Can only apply math operations with int, float or Loss. Received type "

--- a/captum/optim/_core/optimization.py
+++ b/captum/optim/_core/optimization.py
@@ -39,7 +39,7 @@ class InputOptimization(Objective, Parameterized):
 
     def __init__(
         self,
-        model: nn.Module,
+        model: Optional[nn.Module],
         loss_function: LossFunction,
         input_param: Optional[InputParameterization] = None,
         transform: Optional[nn.Module] = None,
@@ -56,7 +56,7 @@ class InputOptimization(Objective, Parameterized):
                         optimization.
             lr (float): The learning rate to use with the Adam optimizer.
         """
-        self.model = model
+        self.model = model or nn.Identity()
         # Grab targets from loss_function
         if hasattr(loss_function.target, "__iter__") and not isinstance(
             loss_function.target, nn.Module

--- a/captum/optim/_core/optimization.py
+++ b/captum/optim/_core/optimization.py
@@ -58,9 +58,8 @@ class InputOptimization(Objective, Parameterized):
         """
         self.model = model or nn.Identity()
         # Grab targets from loss_function
-        if hasattr(loss_function.target, "__iter__") and not isinstance(
-            loss_function.target, nn.Module
-        ):
+        assert hasattr(loss_function, "target")
+        if isinstance(loss_function.target, list):
             self.hooks = ModuleOutputsHook(loss_function.target)
         else:
             self.hooks = ModuleOutputsHook([loss_function.target])

--- a/captum/optim/_core/optimization.py
+++ b/captum/optim/_core/optimization.py
@@ -65,8 +65,9 @@ class InputOptimization(Objective, Parameterized):
             self.hooks = ModuleOutputsHook([loss_function.target])
         self.input_param = input_param or NaturalImage((224, 224))
         if isinstance(self.model, Iterable):
-            if list(self.model.parameters()) != []:
-                self.input_param.to(next(self.model.parameters()).device)
+            param = next(self.model.parameters(), None)
+            if param:
+                self.input_param = self.input_param.to(param.device)
         self.transform = transform or torch.nn.Sequential(
             RandomScale(scale=(1, 0.975, 1.025, 0.95, 1.05)), RandomSpatialJitter(16)
         )

--- a/captum/optim/_core/optimization.py
+++ b/captum/optim/_core/optimization.py
@@ -58,13 +58,16 @@ class InputOptimization(Objective, Parameterized):
         """
         self.model = model
         # Grab targets from loss_function
-        if hasattr(loss_function.target, "__iter__"):
+        if hasattr(loss_function.target, "__iter__") and not isinstance(
+            loss_function.target, nn.Module
+        ):
             self.hooks = ModuleOutputsHook(loss_function.target)
         else:
             self.hooks = ModuleOutputsHook([loss_function.target])
         self.input_param = input_param or NaturalImage((224, 224))
         if isinstance(self.model, Iterable):
-            self.input_param.to(next(self.model.parameters()).device)
+            if list(self.model.parameters()) != []:
+                self.input_param.to(next(self.model.parameters()).device)
         self.transform = transform or torch.nn.Sequential(
             RandomScale(scale=(1, 0.975, 1.025, 0.95, 1.05)), RandomSpatialJitter(16)
         )

--- a/captum/optim/_core/optimization.py
+++ b/captum/optim/_core/optimization.py
@@ -47,14 +47,13 @@ class InputOptimization(Objective, Parameterized):
         r"""
         Args:
 
-            model (nn.Module):  The reference to PyTorch model instance.
+            model (nn.Module, optional):  The reference to PyTorch model instance.
             input_param (nn.Module, optional):  A module that generates an input,
                         consumed by the model.
             transform (nn.Module, optional):  A module that transforms or preprocesses
                         the input before being passed to the model.
             loss_function (callable): The loss function to minimize during optimization
                         optimization.
-            lr (float): The learning rate to use with the Adam optimizer.
         """
         self.model = model or nn.Identity()
         # Grab targets from loss_function

--- a/captum/optim/models/_common.py
+++ b/captum/optim/models/_common.py
@@ -190,7 +190,7 @@ def collect_activations(
     """
     Collect target activations for a model.
     """
-    if not hasattr(targets, "__iter__"):
+    if not isinstance(targets, list):
         targets = [targets]
     catch_activ = ActivationFetcher(model, targets)
     activ_out = catch_activ(model_input)


### PR DESCRIPTION
Some PyTorch modules that can be used as targets have an `__iter__` attribute, like `torch.nn.Sequential`. The current target system only checks for the `__iter__` attribute to determine if a target is already in a list or not, and thus doesn't work with targets like Sequential modules. This PR fixes this bug.

This PR also corrects `InputOptimization`'s model variable type hint to reflect the fact that it's optional.