### PR TITLE
allow "mean" reduction for TracInCPFast, TracInCPFastRandProj

### DIFF
--- a/tests/influence/_core/test_tracin_get_k_most_influential.py
+++ b/tests/influence/_core/test_tracin_get_k_most_influential.py
@@ -48,6 +48,8 @@ class TestTracInGetKMostInfluential(BaseTest):
                 ),
                 ("sum", DataInfluenceConstructor(TracInCPFast)),
                 ("sum", DataInfluenceConstructor(TracInCPFastRandProj)),
+                ("mean", DataInfluenceConstructor(TracInCPFast)),
+                ("mean", DataInfluenceConstructor(TracInCPFastRandProj)),
             ]
         ],
         name_func=build_test_name_func(),

--- a/tests/influence/_core/test_tracin_regression.py
+++ b/tests/influence/_core/test_tracin_regression.py
@@ -50,6 +50,8 @@ class TestTracInRegression(BaseTest):
                 ("sample_wise_trick", None, DataInfluenceConstructor(TracInCP)),
                 ("check_idx", "sum", DataInfluenceConstructor(TracInCPFast)),
                 ("check_idx", "sum", DataInfluenceConstructor(TracInCPFastRandProj)),
+                ("check_idx", "mean", DataInfluenceConstructor(TracInCPFast)),
+                ("check_idx", "mean", DataInfluenceConstructor(TracInCPFastRandProj)),
                 (
                     "check_idx",
                     "sum",
@@ -168,6 +170,8 @@ class TestTracInRegression(BaseTest):
             ),
             ("sum", DataInfluenceConstructor(TracInCPFast)),
             ("sum", DataInfluenceConstructor(TracInCPFastRandProj)),
+            ("mean", DataInfluenceConstructor(TracInCPFast)),
+            ("mean", DataInfluenceConstructor(TracInCPFastRandProj)),
         ],
         name_func=build_test_name_func(),
     )
@@ -248,6 +252,8 @@ class TestTracInRegression(BaseTest):
             ("sample_wise_trick", None, DataInfluenceConstructor(TracInCP)),
             ("check_idx", "sum", DataInfluenceConstructor(TracInCPFast)),
             ("check_idx", "sum", DataInfluenceConstructor(TracInCPFastRandProj)),
+            ("check_idx", "mean", DataInfluenceConstructor(TracInCPFast)),
+            ("check_idx", "mean", DataInfluenceConstructor(TracInCPFastRandProj)),
         ],
         name_func=build_test_name_func(),
     )

--- a/tests/influence/_core/test_tracin_self_influence.py
+++ b/tests/influence/_core/test_tracin_self_influence.py
@@ -31,6 +31,7 @@ class TestTracInSelfInfluence(BaseTest):
                     ),
                 ),
                 ("sum", DataInfluenceConstructor(TracInCPFast)),
+                ("mean", DataInfluenceConstructor(TracInCPFast)),
             ]
         ],
         name_func=build_test_name_func(args_to_skip=["reduction"]),


### PR DESCRIPTION
Summary: This adds support for the "reduction" of the loss function used by `TracInCPFast` and `TracInCPFastRandProj` to be "mean", not just "sum" (as before).  This is done by appropriate scaling in `_basic_computation_tracincp_fast`.  This scaling could alternatively been handled in `_jacobian_loss_wrt_inputs`, if this is a better option, can do that instead.  Tests are run for more parameters - basically if a reduction="sum" test was run, a reduction="mean" test is now added.

Reviewed By: vivekmig

Differential Revision: D34802879

