### PR TITLE
Optim-wip: Change Inception5h model link

### DIFF
--- a/captum/optim/models/_image/inception_v1.py
+++ b/captum/optim/models/_image/inception_v1.py
@@ -5,10 +5,7 @@ import torch
 import torch.nn as nn
 from captum.optim.models._common import Conv2dSame, RedirectedReluLayer, SkipLayer
 
-GS_SAVED_WEIGHTS_URL = (
-    "https://github.com/pytorch/captum/raw/"
-    + "optim-wip/captum/optim/models/_image/inception5h.pth"
-)
+GS_SAVED_WEIGHTS_URL = "https://pytorch.s3.amazonaws.com/models/captum/inception5h.pth"
 
 
 def googlenet(


### PR DESCRIPTION
Not removing the actual file yet as other PRs are still using the GitHub link.