### PR TITLE
Optim-wip: Fix issue with `get_model_layers`

### DIFF
--- a/captum/optim/models/_common.py
+++ b/captum/optim/models/_common.py
@@ -16,19 +16,16 @@ def get_model_layers(model: nn.Module) -> List[str]:
     """
     layers = []
 
-    def get_layers(net: nn.Module, prefix: List = []) -> None:
-        if hasattr(net, "_modules"):
-            for name, layer in net.named_children():
-                if layer is None:
-                    continue
-                name_str = "".join(
-                    [
-                        ("[" + str(i) + "]" if str(i).isdigit() else "." + i)
-                        for i in prefix + [name]
-                    ]
-                ).strip()
-                layers.append(name_str[1:] if name_str[0] == "." else name_str)
-                get_layers(layer, prefix=prefix + [name])
+    def get_layers(net: nn.Module, prefix: str = "") -> None:
+        for name, layer in net.named_children():
+            delimiter = "." if prefix else ""
+            name_str = (
+                f"{prefix}[{name}]"
+                if str(name).isdigit()
+                else f"{prefix}{delimiter}{name}"
+            )
+            layers.append(name_str)
+            get_layers(layer, prefix=name_str)
 
     get_layers(model)
     return layers

--- a/captum/optim/models/_common.py
+++ b/captum/optim/models/_common.py
@@ -18,12 +18,16 @@ def get_model_layers(model: nn.Module) -> List[str]:
 
     def get_layers(net: nn.Module, prefix: List = []) -> None:
         if hasattr(net, "_modules"):
-            for name, layer in net._modules.items():
+            for name, layer in net.named_children():
                 if layer is None:
                     continue
-                separator = "" if str(name).isdigit() else "."
-                name = "[" + str(name) + "]" if str(name).isdigit() else name
-                layers.append(separator.join(prefix + [name]))
+                name_str = "".join(
+                    [
+                        ("[" + str(i) + "]" if str(i).isdigit() else "." + i)
+                        for i in prefix + [name]
+                    ]
+                ).strip()
+                layers.append(name_str[1:] if name_str[0] == "." else name_str)
                 get_layers(layer, prefix=prefix + [name])
 
     get_layers(model)


### PR DESCRIPTION
There was an issue where multiple separators were not used, and thus a layer like: `layer4[5].relu3` was incorrectly listed as `layer4.[5].relu3` (with a period between the list index and the module name, rather than no separator).