### PR TITLE
Adding Explain Like I'm 5 video to the home page

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -267,12 +267,36 @@ Convergence Delta: tensor([2.3842e-07, -4.7684e-07])
       <div>
         <HomeSplash siteConfig={siteConfig} language={language} />
         <div className="landingPage mainContainer">
+          <VideoContainer />
           <Features />
           <QuickStart />
         </div>
       </div>
     );
   }
+}
+
+function VideoContainer() {
+  return (
+    <div className="container text--center margin-bottom--xl margin-top--lg">
+      <div className="row">
+        <div className="col" style={{textAlign: 'center'}}>
+          <h2>Check it out in the intro video</h2>
+          <div>
+            <iframe
+              width="560"
+              height="315"
+              src="https://www.youtube.com/embed/YYatLlT3tPI"
+              title="Explain Like I'm 5: Captum"
+              frameBorder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 module.exports = Index;


### PR DESCRIPTION
## Summary
Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in [Docusaurus home page](https://docusaurus.io/), [Jest](https://jestjs.io/), [Litho](https://fblitho.com/), [Hydra](https://hydra.cc/), etc..

## Test Plan
Here is a screenshot in how it looks:
![image](https://user-images.githubusercontent.com/12485205/154381782-879002d1-4501-4291-80d2-b37d56e2ea8a.png)
