### PR TITLE
add logging to individual TracInCP classes

### DIFF
--- a/captum/influence/_core/tracincp.py
+++ b/captum/influence/_core/tracincp.py
@@ -240,7 +240,7 @@ class TracInCPBase(DataInfluence):
         """
         pass
 
-    @log_usage()
+    @abstractmethod
     def influence(  # type: ignore[override]
         self,
         inputs: Any = None,
@@ -332,14 +332,37 @@ class TracInCPBase(DataInfluence):
               example `i` in the test batch represented by `inputs` and
               `targets`.
         """
-        _inputs = _format_inputs(inputs, unpack_inputs)
+        pass
 
-        if inputs is None:
-            return self._self_influence()
-        elif k is None:
-            return self._influence(_inputs, targets)
-        else:
-            return self._get_k_most_influential(_inputs, targets, k, proponents)
+
+def _influence_route_to_helpers(
+    influence_instance: TracInCPBase,
+    inputs: Any = None,
+    targets: Optional[Tensor] = None,
+    k: Optional[int] = None,
+    proponents: bool = True,
+    unpack_inputs: bool = True,
+) -> Union[Tensor, KMostInfluentialResults]:
+    """
+    This is a helper function called by `TracInCP.influence` and
+    `TracInCPFast.influence`. Those methods share a common logic in that they assume
+    an instance of their respective classes implement 3 private methods
+    (`_self_influence`, `_influence`, `_get_k_most_influential`), and the logic of
+    which private method to call is common, as described in the documentation of the
+    `influence` method. The arguments and return values of this function are the exact
+    same as the `influence` method. Note that `influence_instance` refers to the
+    instance for which the `influence` method was called.
+    """
+    _inputs = _format_inputs(inputs, unpack_inputs)
+
+    if inputs is None:
+        return influence_instance._self_influence()
+    elif k is None:
+        return influence_instance._influence(_inputs, targets)
+    else:
+        return influence_instance._get_k_most_influential(
+            _inputs, targets, k, proponents
+        )
 
 
 class TracInCP(TracInCPBase):
@@ -512,6 +535,107 @@ class TracInCP(TracInCPBase):
                         param.requires_grad = True
                         gradset = True
             assert gradset, "At least one parameter of network must require gradient."
+
+    @log_usage()
+    def influence(  # type: ignore[override]
+        self,
+        inputs: Any = None,
+        targets: Optional[Tensor] = None,
+        k: Optional[int] = None,
+        proponents: bool = True,
+        unpack_inputs: bool = True,
+    ) -> Union[Tensor, KMostInfluentialResults]:
+        r"""
+        This is the key method of this class, and can be run in 3 different modes,
+        where the mode that is run depends on the arguments passed to this method:
+
+        - self influence mode: This mode is used if `inputs` is None. This mode
+          computes the self influence scores for every example in
+          the training dataset `influence_src_dataset`.
+        - influence score mode: This mode is used if `inputs` is not None, and `k` is
+          None. This mode computes the influence score of every example in
+          training dataset `influence_src_dataset` on every example in the test
+          batch represented by `inputs` and `targets`.
+        - k-most influential mode: This mode is used if `inputs` is not None, and
+          `k` is not None, and an int. This mode computes the proponents or
+          opponents of every example in the test batch represented by `inputs`
+          and `targets`. In particular, for each test example in the test batch,
+          this mode computes its proponents (resp. opponents), which are the
+          indices in the training dataset `influence_src_dataset` of the training
+          examples with the `k` highest (resp. lowest) influence scores on the
+          test example. Proponents are computed if `proponents` is True.
+          Otherwise, opponents are computed. For each test example, this method
+          also returns the actual influence score of each proponent (resp.
+          opponent) on the test example.
+
+        Args:
+            inputs (Any, optional): If not provided or `None`, the self influence mode
+                    will be run. Otherwise, `inputs` is the test batch that will be
+                    used when running in either influence score or k-most influential
+                    mode. If the argument `unpack_inputs` is False, the
+                    assumption is that `self.model(inputs)` produces the predictions
+                    for a batch, and `inputs` can be of any type. Otherwise if the
+                    argument `unpack_inputs` is True, the assumption is that
+                    `self.model(*inputs)` produces the predictions for a batch, and
+                    `inputs` will need to be a tuple. In other words, `inputs` will be
+                    unpacked as an argument when passing to `self.model`.
+                    Default: None
+            targets (tensor, optional): If computing influence scores on a loss
+                    function, these are the labels corresponding to the batch `inputs`.
+                    Default: None
+            k (int, optional): If not provided or `None`, the influence score mode will
+                    be run. Otherwise, the k-most influential mode will be run,
+                    and `k` is the number of proponents / opponents to return per
+                    example in the test batch.
+                    Default: None
+            proponents (bool, optional): Whether seeking proponents (`proponents=True`)
+                    or opponents (`proponents=False`), if running in k-most influential
+                    mode.
+                    Default: True
+            unpack_inputs (bool, optional): Whether to unpack the `inputs` argument to
+                    when passing it to `model`, if `inputs` is a tuple (no unpacking
+                    done otherwise).
+                    Default: True
+
+        Returns:
+            The return value of this method depends on which mode is run.
+
+            - self influence mode: if this mode is run (`inputs` is None), returns a 1D
+              tensor of self influence scores over training dataset
+              `influence_src_dataset`. The length of this tensor is the number of
+              examples in `influence_src_dataset`, regardless of whether it is a
+              Dataset or DataLoader.
+            - influence score mode: if this mode is run (`inputs is not None, `k` is
+              None), returns a 2D tensor `influence_scores` of shape
+              `(input_size, influence_src_dataset_size)`, where `input_size` is
+              the number of examples in the test batch, and
+              `influence_src_dataset_size` is the number of examples in
+              training dataset `influence_src_dataset`. In other words,
+              `influence_scores[i][j]` is the influence score of the `j`-th
+              example in `influence_src_dataset` on the `i`-th example in the
+              test batch.
+            - k-most influential mode: if this mode is run (`inputs` is not None,
+              `k` is an int), returns a namedtuple `(indices, influence_scores)`.
+              `indices` is a 2D tensor of shape `(input_size, k)`, where
+              `input_size` is the number of examples in the test batch. If
+              computing proponents (resp. opponents), `indices[i][j]` is the
+              index in training dataset `influence_src_dataset` of the example
+              with the `j`-th highest (resp. lowest) influence score (out of the
+              examples in `influence_src_dataset`) on the `i`-th example in the
+              test batch. `influence_scores` contains the corresponding influence
+              scores. In particular, `influence_scores[i][j]` is the influence
+              score of example `indices[i][j]` in `influence_src_dataset` on
+              example `i` in the test batch represented by `inputs` and
+              `targets`.
+        """
+        return _influence_route_to_helpers(
+            self,
+            inputs,
+            targets,
+            k,
+            proponents,
+            unpack_inputs,
+        )
 
     def _influence_batch_tracincp(
         self,


### PR DESCRIPTION
Summary:
- make sure every subclass of `TracInCPBase` implements the `influence` method, so that sub-class-specific logging can be applied.
- fix documentation error in `TracInCPFastRandProj.influence`
- `TracInCPBase.influence` is now abstract

Differential Revision: D34745175

