### PR TITLE
Add utilities for per-sample param gradients

### DIFF
--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -85,27 +85,6 @@ def undo_gradient_requirements(
             input.requires_grad_(False)
 
 
-def register_backward_hook(
-    module: Module, hook: Callable, attr_obj: Any
-) -> torch.utils.hooks.RemovableHandle:
-    # Special case for supporting output attributions for neuron methods
-    # This can be removed after deprecation of neuron output attributions
-    # for NeuronDeepLift, NeuronDeconvolution, and NeuronGuidedBackprop
-    # in v0.6.0
-    if (
-        hasattr(attr_obj, "skip_new_hook_layer")
-        and attr_obj.skip_new_hook_layer == module
-    ):
-        return module.register_backward_hook(hook)
-
-    try:
-        # Only supported for torch >= 1.8
-        return module.register_full_backward_hook(hook)
-    except AttributeError:
-        # Fallback for previous versions of PyTorch
-        return module.register_backward_hook(hook)
-
-
 def compute_gradients(
     forward_fn: Callable,
     inputs: Union[Tensor, Tuple[Tensor, ...]],

--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -780,9 +780,6 @@ def _compute_jacobian_wrt_params_autograd_hacks(
     reduction_type: Optional[str] = "sum",
 ) -> Tuple[Any, ...]:
     r"""
-    NOT SUPPORTED FOR OPEN SOURCE. This method uses an internal 'hack` and is currently
-    not supported.
-
     Computes the Jacobian of a batch of test examples given a model, and optional
     loss function and target labels. This method uses autograd_hacks to fully vectorize
     the Jacobian calculation. Currently, only linear and conv2d layers are supported.
@@ -827,7 +824,9 @@ def _compute_jacobian_wrt_params_autograd_hacks(
             if labels is not None and loss_fn is not None:
                 loss = loss_fn(out, labels)
                 if hasattr(loss_fn, "reduction"):
-                    msg0 = "Please ensure loss_fn.reduction is set to `sum` or `mean`"
+                    msg0 = (
+                        "Please ensure that loss_fn.reduction is set to `sum` or `mean`"
+                    )
                     assert loss_fn.reduction != "none", msg0
                     msg1 = (
                         f"loss_fn.reduction ({loss_fn.reduction}) does not match"

--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -12,6 +12,7 @@ from captum._utils.common import (
     _sort_key_list,
     _verify_select_neuron,
 )
+from captum._utils.sample_gradient import SampleGradientWrapper
 from captum._utils.typing import (
     Literal,
     ModuleOrModuleList,
@@ -20,7 +21,6 @@ from captum._utils.typing import (
 )
 from torch import Tensor, device
 from torch.nn import Module
-from captum._utils.sample_gradient import SampleGradientWrapper
 
 
 def apply_gradient_requirements(

--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -20,6 +20,7 @@ from captum._utils.typing import (
 )
 from torch import Tensor, device
 from torch.nn import Module
+from captum._utils.sample_gradient import SampleGradientWrapper
 
 
 def apply_gradient_requirements(
@@ -813,48 +814,50 @@ def _compute_jacobian_wrt_params_autograd_hacks(
                 batch. For example, grads[i][j] would reference the gradients for the
                 parameters of the i-th layer, for the j-th member of the minibatch.
     """
-    from captum._utils.fb import autograd_hacks
-
     with torch.autograd.set_grad_enabled(True):
-        autograd_hacks.add_hooks(model)
+        sample_grad_wrapper = SampleGradientWrapper(model)
+        try:
+            sample_grad_wrapper.add_hooks()
 
-        out = model(*inputs)
-        assert out.dim() != 0, "Please ensure model output has at least one dimension."
+            out = model(*inputs)
+            assert (
+                out.dim() != 0
+            ), "Please ensure model output has at least one dimension."
 
-        if labels is not None and loss_fn is not None:
-            loss = loss_fn(out, labels)
-            if hasattr(loss_fn, "reduction"):
-                msg0 = "Please ensure loss_fn.reduction is set to `sum` or `mean`"
-                assert loss_fn.reduction != "none", msg0
-                msg1 = (
-                    f"loss_fn.reduction ({loss_fn.reduction}) does not match reduction "
-                    f"type ({reduction_type}). Please ensure they are matching."
+            if labels is not None and loss_fn is not None:
+                loss = loss_fn(out, labels)
+                if hasattr(loss_fn, "reduction"):
+                    msg0 = "Please ensure loss_fn.reduction is set to `sum` or `mean`"
+                    assert loss_fn.reduction != "none", msg0
+                    msg1 = (
+                        f"loss_fn.reduction ({loss_fn.reduction}) does not match"
+                        f"reduction type ({reduction_type}). Please ensure they are"
+                        " matching."
+                    )
+                    assert loss_fn.reduction == reduction_type, msg1
+                msg2 = (
+                    "Please ensure custom loss function is applying either a "
+                    "sum or mean reduction."
                 )
-                assert loss_fn.reduction == reduction_type, msg1
-            msg2 = (
-                "Please ensure custom loss function is applying either a "
-                "sum or mean reduction."
+                assert out.shape != loss.shape, msg2
+
+                if reduction_type != "sum" and reduction_type != "mean":
+                    raise ValueError(
+                        f"{reduction_type} is not a valid value for reduction_type. "
+                        "Must be either 'sum' or 'mean'."
+                    )
+                out = loss
+
+            sample_grad_wrapper.compute_param_sample_gradients(
+                out, loss_mode=reduction_type
             )
-            assert out.shape != loss.shape, msg2
 
-            if reduction_type != "sum" and reduction_type != "mean":
-                raise ValueError(
-                    f"{reduction_type} is not a valid value for reduction_type. "
-                    "Must be either 'sum' or 'mean'."
-                )
-            out = loss
-
-        model.zero_grad()
-        out.backward(gradient=torch.ones_like(out))
-        autograd_hacks.compute_grad1(model, loss_type=reduction_type)
-
-        grads = tuple(
-            param.grad1  # type: ignore
-            for param in model.parameters()
-            if hasattr(param, "grad1")
-        )
-
-        autograd_hacks.clear_backprops(model)
-        autograd_hacks.remove_hooks(model)
+            grads = tuple(
+                param.sample_grad  # type: ignore
+                for param in model.parameters()
+                if hasattr(param, "sample_grad")
+            )
+        finally:
+            sample_grad_wrapper.remove_hooks()
 
         return grads

--- a/captum/_utils/sample_gradient.py
+++ b/captum/_utils/sample_gradient.py
@@ -4,6 +4,7 @@ from typing import Tuple, Union, cast, Iterable
 
 import torch
 from captum._utils.common import _format_tensor_into_tuples
+from captum._utils.gradient import register_backward_hook
 from torch import Tensor
 from torch.nn import Module
 
@@ -25,6 +26,8 @@ def linear_param_grads(
     (weight and bias). If reset = True, any current sample_grad values are reset,
     otherwise computed gradients are accumulated and added to the existing
     stored gradients.
+
+    Inputs with more than 2 dimensions are only supported with torch 1.8 or later
     """
     if reset:
         _reset_sample_grads(module)
@@ -116,7 +119,7 @@ class SampleGradientWrapper:
                 module.register_forward_hook(self._forward_hook_fn)
             )
             self.backward_hooks.append(
-                module.register_full_backward_hook(self._backward_hook_fn)
+                register_backward_hook(module, self._backward_hook_fn, None)
             )
 
     def _forward_hook_fn(

--- a/captum/_utils/sample_gradient.py
+++ b/captum/_utils/sample_gradient.py
@@ -1,0 +1,144 @@
+from collections import defaultdict
+from enum import Enum
+from typing import Tuple, Union
+
+import torch
+from torch import Tensor
+from torch.nn import Module
+
+from captum._utils.common import _format_tensor_into_tuples
+
+
+def linear_param_grads(
+    module: Module, activation: Tensor, gradient_out: Tensor, reset: bool = False
+):
+    if reset:
+        module.weight.sample_grad = 0
+        if module.bias is not None:
+            module.bias.sample_grad = 0
+    print(gradient_out.shape)
+    print(activation.shape)
+
+    module.weight.sample_grad += torch.einsum(
+        "n...i,n...j->nij", gradient_out, activation
+    )
+    print(module.weight.sample_grad.shape)
+    if module.bias is not None:
+        module.bias.sample_grad += gradient_out
+
+
+def conv2d_param_grads(
+    module: Module, activation: Tensor, gradient_out: Tensor, reset: bool = False
+):
+    if reset:
+        module.weight.sample_grad = 0
+        if module.bias is not None:
+            module.bias.sample_grad = 0
+
+    batch_size = activation.shape[0]
+    unfolded_act = torch.nn.functional.unfold(
+        activation,
+        module.kernel_size,
+        dilation=module.dilation,
+        padding=module.padding,
+        stride=module.stride,
+    )
+    reshaped_grad = gradient_out.reshape(batch_size, -1, unfolded_act.shape[-1])
+    grad1 = torch.einsum("ijk,ilk->ijl", reshaped_grad, unfolded_act)
+    shape = [batch_size] + list(module.weight.shape)
+    module.weight.sample_grad += grad1.reshape(shape)
+    if module.bias is not None:
+        module.bias.sample_grad += torch.sum(reshaped_grad, dim=2)
+
+
+SUPPORTED_MODULES = {
+    torch.nn.Conv2d: conv2d_param_grads,
+    torch.nn.Linear: linear_param_grads,
+}
+
+
+class LossMode(Enum):
+    SUM = 0
+    MEAN = 1
+
+
+class SampleGradientWrapper:
+    def __init__(self, model):
+        self.model = model
+        self.hooks_added = False
+        self.activation_dict = defaultdict(list)
+        self.gradient_dict = defaultdict(list)
+        self.forward_hooks = []
+        self.backward_hooks = []
+
+    def add_hooks(self):
+        self.hooks_added = True
+        self.model.apply(self._register_module_hooks)
+
+    def _register_module_hooks(self, module: torch.nn.Module):
+        if isinstance(module, tuple(SUPPORTED_MODULES.keys())):
+            self.forward_hooks.append(
+                module.register_forward_hook(self._forward_hook_fn)
+            )
+            self.backward_hooks.append(
+                module.register_full_backward_hook(self._backward_hook_fn)
+            )
+
+    def _forward_hook_fn(
+        self,
+        module: Module,
+        module_input: Union[Tensor, Tuple[Tensor, ...]],
+        module_output: Union[Tensor, Tuple[Tensor, ...]],
+    ):
+        inp_tuple = _format_tensor_into_tuples(module_input)
+        self.activation_dict[module].append(inp_tuple[0].clone().detach())
+
+    def _backward_hook_fn(
+        self,
+        module: Module,
+        grad_input: Union[Tensor, Tuple[Tensor, ...]],
+        grad_output: Union[Tensor, Tuple[Tensor, ...]],
+    ):
+        grad_output_tuple = _format_tensor_into_tuples(grad_output)
+        self.gradient_dict[module].append(grad_output_tuple[0].clone().detach())
+
+    def remove_hooks(self):
+        self.hooks_added = False
+
+        for hook in self.forward_hooks:
+            hook.remove()
+
+        for hook in self.backward_hooks:
+            hook.remove()
+
+        self.forward_hooks = []
+        self.backward_hooks = []
+
+    def reset(self):
+        self.activation_dict = defaultdict(list)
+        self.gradient_dict = defaultdict(list)
+
+    def compute_param_sample_gradients(self, loss_blob, loss_mode="mean"):
+        assert (
+            loss_mode.upper() in LossMode.__members__
+        ), f"Provided loss mode {loss_mode} is not valid"
+        mode = LossMode[loss_mode.upper()]
+
+        self.model.zero_grad()
+        loss_blob.backward(gradient=torch.ones_like(loss_blob))
+
+        for module in self.activation_dict:
+            sample_grad_fn = SUPPORTED_MODULES[type(module)]
+            activations = self.activation_dict[module]
+            gradients = self.gradient_dict[module]
+            assert len(activations) == len(gradients), (
+                "Number of saved activations do not match number of saved gradients."
+                " This may occur if mmultiple forward passes are run without calling"
+                " reset or computing param gradients."
+            )
+            for i, (act, grad) in enumerate(
+                zip(activations, list(reversed(gradients)))
+            ):
+                mult = 1 if mode is LossMode.SUM else act.shape[0]
+                sample_grad_fn(module, act, grad * mult, reset=(i == 0))
+        self.reset()

--- a/captum/_utils/sample_gradient.py
+++ b/captum/_utils/sample_gradient.py
@@ -165,7 +165,7 @@ class SampleGradientWrapper:
             gradients = self.gradient_dict[module]
             assert len(activations) == len(gradients), (
                 "Number of saved activations do not match number of saved gradients."
-                " This may occur if mmultiple forward passes are run without calling"
+                " This may occur if multiple forward passes are run without calling"
                 " reset or computing param gradients."
             )
             for i, (act, grad) in enumerate(

--- a/captum/_utils/sample_gradient.py
+++ b/captum/_utils/sample_gradient.py
@@ -28,7 +28,9 @@ def linear_param_grads(
         "n...i,n...j->nij", gradient_out, activation
     )
     if module.bias is not None:
-        module.bias.sample_grad += gradient_out  # type: ignore
+        module.bias.sample_grad += torch.einsum(
+            "n...i->ni", gradient_out  # type: ignore
+        )
 
 
 def conv2d_param_grads(

--- a/captum/_utils/sample_gradient.py
+++ b/captum/_utils/sample_gradient.py
@@ -3,8 +3,7 @@ from enum import Enum
 from typing import Tuple, Union, cast, Iterable
 
 import torch
-from captum._utils.common import _format_tensor_into_tuples
-from captum._utils.gradient import register_backward_hook
+from captum._utils.common import _format_tensor_into_tuples, _register_backward_hook
 from torch import Tensor
 from torch.nn import Module
 
@@ -119,7 +118,7 @@ class SampleGradientWrapper:
                 module.register_forward_hook(self._forward_hook_fn)
             )
             self.backward_hooks.append(
-                register_backward_hook(module, self._backward_hook_fn, None)
+                _register_backward_hook(module, self._backward_hook_fn, None)
             )
 
     def _forward_hook_fn(

--- a/captum/_utils/sample_gradient.py
+++ b/captum/_utils/sample_gradient.py
@@ -28,8 +28,8 @@ def linear_param_grads(
         "n...i,n...j->nij", gradient_out, activation
     )
     if module.bias is not None:
-        module.bias.sample_grad += torch.einsum(
-            "n...i->ni", gradient_out  # type: ignore
+        module.bias.sample_grad += torch.einsum(  # type: ignore
+            "n...i->ni", gradient_out
         )
 
 

--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -18,10 +18,10 @@ from captum._utils.common import (
     _is_tuple,
     _run_forward,
     _select_targets,
+    _register_backward_hook,
 )
 from captum._utils.gradient import (
     apply_gradient_requirements,
-    register_backward_hook,
     undo_gradient_requirements,
 )
 from captum._utils.typing import (
@@ -546,7 +546,7 @@ class DeepLift(GradientAttribution):
         # adds forward hook to leaf nodes that are non-linear
         forward_handle = module.register_forward_hook(self._forward_hook)
         pre_forward_handle = module.register_forward_pre_hook(self._forward_pre_hook)
-        backward_handle = register_backward_hook(module, self._backward_hook, self)
+        backward_handle = _register_backward_hook(module, self._backward_hook, self)
         self.forward_handles.append(forward_handle)
         self.forward_handles.append(pre_forward_handle)
         self.backward_handles.append(backward_handle)

--- a/captum/attr/_core/guided_backprop_deconvnet.py
+++ b/captum/attr/_core/guided_backprop_deconvnet.py
@@ -4,10 +4,14 @@ from typing import Any, List, Tuple, Union
 
 import torch
 import torch.nn.functional as F
-from captum._utils.common import _format_input, _format_output, _is_tuple
+from captum._utils.common import (
+    _format_input,
+    _format_output,
+    _is_tuple,
+    _register_backward_hook,
+)
 from captum._utils.gradient import (
     apply_gradient_requirements,
-    register_backward_hook,
     undo_gradient_requirements,
 )
 from captum._utils.typing import TargetType, TensorOrTupleOfTensorsGeneric
@@ -75,7 +79,7 @@ class ModifiedReluGradientAttribution(GradientAttribution):
 
     def _register_hooks(self, module: Module):
         if isinstance(module, torch.nn.ReLU):
-            hook = register_backward_hook(module, self._backward_hook, self)
+            hook = _register_backward_hook(module, self._backward_hook, self)
             self.backward_hooks.append(hook)
 
     def _backward_hook(

--- a/captum/attr/_core/lrp.py
+++ b/captum/attr/_core/lrp.py
@@ -5,10 +5,15 @@ from collections import defaultdict
 from typing import Any, List, Tuple, Union, cast
 
 import torch.nn as nn
-from captum._utils.common import _format_input, _format_output, _is_tuple, _run_forward
+from captum._utils.common import (
+    _format_input,
+    _format_output,
+    _is_tuple,
+    _run_forward,
+    _register_backward_hook,
+)
 from captum._utils.gradient import (
     apply_gradient_requirements,
-    register_backward_hook,
     undo_gradient_requirements,
 )
 from captum._utils.typing import Literal, TargetType, TensorOrTupleOfTensorsGeneric
@@ -309,7 +314,7 @@ class LRP(GradientAttribution):
     def _register_forward_hooks(self) -> None:
         for layer in self.layers:
             if type(layer) in SUPPORTED_NON_LINEAR_LAYERS:
-                backward_handle = register_backward_hook(
+                backward_handle = _register_backward_hook(
                     layer, PropagationRule.backward_hook_activation, self
                 )
                 self.backward_handles.append(backward_handle)

--- a/tests/helpers/basic_models.py
+++ b/tests/helpers/basic_models.py
@@ -468,14 +468,14 @@ class BasicModel_ConvNetWithPaddingDilation(nn.Module):
         super().__init__()
         self.conv1 = nn.Conv2d(1, 2, 3, padding=3, stride=2, dilation=2)
         self.relu1 = nn.ReLU(inplace=inplace)
-        self.fc1 = nn.Linear(32, 4)
+        self.fc1 = nn.Linear(16, 4)
 
     @no_type_check
     def forward(self, x: Tensor):
         bsz = x.shape[0]
         x = self.relu1(self.conv1(x))
-        x = x.view(bsz, -1)
-        return self.fc1(x)
+        x = x.reshape(bsz, 2, -1)
+        return self.fc1(x).reshape(bsz, -1)
 
 
 class BasicModel_ConvNet(nn.Module):

--- a/tests/helpers/basic_models.py
+++ b/tests/helpers/basic_models.py
@@ -463,6 +463,21 @@ class BasicModel_ConvNet_One_Conv(nn.Module):
         return self.relu2(self.fc1(x))
 
 
+class BasicModel_ConvNetWithPaddingDilation(nn.Module):
+    def __init__(self, inplace: bool = False) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv2d(1, 2, 3, padding=3, stride=2, dilation=2)
+        self.relu1 = nn.ReLU(inplace=inplace)
+        self.fc1 = nn.Linear(32, 4)
+
+    @no_type_check
+    def forward(self, x: Tensor):
+        bsz = x.shape[0]
+        x = self.relu1(self.conv1(x))
+        x = x.view(bsz, -1)
+        return self.fc1(x)
+
+
 class BasicModel_ConvNet(nn.Module):
     def __init__(self) -> None:
         super().__init__()

--- a/tests/utils/test_jacobian.py
+++ b/tests/utils/test_jacobian.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+
+import torch
+import torch.nn as nn
+from captum._utils.gradient import (
+    _compute_jacobian_wrt_params,
+    _compute_jacobian_wrt_params_autograd_hacks,
+)
+from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
+from tests.helpers.basic_models import BasicLinearModel2, BasicLinearModel_Multilayer
+
+
+class Test(BaseTest):
+    def test_jacobian_scores_single_scalar(self) -> None:
+        model = BasicLinearModel2(5, 1)
+        model.linear.weight = nn.Parameter(torch.arange(0, 5).float())
+
+        a = torch.ones(5).unsqueeze(0)
+
+        grads = _compute_jacobian_wrt_params(model, a)
+        assertTensorAlmostEqual(self, grads[0][0], a)
+
+        grads = _compute_jacobian_wrt_params_autograd_hacks(model, a)
+        assertTensorAlmostEqual(self, grads[0][0], a)
+
+    def test_jacobian_scores_single_vector(self) -> None:
+        model = BasicLinearModel2(5, 2)
+        model.linear.weight = nn.Parameter(torch.arange(0, 10).view(2, 5).float())
+
+        a = torch.ones(5).unsqueeze(0)
+
+        grads = _compute_jacobian_wrt_params(model, a)
+        assertTensorAlmostEqual(self, grads[0][0], a)
+
+        grads = _compute_jacobian_wrt_params_autograd_hacks(model, a)
+        assertTensorAlmostEqual(self, grads[0][0], a)
+
+    def test_jacobian_scores_single_scalar_multilayer(self) -> None:
+        model = BasicLinearModel_Multilayer(5, 2, 1)
+        model.linear1.weight = nn.Parameter(torch.arange(0, 10).view(2, 5).float())
+        model.linear2.weight = nn.Parameter(torch.arange(1, 3).view(1, 2).float())
+
+        a = torch.ones(5).unsqueeze(0)
+
+        grads = _compute_jacobian_wrt_params(model, a)
+        assertTensorAlmostEqual(self, grads[0][0], torch.stack((a, 2 * a)))
+        assertTensorAlmostEqual(self, grads[1][0], torch.Tensor([10, 35]))
+
+        grads = _compute_jacobian_wrt_params_autograd_hacks(model, a)
+        assertTensorAlmostEqual(self, grads[0][0], torch.stack((a, 2 * a)))
+        assertTensorAlmostEqual(self, grads[1][0], torch.Tensor([10, 35]))
+
+    def test_jacobian_scores_single_vector_multilayer(self) -> None:
+        model = BasicLinearModel_Multilayer(5, 2, 2)
+        model.linear1.weight = nn.Parameter(torch.arange(0, 10).view(2, 5).float())
+        model.linear2.weight = nn.Parameter(torch.arange(0, 4).view(2, 2).float())
+
+        a = torch.ones(5).unsqueeze(0)
+
+        grads = _compute_jacobian_wrt_params(model, a)
+        assertTensorAlmostEqual(self, grads[0][0], torch.stack((2 * a, 4 * a)))
+        assertTensorAlmostEqual(self, grads[1][0], torch.Tensor([[10, 35], [10, 35]]))
+
+        grads = _compute_jacobian_wrt_params_autograd_hacks(model, a)
+        assertTensorAlmostEqual(self, grads[0][0], torch.stack((2 * a, 4 * a)))
+        assertTensorAlmostEqual(self, grads[1][0], torch.Tensor([[10, 35], [10, 35]]))
+
+    def test_jacobian_scores_batch_scalar(self) -> None:
+        model = BasicLinearModel2(5, 1)
+        model.linear.weight = nn.Parameter(torch.arange(0, 5).float())
+
+        a = torch.stack((torch.ones(5), torch.ones(5) * 2))
+
+        grads = _compute_jacobian_wrt_params(model, a)
+        assertTensorAlmostEqual(self, grads[0][0], a[0])
+        assertTensorAlmostEqual(self, grads[0][1], a[1])
+
+        grads = _compute_jacobian_wrt_params_autograd_hacks(model, a)
+        assertTensorAlmostEqual(self, grads[0][0], a[0])
+        assertTensorAlmostEqual(self, grads[0][1], a[1])
+
+    def test_jacobian_scores_batch_vector(self) -> None:
+        model = BasicLinearModel2(5, 2)
+        model.linear.weight = nn.Parameter(torch.arange(0, 10).view(2, 5).float())
+
+        a = torch.stack((torch.ones(5), torch.ones(5) * 2))
+
+        grads = _compute_jacobian_wrt_params(model, a)
+        assertTensorAlmostEqual(self, grads[0][0], torch.stack((a[0], a[0])))
+        assertTensorAlmostEqual(self, grads[0][1], torch.stack((a[1], a[1])))
+
+        grads = _compute_jacobian_wrt_params_autograd_hacks(model, a)
+        assertTensorAlmostEqual(self, grads[0][0], torch.stack((a[0], a[0])))
+        assertTensorAlmostEqual(self, grads[0][1], torch.stack((a[1], a[1])))
+
+    def test_jacobian_scores_batch_scalar_multilayer(self) -> None:
+        model = BasicLinearModel_Multilayer(5, 2, 1)
+        model.linear1.weight = nn.Parameter(torch.arange(0, 10).view(2, 5).float())
+        model.linear2.weight = nn.Parameter(torch.arange(1, 3).view(1, 2).float())
+
+        a = torch.stack((torch.ones(5), torch.ones(5) * 2))
+
+        grads = _compute_jacobian_wrt_params(model, a)
+        assertTensorAlmostEqual(self, grads[0][0], torch.stack((a[0], 2 * a[0])))
+        assertTensorAlmostEqual(self, grads[1][0], torch.Tensor([10, 35]))
+        assertTensorAlmostEqual(self, grads[0][1], torch.stack((a[1], 2 * a[1])))
+        assertTensorAlmostEqual(self, grads[1][1], torch.Tensor([20, 70]))
+
+        grads = _compute_jacobian_wrt_params_autograd_hacks(model, a)
+        assertTensorAlmostEqual(self, grads[0][0], torch.stack((a[0], 2 * a[0])))
+        assertTensorAlmostEqual(self, grads[1][0], torch.Tensor([10, 35]))
+        assertTensorAlmostEqual(self, grads[0][1], torch.stack((a[1], 2 * a[1])))
+        assertTensorAlmostEqual(self, grads[1][1], torch.Tensor([20, 70]))
+
+    def test_jacobian_scores_batch_vector_multilayer(self) -> None:
+        model = BasicLinearModel_Multilayer(5, 2, 2)
+        model.linear1.weight = nn.Parameter(torch.arange(0, 10).view(2, 5).float())
+        model.linear2.weight = nn.Parameter(torch.arange(0, 4).view(2, 2).float())
+
+        a = torch.stack((torch.ones(5), torch.ones(5) * 2))
+
+        grads = _compute_jacobian_wrt_params(model, a)
+        assertTensorAlmostEqual(self, grads[0][0], torch.stack((2 * a[0], 4 * a[0])))
+        assertTensorAlmostEqual(self, grads[1][0], torch.Tensor([[10, 35], [10, 35]]))
+        assertTensorAlmostEqual(self, grads[0][1], torch.stack((2 * a[1], 4 * a[1])))
+        assertTensorAlmostEqual(self, grads[1][1], torch.Tensor([[20, 70], [20, 70]]))
+
+        grads = _compute_jacobian_wrt_params_autograd_hacks(model, a)
+        assertTensorAlmostEqual(self, grads[0][0], torch.stack((2 * a[0], 4 * a[0])))
+        assertTensorAlmostEqual(self, grads[1][0], torch.Tensor([[10, 35], [10, 35]]))
+        assertTensorAlmostEqual(self, grads[0][1], torch.stack((2 * a[1], 4 * a[1])))
+        assertTensorAlmostEqual(self, grads[1][1], torch.Tensor([[20, 70], [20, 70]]))
+
+    def test_jacobian_loss_single_scalar(self) -> None:
+        model = BasicLinearModel2(5, 1)
+        model.linear.weight = nn.Parameter(torch.arange(0, 5).float())
+
+        a = torch.ones(5).unsqueeze(0)
+        label = torch.Tensor([9])
+
+        loss_fn = nn.MSELoss(reduction="none")
+        grads = _compute_jacobian_wrt_params(model, a, label, loss_fn)
+        assertTensorAlmostEqual(self, grads[0][0], 2 * (10 - 9) * a)
+
+        loss_fn = nn.MSELoss(reduction="sum")
+        grads = _compute_jacobian_wrt_params_autograd_hacks(model, a, label, loss_fn)
+        assertTensorAlmostEqual(self, grads[0], 2 * (10 - 9) * a)
+
+    def test_jacobian_loss_single_vector(self) -> None:
+        model = BasicLinearModel2(5, 2)
+        model.linear.weight = nn.Parameter(torch.arange(0, 10).view(2, 5).float())
+
+        a = torch.ones(5).unsqueeze(0)
+        label = torch.Tensor([[9, 38]])
+
+        loss_fn = nn.MSELoss(reduction="none")
+        grads = _compute_jacobian_wrt_params(model, a, label, loss_fn)
+        assertTensorAlmostEqual(
+            self, grads[0][0], torch.stack((2 * (10 - 9) * a, 2 * (35 - 38) * a))
+        )
+
+        loss_fn = nn.MSELoss(reduction="sum")
+        grads = _compute_jacobian_wrt_params_autograd_hacks(model, a, label, loss_fn)
+        assertTensorAlmostEqual(
+            self, grads[0], torch.stack((2 * (10 - 9) * a, 2 * (35 - 38) * a))
+        )
+
+    def test_jacobian_loss_batch_scalar(self) -> None:
+        model = BasicLinearModel2(5, 1)
+        model.linear.weight = nn.Parameter(torch.arange(0, 5).float())
+
+        a = torch.stack((torch.ones(5), torch.ones(5) * 2))
+        label = torch.Tensor([9, 18])
+
+        loss_fn = nn.MSELoss(reduction="none")
+        grads = _compute_jacobian_wrt_params(model, a, label, loss_fn)
+        assertTensorAlmostEqual(self, grads[0][0], 2 * (10 - 9) * a[0])
+        assertTensorAlmostEqual(self, grads[0][1], 2 * (20 - 18) * a[1])
+
+        loss_fn = nn.MSELoss(reduction="sum")
+        grads = _compute_jacobian_wrt_params_autograd_hacks(model, a, label, loss_fn)
+        assertTensorAlmostEqual(self, grads[0][0], 2 * (10 - 9) * a[0])
+        assertTensorAlmostEqual(self, grads[0][1], 2 * (20 - 18) * a[1])
+
+    def test_jacobian_loss_batch_vector(self) -> None:
+        model = BasicLinearModel2(5, 2)
+        model.linear.weight = nn.Parameter(torch.arange(0, 10).view(2, 5).float())
+
+        a = torch.stack((torch.ones(5), torch.ones(5) * 2))
+        label = torch.Tensor([[9, 38], [18, 74]])
+
+        loss_fn = nn.MSELoss(reduction="none")
+        grads = _compute_jacobian_wrt_params(model, a, label, loss_fn)
+        assertTensorAlmostEqual(
+            self, grads[0][0], torch.stack((2 * (10 - 9) * a[0], 2 * (35 - 38) * a[0]))
+        )
+        assertTensorAlmostEqual(
+            self, grads[0][1], torch.stack((2 * (20 - 18) * a[1], 2 * (70 - 74) * a[1]))
+        )
+
+        loss_fn = nn.MSELoss(reduction="sum")
+        grads = _compute_jacobian_wrt_params_autograd_hacks(model, a, label, loss_fn)
+        assertTensorAlmostEqual(
+            self, grads[0][0], torch.stack((2 * (10 - 9) * a[0], 2 * (35 - 38) * a[0]))
+        )
+        assertTensorAlmostEqual(
+            self, grads[0][1], torch.stack((2 * (20 - 18) * a[1], 2 * (70 - 74) * a[1]))
+        )
+
+    def test_jacobian_loss_single_scalar_multilayer(self) -> None:
+        model = BasicLinearModel_Multilayer(5, 2, 1)
+        model.linear1.weight = nn.Parameter(torch.arange(0, 10).view(2, 5).float())
+        model.linear2.weight = nn.Parameter(torch.arange(1, 3).view(1, 2).float())
+
+        a = torch.ones(5).unsqueeze(0)
+        label = torch.Tensor([[78]])
+
+        loss_fn = nn.MSELoss(reduction="none")
+        grads = _compute_jacobian_wrt_params(model, a, label, loss_fn)
+        assertTensorAlmostEqual(
+            self, grads[0][0], torch.stack((2 * (80 - 78) * a, 2 * 2 * (80 - 78) * a))
+        )
+        assertTensorAlmostEqual(
+            self, grads[1][0], 2 * (80 - 78) * torch.Tensor([10, 35])
+        )
+
+        loss_fn = nn.MSELoss(reduction="sum")
+        grads = _compute_jacobian_wrt_params_autograd_hacks(model, a, label, loss_fn)
+        assertTensorAlmostEqual(
+            self, grads[0][0], torch.stack((2 * (80 - 78) * a, 2 * 2 * (80 - 78) * a))
+        )
+        assertTensorAlmostEqual(
+            self, grads[1][0], 2 * (80 - 78) * torch.Tensor([10, 35])
+        )
+
+    def test_jacobian_loss_batch_vector_multilayer(self) -> None:
+        model = BasicLinearModel_Multilayer(5, 2, 2)
+        model.linear1.weight = nn.Parameter(torch.arange(0, 10).view(2, 5).float())
+        model.linear2.weight = nn.Parameter(torch.arange(0, 4).view(2, 2).float())
+
+        a = torch.stack((torch.ones(5), torch.ones(5) * 2))
+        label = torch.Tensor([[33, 124], [69, 256]])
+
+        loss_fn = nn.MSELoss(reduction="none")
+        grads = _compute_jacobian_wrt_params(model, a, label, loss_fn)
+        assertTensorAlmostEqual(
+            self,
+            grads[0][0],
+            torch.stack(
+                (
+                    2 * (0 * (35 - 33) + 2 * (125 - 124)) * a[0],
+                    2 * (1 * (35 - 33) + 3 * (125 - 124)) * a[0],
+                )
+            ),
+        )
+        assertTensorAlmostEqual(
+            self,
+            grads[1][0],
+            torch.Tensor(
+                [
+                    [2 * (35 - 33) * 10, 2 * (35 - 33) * 35],
+                    [2 * (125 - 124) * 10, 2 * (125 - 124) * 35],
+                ]
+            ),
+        )
+        assertTensorAlmostEqual(
+            self,
+            grads[0][1],
+            torch.stack(
+                (
+                    2 * (0 * (70 - 69) + 2 * (250 - 256)) * a[1],
+                    2 * (1 * (70 - 69) + 3 * (250 - 256)) * a[1],
+                )
+            ),
+        )
+        assertTensorAlmostEqual(
+            self,
+            grads[1][1],
+            torch.Tensor(
+                [
+                    [2 * (70 - 69) * 10 * 2, 2 * (70 - 69) * 35 * 2],
+                    [2 * (250 - 256) * 10 * 2, 2 * (250 - 256) * 35 * 2],
+                ]
+            ),
+        )
+
+        loss_fn = nn.MSELoss(reduction="sum")
+        grads_h = _compute_jacobian_wrt_params_autograd_hacks(model, a, label, loss_fn)
+        assertTensorAlmostEqual(self, grads_h[0][0], grads[0][0])
+        assertTensorAlmostEqual(self, grads_h[1][0], grads[1][0])
+        assertTensorAlmostEqual(self, grads_h[0][1], grads[0][1])
+        assertTensorAlmostEqual(self, grads_h[1][1], grads[1][1])
+
+    def test_jacobian_loss_custom_correct(self) -> None:
+        model = BasicLinearModel2(5, 2)
+        model.linear.weight = nn.Parameter(torch.arange(0, 10).view(2, 5).float())
+
+        def my_loss(out, label):
+            return torch.square(out - label)
+
+        a = torch.stack((torch.ones(5), torch.ones(5) * 2))
+        label = torch.Tensor([[9, 38], [18, 74]])
+        grads = _compute_jacobian_wrt_params(model, a, label, my_loss)
+
+        assertTensorAlmostEqual(
+            self, grads[0][0], torch.stack((2 * (10 - 9) * a[0], 2 * (35 - 38) * a[0]))
+        )
+        assertTensorAlmostEqual(
+            self, grads[0][1], torch.stack((2 * (20 - 18) * a[1], 2 * (70 - 74) * a[1]))
+        )
+
+    def test_jacobian_loss_custom_wrong(self) -> None:
+        model = BasicLinearModel2(5, 2)
+        model.linear.weight = nn.Parameter(torch.arange(0, 10).view(2, 5).float())
+
+        def my_loss(out, label):
+            return torch.sum(torch.square(out - label))
+
+        a = torch.stack((torch.ones(5), torch.ones(5) * 2))
+        label = torch.Tensor([[9, 38], [18, 74]])
+
+        with self.assertRaises(AssertionError):
+            _compute_jacobian_wrt_params(model, a, label, my_loss)
+
+    def test_jacobian_loss_custom_correct_hack(self) -> None:
+        model = BasicLinearModel2(5, 2)
+        model.linear.weight = nn.Parameter(torch.arange(0, 10).view(2, 5).float())
+
+        def my_loss(out, label):
+            return torch.sum(torch.square(out - label))
+
+        a = torch.stack((torch.ones(5), torch.ones(5) * 2))
+        label = torch.Tensor([[9, 38], [18, 74]])
+        grads = _compute_jacobian_wrt_params_autograd_hacks(model, a, label, my_loss)
+
+        assertTensorAlmostEqual(
+            self, grads[0][0], torch.stack((2 * (10 - 9) * a[0], 2 * (35 - 38) * a[0]))
+        )
+        assertTensorAlmostEqual(
+            self, grads[0][1], torch.stack((2 * (20 - 18) * a[1], 2 * (70 - 74) * a[1]))
+        )
+
+    def test_jacobian_loss_custom_wrong_hack(self) -> None:
+        model = BasicLinearModel2(5, 2)
+        model.linear.weight = nn.Parameter(torch.arange(0, 10).view(2, 5).float())
+
+        def my_loss(out, label):
+            return torch.square(out - label)
+
+        a = torch.stack((torch.ones(5), torch.ones(5) * 2))
+        label = torch.Tensor([[9, 38], [18, 74]])
+
+        with self.assertRaises(AssertionError):
+            _compute_jacobian_wrt_params_autograd_hacks(model, a, label, my_loss)
+
+    def test_jacobian_loss_wrong_reduction_hack(self) -> None:
+        model = BasicLinearModel2(5, 2)
+        model.linear.weight = nn.Parameter(torch.arange(0, 10).view(2, 5).float())
+        loss_fn = nn.MSELoss(reduction="none")
+
+        a = torch.stack((torch.ones(5), torch.ones(5) * 2))
+        label = torch.Tensor([[9, 38], [18, 74]])
+
+        with self.assertRaises(AssertionError):
+            _compute_jacobian_wrt_params_autograd_hacks(model, a, label, loss_fn)

--- a/tests/utils/test_jacobian.py
+++ b/tests/utils/test_jacobian.py
@@ -299,7 +299,7 @@ class Test(BaseTest):
         model.linear.weight = nn.Parameter(torch.arange(0, 10).view(2, 5).float())
 
         def my_loss(out, label):
-            return torch.square(out - label)
+            return (out - label).pow(2)
 
         a = torch.stack((torch.ones(5), torch.ones(5) * 2))
         label = torch.Tensor([[9, 38], [18, 74]])
@@ -317,7 +317,7 @@ class Test(BaseTest):
         model.linear.weight = nn.Parameter(torch.arange(0, 10).view(2, 5).float())
 
         def my_loss(out, label):
-            return torch.sum(torch.square(out - label))
+            return torch.sum((out - label).pow(2))
 
         a = torch.stack((torch.ones(5), torch.ones(5) * 2))
         label = torch.Tensor([[9, 38], [18, 74]])
@@ -330,7 +330,7 @@ class Test(BaseTest):
         model.linear.weight = nn.Parameter(torch.arange(0, 10).view(2, 5).float())
 
         def my_loss(out, label):
-            return torch.sum(torch.square(out - label))
+            return torch.sum((out - label).pow(2))
 
         a = torch.stack((torch.ones(5), torch.ones(5) * 2))
         label = torch.Tensor([[9, 38], [18, 74]])
@@ -349,7 +349,7 @@ class Test(BaseTest):
         model.linear.weight = nn.Parameter(torch.arange(0, 10).view(2, 5).float())
 
         def my_loss(out, label):
-            return torch.square(out - label)
+            return (out - label).pow(2)
 
         a = torch.stack((torch.ones(5), torch.ones(5) * 2))
         label = torch.Tensor([[9, 38], [18, 74]])

--- a/tests/utils/test_jacobian.py
+++ b/tests/utils/test_jacobian.py
@@ -334,8 +334,8 @@ class Test(BaseTest):
 
         a = torch.stack((torch.ones(5), torch.ones(5) * 2))
         label = torch.Tensor([[9, 38], [18, 74]])
-        grads = _compute_jacobian_wrt_params_autograd_hacks(  # type: ignore
-            model, (a,), label, my_loss
+        grads = _compute_jacobian_wrt_params_autograd_hacks(
+            model, (a,), label, my_loss  # type: ignore
         )
         assertTensorAlmostEqual(
             self, grads[0][0], torch.stack((2 * (10 - 9) * a[0], 2 * (35 - 38) * a[0]))
@@ -355,7 +355,9 @@ class Test(BaseTest):
         label = torch.Tensor([[9, 38], [18, 74]])
 
         with self.assertRaises(AssertionError):
-            _compute_jacobian_wrt_params_autograd_hacks(model, (a,), label, my_loss)
+            _compute_jacobian_wrt_params_autograd_hacks(
+                model, (a,), label, my_loss  # type: ignore
+            )
 
     def test_jacobian_loss_wrong_reduction_hack(self) -> None:
         model = BasicLinearModel2(5, 2)

--- a/tests/utils/test_jacobian.py
+++ b/tests/utils/test_jacobian.py
@@ -334,8 +334,9 @@ class Test(BaseTest):
 
         a = torch.stack((torch.ones(5), torch.ones(5) * 2))
         label = torch.Tensor([[9, 38], [18, 74]])
-        grads = _compute_jacobian_wrt_params_autograd_hacks(model, (a,), label, my_loss)
-
+        grads = _compute_jacobian_wrt_params_autograd_hacks(  # type: ignore
+            model, (a,), label, my_loss
+        )
         assertTensorAlmostEqual(
             self, grads[0][0], torch.stack((2 * (10 - 9) * a[0], 2 * (35 - 38) * a[0]))
         )

--- a/tests/utils/test_sample_gradient.py
+++ b/tests/utils/test_sample_gradient.py
@@ -68,8 +68,14 @@ class Test(BaseTest):
             for layer in model.modules():
                 if isinstance(layer, tuple(SUPPORTED_MODULES.keys())):
                     assertTensorAlmostEqual(
-                        self, layer.weight.grad, layer.weight.sample_grad[i], mode="max"
+                        self,
+                        layer.weight.grad,
+                        layer.weight.sample_grad[i],
+                        mode="max",  # type: ignore
                     )
                     assertTensorAlmostEqual(
-                        self, layer.bias.grad, layer.bias.sample_grad[i], mode="max"
+                        self,
+                        layer.bias.grad,
+                        layer.bias.sample_grad[i],
+                        mode="max",  # type: ignore
                     )

--- a/tests/utils/test_sample_gradient.py
+++ b/tests/utils/test_sample_gradient.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+from typing import Tuple, Callable
+
+import torch
+from captum._utils.sample_gradient import SampleGradientWrapper, SUPPORTED_MODULES
+from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
+from tests.helpers.basic_models import (
+    BasicModel_ConvNet_One_Conv,
+    BasicModel_MultiLayer,
+    BasicModel_ConvNetWithPaddingDilation,
+)
+from torch import Tensor
+from torch.nn import Module
+
+
+class Test(BaseTest):
+    def test_sample_grads_linear_sum(self) -> None:
+        model = BasicModel_MultiLayer(multi_input_module=True)
+        inp = (torch.randn(6, 3), torch.randn(6, 3))
+        self._compare_sample_grads_per_sample(model, inp, lambda x: torch.sum(x), "sum")
+
+    def test_sample_grads_linear_mean(self) -> None:
+        model = BasicModel_MultiLayer(multi_input_module=True)
+        inp = (20 * torch.randn(6, 3),)
+        self._compare_sample_grads_per_sample(model, inp, lambda x: torch.mean(x))
+
+    def test_sample_grads_conv_sum(self) -> None:
+        model = BasicModel_ConvNet_One_Conv()
+        inp = (123 * torch.randn(6, 1, 4, 4),)
+        self._compare_sample_grads_per_sample(model, inp, lambda x: torch.sum(x), "sum")
+
+    def test_sample_grads_conv_mean_multi_inp(self) -> None:
+        model = BasicModel_ConvNet_One_Conv()
+        inp = (20 * torch.randn(6, 1, 4, 4), 9 * torch.randn(6, 1, 4, 4))
+        self._compare_sample_grads_per_sample(model, inp, lambda x: torch.mean(x))
+
+    def test_sample_grads_modified_conv_mean(self) -> None:
+        model = BasicModel_ConvNetWithPaddingDilation()
+        inp = (20 * torch.randn(6, 1, 5, 5),)
+        self._compare_sample_grads_per_sample(
+            model, inp, lambda x: torch.mean(x), "mean"
+        )
+
+    def test_sample_grads_modified_conv_sum(self) -> None:
+        model = BasicModel_ConvNetWithPaddingDilation()
+        inp = (20 * torch.randn(6, 1, 5, 5),)
+        self._compare_sample_grads_per_sample(model, inp, lambda x: torch.sum(x), "sum")
+
+    def _compare_sample_grads_per_sample(
+        self,
+        model: Module,
+        inputs: Tuple[Tensor, ...],
+        loss_fn: Callable,
+        loss_type: str = "mean",
+    ):
+        wrapper = SampleGradientWrapper(model)
+        wrapper.add_hooks()
+        out = model(*inputs)
+        wrapper.compute_param_sample_gradients(loss_fn(out), loss_type)
+
+        batch_size = inputs[0].shape[0]
+        for i in range(batch_size):
+            model.zero_grad()
+            single_inp = tuple(inp[i : i + 1] for inp in inputs)
+            out = model(*single_inp)
+            loss_fn(out).backward()
+            for layer in model.modules():
+                if isinstance(layer, tuple(SUPPORTED_MODULES.keys())):
+                    assertTensorAlmostEqual(
+                        self, layer.weight.grad, layer.weight.sample_grad[i], mode="max"
+                    )
+                    assertTensorAlmostEqual(
+                        self, layer.bias.grad, layer.bias.sample_grad[i], mode="max"
+                    )

--- a/tests/utils/test_sample_gradient.py
+++ b/tests/utils/test_sample_gradient.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import unittest
 from typing import Tuple, Callable
 
 import torch
@@ -36,6 +37,12 @@ class Test(BaseTest):
         self._compare_sample_grads_per_sample(model, inp, lambda x: torch.mean(x))
 
     def test_sample_grads_modified_conv_mean(self) -> None:
+        if torch.__version__ < "1.8":
+            raise unittest.SkipTest(
+                "Skipping sample gradient test with 3D linear module"
+                "since torch version < 1.8"
+            )
+
         model = BasicModel_ConvNetWithPaddingDilation()
         inp = (20 * torch.randn(6, 1, 5, 5),)
         self._compare_sample_grads_per_sample(
@@ -43,6 +50,12 @@ class Test(BaseTest):
         )
 
     def test_sample_grads_modified_conv_sum(self) -> None:
+        if torch.__version__ < "1.8":
+            raise unittest.SkipTest(
+                "Skipping sample gradient test with 3D linear module"
+                "since torch version < 1.8"
+            )
+
         model = BasicModel_ConvNetWithPaddingDilation()
         inp = (20 * torch.randn(6, 1, 5, 5),)
         self._compare_sample_grads_per_sample(model, inp, lambda x: torch.sum(x), "sum")

--- a/tests/utils/test_sample_gradient.py
+++ b/tests/utils/test_sample_gradient.py
@@ -70,12 +70,12 @@ class Test(BaseTest):
                     assertTensorAlmostEqual(
                         self,
                         layer.weight.grad,
-                        layer.weight.sample_grad[i],
-                        mode="max",  # type: ignore
+                        layer.weight.sample_grad[i],  # type: ignore
+                        mode="max",
                     )
                     assertTensorAlmostEqual(
                         self,
                         layer.bias.grad,
-                        layer.bias.sample_grad[i],
-                        mode="max",  # type: ignore
+                        layer.bias.sample_grad[i],  # type: ignore
+                        mode="max",
                     )


### PR DESCRIPTION
This PR adds utilities for computing per-sample param gradients, refactoring and improving upon the initial version of autograd hacks utilized.

Particularly this implementation now supports:
- Most conv layers with custom settings of padding, stride, dilation etc.
- Multi-dimensional inputs to linear models (> 2d)
- GPU inputs / outputs
- Repeated usage of a single nn.module