### PR TITLE
Fixes TCAV concept ordering bug reported in issue 909 on GH

### DIFF
--- a/captum/concept/_core/tcav.py
+++ b/captum/concept/_core/tcav.py
@@ -772,9 +772,11 @@ class TCAV(ConceptInterpreter):
             concepts_key = concepts_to_str(concepts)
 
             # sort classes / concepts in the order specified in concept_keys
-            concept_ord = {concept.id: ci for ci, concept in enumerate(concepts)}
+            concept_ord = [concept.id for concept in concepts]
+            class_ord = {cls_: idx for idx, cls_ in enumerate(cls_set)}
+
             new_ord = torch.tensor(
-                [concept_ord[cls] for cls in cls_set], device=tcav_score.device
+                [class_ord[cncpt] for cncpt in concept_ord], device=tcav_score.device
             )
 
             # sort based on classes

--- a/tests/concept/test_tcav.py
+++ b/tests/concept/test_tcav.py
@@ -1110,6 +1110,16 @@ class Test(BaseTest):
             processes=1,
         )
 
+    def test_TCAV_x_1_1_c_concept_order_changed(self) -> None:
+        self.compute_cavs_interpret(
+            [["random", "striped"], ["random", "ceo"], ["ceo", "striped"]],
+            True,
+            0.4848,
+            0.5000,
+            8.185208066890937e-09,
+            processes=1,
+        )
+
     # Non-existing concept in the experimental set ("dotted")
     def test_TCAV_x_1_1_d(self) -> None:
         self.compute_cavs_interpret(


### PR DESCRIPTION
Summary:
Fixes TCAV concept ordering bug reported in this issue: https://github.com/pytorch/captum/issues/909

The original implementation wasn't sorting the concepts correctly in the output. I changed so that the ordering is based on the input concept ordering in the experimental set.

Differential Revision: D35302278

