### PR TITLE
Rename use_autograd_hacks to sample_wise_grads_per_batch

### DIFF
--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -772,7 +772,7 @@ def _compute_jacobian_wrt_params(
         return tuple(grads)
 
 
-def _compute_jacobian_wrt_params_autograd_hacks(
+def _compute_jacobian_wrt_params_with_sample_wise_trick(
     model: Module,
     inputs: Tuple[Any, ...],
     labels: Optional[Tensor] = None,
@@ -781,8 +781,9 @@ def _compute_jacobian_wrt_params_autograd_hacks(
 ) -> Tuple[Any, ...]:
     r"""
     Computes the Jacobian of a batch of test examples given a model, and optional
-    loss function and target labels. This method uses autograd_hacks to fully vectorize
-    the Jacobian calculation. Currently, only linear and conv2d layers are supported.
+    loss function and target labels. This method uses sample-wise gradients per
+    batch trick to fully vectorize the Jacobian calculation. Currently, only
+    linear and conv2d layers are supported.
 
     User must `add_hooks(model)` before calling this function.
 

--- a/tests/influence/_core/test_tracincp.py
+++ b/tests/influence/_core/test_tracincp.py
@@ -7,10 +7,10 @@ from tests.influence._utils.common import (
     _TestTracInRegression20DCheckIdx,
     _TestTracInXORCheckIdx,
     _TestTracInIdentityRegressionCheckIdx,
-    _TestTracInRegression1DCheckAutogradHacks,
-    _TestTracInRegression20DCheckAutogradHacks,
-    _TestTracInXORCheckAutogradHacks,
-    _TestTracInIdentityRegressionCheckAutogradHacks,
+    _TestTracInRegression1DCheckSampleWiseTrick,
+    _TestTracInRegression20DCheckSampleWiseTrick,
+    _TestTracInXORCheckSampleWiseTrick,
+    _TestTracInIdentityRegressionCheckSampleWiseTrick,
     _TestTracInRegression1DNumerical,
     _TestTracInGetKMostInfluential,
     _TestTracInSelfInfluence,
@@ -38,29 +38,29 @@ class TestTracInCP(
                 tmpdir,
                 batch_size=batch_size,
                 loss_fn=loss_fn,
-                use_autograd_hacks=False,
+                sample_wise_grads_per_batch=False,
             )
         )
         super(TestTracInCP, self).setUp()
 
 
-class TestTracInCPCheckAutogradHacks(
-    _TestTracInRegression1DCheckAutogradHacks,
-    _TestTracInRegression20DCheckAutogradHacks,
-    _TestTracInXORCheckAutogradHacks,
-    _TestTracInIdentityRegressionCheckAutogradHacks,
+class TestTracInCPCheckSampleWiseTrick(
+    _TestTracInRegression1DCheckSampleWiseTrick,
+    _TestTracInRegression20DCheckSampleWiseTrick,
+    _TestTracInXORCheckSampleWiseTrick,
+    _TestTracInIdentityRegressionCheckSampleWiseTrick,
     BaseTest,
 ):
     def setUp(self):
         self.tracin_constructor = (
-            lambda net, dataset, tmpdir, batch_size, loss_fn, use_autograd_hacks: (
+            lambda net, dataset, tmpdir, batch_size, loss_fn, sample_wise_trick: (
                 TracInCP(
                     net,
                     dataset,
                     tmpdir,
                     batch_size=batch_size,
                     loss_fn=loss_fn,
-                    use_autograd_hacks=use_autograd_hacks,
+                    sample_wise_grads_per_batch=sample_wise_trick,
                 )
             )
         )
@@ -82,6 +82,6 @@ class TestTracInCPFastRandProjTests(
                 tmpdir,
                 batch_size=batch_size,
                 loss_fn=loss_fn,
-                use_autograd_hacks=True,
+                sample_wise_grads_per_batch=True,
             )
         )

--- a/tests/influence/_utils/common.py
+++ b/tests/influence/_utils/common.py
@@ -215,7 +215,7 @@ class _TestTracInRegression:
                 for i in range(len(idx)):
                     self.assertTrue(isSorted(idx[i]))
 
-            if mode == "check_autograd_hacks":
+            if mode == "sample_wise_trick":
 
                 criterion = nn.MSELoss(reduction="none")
 
@@ -228,19 +228,27 @@ class _TestTracInRegression:
                     False,
                 )
 
-                # With autograd hacks
+                # With sample-wise trick
                 criterion = nn.MSELoss(reduction="sum")
-                tracin_hack = self.tracin_constructor(
+                tracin_sample_wise_trick = self.tracin_constructor(
                     net, dataset, tmpdir, batch_size, criterion, True
                 )
 
                 train_scores = tracin.influence(train_inputs, train_labels)
-                train_scores_hack = tracin_hack.influence(train_inputs, train_labels)
-                assertTensorAlmostEqual(self, train_scores, train_scores_hack)
+                train_scores_sample_wise_trick = tracin_sample_wise_trick.influence(
+                    train_inputs, train_labels
+                )
+                assertTensorAlmostEqual(
+                    self, train_scores, train_scores_sample_wise_trick
+                )
 
                 test_scores = tracin.influence(test_inputs, test_labels)
-                test_scores_hack = tracin_hack.influence(test_inputs, test_labels)
-                assertTensorAlmostEqual(self, test_scores, test_scores_hack)
+                test_scores_sample_wise_trick = tracin_sample_wise_trick.influence(
+                    test_inputs, test_labels
+                )
+                assertTensorAlmostEqual(
+                    self, test_scores, test_scores_sample_wise_trick
+                )
 
 
 class _TestTracInRegression1DCheckIdx(_TestTracInRegression):
@@ -248,9 +256,9 @@ class _TestTracInRegression1DCheckIdx(_TestTracInRegression):
         self._test_tracin_regression(1, "check_idx")
 
 
-class _TestTracInRegression1DCheckAutogradHacks(_TestTracInRegression):
-    def test_tracin_regression_1D_check_autograd_hacks(self):
-        self._test_tracin_regression(1, "check_autograd_hacks")
+class _TestTracInRegression1DCheckSampleWiseTrick(_TestTracInRegression):
+    def test_tracin_regression_1D_check_sample_wise_trick(self):
+        self._test_tracin_regression(1, "sample_wise_trick")
 
 
 class _TestTracInRegression20DCheckIdx(_TestTracInRegression):
@@ -258,9 +266,9 @@ class _TestTracInRegression20DCheckIdx(_TestTracInRegression):
         self._test_tracin_regression(20, "check_idx")
 
 
-class _TestTracInRegression20DCheckAutogradHacks(_TestTracInRegression):
-    def test_tracin_regression_20D_check_autograd_hacks(self):
-        self._test_tracin_regression(20, "check_autograd_hacks")
+class _TestTracInRegression20DCheckSampleWiseTrick(_TestTracInRegression):
+    def test_tracin_regression_20D_check_sample_wise_trick(self):
+        self._test_tracin_regression(20, "sample_wise_tricksample_wise_trick")
 
 
 class _TestTracInXOR:
@@ -434,7 +442,7 @@ class _TestTracInXOR:
                     influence_labels = dataset.labels[idx[i][0:5], 0]
                     self.assertTrue(torch.all(testlabels[i, 0] == influence_labels))
 
-            if mode == "check_autograd_hacks":
+            if mode == "sample_wise_trick":
 
                 criterion = nn.MSELoss(reduction="none")
 
@@ -447,9 +455,9 @@ class _TestTracInXOR:
                     False,
                 )
 
-                # With autograd hacks
+                # With sample-wise trick
                 criterion = nn.MSELoss(reduction="sum")
-                tracin_hack = self.tracin_constructor(
+                tracin_sample_wise_trick = self.tracin_constructor(
                     net,
                     dataset,
                     tmpdir,
@@ -459,8 +467,12 @@ class _TestTracInXOR:
                 )
 
                 test_scores = tracin.influence(testset, testlabels)
-                test_scores_hack = tracin_hack.influence(testset, testlabels)
-                assertTensorAlmostEqual(self, test_scores, test_scores_hack)
+                test_scores_sample_wise_trick = tracin_sample_wise_trick.influence(
+                    testset, testlabels
+                )
+                assertTensorAlmostEqual(
+                    self, test_scores, test_scores_sample_wise_trick
+                )
 
 
 class _TestTracInXORCheckIdx(_TestTracInXOR):
@@ -468,9 +480,9 @@ class _TestTracInXORCheckIdx(_TestTracInXOR):
         self._test_tracin_xor("check_idx")
 
 
-class _TestTracInXORCheckAutogradHacks(_TestTracInXOR):
-    def test_tracin_xor_check_autograd_hacks(self):
-        self._test_tracin_xor("check_autograd_hacks")
+class _TestTracInXORCheckSampleWiseTrick(_TestTracInXOR):
+    def test_tracin_xor_check_sample_wise_trick(self):
+        self._test_tracin_xor("sample_wise_trick")
 
 
 class _TestTracInIdentityRegression:
@@ -537,7 +549,7 @@ class _TestTracInIdentityRegression:
                 for i in range(len(idx)):
                     self.assertEqual(idx[i][0], i)
 
-            if mode == "check_autograd_hacks":
+            if mode == "sample_wise_trick":
 
                 criterion = nn.MSELoss(reduction="none")
 
@@ -550,9 +562,9 @@ class _TestTracInIdentityRegression:
                     False,
                 )
 
-                # With autograd hacks
+                # With sample-wise trick
                 criterion = nn.MSELoss(reduction="sum")
-                tracin_hack = self.tracin_constructor(
+                tracin_sample_wise_trick = self.tracin_constructor(
                     net,
                     dataset,
                     tmpdir,
@@ -562,8 +574,12 @@ class _TestTracInIdentityRegression:
                 )
 
                 train_scores = tracin.influence(train_inputs, train_labels)
-                train_scores_hack = tracin_hack.influence(train_inputs, train_labels)
-                assertTensorAlmostEqual(self, train_scores, train_scores_hack)
+                train_scores_tracin_sample_wise_trick = (
+                    tracin_sample_wise_trick.influence(train_inputs, train_labels)
+                )
+                assertTensorAlmostEqual(
+                    self, train_scores, train_scores_tracin_sample_wise_trick
+                )
 
 
 class _TestTracInIdentityRegressionCheckIdx(_TestTracInIdentityRegression):
@@ -571,9 +587,9 @@ class _TestTracInIdentityRegressionCheckIdx(_TestTracInIdentityRegression):
         self._test_tracin_identity_regression("check_idx")
 
 
-class _TestTracInIdentityRegressionCheckAutogradHacks(_TestTracInIdentityRegression):
-    def test_tracin_identity_regression_check_autograd_hacks(self):
-        self._test_tracin_identity_regression("check_autograd_hacks")
+class _TestTracInIdentityRegressionCheckSampleWiseTrick(_TestTracInIdentityRegression):
+    def test_tracin_identity_regression_check_sample_wise_trick(self):
+        self._test_tracin_identity_regression("sample_wise_trick")
 
 
 class _TestTracInRandomProjectionRegression:


### PR DESCRIPTION
Summary:
This diff rename use_autograd_hacks to sample_wise_grads_per_batch.

Also updated the docs for `sample_wise_grads_per_batch`.

Differential Revision: D34506676

