### PR TITLE
SGD Linear Model Fixes for Lime

### DIFF
--- a/captum/_utils/models/linear_model/model.py
+++ b/captum/_utils/models/linear_model/model.py
@@ -2,7 +2,7 @@ from typing import Callable, cast, List, Optional
 
 import torch.nn as nn
 from captum._utils.models.model import Model
-from torch import Tensor
+from torch import Tensor, dtype
 from torch.utils.data import DataLoader
 
 
@@ -47,6 +47,7 @@ class LinearModel(nn.Module, Model):
         weight_values: Optional[Tensor] = None,
         bias_value: Optional[Tensor] = None,
         classes: Optional[Tensor] = None,
+        dtype: Optional[dtype] = None,
     ):
         r"""
         Lazily initializes a linear model. This will be called for you in a
@@ -102,7 +103,7 @@ class LinearModel(nn.Module, Model):
         else:
             self.norm = None
 
-        self.linear = nn.Linear(in_features, out_features, bias=bias)
+        self.linear = nn.Linear(in_features, out_features, bias=bias, dtype=dtype)
 
         if weight_values is not None:
             self.linear.weight.data = weight_values

--- a/captum/_utils/models/linear_model/model.py
+++ b/captum/_utils/models/linear_model/model.py
@@ -2,7 +2,7 @@ from typing import Callable, cast, List, Optional
 
 import torch.nn as nn
 from captum._utils.models.model import Model
-from torch import Tensor, dtype
+from torch import Tensor
 from torch.utils.data import DataLoader
 
 
@@ -47,7 +47,6 @@ class LinearModel(nn.Module, Model):
         weight_values: Optional[Tensor] = None,
         bias_value: Optional[Tensor] = None,
         classes: Optional[Tensor] = None,
-        dtype: Optional[dtype] = None,
     ):
         r"""
         Lazily initializes a linear model. This will be called for you in a
@@ -103,7 +102,7 @@ class LinearModel(nn.Module, Model):
         else:
             self.norm = None
 
-        self.linear = nn.Linear(in_features, out_features, bias=bias, dtype=dtype)
+        self.linear = nn.Linear(in_features, out_features, bias=bias)
 
         if weight_values is not None:
             self.linear.weight.data = weight_values

--- a/captum/_utils/models/linear_model/train.py
+++ b/captum/_utils/models/linear_model/train.py
@@ -126,7 +126,6 @@ def sgd_train_linear_model(
     model._construct_model_params(
         in_features=x.shape[1],
         out_features=y.shape[1] if len(y.shape) == 2 else 1,
-        dtype=x.dtype,
         **construct_kwargs,
     )
     model.train()

--- a/captum/_utils/models/linear_model/train.py
+++ b/captum/_utils/models/linear_model/train.py
@@ -127,6 +127,7 @@ def sgd_train_linear_model(
     model._construct_model_params(
         in_features=x.shape[1],
         out_features=y.shape[1] if len(y.shape) == 2 else 1,
+        dtype=x.dtype,
         **construct_kwargs,
     )
     model.train()

--- a/captum/_utils/models/linear_model/train.py
+++ b/captum/_utils/models/linear_model/train.py
@@ -99,132 +99,129 @@ def sgd_train_linear_model(
         This will return the final training loss (averaged with
         `running_loss_window`)
     """
+    with torch.enable_grad():
+        loss_window: List[torch.Tensor] = []
+        min_avg_loss = None
+        convergence_counter = 0
+        converged = False
 
-    loss_window: List[torch.Tensor] = []
-    min_avg_loss = None
-    convergence_counter = 0
-    converged = False
-
-    def get_point(datapoint):
-        if len(datapoint) == 2:
-            x, y = datapoint
-            w = None
-        else:
-            x, y, w = datapoint
-
-        if device is not None:
-            x = x.to(device)
-            y = y.to(device)
-            if w is not None:
-                w = w.to(device)
-
-        return x, y, w
-
-    # get a point and construct the model
-    data_iter = iter(dataloader)
-    x, y, w = get_point(next(data_iter))
-
-    model._construct_model_params(
-        in_features=x.shape[1],
-        out_features=y.shape[1] if len(y.shape) == 2 else 1,
-        dtype=x.dtype,
-        **construct_kwargs,
-    )
-    model.train()
-
-    assert model.linear is not None
-
-    if init_scheme is not None:
-        assert init_scheme in ["xavier", "zeros"]
-
-        with torch.no_grad():
-            if init_scheme == "xavier":
-                torch.nn.init.xavier_uniform_(model.linear.weight)
+        def get_point(datapoint):
+            if len(datapoint) == 2:
+                x, y = datapoint
+                w = None
             else:
-                model.linear.weight.zero_()
+                x, y, w = datapoint
 
-            if model.linear.bias is not None:
-                model.linear.bias.zero_()
+            if device is not None:
+                x = x.to(device)
+                y = y.to(device)
+                if w is not None:
+                    w = w.to(device)
 
-    optim = torch.optim.SGD(model.parameters(), lr=initial_lr)
-    if reduce_lr:
-        scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
-            optim, factor=0.5, patience=patience, threshold=threshold
-        )
+            return x, y, w
 
-    t1 = time.time()
-    epoch = 0
-    i = 0
-    while epoch < max_epoch:
-        while True:  # for x, y, w in dataloader
-            if running_loss_window is None:
-                running_loss_window = x.shape[0] * len(dataloader)
-
-            y = y.view(x.shape[0], -1)
-            if w is not None:
-                w = w.view(x.shape[0], -1)
-
-            i += 1
-
-            out = model(x)
-
-            loss = loss_fn(y, out, w)
-            if reg_term is not None:
-                reg = torch.norm(model.linear.weight, p=reg_term)
-                loss += reg.sum() * alpha
-
-            if len(loss_window) >= running_loss_window:
-                loss_window = loss_window[1:]
-            loss_window.append(loss.clone().detach())
-            assert len(loss_window) <= running_loss_window
-
-            average_loss = torch.mean(torch.stack(loss_window))
-            if min_avg_loss is not None:
-                # if we haven't improved by at least `threshold`
-                if average_loss > min_avg_loss or torch.isclose(
-                    min_avg_loss, average_loss, atol=threshold
-                ):
-                    convergence_counter += 1
-                    if convergence_counter >= patience:
-                        converged = True
-                        break
-                else:
-                    convergence_counter = 0
-            if min_avg_loss is None or min_avg_loss >= average_loss:
-                min_avg_loss = average_loss.clone()
-
-            if debug:
-                print(
-                    f"lr={optim.param_groups[0]['lr']}, Loss={loss},"
-                    + "Aloss={average_loss}, min_avg_loss={min_avg_loss}"
-                )
-
-            loss.backward()
-
-            optim.step()
-            model.zero_grad()
-            if scheduler:
-                scheduler.step(average_loss)
-
-            temp = next(data_iter, None)
-            if temp is None:
-                break
-            x, y, w = get_point(temp)
-
-        if converged:
-            break
-
-        epoch += 1
+        # get a point and construct the model
         data_iter = iter(dataloader)
         x, y, w = get_point(next(data_iter))
 
-    t2 = time.time()
-    return {
-        "train_time": t2 - t1,
-        "train_loss": torch.mean(torch.stack(loss_window)).item(),
-        "train_iter": i,
-        "train_epoch": epoch,
-    }
+        model._construct_model_params(
+            in_features=x.shape[1],
+            out_features=y.shape[1] if len(y.shape) == 2 else 1,
+            dtype=x.dtype,
+            **construct_kwargs,
+        )
+        model.train()
+
+        assert model.linear is not None
+
+        if init_scheme is not None:
+            assert init_scheme in ["xavier", "zeros"]
+
+            with torch.no_grad():
+                if init_scheme == "xavier":
+                    torch.nn.init.xavier_uniform_(model.linear.weight)
+                else:
+                    model.linear.weight.zero_()
+
+                if model.linear.bias is not None:
+                    model.linear.bias.zero_()
+
+        optim = torch.optim.SGD(model.parameters(), lr=initial_lr)
+        if reduce_lr:
+            scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+                optim, factor=0.5, patience=patience, threshold=threshold
+            )
+
+        t1 = time.time()
+        epoch = 0
+        i = 0
+        while epoch < max_epoch:
+            while True:  # for x, y, w in dataloader
+                if running_loss_window is None:
+                    running_loss_window = x.shape[0] * len(dataloader)
+
+                y = y.view(x.shape[0], -1)
+                if w is not None:
+                    w = w.view(x.shape[0], -1)
+
+                i += 1
+                out = model(x)
+                loss = loss_fn(y, out, w)
+                if reg_term is not None:
+                    reg = torch.norm(model.linear.weight, p=reg_term)
+                    loss += reg.sum() * alpha
+
+                if len(loss_window) >= running_loss_window:
+                    loss_window = loss_window[1:]
+                loss_window.append(loss.clone().detach())
+                assert len(loss_window) <= running_loss_window
+
+                average_loss = torch.mean(torch.stack(loss_window))
+                if min_avg_loss is not None:
+                    # if we haven't improved by at least `threshold`
+                    if average_loss > min_avg_loss or torch.isclose(
+                        min_avg_loss, average_loss, atol=threshold
+                    ):
+                        convergence_counter += 1
+                        if convergence_counter >= patience:
+                            converged = True
+                            break
+                    else:
+                        convergence_counter = 0
+                if min_avg_loss is None or min_avg_loss >= average_loss:
+                    min_avg_loss = average_loss.clone()
+
+                if debug:
+                    print(
+                        f"lr={optim.param_groups[0]['lr']}, Loss={loss},"
+                        + "Aloss={average_loss}, min_avg_loss={min_avg_loss}"
+                    )
+
+                loss.backward()
+                optim.step()
+                model.zero_grad()
+                if scheduler:
+                    scheduler.step(average_loss)
+
+                temp = next(data_iter, None)
+                if temp is None:
+                    break
+                x, y, w = get_point(temp)
+
+            if converged:
+                break
+
+            epoch += 1
+            data_iter = iter(dataloader)
+            x, y, w = get_point(next(data_iter))
+
+        t2 = time.time()
+        return {
+            "train_time": t2 - t1,
+            "train_loss": torch.mean(torch.stack(loss_window)).item(),
+            "train_iter": i,
+            "train_epoch": epoch,
+        }
 
 
 class NormLayer(nn.Module):

--- a/captum/_utils/models/linear_model/train.py
+++ b/captum/_utils/models/linear_model/train.py
@@ -165,7 +165,9 @@ def sgd_train_linear_model(
                     w = w.view(x.shape[0], -1)
 
                 i += 1
+
                 out = model(x)
+
                 loss = loss_fn(y, out, w)
                 if reg_term is not None:
                     reg = torch.norm(model.linear.weight, p=reg_term)

--- a/captum/attr/_core/lime.py
+++ b/captum/attr/_core/lime.py
@@ -512,17 +512,17 @@ class LimeBase(PerturbationAttribution):
             if show_progress:
                 attr_progress.close()
 
-            combined_interp_inps = torch.cat(interpretable_inps).double()
+            combined_interp_inps = torch.cat(interpretable_inps).float()
             combined_outputs = (
                 torch.cat(outputs)
                 if len(outputs[0].shape) > 0
                 else torch.stack(outputs)
-            ).double()
+            ).float()
             combined_sim = (
                 torch.cat(similarities)
                 if len(similarities[0].shape) > 0
                 else torch.stack(similarities)
-            ).double()
+            ).float()
             dataset = TensorDataset(
                 combined_interp_inps, combined_outputs, combined_sim
             )

--- a/tests/attr/test_lime.py
+++ b/tests/attr/test_lime.py
@@ -126,7 +126,7 @@ class Test(BaseTest):
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[20.0, 50.0, 30.0]], requires_grad=True)
         interpretable_model = SGDLasso()
-        interpretable_model.fit = partial(
+        interpretable_model.fit = partial( # type: ignore
             interpretable_model.fit, initial_lr=0.1, max_epoch=500
         )
         self._lime_test_assert(

--- a/tests/attr/test_lime.py
+++ b/tests/attr/test_lime.py
@@ -3,6 +3,7 @@
 import io
 import unittest
 import unittest.mock
+from functools import partial
 from typing import Any, Callable, Generator, List, Tuple, Optional, Union
 
 import torch
@@ -28,7 +29,7 @@ from tests.helpers.basic_models import (
     BasicModelBoolInput,
 )
 from torch import Tensor
-from functools import partial
+
 
 def alt_perturb_func(
     original_inp: TensorOrTupleOfTensorsGeneric, **kwargs
@@ -125,14 +126,16 @@ class Test(BaseTest):
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[20.0, 50.0, 30.0]], requires_grad=True)
         interpretable_model = SGDLasso()
-        interpretable_model.fit = partial(interpretable_model.fit, initial_lr=0.1, max_epoch=500)
+        interpretable_model.fit = partial(
+            interpretable_model.fit, initial_lr=0.1, max_epoch=500
+        )
         self._lime_test_assert(
             net,
             inp,
             [[73.3716, 193.3349, 113.3349]],
             n_samples=1000,
             expected_coefs_only=[[73.3716, 193.3349, 113.3349]],
-            interpretable_model=interpretable_model
+            interpretable_model=interpretable_model,
         )
 
     def test_simple_lime_with_mask(self) -> None:
@@ -508,7 +511,9 @@ class Test(BaseTest):
             lime = Lime(
                 model,
                 similarity_func=get_exp_kernel_similarity_function("cosine", 10.0),
-                interpretable_model=interpretable_model if interpretable_model else SkLearnLasso(alpha=1.0),
+                interpretable_model=interpretable_model
+                if interpretable_model
+                else SkLearnLasso(alpha=1.0),
             )
             attributions = lime.attribute(
                 test_input,
@@ -542,7 +547,9 @@ class Test(BaseTest):
 
                 lime_alt = LimeBase(
                     model,
-                    interpretable_model if interpretable_model else SkLearnLasso(alpha=1.0),
+                    interpretable_model
+                    if interpretable_model
+                    else SkLearnLasso(alpha=1.0),
                     get_exp_kernel_similarity_function("euclidean", 1000.0),
                     alt_perturb_generator if test_generator else alt_perturb_func,
                     False,

--- a/tests/attr/test_lime.py
+++ b/tests/attr/test_lime.py
@@ -126,7 +126,7 @@ class Test(BaseTest):
         net = BasicModel_MultiLayer()
         inp = torch.tensor([[20.0, 50.0, 30.0]], requires_grad=True)
         interpretable_model = SGDLasso()
-        interpretable_model.fit = partial( # type: ignore
+        interpretable_model.fit = partial(  # type: ignore
             interpretable_model.fit, initial_lr=0.1, max_epoch=500
         )
         self._lime_test_assert(

--- a/tests/attr/test_lime.py
+++ b/tests/attr/test_lime.py
@@ -4,10 +4,10 @@ import io
 import unittest
 import unittest.mock
 from functools import partial
-from typing import Any, Callable, Generator, List, Tuple, Optional, Union
+from typing import Any, Callable, Generator, List, Optional, Tuple, Union
 
 import torch
-from captum._utils.models.linear_model import SkLearnLasso, SGDLasso
+from captum._utils.models.linear_model import SGDLasso, SkLearnLasso
 from captum._utils.models.model import Model
 from captum._utils.typing import BaselineType, TensorOrTupleOfTensorsGeneric
 from captum.attr._core.lime import get_exp_kernel_similarity_function, Lime, LimeBase


### PR DESCRIPTION
This updates SGD linear models to work appropriately with Lime, addressing #910 . Particularly, this switches Lime interpretable model inputs / outputs from double to float and enables gradients when necessary. Also adds a unit test to Lime for testing with SGD linear models.