### PR TITLE
Remove the `insights` module from the main `__init__.py` file

### DIFF
--- a/captum/__init__.py
+++ b/captum/__init__.py
@@ -2,7 +2,6 @@
 import captum.attr as attr  # noqa
 import captum.concept as concept  # noqa
 import captum.influence as influence  # noqa
-import captum.insights as insights  # noqa
 import captum.log as log  # noqa
 import captum.metrics as metrics  # noqa
 import captum.robust as robust  # noqa


### PR DESCRIPTION
Fixes: https://github.com/pytorch/captum/issues/988

According the `setup.py` and the `README`, users wishing to use insights need to use the custom install option provided or install the modules separately. https://github.com/pytorch/captum/blob/master/setup.py#L54, https://github.com/pytorch/captum/blob/master/README.md#installation

Therefore the insights module should not be loaded in the `__init__.py` file, and users will have to call it like before the changes proposed in https://github.com/pytorch/captum/pull/912, and added to the master branch in https://github.com/pytorch/captum/commit/9305b109417ca24ee6893075e03f3da241e59252