### PR TITLE
Fix version check bug

### DIFF
--- a/tests/utils/test_sample_gradient.py
+++ b/tests/utils/test_sample_gradient.py
@@ -5,6 +5,7 @@ from typing import Callable, Tuple
 
 import torch
 from captum._utils.sample_gradient import SampleGradientWrapper, SUPPORTED_MODULES
+from packaging import version
 from tests.helpers.basic import assertTensorAlmostEqual, BaseTest
 from tests.helpers.basic_models import (
     BasicModel_ConvNet_One_Conv,
@@ -37,7 +38,7 @@ class Test(BaseTest):
         self._compare_sample_grads_per_sample(model, inp, lambda x: torch.mean(x))
 
     def test_sample_grads_modified_conv_mean(self) -> None:
-        if torch.__version__ < "1.8":
+        if version.parse(torch.__version__) <= version.parse("1.8.0"):
             raise unittest.SkipTest(
                 "Skipping sample gradient test with 3D linear module"
                 "since torch version < 1.8"
@@ -50,7 +51,7 @@ class Test(BaseTest):
         )
 
     def test_sample_grads_modified_conv_sum(self) -> None:
-        if torch.__version__ < "1.8":
+        if version.parse(torch.__version__) <= version.parse("1.8.0"):
             raise unittest.SkipTest(
                 "Skipping sample gradient test with 3D linear module"
                 "since torch version < 1.8"


### PR DESCRIPTION
By default: `"1.8.0" > "1.10.0"` will be equal to True, despite 1.10 being a later version that 1.8.0. This PR fixes this issue.