### PR TITLE
Fix `set_all_random_seeds` testing function

### DIFF
--- a/tests/helpers/basic.py
+++ b/tests/helpers/basic.py
@@ -81,11 +81,11 @@ def assert_delta(test, delta):
     )
 
 
-def set_all_random_seeds(seed):
-    random.seed(1234)
-    np.random.seed(1234)
-    torch.manual_seed(1234)
-    torch.cuda.manual_seed_all(1234)
+def set_all_random_seeds(seed: int = 1234) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
     torch.backends.cudnn.deterministic = True
 
 

--- a/tests/helpers/basic.py
+++ b/tests/helpers/basic.py
@@ -96,6 +96,6 @@ class BaseTest(unittest.TestCase):
     initializations are random, this ensures that tests run deterministically.
     """
 
-    def setUp(self):
+    def setUp(self) -> None:
         set_all_random_seeds(1234)
         patch_methods(self)


### PR DESCRIPTION
A seed value was being passed to the function, but it was ignored. This PR fixes that.