### PR TITLE
Fix wheel build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,15 @@ commands:
             python -m pip install --upgrade pip
             python -m pip install -e .[dev]
 
+  build_package:
+    description: "Build the source and wheel packages"
+    steps:
+      - run:
+          name: "Build captum"
+          command: |
+            python -m pip install build
+            python -m build
+
   py_3_7_setup:
     description: "Set python version to 3.7 and install pip and pytest"
     steps:
@@ -211,6 +220,7 @@ jobs:
       - install_cuda
       - py_3_7_setup
       - simple_pip_install
+      - build_package
       - unit_tests
 
   auto_deploy_site:

--- a/setup.py
+++ b/setup.py
@@ -160,8 +160,8 @@ if __name__ == "__main__":
             (
                 "share/jupyter/nbextensions/jupyter-captum-insights",
                 [
-                    "captum/insights/attr_vis/widget/static/extension.js",
-                    "captum/insights/attr_vis/widget/static/index.js",
+                    "captum/insights/attr_vis/frontend/widget/src/extension.js",
+                    "captum/insights/attr_vis/frontend/widget/src/index.js",
                 ],
             ),
             (


### PR DESCRIPTION
This PR should fix the wheel build.

```sh
$ python -m build
...
error: can't copy 'captum/insights/attr_vis/widget/static/extension.js': doesn't exist or not a regular file

ERROR Backend subproccess exited when trying to invoke build_wheel
```

This was also an issue in the past (https://github.com/pytorch/captum/issues/284), so I added a ci step to test the wheel build.
