### PR TITLE
Fix failing conda test, & fix a GPU test bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,7 @@ commands:
             sudo dpkg -i cuda-repo-ubuntu2004-11-4-local_11.4.2-470.57.02-1_amd64.deb
             sudo apt-key add /var/cuda-repo-ubuntu2004-11-4-local/7fa2af80.pub
             sudo apt-get update
+            sudo dpkg --configure -a
             sudo apt-get --yes --force-yes install cuda
 
 jobs:

--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -46,7 +46,7 @@ conda install -y -c conda-forge matplotlib pytest-cov mypy flask flask-compress
 # install node/yarn for insights build
 conda install -y -c conda-forge yarn
 # nodejs should be last, otherwise other conda packages will downgrade node
-conda install -y --repodata-fn=repodata.json --no-channel-priority -c conda-forge nodejs=14
+conda install -y --no-channel-priority -c conda-forge nodejs=14
 
 # build insights and install captum
 BUILD_INSIGHTS=1 python setup.py develop

--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -21,7 +21,7 @@ conda update --all --yes
 # required to use conda develop
 conda install -y conda-build
 
-# Use better Conda solver
+# Use faster Conda solver
 conda install -n base conda-libmamba-solver
 conda config --set experimental_solver libmamba
 

--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -46,7 +46,7 @@ conda install -y -c conda-forge matplotlib pytest-cov mypy flask flask-compress
 # install node/yarn for insights build
 conda install -y -c conda-forge yarn
 # nodejs should be last, otherwise other conda packages will downgrade node
-conda install -y --no-channel-priority -c conda-forge nodejs=14
+conda install -y --repodata-fn=repodata.json --no-channel-priority -c conda-forge nodejs=14
 
 # build insights and install captum
 BUILD_INSIGHTS=1 python setup.py develop

--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -35,8 +35,13 @@ else
 fi
 
 # install other deps
+# conda install -y numpy sphinx pytest flake8 ipywidgets ipython scikit-learn parameterized
+# conda install -y -c conda-forge matplotlib pytest-cov sphinx-autodoc-typehints mypy flask flask-compress
 conda install -y pytest flake8 ipywidgets ipython scikit-learn parameterized
 conda install -y -c conda-forge matplotlib pytest-cov mypy flask flask-compress
+
+# deps not available in conda
+# pip install sphinxcontrib-katex
 
 # install node/yarn for insights build
 conda install -y -c conda-forge yarn

--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -21,7 +21,7 @@ conda update --all --yes
 # required to use conda develop
 conda install -y conda-build
 
-# Use faster Conda solver
+# Use faster conda solver
 conda install -n base conda-libmamba-solver
 conda config --set experimental_solver libmamba
 

--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -21,6 +21,10 @@ conda update --all --yes
 # required to use conda develop
 conda install -y conda-build
 
+# Use better Conda solver
+conda install -n base conda-libmamba-solver
+conda config --set experimental_solver libmamba
+
 # install other frameworks if asked for and make sure this is before pytorch
 if [[ $FRAMEWORKS == true ]]; then
   pip install pytext-nlp

--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -35,10 +35,8 @@ else
 fi
 
 # install other deps
-conda install -y numpy sphinx pytest flake8 ipywidgets ipython scikit-learn parameterized
-conda install -y -c conda-forge matplotlib pytest-cov sphinx-autodoc-typehints mypy flask flask-compress
-# deps not available in conda
-pip install sphinxcontrib-katex
+conda install -y pytest flake8 ipywidgets ipython scikit-learn parameterized
+conda install -y -c conda-forge matplotlib pytest-cov mypy flask flask-compress
 
 # install node/yarn for insights build
 conda install -y -c conda-forge yarn


### PR DESCRIPTION
I think that the amount of Conda install timeouts can be lessened by removing unnecessary installs: 

* Sphinx is not used for the Conda tests, so it doesn't make sense to install it.
* NumPy is a dependency of PyTorch, so there is no need to install it after installing PyTorch.

The `nodejs` install seems to be what takes up the most time, and I think its where the solver sometimes fails. Using the libmamba solver seems to prevent it from failing, but it still takes vast majority of the install time (around 20 minutes) to install `nodejs`. https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community


I also noticed a recurring error in the GPU tests, and implemented a fix for it:

```
Errors were encountered while processing:
 sane-utils
W: --force-yes is deprecated, use one of the options starting with --allow instead.
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

This PR along with #1007 should fix the test failures that Captum is experiencing.

@vivekmig