### PR TITLE
Add support for captum toplevel-import.

### DIFF
--- a/captum/__init__.py
+++ b/captum/__init__.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-import captum.attr as attr
-import captum.concept as concept
-import captum.influence as influence
-import captum.insights as insights
-import captum.log as log
-import captum.metrics as metrics
-import captum.robust as robust
+import captum.attr as attr  # noqa
+import captum.concept as concept  # noqa
+import captum.influence as influence  # noqa
+import captum.insights as insights  # noqa
+import captum.log as log  # noqa
+import captum.metrics as metrics  # noqa
+import captum.robust as robust  # noqa
 
 
 __version__ = "0.5.0"

--- a/captum/__init__.py
+++ b/captum/__init__.py
@@ -1,3 +1,11 @@
 #!/usr/bin/env python3
+import captum.attr as attr
+import captum.concept as concept
+import captum.influence as influence
+import captum.insights as insights
+import captum.log as log
+import captum.metrics as metrics
+import captum.robust as robust
+
 
 __version__ = "0.5.0"


### PR DESCRIPTION
This fixes issue #680 Strange import issue --> AttributeError: module 'captum' has no attribute 'attr'

In most python packages, you can import the toplevel package, like numpy, scipy, torch, etc.. and then access the submodules simply by the dot-operator. Like you can use `import numpy` and after that you can use any submodules à la `numpy.random.uniform`.

With this PR, you can just `import captum` and then for example use `captum.attr.DeepLift` or `captum.robust.Perturbation` instead of having to import both. It's just a small convenience, and I think there are more people that expect this kind of import to work but don't bother to create an issue out of this.

I hope this PR is considered as helpful.