### PR TITLE
Change _forward_layer_distributed_eval to take Any inputs

### DIFF
--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -161,8 +161,14 @@ def _format_tensor_into_tuples(
     return inputs
 
 
-def _format_input(inputs: Union[Tensor, Tuple[Tensor, ...]]) -> Tuple[Tensor, ...]:
-    return _format_tensor_into_tuples(inputs)
+def _format_inputs(inputs: Any, unpack_inputs: bool = True) -> Any:
+    if inputs is None:
+        return None
+    return (
+        inputs
+        if (isinstance(inputs, tuple) or isinstance(inputs, list)) and unpack_inputs
+        else (inputs,)
+    )
 
 
 def _format_float_or_tensor_into_tuples(
@@ -439,7 +445,7 @@ def _format_outputs(
 
 def _run_forward(
     forward_func: Callable,
-    inputs: Union[Tensor, Tuple[Tensor, ...]],
+    inputs: Any,
     target: TargetType = None,
     additional_forward_args: Any = None,
 ) -> Tensor:
@@ -450,7 +456,7 @@ def _run_forward(
 
     # make everything a tuple so that it is easy to unpack without
     # using if-statements
-    inputs = _format_input(inputs)
+    inputs = _format_inputs(inputs)
     additional_forward_args = _format_additional_forward_args(additional_forward_args)
 
     output = forward_func(

--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -194,7 +194,7 @@ def _forward_layer_eval(
 @typing.overload
 def _forward_layer_distributed_eval(
     forward_fn: Callable,
-    inputs: Union[Tensor, Tuple[Tensor, ...]],
+    inputs: Any,
     layer: ModuleOrModuleList,
     target_ind: TargetType = None,
     additional_forward_args: Any = None,
@@ -208,7 +208,7 @@ def _forward_layer_distributed_eval(
 @typing.overload
 def _forward_layer_distributed_eval(
     forward_fn: Callable,
-    inputs: Union[Tensor, Tuple[Tensor, ...]],
+    inputs: Any,
     layer: ModuleOrModuleList,
     target_ind: TargetType = None,
     additional_forward_args: Any = None,
@@ -222,7 +222,7 @@ def _forward_layer_distributed_eval(
 
 def _forward_layer_distributed_eval(
     forward_fn: Callable,
-    inputs: Union[Tensor, Tuple[Tensor, ...]],
+    inputs: Any,
     layer: ModuleOrModuleList,
     target_ind: TargetType = None,
     additional_forward_args: Any = None,

--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -12,7 +12,6 @@ from captum._utils.common import (
     _expand_target,
     _format_additional_forward_args,
     _format_baseline,
-    _format_input,
     _format_output,
     _format_tensor_into_tuples,
     _is_tuple,
@@ -325,7 +324,7 @@ class DeepLift(GradientAttribution):
         # converting it into a tuple.
         is_inputs_tuple = _is_tuple(inputs)
 
-        inputs = _format_input(inputs)
+        inputs = _format_tensor_into_tuples(inputs)
         baselines = _format_baseline(baselines, inputs)
 
         gradient_mask = apply_gradient_requirements(inputs)
@@ -840,7 +839,7 @@ class DeepLiftShap(DeepLift):
         # converting it into a tuple.
         is_inputs_tuple = _is_tuple(inputs)
 
-        inputs = _format_input(inputs)
+        inputs = _format_tensor_into_tuples(inputs)
 
         # batch sizes
         inp_bsz = inputs[0].shape[0]

--- a/captum/attr/_core/feature_ablation.py
+++ b/captum/attr/_core/feature_ablation.py
@@ -8,8 +8,8 @@ from captum._utils.common import (
     _expand_additional_forward_args,
     _expand_target,
     _format_additional_forward_args,
-    _format_input,
     _format_output,
+    _format_tensor_into_tuples,
     _is_tuple,
     _run_forward,
 )
@@ -251,7 +251,11 @@ class FeatureAblation(PerturbationAttribution):
             additional_forward_args
         )
         num_examples = inputs[0].shape[0]
-        feature_mask = _format_input(feature_mask) if feature_mask is not None else None
+        feature_mask = (
+            _format_tensor_into_tuples(feature_mask)
+            if feature_mask is not None
+            else None
+        )
         assert (
             isinstance(perturbations_per_eval, int) and perturbations_per_eval >= 1
         ), "Perturbations per evaluation must be an integer and at least 1."

--- a/captum/attr/_core/guided_backprop_deconvnet.py
+++ b/captum/attr/_core/guided_backprop_deconvnet.py
@@ -5,8 +5,8 @@ from typing import Any, List, Tuple, Union
 import torch
 import torch.nn.functional as F
 from captum._utils.common import (
-    _format_input,
     _format_output,
+    _format_tensor_into_tuples,
     _is_tuple,
     _register_backward_hook,
 )
@@ -57,7 +57,7 @@ class ModifiedReluGradientAttribution(GradientAttribution):
         # converting it into a tuple.
         is_inputs_tuple = _is_tuple(inputs)
 
-        inputs = _format_input(inputs)
+        inputs = _format_tensor_into_tuples(inputs)
         gradient_mask = apply_gradient_requirements(inputs)
 
         # set hooks for overriding ReLU gradients

--- a/captum/attr/_core/guided_grad_cam.py
+++ b/captum/attr/_core/guided_grad_cam.py
@@ -3,7 +3,7 @@ import warnings
 from typing import Any, List, Union
 
 import torch
-from captum._utils.common import _format_input, _format_output, _is_tuple
+from captum._utils.common import _format_output, _format_tensor_into_tuples, _is_tuple
 from captum._utils.typing import TargetType, TensorOrTupleOfTensorsGeneric
 from captum.attr._core.guided_backprop_deconvnet import GuidedBackprop
 from captum.attr._core.layer.grad_cam import LayerGradCam
@@ -182,7 +182,7 @@ class GuidedGradCam(GradientAttribution):
             >>> attribution = guided_gc.attribute(input, 3)
         """
         is_inputs_tuple = _is_tuple(inputs)
-        inputs = _format_input(inputs)
+        inputs = _format_tensor_into_tuples(inputs)
         grad_cam_attr = self.grad_cam.attribute.__wrapped__(
             self.grad_cam,  # self
             inputs=inputs,

--- a/captum/attr/_core/input_x_gradient.py
+++ b/captum/attr/_core/input_x_gradient.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 from typing import Any, Callable
 
-from captum._utils.common import _format_input, _format_output, _is_tuple
+from captum._utils.common import _format_output, _format_tensor_into_tuples, _is_tuple
 from captum._utils.gradient import (
     apply_gradient_requirements,
     undo_gradient_requirements,
@@ -111,7 +111,7 @@ class InputXGradient(GradientAttribution):
         # converting it into a tuple.
         is_inputs_tuple = _is_tuple(inputs)
 
-        inputs = _format_input(inputs)
+        inputs = _format_tensor_into_tuples(inputs)
         gradient_mask = apply_gradient_requirements(inputs)
 
         gradients = self.gradient_func(

--- a/captum/attr/_core/layer/grad_cam.py
+++ b/captum/attr/_core/layer/grad_cam.py
@@ -5,8 +5,8 @@ import torch
 import torch.nn.functional as F
 from captum._utils.common import (
     _format_additional_forward_args,
-    _format_input,
     _format_output,
+    _format_tensor_into_tuples,
 )
 from captum._utils.gradient import compute_layer_gradients_and_eval
 from captum._utils.typing import TargetType
@@ -181,7 +181,7 @@ class LayerGradCam(LayerAttribution, GradientAttribution):
             >>> # This can be done with LayerAttribution's interpolate method.
             >>> upsampled_attr = LayerAttribution.interpolate(attr, (32, 32))
         """
-        inputs = _format_input(inputs)
+        inputs = _format_tensor_into_tuples(inputs)
         additional_forward_args = _format_additional_forward_args(
             additional_forward_args
         )

--- a/captum/attr/_core/layer/layer_deep_lift.py
+++ b/captum/attr/_core/layer/layer_deep_lift.py
@@ -8,7 +8,7 @@ from captum._utils.common import (
     _expand_target,
     _format_additional_forward_args,
     _format_baseline,
-    _format_input,
+    _format_tensor_into_tuples,
 )
 from captum._utils.gradient import compute_layer_gradients_and_eval
 from captum._utils.typing import (
@@ -290,7 +290,7 @@ class LayerDeepLift(LayerAttribution, DeepLift):
             >>> # Computes deeplift attribution scores for conv4 layer and class 3.
             >>> attribution = dl.attribute(input, target=1)
         """
-        inputs = _format_input(inputs)
+        inputs = _format_tensor_into_tuples(inputs)
         baselines = _format_baseline(baselines, inputs)
         _validate_input(inputs, baselines)
 
@@ -624,7 +624,7 @@ class LayerDeepLiftShap(LayerDeepLift, DeepLiftShap):
             >>> # Computes shap values using deeplift for class 3.
             >>> attribution = dl.attribute(input, target=3)
         """
-        inputs = _format_input(inputs)
+        inputs = _format_tensor_into_tuples(inputs)
         baselines = _format_callable_baseline(baselines, inputs)
 
         assert isinstance(baselines[0], torch.Tensor) and baselines[0].shape[0] > 1, (

--- a/captum/attr/_core/layer/layer_feature_ablation.py
+++ b/captum/attr/_core/layer/layer_feature_ablation.py
@@ -5,8 +5,8 @@ import torch
 from captum._utils.common import (
     _extract_device,
     _format_additional_forward_args,
-    _format_input,
     _format_output,
+    _format_tensor_into_tuples,
     _run_forward,
 )
 from captum._utils.gradient import _forward_layer_eval
@@ -269,7 +269,7 @@ class LayerFeatureAblation(LayerAttribution, PerturbationAttribution):
             return eval
 
         with torch.no_grad():
-            inputs = _format_input(inputs)
+            inputs = _format_tensor_into_tuples(inputs)
             additional_forward_args = _format_additional_forward_args(
                 additional_forward_args
             )

--- a/captum/attr/_core/layer/layer_gradient_x_activation.py
+++ b/captum/attr/_core/layer/layer_gradient_x_activation.py
@@ -3,8 +3,8 @@ from typing import Any, Callable, List, Tuple, Union
 
 from captum._utils.common import (
     _format_additional_forward_args,
-    _format_input,
     _format_output,
+    _format_tensor_into_tuples,
 )
 from captum._utils.gradient import compute_layer_gradients_and_eval
 from captum._utils.typing import ModuleOrModuleList, TargetType
@@ -161,7 +161,7 @@ class LayerGradientXActivation(LayerAttribution, GradientAttribution):
             >>> # attribution size matches layer output, Nx12x32x32
             >>> attribution = layer_ga.attribute(input, 3)
         """
-        inputs = _format_input(inputs)
+        inputs = _format_tensor_into_tuples(inputs)
         additional_forward_args = _format_additional_forward_args(
             additional_forward_args
         )

--- a/captum/attr/_core/layer/layer_lrp.py
+++ b/captum/attr/_core/layer/layer_lrp.py
@@ -2,7 +2,11 @@
 import typing
 from typing import Any, List, Tuple, Union, cast
 
-from captum._utils.common import _format_input, _reduce_list, _sort_key_list
+from captum._utils.common import (
+    _format_tensor_into_tuples,
+    _reduce_list,
+    _sort_key_list,
+)
 from captum._utils.gradient import (
     apply_gradient_requirements,
     compute_gradients,
@@ -215,7 +219,7 @@ class LayerLRP(LRP, LayerAttribution):
         self.backward_handles = []
         self.forward_handles = []
 
-        inputs = _format_input(inputs)
+        inputs = _format_tensor_into_tuples(inputs)
         gradient_mask = apply_gradient_requirements(inputs)
 
         try:

--- a/captum/attr/_core/lime.py
+++ b/captum/attr/_core/lime.py
@@ -10,8 +10,8 @@ from captum._utils.common import (
     _expand_additional_forward_args,
     _expand_target,
     _flatten_tensor_or_tuple,
-    _format_input,
     _format_output,
+    _format_tensor_into_tuples,
     _is_tuple,
     _reduce_list,
     _run_forward,
@@ -652,7 +652,7 @@ def construct_feature_mask(feature_mask, formatted_inputs):
             formatted_inputs
         )
     else:
-        feature_mask = _format_input(feature_mask)
+        feature_mask = _format_tensor_into_tuples(feature_mask)
         min_interp_features = int(
             min(
                 torch.min(single_mask).item()

--- a/captum/attr/_core/lrp.py
+++ b/captum/attr/_core/lrp.py
@@ -6,11 +6,11 @@ from typing import Any, List, Tuple, Union, cast
 
 import torch.nn as nn
 from captum._utils.common import (
-    _format_input,
     _format_output,
+    _format_tensor_into_tuples,
     _is_tuple,
-    _run_forward,
     _register_backward_hook,
+    _run_forward,
 )
 from captum._utils.gradient import (
     apply_gradient_requirements,
@@ -193,7 +193,7 @@ class LRP(GradientAttribution):
         self.forward_handles: List[RemovableHandle] = []
 
         is_inputs_tuple = _is_tuple(inputs)
-        inputs = _format_input(inputs)
+        inputs = _format_tensor_into_tuples(inputs)
         gradient_mask = apply_gradient_requirements(inputs)
 
         try:

--- a/captum/attr/_core/neuron/neuron_gradient.py
+++ b/captum/attr/_core/neuron/neuron_gradient.py
@@ -3,8 +3,8 @@ from typing import Any, Callable, List, Tuple, Union
 
 from captum._utils.common import (
     _format_additional_forward_args,
-    _format_input,
     _format_output,
+    _format_tensor_into_tuples,
     _is_tuple,
 )
 from captum._utils.gradient import (
@@ -159,7 +159,7 @@ class NeuronGradient(NeuronAttribution, GradientAttribution):
             >>> attribution = neuron_ig.attribute(input, (4,1,2))
         """
         is_inputs_tuple = _is_tuple(inputs)
-        inputs = _format_input(inputs)
+        inputs = _format_tensor_into_tuples(inputs)
         additional_forward_args = _format_additional_forward_args(
             additional_forward_args
         )

--- a/captum/attr/_core/noise_tunnel.py
+++ b/captum/attr/_core/noise_tunnel.py
@@ -8,7 +8,6 @@ from captum._utils.common import (
     _expand_and_update_baselines,
     _expand_and_update_feature_mask,
     _expand_and_update_target,
-    _format_input,
     _format_output,
     _format_tensor_into_tuples,
     _is_tuple,
@@ -342,7 +341,7 @@ class NoiseTunnel(Attribution):
             # converting it into a tuple.
             is_inputs_tuple = isinstance(inputs, tuple)
 
-            inputs = _format_input(inputs)  # type: ignore
+            inputs = _format_tensor_into_tuples(inputs)  # type: ignore
 
             _validate_noise_tunnel_type(nt_type, SUPPORTED_NOISE_TUNNEL_TYPES)
 

--- a/captum/attr/_core/occlusion.py
+++ b/captum/attr/_core/occlusion.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Tuple, Union
 
 import numpy as np
 import torch
-from captum._utils.common import _format_input
+from captum._utils.common import _format_tensor_into_tuples
 from captum._utils.typing import BaselineType, TargetType, TensorOrTupleOfTensorsGeneric
 from captum.attr._core.feature_ablation import FeatureAblation
 from captum.attr._utils.common import (
@@ -210,7 +210,7 @@ class Occlusion(FeatureAblation):
             >>> # shifting in each direction by the default of 1.
             >>> attr = ablator.attribute(input, target=1, sliding_window_shapes=(3,3))
         """
-        formatted_inputs = _format_input(inputs)
+        formatted_inputs = _format_tensor_into_tuples(inputs)
 
         # Formatting strides
         strides = _format_and_verify_strides(strides, formatted_inputs)

--- a/captum/attr/_core/saliency.py
+++ b/captum/attr/_core/saliency.py
@@ -3,7 +3,7 @@
 from typing import Any, Callable
 
 import torch
-from captum._utils.common import _format_input, _format_output, _is_tuple
+from captum._utils.common import _format_output, _format_tensor_into_tuples, _is_tuple
 from captum._utils.gradient import (
     apply_gradient_requirements,
     undo_gradient_requirements,
@@ -122,7 +122,7 @@ class Saliency(GradientAttribution):
         # converting it into a tuple.
         is_inputs_tuple = _is_tuple(inputs)
 
-        inputs = _format_input(inputs)
+        inputs = _format_tensor_into_tuples(inputs)
         gradient_mask = apply_gradient_requirements(inputs)
 
         # No need to format additional_forward_args here.

--- a/captum/attr/_core/shapley_value.py
+++ b/captum/attr/_core/shapley_value.py
@@ -10,8 +10,8 @@ from captum._utils.common import (
     _expand_additional_forward_args,
     _expand_target,
     _format_additional_forward_args,
-    _format_input,
     _format_output,
+    _format_tensor_into_tuples,
     _is_tuple,
     _run_forward,
 )
@@ -276,7 +276,11 @@ class ShapleyValueSampling(PerturbationAttribution):
         additional_forward_args = _format_additional_forward_args(
             additional_forward_args
         )
-        feature_mask = _format_input(feature_mask) if feature_mask is not None else None
+        feature_mask = (
+            _format_tensor_into_tuples(feature_mask)
+            if feature_mask is not None
+            else None
+        )
         assert (
             isinstance(perturbations_per_eval, int) and perturbations_per_eval >= 1
         ), "Ablations per evaluation must be at least 1."
@@ -712,7 +716,9 @@ class ShapleyValues(ShapleyValueSampling):
             >>> attr = sv.attribute(input, target=1, feature_mask=feature_mask)
         """
         if feature_mask is None:
-            total_features = sum(torch.numel(inp[0]) for inp in _format_input(inputs))
+            total_features = sum(
+                torch.numel(inp[0]) for inp in _format_tensor_into_tuples(inputs)
+            )
         else:
             total_features = (
                 int(max(torch.max(single_mask).item() for single_mask in feature_mask))

--- a/captum/attr/_utils/batching.py
+++ b/captum/attr/_utils/batching.py
@@ -6,8 +6,8 @@ from typing import Any, Callable, Iterator, Tuple, Union
 import torch
 from captum._utils.common import (
     _format_additional_forward_args,
-    _format_input,
     _format_output,
+    _format_tensor_into_tuples,
     _reduce_list,
 )
 from captum._utils.typing import (
@@ -139,7 +139,7 @@ def _batched_generator(
     assert internal_batch_size is None or (
         isinstance(internal_batch_size, int) and internal_batch_size > 0
     ), "Batch size must be greater than 0."
-    inputs = _format_input(inputs)
+    inputs = _format_tensor_into_tuples(inputs)
     additional_forward_args = _format_additional_forward_args(additional_forward_args)
     num_examples = inputs[0].shape[0]
     # TODO Reconsider this check if _batched_generator is used for non gradient-based

--- a/captum/attr/_utils/common.py
+++ b/captum/attr/_utils/common.py
@@ -4,8 +4,12 @@ from inspect import signature
 from typing import TYPE_CHECKING, Any, Callable, List, Tuple, Union
 
 import torch
-from captum._utils.common import _format_baseline, _format_input, _format_output
-from captum._utils.common import _validate_input as _validate_input_basic
+from captum._utils.common import (
+    _format_baseline,
+    _format_output,
+    _format_tensor_into_tuples,
+    _validate_input as _validate_input_basic,
+)
 from captum._utils.typing import (
     BaselineType,
     Literal,
@@ -81,7 +85,7 @@ def _format_input_baseline(
 def _format_input_baseline(
     inputs: Union[Tensor, Tuple[Tensor, ...]], baselines: BaselineType
 ) -> Tuple[Tuple[Tensor, ...], Tuple[Union[Tensor, int, float], ...]]:
-    inputs = _format_input(inputs)
+    inputs = _format_tensor_into_tuples(inputs)
     baselines = _format_baseline(baselines, inputs)
     return inputs, baselines
 
@@ -137,7 +141,7 @@ def _format_callable_baseline(
             baselines = baselines()
         else:
             baselines = baselines(inputs)
-    return _format_baseline(baselines, _format_input(inputs))
+    return _format_baseline(baselines, _format_tensor_into_tuples(inputs))
 
 
 def _format_and_verify_strides(

--- a/captum/influence/_core/tracincp.py
+++ b/captum/influence/_core/tracincp.py
@@ -8,16 +8,16 @@ from typing import Any, Callable, Iterator, List, Optional, Union, Tuple, NamedT
 
 import torch
 from captum._utils.av import AV
+from captum._utils.common import _format_inputs
 from captum._utils.gradient import (
     _compute_jacobian_wrt_params,
     _compute_jacobian_wrt_params_with_sample_wise_trick,
 )
 from captum.influence._core.influence import DataInfluence
 from captum.influence._utils.common import (
+    _get_k_most_influential_helper,
     _gradient_dot_product,
     _load_flexible_state_dict,
-    _get_k_most_influential_helper,
-    _format_inputs,
 )
 from captum.log import log_usage
 from torch import Tensor

--- a/captum/influence/_utils/common.py
+++ b/captum/influence/_utils/common.py
@@ -124,16 +124,6 @@ def _load_flexible_state_dict(
     return learning_rate
 
 
-def _format_inputs(inputs: Any, unpack_inputs: bool):
-    if inputs is None:
-        return None
-    return (
-        inputs
-        if (isinstance(inputs, tuple) or isinstance(inputs, list)) and unpack_inputs
-        else (inputs,)
-    )
-
-
 def _get_k_most_influential_helper(
     influence_src_dataloader: DataLoader,
     influence_batch_fn: Callable,

--- a/captum/metrics/_core/infidelity.py
+++ b/captum/metrics/_core/infidelity.py
@@ -9,7 +9,6 @@ from captum._utils.common import (
     _expand_target,
     _format_additional_forward_args,
     _format_baseline,
-    _format_input,
     _format_tensor_into_tuples,
     _run_forward,
     safe_div,
@@ -74,8 +73,8 @@ def infidelity_perturb_func_decorator(multipy_by_inputs: bool = True) -> Callabl
                 if baselines is not None
                 else pertub_func(inputs)
             )
-            inputs_perturbed = _format_input(inputs_perturbed)
-            inputs = _format_input(inputs)
+            inputs_perturbed = _format_tensor_into_tuples(inputs_perturbed)
+            inputs = _format_tensor_into_tuples(inputs)
             baselines = _format_baseline(baselines, inputs)
             if baselines is None:
                 perturbations = tuple(
@@ -533,7 +532,7 @@ def infidelity(
         return tuple(agg_t + t for agg_t, t in zip(agg_tensors, tensors))
 
     # perform argument formattings
-    inputs = _format_input(inputs)  # type: ignore
+    inputs = _format_tensor_into_tuples(inputs)  # type: ignore
     if baselines is not None:
         baselines = _format_baseline(baselines, cast(Tuple[Tensor, ...], inputs))
     additional_forward_args = _format_additional_forward_args(additional_forward_args)

--- a/captum/metrics/_core/sensitivity.py
+++ b/captum/metrics/_core/sensitivity.py
@@ -10,7 +10,6 @@ from captum._utils.common import (
     _expand_and_update_baselines,
     _expand_and_update_target,
     _format_baseline,
-    _format_input,
     _format_tensor_into_tuples,
 )
 from captum._utils.typing import TensorOrTupleOfTensorsGeneric
@@ -46,7 +45,7 @@ def default_perturb_func(
                 original inputs.
 
     """
-    inputs = _format_input(inputs)
+    inputs = _format_tensor_into_tuples(inputs)
     perturbed_input = tuple(
         input
         + torch.FloatTensor(input.size())  # type: ignore
@@ -301,7 +300,7 @@ def sensitivity_max(
         )
         return max_values(sensitivities_norm.view(bsz, -1))
 
-    inputs = _format_input(inputs)  # type: ignore
+    inputs = _format_tensor_into_tuples(inputs)  # type: ignore
 
     bsz = inputs[0].size(0)
 

--- a/captum/robust/_core/fgsm.py
+++ b/captum/robust/_core/fgsm.py
@@ -4,8 +4,8 @@ from typing import Any, Callable, Tuple
 import torch
 from captum._utils.common import (
     _format_additional_forward_args,
-    _format_input,
     _format_output,
+    _format_tensor_into_tuples,
     _is_tuple,
     _select_targets,
 )
@@ -133,7 +133,7 @@ class FGSM(Perturbation):
                         corresponding sized tensors is returned.
         """
         is_inputs_tuple = _is_tuple(inputs)
-        inputs: Tuple[Tensor, ...] = _format_input(inputs)
+        inputs: Tuple[Tensor, ...] = _format_tensor_into_tuples(inputs)
         gradient_mask = apply_gradient_requirements(inputs)
 
         def _forward_with_loss() -> Tensor:

--- a/captum/robust/_core/pgd.py
+++ b/captum/robust/_core/pgd.py
@@ -3,7 +3,7 @@ from typing import Any, Callable
 
 import torch
 import torch.nn.functional as F
-from captum._utils.common import _format_input, _format_output, _is_tuple
+from captum._utils.common import _format_output, _format_tensor_into_tuples, _is_tuple
 from captum._utils.typing import TensorOrTupleOfTensorsGeneric
 from captum.robust._core.fgsm import FGSM
 from captum.robust._core.perturbation import Perturbation
@@ -153,7 +153,7 @@ class PGD(Perturbation):
                 raise AssertionError("Norm constraint must be L2 or Linf.")
 
         is_inputs_tuple = _is_tuple(inputs)
-        formatted_inputs = _format_input(inputs)
+        formatted_inputs = _format_tensor_into_tuples(inputs)
         perturbed_inputs = formatted_inputs
         if random_start:
             perturbed_inputs = tuple(

--- a/tests/attr/test_jit.py
+++ b/tests/attr/test_jit.py
@@ -4,7 +4,10 @@ from enum import Enum
 from typing import Any, Callable, Dict, Tuple, Type, cast
 
 import torch
-from captum._utils.common import _format_additional_forward_args, _format_input
+from captum._utils.common import (
+    _format_additional_forward_args,
+    _format_tensor_into_tuples,
+)
 from captum.attr._core.feature_ablation import FeatureAblation
 from captum.attr._core.feature_permutation import FeaturePermutation
 from captum.attr._core.gradient_shap import GradientShap
@@ -158,11 +161,11 @@ class JITMeta(type):
                 mode is JITCompareMode.cpu_jit_trace
                 or JITCompareMode.data_parallel_jit_trace
             ):
-                all_inps = _format_input(args["inputs"]) + (
+                all_inps = _format_tensor_into_tuples(args["inputs"]) + (
                     _format_additional_forward_args(args["additional_forward_args"])
                     if "additional_forward_args" in args
                     and args["additional_forward_args"] is not None
-                    else tuple()
+                    else ()
                 )
                 model_2 = torch.jit.trace(model_1, all_inps)  # type: ignore
             else:

--- a/tests/attr/test_lime.py
+++ b/tests/attr/test_lime.py
@@ -12,8 +12,8 @@ from captum.attr._core.lime import Lime, LimeBase, get_exp_kernel_similarity_fun
 from captum.attr._utils.batching import _batch_example_iterator
 from captum.attr._utils.common import (
     _construct_default_feature_mask,
-    _format_input,
     _format_input_baseline,
+    _format_tensor_into_tuples,
 )
 from tests.helpers.basic import (
     BaseTest,
@@ -544,7 +544,7 @@ class Test(BaseTest):
                         num_interp_features,
                     ) = _construct_default_feature_mask(formatted_inputs)
                 else:
-                    formatted_feature_mask = _format_input(feature_mask)
+                    formatted_feature_mask = _format_tensor_into_tuples(feature_mask)
                     num_interp_features = int(
                         max(
                             torch.max(single_mask).item()


### PR DESCRIPTION
Summary:
+ Allows `_forward_layer_distributed_eval` to take inputs of type Any. Changed everywhere in attribution, robustness and metrics to call `_format_tensor_into_tuples` instead of  `_format_inputs`. `_format_inputs` is now a generic function in `common.py` that formats inputs of type Any.

+ Removed duplicated `test_jacobian.py` file
+ Fixed failing test cases in captum.robust.

Differential Revision: D34992445

