### PR TITLE
add progress bar to TracInCP

### DIFF
--- a/captum/influence/_core/tracincp.py
+++ b/captum/influence/_core/tracincp.py
@@ -4,7 +4,17 @@ import glob
 import warnings
 from abc import abstractmethod
 from os.path import join
-from typing import Any, Callable, Iterator, List, Optional, Union, Tuple, NamedTuple
+from typing import (
+    Any,
+    Callable,
+    Iterator,
+    List,
+    Optional,
+    Union,
+    Tuple,
+    NamedTuple,
+    Type,
+)
 
 import torch
 from captum._utils.av import AV
@@ -13,6 +23,7 @@ from captum._utils.gradient import (
     _compute_jacobian_wrt_params,
     _compute_jacobian_wrt_params_with_sample_wise_trick,
 )
+from captum._utils.progress import progress
 from captum.influence._core.influence import DataInfluence
 from captum.influence._utils.common import (
     _get_k_most_influential_helper,
@@ -165,13 +176,33 @@ class TracInCPBase(DataInfluence):
         else:
             self.influence_src_dataloader = influence_src_dataset
 
+        self.influence_src_dataloader_len: Optional[int] = None
+        try:
+
+            # since we will calculate the number of batches in
+            # `self.influence_src_dataloader` whenever we use progress bar, calculate
+            # it once in initialization, for re-use.
+            self.influence_src_dataloader_len = len(self.influence_src_dataloader)
+        except AttributeError:
+            pass
+
     @abstractmethod
-    def _self_influence(self):
+    def _self_influence(self, show_progress: bool = False):
         """
         Returns:
             self influence scores (tensor): 1D tensor containing self influence
                     scores for all examples in training dataset
                     `influence_src_dataset`.
+            show_progress (bool, optional): To compute the self influence scores for
+                    all examples in training dataset `influence_src_dataset`, we
+                    compute the self influence scores for each batch. If
+                    `show_progress`is true, the progress of this computation will be
+                    displayed. In particular, the number of batches for which self
+                    influence scores have been computed will be displayed. It will
+                    try to use tqdm if available for advanced features (e.g. time
+                    estimation). Otherwise, it will fallback to a simple output of
+                    progress.
+                    Default: False
         """
         pass
 
@@ -182,6 +213,7 @@ class TracInCPBase(DataInfluence):
         targets: Optional[Tensor] = None,
         k: int = 5,
         proponents: bool = True,
+        show_progress: bool = False,
     ) -> KMostInfluentialResults:
         r"""
         Args:
@@ -196,6 +228,15 @@ class TracInCPBase(DataInfluence):
             proponents (bool, optional): Whether seeking proponents (`proponents=True`)
                     or opponents (`proponents=False`)
                     Default: True
+            show_progress (bool, optional): To compute the proponents (or opponents)
+                    for the batch of examples, we perform computation for each batch in
+                    training dataset `influence_src_dataset`, If `show_progress`is
+                    true, the progress of this computation will be displayed. In
+                    particular, the number of batches for which the computation has
+                    been performed will be displayed. It will try to use tqdm if
+                    available for advanced features (e.g. time estimation). Otherwise,
+                    it will fallback to a simple output of progress.
+                    Default: False
 
         Returns:
             (indices, influence_scores) (namedtuple): `indices` is a torch.long Tensor
@@ -220,6 +261,7 @@ class TracInCPBase(DataInfluence):
         self,
         inputs: Tuple[Any, ...],
         targets: Optional[Tensor] = None,
+        show_progress: bool = False,
     ) -> Tensor:
         r"""
         Args:
@@ -237,6 +279,15 @@ class TracInCPBase(DataInfluence):
                     (inputs_batch_size, src_dataset_size). For example:
                     influence_scores[i][j] = the influence score for the j-th training
                     example to the i-th input example.
+            show_progress (bool, optional): To compute the influence of examples in
+                    training dataset `influence_src_dataset`, we compute the influence
+                    of each batch. If `show_progress`is true, the progress of this
+                    computation will be displayed. In particular, the number of batches
+                    for which influence has been computed will be displayed. It will
+                    try to use tqdm if available for advanced features (e.g. time
+                    estimation). Otherwise, it will fallback to a simple output of
+                    progress.
+                    Default: False
         """
         pass
 
@@ -248,6 +299,7 @@ class TracInCPBase(DataInfluence):
         k: Optional[int] = None,
         proponents: bool = True,
         unpack_inputs: bool = True,
+        show_progress: bool = False,
     ) -> Union[Tensor, KMostInfluentialResults]:
         r"""
         This is the key method of this class, and can be run in 3 different modes,
@@ -300,6 +352,16 @@ class TracInCPBase(DataInfluence):
                     when passing it to `model`, if `inputs` is a tuple (no unpacking
                     done otherwise).
                     Default: True
+            show_progress (bool, optional): For all modes, computation of results
+                    requires "training dataset computations": computations for each
+                    batch in the training dataset `influence_src_dataset`, which may
+                    take a long time. If `show_progress`is true, the progress of
+                    "training dataset computations" will be displayed. In particular,
+                    the number of batches for which computations have been performed
+                    will be displayed. It will try to use tqdm if available for
+                    advanced features (e.g. time estimation). Otherwise, it will
+                    fallback to a simple output of progress.
+                    Default: False
 
         Returns:
             The return value of this method depends on which mode is run.
@@ -334,6 +396,18 @@ class TracInCPBase(DataInfluence):
         """
         pass
 
+    @classmethod
+    def get_name(cls: Type["TracInCPBase"]) -> str:
+        r"""
+        Create readable class name.  Due to the nature of the names of `TracInCPBase`
+        subclasses, simplies returns the class name.  For example, for a class called
+        TracInCP, we return the string TracInCP.
+
+        Returns:
+            name (str): a readable class name
+        """
+        return cls.__name__
+
 
 def _influence_route_to_helpers(
     influence_instance: TracInCPBase,
@@ -342,6 +416,7 @@ def _influence_route_to_helpers(
     k: Optional[int] = None,
     proponents: bool = True,
     unpack_inputs: bool = True,
+    show_progress: bool = False,
 ) -> Union[Tensor, KMostInfluentialResults]:
     """
     This is a helper function called by `TracInCP.influence` and
@@ -356,12 +431,12 @@ def _influence_route_to_helpers(
     _inputs = _format_inputs(inputs, unpack_inputs)
 
     if inputs is None:
-        return influence_instance._self_influence()
+        return influence_instance._self_influence(show_progress)
     elif k is None:
-        return influence_instance._influence(_inputs, targets)
+        return influence_instance._influence(_inputs, targets, show_progress)
     else:
         return influence_instance._get_k_most_influential(
-            _inputs, targets, k, proponents
+            _inputs, targets, k, proponents, show_progress
         )
 
 
@@ -544,6 +619,7 @@ class TracInCP(TracInCPBase):
         k: Optional[int] = None,
         proponents: bool = True,
         unpack_inputs: bool = True,
+        show_progress: bool = False,
     ) -> Union[Tensor, KMostInfluentialResults]:
         r"""
         This is the key method of this class, and can be run in 3 different modes,
@@ -596,6 +672,16 @@ class TracInCP(TracInCPBase):
                     when passing it to `model`, if `inputs` is a tuple (no unpacking
                     done otherwise).
                     Default: True
+            show_progress (bool, optional): For all modes, computation of results
+                    requires "training dataset computations": computations for each
+                    batch in the training dataset `influence_src_dataset`, which may
+                    take a long time. If `show_progress`is true, the progress of
+                    "training dataset computations" will be displayed. In particular,
+                    the number of batches for which computations have been performed
+                    will be displayed. It will try to use tqdm if available for
+                    advanced features (e.g. time estimation). Otherwise, it will
+                    fallback to a simple output of progress.
+                    Default: False
 
         Returns:
             The return value of this method depends on which mode is run.
@@ -635,6 +721,7 @@ class TracInCP(TracInCPBase):
             k,
             proponents,
             unpack_inputs,
+            show_progress,
         )
 
     def _influence_batch_tracincp(
@@ -679,6 +766,7 @@ class TracInCP(TracInCPBase):
         self,
         inputs: Tuple[Any, ...],
         targets: Optional[Tensor] = None,
+        show_progress: bool = False,
     ) -> Tensor:
         r"""
         Computes the influence of examples in training dataset `influence_src_dataset`
@@ -694,6 +782,15 @@ class TracInCP(TracInCPBase):
             targets (tensor, optional): If computing influence scores on a loss
                     function, these are the labels corresponding to the batch `inputs`.
                     Default: None
+            show_progress (bool, optional): To compute the influence of examples in
+                    training dataset `influence_src_dataset`, we compute the influence
+                    of each batch. If `show_progress`is true, the progress of this
+                    computation will be displayed. In particular, the number of batches
+                    for which influence has been computed will be displayed. It will
+                    try to use tqdm if available for advanced features (e.g. time
+                    estimation). Otherwise, it will fallback to a simple output of
+                    progress.
+                    Default: False
 
         Returns:
             influence_scores (tensor): Influence scores from the TracInCP method.
@@ -704,10 +801,22 @@ class TracInCP(TracInCPBase):
             `influence_scores[i][j]` is the influence score for the j-th training
             example to the i-th input example.
         """
+        influence_src_dataloader = self.influence_src_dataloader
+
+        if show_progress:
+            influence_src_dataloader = progress(
+                influence_src_dataloader,
+                desc=(
+                    f"Using {self.get_name()} to compute "
+                    "influence for training batches"
+                ),
+                total=self.influence_src_dataloader_len,
+            )
+
         return torch.cat(
             [
                 self._influence_batch_tracincp(inputs, targets, batch)
-                for batch in self.influence_src_dataloader
+                for batch in influence_src_dataloader
             ],
             dim=1,
         )
@@ -718,6 +827,7 @@ class TracInCP(TracInCPBase):
         targets: Optional[Tensor] = None,
         k: int = 5,
         proponents: bool = True,
+        show_progress: bool = False,
     ) -> KMostInfluentialResults:
         r"""
         Args:
@@ -732,6 +842,15 @@ class TracInCP(TracInCPBase):
             proponents (bool, optional): Whether seeking proponents (`proponents=True`)
                     or opponents (`proponents=False`)
                     Default: True
+            show_progress (bool, optional): To compute the proponents (or opponents)
+                    for the batch of examples, we perform computation for each batch in
+                    training dataset `influence_src_dataset`, If `show_progress`is
+                    true, the progress of this computation will be displayed. In
+                    particular, the number of batches for which the computation has
+                    been performed will be displayed. It will try to use tqdm if
+                    available for advanced features (e.g. time estimation). Otherwise,
+                    it will fallback to a simple output of progress.
+                    Default: False
 
         Returns:
             (indices, influence_scores) (namedtuple): `indices` is a torch.long Tensor
@@ -749,6 +868,17 @@ class TracInCP(TracInCPBase):
                     on example `i` in the test batch represented by `inputs` and
                     `targets`.
         """
+        desc = (
+            None
+            if not show_progress
+            else (
+                (
+                    f"Using {self.get_name()} to perform computation for "
+                    f'getting {"proponents" if proponents else "opponents"}. '
+                    "Processing training batches: 100%"
+                )
+            )
+        )
         return KMostInfluentialResults(
             *_get_k_most_influential_helper(
                 self.influence_src_dataloader,
@@ -757,6 +887,8 @@ class TracInCP(TracInCPBase):
                 targets,
                 k,
                 proponents,
+                show_progress,
+                desc,
             )
         )
 
@@ -804,17 +936,39 @@ class TracInCP(TracInCPBase):
 
         return batch_self_tracin_scores
 
-    def _self_influence(self):
+    def _self_influence(self, show_progress: bool = False):
         """
         Returns:
             self influence scores (tensor): 1D tensor containing self influence
                     scores for all examples in training dataset
                     `influence_src_dataset`.
+            show_progress (bool, optional): To compute the self influence scores for
+                    all examples in training dataset `influence_src_dataset`, we
+                    compute the self influence scores for each batch. If
+                    `show_progress`is true, the progress of this computation will be
+                    displayed. In particular, the number of batches for which self
+                    influence scores have been computed will be displayed. It will
+                    try to use tqdm if available for advanced features (e.g. time
+                    estimation). Otherwise, it will fallback to a simple output of
+                    progress.
+                    Default: False
         """
+        influence_src_dataloader = self.influence_src_dataloader
+
+        if show_progress:
+            influence_src_dataloader = progress(
+                influence_src_dataloader,
+                desc=(
+                    f"Using {self.get_name()} to compute self "
+                    "influence for training batches"
+                ),
+                total=self.influence_src_dataloader_len,
+            )
+
         return torch.cat(
             [
                 self._self_influence_batch_tracincp(batch)
-                for batch in self.influence_src_dataloader
+                for batch in influence_src_dataloader
             ],
             dim=0,
         )

--- a/captum/influence/_utils/common.py
+++ b/captum/influence/_utils/common.py
@@ -4,6 +4,7 @@ from typing import Callable, Optional, Tuple, Union, Any, List
 
 import torch
 import torch.nn as nn
+from captum._utils.progress import progress
 from torch import Tensor
 from torch.nn import Module
 from torch.utils.data import DataLoader, Dataset
@@ -194,6 +195,8 @@ def _get_k_most_influential_helper(
     targets: Optional[Tensor],
     k: int = 5,
     proponents: bool = True,
+    show_progress: bool = False,
+    desc: Optional[str] = None,
 ) -> Tuple[Tensor, Tensor]:
     r"""
     Helper function that computes the quantities returned by
@@ -217,6 +220,19 @@ def _get_k_most_influential_helper(
         proponents (bool, optional): Whether seeking proponents (`proponents=True`)
                 or opponents (`proponents=False`)
                 Default: True
+        show_progress (bool, optional): To compute the proponents (or opponents)
+                for the batch of examples, we perform computation for each batch in
+                training dataset `influence_src_dataloader`, If `show_progress`is
+                true, the progress of this computation will be displayed. In
+                particular, the number of batches for which the computation has
+                been performed will be displayed. It will try to use tqdm if
+                available for advanced features (e.g. time estimation). Otherwise,
+                it will fallback to a simple output of progress.
+                Default: False
+        desc (str, optional): If `show_progress` is true, this is the description to
+                show when displaying progress. If `desc` is none, no description is
+                shown.
+                Default: None
 
     Returns:
         (indices, influence_scores): `indices` is a torch.long Tensor that contains the
@@ -242,6 +258,19 @@ def _get_k_most_influential_helper(
 
     # needed to map from relative index in a batch fo index within entire `dataloader`
     num_instances_processed = 0
+
+    # if show_progress, create progress bar
+    total: Optional[int] = None
+    if show_progress:
+        try:
+            total = len(influence_src_dataloader)
+        except AttributeError:
+            pass
+        influence_src_dataloader = progress(
+            influence_src_dataloader,
+            desc=desc,
+            total=total,
+        )
 
     for batch in influence_src_dataloader:
 

--- a/tests/influence/_core/test_tracin_show_progress.py
+++ b/tests/influence/_core/test_tracin_show_progress.py
@@ -1,0 +1,165 @@
+import io
+import tempfile
+import unittest
+import unittest.mock
+from typing import Callable
+
+import torch.nn as nn
+from captum.influence._core.tracincp import TracInCP
+from captum.influence._core.tracincp_fast_rand_proj import (
+    TracInCPFast,
+)
+from parameterized import parameterized
+from tests.helpers.basic import BaseTest
+from tests.influence._utils.common import (
+    get_random_model_and_data,
+    DataInfluenceConstructor,
+    build_test_name_func,
+)
+
+
+class TestTracInShowProgress(BaseTest):
+    """
+    This tests that the progress bar correctly shows a "100%" message at some point in
+    the relevant computations.  Progress bars are shown for calls to the `influence`
+    method for all 3 modes.  This is why 3 different modes are tested, and the mode
+    being tested is a parameter in the test.  `TracInCPFastRandProj.influence` is not
+    tested, because none of its modes involve computations over the entire training
+    dataset, so that no progress bar is shown (the computation is instead done in
+    `TracInCPFastRandProj.__init__`.  TODO: add progress bar for computations done
+    in `TracInCPFastRandProj.__init__`).
+    """
+
+    @parameterized.expand(
+        [
+            (
+                reduction,
+                constr,
+                mode,
+            )
+            for reduction, constr in [
+                (
+                    "none",
+                    DataInfluenceConstructor(TracInCP),
+                ),
+                (
+                    "sum",
+                    DataInfluenceConstructor(TracInCPFast),
+                ),
+            ]
+            for mode in ["self influence", "influence", "k-most"]
+        ],
+        name_func=build_test_name_func(args_to_skip=["reduction"]),
+    )
+    @unittest.mock.patch("sys.stderr", new_callable=io.StringIO)
+    def test_tracin_show_progress(
+        self,
+        reduction: str,
+        tracin_constructor: Callable,
+        mode: str,
+        mock_stderr,
+    ) -> None:
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+
+            batch_size = 5
+
+            (
+                net,
+                train_dataset,
+                test_samples,
+                test_labels,
+            ) = get_random_model_and_data(
+                tmpdir, unpack_inputs=False, return_test_data=True
+            )
+
+            self.assertTrue(isinstance(reduction, str))
+            criterion = nn.MSELoss(reduction=reduction)
+
+            self.assertTrue(callable(tracin_constructor))
+            tracin = tracin_constructor(
+                net,
+                train_dataset,
+                tmpdir,
+                batch_size,
+                criterion,
+            )
+
+            if mode == "self influence":
+                tracin.influence(show_progress=True)
+                output = mock_stderr.getvalue()
+                self.assertTrue(
+                    (
+                        (
+                            f"Using {tracin.get_name()} to compute self influence "
+                            "for training batches: 100%"
+                        )
+                        in output
+                    ),
+                    f"Error progress output: {repr(output)}",
+                )
+            elif mode == "influence":
+
+                tracin.influence(
+                    test_samples,
+                    test_labels,
+                    k=None,
+                    show_progress=True,
+                )
+                output = mock_stderr.getvalue()
+                self.assertTrue(
+                    (
+                        (
+                            f"Using {tracin.get_name()} to compute influence "
+                            "for training batches: 100%"
+                        )
+                        in output
+                    ),
+                    f"Error progress output: {repr(output)}",
+                )
+            elif mode == "k-most":
+
+                tracin.influence(
+                    test_samples,
+                    test_labels,
+                    k=2,
+                    proponents=True,
+                    show_progress=True,
+                )
+                output = mock_stderr.getvalue()
+                self.assertTrue(
+                    (
+                        (
+                            f"Using {tracin.get_name()} to perform computation for "
+                            "getting proponents. Processing training batches: 100%"
+                        )
+                        in output
+                    ),
+                    f"Error progress output: {repr(output)}",
+                )
+                mock_stderr.seek(0)
+                mock_stderr.truncate(0)
+
+                tracin.influence(
+                    test_samples,
+                    test_labels,
+                    k=2,
+                    proponents=False,
+                    show_progress=True,
+                )
+                output = mock_stderr.getvalue()
+                self.assertTrue(
+                    (
+                        (
+                            f"Using {tracin.get_name()} to perform computation for "
+                            "getting opponents. Processing training batches: 100%"
+                        )
+                        in output
+                    ),
+                    f"Error progress output: {repr(output)}",
+                )
+            else:
+                raise Exception("unknown test mode")
+
+            mock_stderr.seek(0)
+            mock_stderr.truncate(0)


### PR DESCRIPTION
Summary:
- add progress bar to all computations involving iterating over all batches in the training data
- add test, but only for case where `influence_src_dataloader` implements `len`

Reviewed By: aobo-y

Differential Revision: D34776754

