### PR TITLE
update CI linting and testing jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,6 @@ jobs:
       - checkout
       - pip_install:
           args: "-v 1.6"
-      - mypy_check
       - unit_tests
 
   test_py36_pip_torch_1_7:
@@ -171,7 +170,6 @@ jobs:
       - checkout
       - pip_install:
           args: "-v 1.7"
-      - mypy_check
       - unit_tests
 
   test_py36_pip_torch_1_8:
@@ -181,7 +179,6 @@ jobs:
       - checkout
       - pip_install:
           args: "-v 1.8"
-      - mypy_check
       - unit_tests
 
   test_py36_pip_torch_1_9:
@@ -191,7 +188,6 @@ jobs:
       - checkout
       - pip_install:
           args: "-v 1.9"
-      - mypy_check
       - unit_tests
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,19 +125,7 @@ commands:
 
 jobs:
 
-  lint_test_py36_pip:
-    docker:
-      - image: circleci/python:3.6.8
-    steps:
-      - checkout
-      - pip_install:
-          args: "-n"
-      - lint_flake8
-      - ufmt_check
-      - unit_tests
-      - sphinx
-
-  lint_test_py36_pip_release:
+  lint_py36:
     docker:
       - image: circleci/python:3.6.8
     steps:
@@ -145,9 +133,26 @@ jobs:
       - pip_install
       - lint_flake8
       - ufmt_check
+      - sphinx
+
+  test_py36_pip:
+    docker:
+      - image: circleci/python:3.6.8
+    steps:
+      - checkout
+      - pip_install:
+          args: "-n"
       - mypy_check
       - unit_tests
-      - sphinx
+
+  test_py36_pip_release:
+    docker:
+      - image: circleci/python:3.6.8
+    steps:
+      - checkout
+      - pip_install
+      - mypy_check
+      - unit_tests
 
   test_py36_pip_torch_1_6:
     docker:
@@ -156,6 +161,7 @@ jobs:
       - checkout
       - pip_install:
           args: "-v 1.6"
+      - mypy_check
       - unit_tests
 
   test_py36_pip_torch_1_7:
@@ -165,6 +171,7 @@ jobs:
       - checkout
       - pip_install:
           args: "-v 1.7"
+      - mypy_check
       - unit_tests
 
   test_py36_pip_torch_1_8:
@@ -174,6 +181,7 @@ jobs:
       - checkout
       - pip_install:
           args: "-v 1.8"
+      - mypy_check
       - unit_tests
 
   test_py36_pip_torch_1_9:
@@ -183,20 +191,19 @@ jobs:
       - checkout
       - pip_install:
           args: "-v 1.9"
+      - mypy_check
       - unit_tests
 
 
-  lint_test_py37_conda:
+  test_py37_conda:
     docker:
       - image: continuumio/miniconda3
     steps:
       - checkout
       - conda_install:
           args: "-n"
-      - lint_flake8
-      - ufmt_check
       - unit_tests
-      - sphinx
+
 
   test_cuda_multi_gpu:
     machine:
@@ -216,10 +223,6 @@ jobs:
       - checkout
       - pip_install:
           args: "-n -d"
-      - lint_flake8
-      - ufmt_check
-      - unit_tests
-      - sphinx
       - configure_github_bot
       - deploy_site
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,11 +240,13 @@ workflows:
 
   lint_and_test:
     jobs:
-      - lint_test_py36_pip:
+      - lint_py36:
           filters: *exclude_ghpages_fbconfig
-      - lint_test_py36_pip_release:
+      - test_py36_pip:
           filters: *exclude_ghpages_fbconfig
-      - lint_test_py37_conda:
+      - test_py36_pip_release:
+          filters: *exclude_ghpages_fbconfig
+      - test_py37_conda:
           filters: *exclude_ghpages_fbconfig
       - test_py36_pip_torch_1_6:
           filters: *exclude_ghpages_fbconfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,5 @@
 [tool.usort]
 first_party_detection = false
+
+[tool.black]
+target-version = ['py36']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,2 @@
 [tool.usort]
 first_party_detection = false
-
-[tool.black]
-target-version = ['py36']

--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -44,8 +44,5 @@ conda install -y -c conda-forge yarn
 # nodejs should be last, otherwise other conda packages will downgrade node
 conda install -y --no-channel-priority -c conda-forge nodejs=14
 
-# install lint deps
-pip install black==21.4b2 usort==0.6.4 ufmt
-
 # build insights and install captum
 BUILD_INSIGHTS=1 python setup.py develop


### PR DESCRIPTION
- extract linting related steps (flake8, ufmt, sphinx) to a dedicated ci job & only run it once as they are unlikely to be impacted by different pytorch version
- remove linting & testing from the job for website deployment
- remove no longer needed installation of linting deps in conda