### PR TITLE
Update IPython import to resolve deprecation warning

### DIFF
--- a/captum/attr/_utils/visualization.py
+++ b/captum/attr/_utils/visualization.py
@@ -12,7 +12,7 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 from numpy import ndarray
 
 try:
-    from IPython.core.display import display, HTML
+    from IPython.display import display, HTML
 
     HAS_IPYTHON = True
 except ImportError:


### PR DESCRIPTION
Address #936 by switching IPython import from IPython.core.display to from IPython.display