### PR TITLE
Improve version checking

### DIFF
--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -3,7 +3,7 @@ import typing
 from enum import Enum
 from functools import reduce
 from inspect import signature
-from typing import Any, Callable, cast, Dict, List, Optional, overload, Tuple, Union
+from typing import Any, Callable, cast, Dict, List, overload, Tuple, Union
 
 import numpy as np
 import torch
@@ -18,7 +18,7 @@ from torch import device, Tensor
 from torch.nn import Module
 
 
-def _parse_version(v: str, length: Optional[int] = 3) -> Tuple[int, ...]:
+def _parse_version(v: str) -> Tuple[int, ...]:
     """
     Parse version strings into tuples for comparison.
 
@@ -29,10 +29,6 @@ def _parse_version(v: str, length: Optional[int] = 3) -> Tuple[int, ...]:
     Args:
 
         v (str): A version string.
-        length (int, optional): The expected length of the output tuple. If the output
-            is less than the expected length, then it will be padded with 0 values. Set
-            to None for no padding or length checks.
-            Default: ``3``
 
     Returns:
         version_tuple (tuple of int): A tuple of integer values to use for version
@@ -40,9 +36,6 @@ def _parse_version(v: str, length: Optional[int] = 3) -> Tuple[int, ...]:
     """
     v = [n for n in v.split(".") if n.isdigit()]
     assert v != []
-    if length is not None:
-        v += ["0"] * (length - len(v))
-        assert len(v) == length
     return tuple(map(int, v))
 
 

--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -14,6 +14,7 @@ from captum._utils.typing import (
     TensorOrTupleOfTensorsGeneric,
     TupleOrTensorOrBoolGeneric,
 )
+from packaging import version
 from torch import device, Tensor
 from torch.nn import Module
 
@@ -671,7 +672,7 @@ def _register_backward_hook(
     ):
         return module.register_backward_hook(hook)
 
-    if torch.__version__ >= "1.9":
+    if version.parse(torch.__version__) >= version.parse("1.9.0"):
         # Only supported for torch >= 1.9
         return module.register_full_backward_hook(hook)
     else:

--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -3,7 +3,7 @@ import typing
 from enum import Enum
 from functools import reduce
 from inspect import signature
-from typing import Any, Callable, cast, Dict, List, overload, Tuple, Union
+from typing import Any, Callable, cast, Dict, List, Optional, overload, Tuple, Union
 
 import numpy as np
 import torch
@@ -14,9 +14,36 @@ from captum._utils.typing import (
     TensorOrTupleOfTensorsGeneric,
     TupleOrTensorOrBoolGeneric,
 )
-from packaging import version
 from torch import device, Tensor
 from torch.nn import Module
+
+
+def _parse_version(v: str, length: Optional[int] = 3) -> Tuple[int, ...]:
+    """
+    Parse version strings into tuples for comparison.
+
+    Versions should be in the form of "<major>.<minor>.<patch>", "<major>.<minor>",
+    or "<major>". The "dev", "post" and other letter portions of the given version will
+    be ignored.
+
+    Args:
+
+        v (str): A version string.
+        length (int, optional): The expected length of the output tuple. If the output
+            is less than the expected length, then it will be padded with 0 values. Set
+            to None for no padding or length checks.
+            Default: ``3``
+
+    Returns:
+        version_tuple (tuple of int): A tuple of integer values to use for version
+            comparison.
+    """
+    v = [n for n in v.split(".") if n.isdigit()]
+    assert v != []
+    if length is not None:
+        v += ["0"] * (length - len(v))
+        assert len(v) == length
+    return tuple(map(int, v))
 
 
 class ExpansionTypes(Enum):
@@ -672,7 +699,7 @@ def _register_backward_hook(
     ):
         return module.register_backward_hook(hook)
 
-    if version.parse(torch.__version__) >= version.parse("1.9.0"):
+    if _parse_version(torch.__version__) >= (1, 9, 0):
         # Only supported for torch >= 1.9
         return module.register_full_backward_hook(hook)
     else:

--- a/captum/influence/_core/similarity_influence.py
+++ b/captum/influence/_core/similarity_influence.py
@@ -9,6 +9,7 @@ import torch
 from captum._utils.av import AV
 from captum.attr import LayerActivation
 from captum.influence._core.influence import DataInfluence
+from packaging import version
 from torch import Tensor
 from torch.nn import Module
 from torch.utils.data import DataLoader, Dataset
@@ -40,7 +41,7 @@ def cosine_similarity(test, train, replace_nan=0) -> Tensor:
     test = test.view(test.shape[0], -1)
     train = train.view(train.shape[0], -1)
 
-    if torch.__version__ <= "1.6.0":
+    if version.parse(torch.__version__) <= version.parse("1.6.0"):
         test_norm = torch.norm(test, p=None, dim=1, keepdim=True)
         train_norm = torch.norm(train, p=None, dim=1, keepdim=True)
     else:

--- a/captum/influence/_core/similarity_influence.py
+++ b/captum/influence/_core/similarity_influence.py
@@ -9,7 +9,6 @@ import torch
 from captum._utils.av import AV
 from captum.attr import LayerActivation
 from captum.influence._core.influence import DataInfluence
-from packaging import version
 from torch import Tensor
 from torch.nn import Module
 from torch.utils.data import DataLoader, Dataset
@@ -41,7 +40,7 @@ def cosine_similarity(test, train, replace_nan=0) -> Tensor:
     test = test.view(test.shape[0], -1)
     train = train.view(train.shape[0], -1)
 
-    if version.parse(torch.__version__) <= version.parse("1.6.0"):
+    if common._parse_version(torch.__version__) <= (1, 6, 0):
         test_norm = torch.norm(test, p=None, dim=1, keepdim=True)
         train_norm = torch.norm(train, p=None, dim=1, keepdim=True)
     else:

--- a/captum/influence/_utils/common.py
+++ b/captum/influence/_utils/common.py
@@ -5,9 +5,9 @@ from typing import Any, Callable, List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
+from captum._utils.common import _parse_version
 from captum._utils.progress import progress
 
-from packaging import version
 from torch import Tensor
 from torch.nn import Module
 from torch.utils.data import DataLoader, Dataset
@@ -128,7 +128,7 @@ def _jacobian_loss_wrt_inputs(
             "Must be either 'sum' or 'mean'."
         )
 
-    if version.parse(torch.__version__) >= version.parse("1.8.0"):
+    if _parse_version(torch.__version__) >= (1, 8, 0):
         input_jacobians = torch.autograd.functional.jacobian(
             lambda out: loss_fn(out, targets), out, vectorize=vectorize
         )

--- a/captum/influence/_utils/common.py
+++ b/captum/influence/_utils/common.py
@@ -5,6 +5,8 @@ from typing import Any, Callable, List, Optional, Tuple, Union
 import torch
 import torch.nn as nn
 from captum._utils.progress import progress
+
+from packaging import version
 from torch import Tensor
 from torch.nn import Module
 from torch.utils.data import DataLoader, Dataset
@@ -125,7 +127,7 @@ def _jacobian_loss_wrt_inputs(
             "Must be either 'sum' or 'mean'."
         )
 
-    if torch.__version__ >= "1.8":
+    if version.parse(torch.__version__) >= version.parse("1.8.0"):
         input_jacobians = torch.autograd.functional.jacobian(
             lambda out: loss_fn(out, targets), out, vectorize=vectorize
         )

--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ if __name__ == "__main__":
         long_description=long_description,
         long_description_content_type="text/markdown",
         python_requires=">=3.6",
-        install_requires=["matplotlib", "numpy", "torch>=1.6"],
+        install_requires=["matplotlib", "numpy", "packaging", "torch>=1.6"],
         packages=find_packages(exclude=("tests", "tests.*")),
         extras_require={
             "dev": DEV_REQUIRES,

--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ if __name__ == "__main__":
         long_description=long_description,
         long_description_content_type="text/markdown",
         python_requires=">=3.6",
-        install_requires=["matplotlib", "numpy", "packaging", "torch>=1.6"],
+        install_requires=["matplotlib", "numpy", "torch>=1.6"],
         packages=find_packages(exclude=("tests", "tests.*")),
         extras_require={
             "dev": DEV_REQUIRES,

--- a/tests/utils/test_common.py
+++ b/tests/utils/test_common.py
@@ -146,9 +146,4 @@ class TestParseVersion(BaseTest):
     def test_parse_version_1_12(self) -> None:
         version_str = "1.12"
         output = _parse_version(version_str)
-        self.assertEqual(output, (1, 12, 0))
-
-    def test_parse_version_length(self) -> None:
-        version_str = "1.12.0.1"
-        output = _parse_version(version_str, 4)
-        self.assertEqual(output, (1, 12, 0, 1))
+        self.assertEqual(output, (1, 12))

--- a/tests/utils/test_common.py
+++ b/tests/utils/test_common.py
@@ -3,7 +3,13 @@
 from typing import cast, List, Tuple
 
 import torch
-from captum._utils.common import _reduce_list, _select_targets, _sort_key_list, safe_div
+from captum._utils.common import (
+    _parse_version,
+    _reduce_list,
+    _select_targets,
+    _sort_key_list,
+    safe_div,
+)
 from tests.helpers.basic import assertTensorAlmostEqual, BaseTest
 
 
@@ -109,3 +115,40 @@ class Test(BaseTest):
         # Verify error is raised if too many dimensions are provided.
         with self.assertRaises(AssertionError):
             _select_targets(output_tensor, (1, 2, 3))
+
+
+class TestParseVersion(BaseTest):
+    def test_parse_version_dev(self) -> None:
+        version_str = "1.12.0.dev20201109"
+        output = _parse_version(version_str)
+        self.assertEqual(output, (1, 12, 0))
+
+    def test_parse_version_post(self) -> None:
+        version_str = "1.3.0.post2"
+        output = _parse_version(version_str)
+        self.assertEqual(output, (1, 3, 0))
+
+    def test_parse_version_1_12_0(self) -> None:
+        version_str = "1.12.0"
+        output = _parse_version(version_str)
+        self.assertEqual(output, (1, 12, 0))
+
+    def test_parse_version_1_12_2(self) -> None:
+        version_str = "1.12.2"
+        output = _parse_version(version_str)
+        self.assertEqual(output, (1, 12, 2))
+
+    def test_parse_version_1_6_0(self) -> None:
+        version_str = "1.6.0"
+        output = _parse_version(version_str)
+        self.assertEqual(output, (1, 6, 0))
+
+    def test_parse_version_1_12(self) -> None:
+        version_str = "1.12"
+        output = _parse_version(version_str)
+        self.assertEqual(output, (1, 12, 0))
+
+    def test_parse_version_length(self) -> None:
+        version_str = "1.12.0.1"
+        output = _parse_version(version_str, 4)
+        self.assertEqual(output, (1, 12, 0, 1))


### PR DESCRIPTION
Without the packaging library, statements like: `"1.8.0" > "1.10.0"` will be equal to True, despite v1.10 being a later version that v1.8.0.

The `packaging` library will in some cases not be already installed on a user's device, so I've also added it the `setup.py` file. It's one of the core libraries from the Python Packaging Authority, but it's not included with the base Python installation: https://packaging.python.org/en/latest/key_projects/#pypa-projects

This wasn't an issue in https://github.com/pytorch/captum/pull/940 as one the libraries in dev install has `packaging` as a dependency. So, there's no error when the tests are using the `packaging` library.