### PR TITLE
Add runtime error to LRP for duplicated module

### DIFF
--- a/captum/attr/_utils/lrp_rules.py
+++ b/captum/attr/_utils/lrp_rules.py
@@ -70,6 +70,13 @@ class PropagationRule(ABC):
     def forward_hook_weights(self, module, inputs, outputs):
         """Save initial activations a_j before modules are changed"""
         device = inputs[0].device if isinstance(inputs, tuple) else inputs.device
+        if hasattr(module, "activations") and device in module.activations:
+            raise RuntimeError(
+                "Module {} is being used more than once in the network, which "
+                "is not supported by LRP. "
+                "Please ensure that module is being used only once in the "
+                "network.".format(module)
+            )
         module.activations[device] = tuple(input.data for input in inputs)
         self._manipulate_weights(module, inputs, outputs)
 

--- a/tests/attr/test_deeplift_basic.py
+++ b/tests/attr/test_deeplift_basic.py
@@ -12,7 +12,7 @@ from tests.helpers.basic import (
     assertTensorAlmostEqual,
 )
 from tests.helpers.basic_models import (
-    BasicModelWithReusableModules,
+    BasicModelWithReusedModules,
     Conv1dSeqModel,
     LinearMaxPoolLinearModel,
     ReLUDeepLiftModel,
@@ -247,7 +247,7 @@ class Test(BaseTest):
         self.assertEqual(attr.shape, rand_seq_data.shape)
 
     def test_reusable_modules(self) -> None:
-        model = BasicModelWithReusableModules()
+        model = BasicModelWithReusedModules()
         input = torch.rand(1, 3)
         dl = DeepLift(model)
         with self.assertRaises(RuntimeError):

--- a/tests/attr/test_lrp.py
+++ b/tests/attr/test_lrp.py
@@ -14,6 +14,7 @@ from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
 from tests.helpers.basic_models import (
     BasicModel_ConvNet_One_Conv,
     BasicModel_MultiLayer,
+    BasicModelWithReusableLinear,
     SimpleLRPModel,
 )
 from torch import Tensor
@@ -305,3 +306,10 @@ class Test(BaseTest):
         assertTensorAlmostEqual(
             self, attributions_lrp, attributions_ixg
         )  # Divide by score because LRP relevance is normalized.
+
+    def test_lrp_repeated_module(self) -> None:
+        model = BasicModelWithReusableLinear()
+        inp = torch.ones(2, 3)
+        lrp = LRP(model)
+        with self.assertRaisesRegexp(RuntimeError, "more than once"):
+            lrp.attribute(inp, target=0)

--- a/tests/attr/test_lrp.py
+++ b/tests/attr/test_lrp.py
@@ -14,7 +14,7 @@ from tests.helpers.basic import BaseTest, assertTensorAlmostEqual
 from tests.helpers.basic_models import (
     BasicModel_ConvNet_One_Conv,
     BasicModel_MultiLayer,
-    BasicModelWithReusableLinear,
+    BasicModelWithReusedLinear,
     SimpleLRPModel,
 )
 from torch import Tensor
@@ -308,7 +308,7 @@ class Test(BaseTest):
         )  # Divide by score because LRP relevance is normalized.
 
     def test_lrp_repeated_module(self) -> None:
-        model = BasicModelWithReusableLinear()
+        model = BasicModelWithReusedLinear()
         inp = torch.ones(2, 3)
         lrp = LRP(model)
         with self.assertRaisesRegexp(RuntimeError, "more than once"):

--- a/tests/helpers/basic_models.py
+++ b/tests/helpers/basic_models.py
@@ -194,6 +194,16 @@ class BasicModelWithReusableModules(nn.Module):
         return self.relu(self.lin2(self.relu(self.lin1(inputs))))
 
 
+class BasicModelWithReusableLinear(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.lin1 = nn.Linear(3, 3)
+        self.relu = nn.ReLU()
+
+    def forward(self, inputs):
+        return self.relu(self.lin1(self.relu(self.lin1(inputs))))
+
+
 class BasicModelWithSparseInputs(nn.Module):
     def __init__(self) -> None:
         super().__init__()

--- a/tests/helpers/basic_models.py
+++ b/tests/helpers/basic_models.py
@@ -183,7 +183,7 @@ class LinearMaxPoolLinearModel(nn.Module):
         return self.lin2(self.pool1(self.lin1(x))[:, 0, :])
 
 
-class BasicModelWithReusableModules(nn.Module):
+class BasicModelWithReusedModules(nn.Module):
     def __init__(self) -> None:
         super().__init__()
         self.lin1 = nn.Linear(3, 2)
@@ -194,7 +194,7 @@ class BasicModelWithReusableModules(nn.Module):
         return self.relu(self.lin2(self.relu(self.lin1(inputs))))
 
 
-class BasicModelWithReusableLinear(nn.Module):
+class BasicModelWithReusedLinear(nn.Module):
     def __init__(self) -> None:
         super().__init__()
         self.lin1 = nn.Linear(3, 3)


### PR DESCRIPTION
This addresses #857 , adding an error message to LRP in the case where module reuse is detected.