### PR TITLE
Notebook support for tqdm

### DIFF
--- a/captum/_utils/progress.py
+++ b/captum/_utils/progress.py
@@ -6,7 +6,7 @@ from time import time
 from typing import cast, Iterable, Sized, TextIO
 
 try:
-    from tqdm import tqdm
+    from tqdm.auto import tqdm
 except ImportError:
     tqdm = None
 


### PR DESCRIPTION
The `tqdm` progress in notebooks breaks in some cases (for me this behavior was persistent after I stopped the cell running this even once), possibly because it is not imported from the **recommmended** `tqdm.auto`

```python
from tqdm import tqdm
```
![image](https://user-images.githubusercontent.com/40922889/181494132-739f7097-1f86-4a3b-9089-d5cf650a84b3.png)

However, when imported from `tqdm.auto` it works flawlessly:
```python
from tqdm.auto import tqdm
```
![image](https://user-images.githubusercontent.com/40922889/181494202-349666fd-cc89-42c7-b59c-6e9ad9967f03.png)
