### PR TITLE
Update black version to 22.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ DEV_REQUIRES = (
     INSIGHTS_REQUIRES
     + TEST_REQUIRES
     + [
-        "black==21.4b2",
+        "black==22.3.0",
         "flake8",
         "sphinx",
         "sphinx-autodoc-typehints",


### PR DESCRIPTION
Fixes failing CircleCI tests by updating pinned black version in OSS to match internal version used for linting.