### PR TITLE
include changes within captum folder as website related in ci deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ commands:
           name: "Deploy website to GitHub Pages"
             # TODO: make the installation above conditional on there being relevant changes (no need to install if there are none)
           command: |
-            if ! git diff --name-only HEAD^ | grep -E "(^\.circleci\/.*)|(^docs\/.*)|(^website\/.*)|(^scripts\/.*)|(^sphinx\/.*)|(^tutorials\/.*)"; then
+            if ! git diff --name-only HEAD^ | grep -E "(^captum\/.*)|(^\.circleci\/.*)|(^docs\/.*)|(^website\/.*)|(^scripts\/.*)|(^sphinx\/.*)|(^tutorials\/.*)"; then
               echo "Skipping deploy. No relevant website files have changed"
             elif [[ $CIRCLE_PROJECT_USERNAME == "pytorch" && -z $CI_PULL_REQUEST && -z $CIRCLE_PR_USERNAME ]]; then
               mkdir -p website/static/.circleci && cp -a .circleci/. website/static/.circleci/.


### PR DESCRIPTION
CI sometime fails to continuous deploy the updated docs () because changes in `captum/` folder are excluded from website related and will not trigger the deploy job. But docstring changes within `captum/` should update our doc website.

Example: 
commit https://github.com/pytorch/captum/commit/b795e83e504c7a9423004eeba6cfeea1510bd7bd only changed docstring, the CI skipped the auto deploy https://app.circleci.com/pipelines/github/pytorch/captum/3719/workflows/d1620272-1728-455d-8998-840f7c157dba/jobs/19440

This pr allow changes in `captum/` to trigger website deployment job. Worth notice this does not mean every commit in `captum/` will cause an actual deployment. If there is no changes in the built website files, the `docusaurus`' will push nothing to the `gh-pages` branch  https://github.com/facebook/docusaurus/blob/docusaurus-v1/packages/docusaurus-1.x/lib/publish-gh-pages.js#L186