### PR TITLE
doc: rectify layerlrp example

### DIFF
--- a/captum/attr/_core/layer/layer_lrp.py
+++ b/captum/attr/_core/layer/layer_lrp.py
@@ -204,10 +204,10 @@ class LayerLRP(LRP, LayerAttribution):
                 >>> # and returns an Nx10 tensor of class probabilities. It has one
                 >>> # Conv2D and a ReLU layer.
                 >>> net = ImageClassifier()
-                >>> lrp = LRP(net, net.conv1)
+                >>> layer_lrp = LayerLRP(net, net.conv1)
                 >>> input = torch.randn(3, 3, 32, 32)
                 >>> # Attribution size matches input size: 3x3x32x32
-                >>> attribution = lrp.attribute(input, target=5)
+                >>> attribution = layer_lrp.attribute(input, target=5)
 
         """
         self.verbose = verbose


### PR DESCRIPTION
This PR aims to rectify the LayerLRP example since it's talking about LayerLRP and not LRP. Moreover LRP doesn't require 2 arguments.