### PR TITLE
Optim-wip: Fix duplicated target bug

### DIFF
--- a/captum/optim/_core/loss.py
+++ b/captum/optim/_core/loss.py
@@ -130,6 +130,9 @@ def module_op(
         target = (self.target if isinstance(self.target, list) else [self.target]) + (
             other.target if isinstance(other.target, list) else [other.target]
         )
+
+        # Filter out duplicate targets
+        target = list(dict.fromkeys(target))
     else:
         raise TypeError(
             "Can only apply math operations with int, float or Loss. Received type "


### PR DESCRIPTION
Currently a hook is created in `ModuleOutputsHook` for ever instance of a target in the target list. Each captured set of activations for the same hook overwrites the previous set of activations, potentially leading to negative performance impacts. This bug also causes the of the warning messages in `ModuleOutputsHook` to repeat every iteration.

This PR solves the issue by ensuring that duplicate target values are removed.