### PR TITLE
Run influence tests using annoy.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ DEV_REQUIRES = (
         "usort==0.6.4",
         "ufmt",
         "scikit-learn",
+        "annoy",
     ]
 )
 


### PR DESCRIPTION
Summary:
Some of the influence tests require the annoy package to run. This change adds the annoy dependencies so these tests are run instead of skipped.
This also adds annoy as a dependency for the captum bento kernel.

Differential Revision: D34729957

