### PR TITLE
 Adding the Latent Shift attribution method

### DIFF
--- a/captum/attr/__init__.py
+++ b/captum/attr/__init__.py
@@ -50,6 +50,7 @@ from captum.attr._core.neuron.neuron_integrated_gradients import (  # noqa
 from captum.attr._core.noise_tunnel import NoiseTunnel  # noqa
 from captum.attr._core.occlusion import Occlusion  # noqa
 from captum.attr._core.saliency import Saliency  # noqa
+from captum.attr._core.latent_shift import LatentShift  # noqa
 from captum.attr._core.shapley_value import ShapleyValues, ShapleyValueSampling  # noqa
 from captum.attr._models.base import (  # noqa
     configure_interpretable_embedding_layer,
@@ -140,4 +141,5 @@ __all__ = [
     "Max",
     "Sum",
     "Count",
+    "LatentShift",
 ]

--- a/captum/attr/_core/latent_shift.py
+++ b/captum/attr/_core/latent_shift.py
@@ -69,6 +69,17 @@ class LatentShift(GradientAttribution):
         heatmap_method: str = 'int',
     ) -> dict:
         r"""
+        This method performs a search in order to determine the correct lambda
+        values to generate the shift. The search starts by stepping by
+        `search_step_size` in the negative direction while trying to determine
+        if the output of the classifier has changed by `search_pred_diff` or
+        when the change in the predict in stops going down. In order to avoid
+        artifacts if the shift is too large or in the wrong direction an extra
+        stop conditions is added `search_max_pixel_diff` if the change in the
+        image is too large. To avoid the search from taking too long a
+        `search_max_steps` will prevent the search from going on endlessly.
+
+
         Args:
 
             inputs (tensor):  Input for which the counterfactual is computed.

--- a/captum/attr/_core/latent_shift.py
+++ b/captum/attr/_core/latent_shift.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from typing import Any, Callable, Tuple
+from typing import Callable, Tuple
 
 import os
 import shutil
@@ -146,7 +146,7 @@ class LatentShift(GradientAttribution):
         def compute_shift(lambdax):
             """Compute the shift for a specific lambda"""
             if lambdax not in cache:
-                x_lambdax = self.ae.decode(z+dzdxp*lambdax).detach()
+                x_lambdax = self.ae.decode(z + dzdxp * lambdax).detach()
                 pred1 = torch.sigmoid(self.forward_func(x_lambdax))[:, target]
                 pred1 = pred1.detach().cpu().numpy() 
                 cache[lambdax] = x_lambdax, pred1
@@ -182,7 +182,7 @@ class LatentShift(GradientAttribution):
                     break
                     
                 last_pred = cur_pred
-                lbound = lbound - search_step_size + lbound//10
+                lbound = lbound - search_step_size + lbound // 10
 
             # Right range search not implemented
             rbound = 0
@@ -193,7 +193,7 @@ class LatentShift(GradientAttribution):
         lambdas = np.arange(
             lbound,
             rbound,
-            np.abs((lbound-rbound)/lambda_sweep_steps)
+            np.abs((lbound - rbound) / lambda_sweep_steps)
         )
         
         preds = []
@@ -232,9 +232,9 @@ class LatentShift(GradientAttribution):
         elif heatmap_method == 'int':
             # Average per frame differences 
             image_changes = []
-            for i in range(len(generated_images)-1):
+            for i in range(len(generated_images) - 1):
                 image_changes.append(np.abs(
-                    generated_images[i][0][0] - generated_images[i+1][0][0]
+                    generated_images[i][0][0] - generated_images[i + 1][0][0]
                 ))
             heatmap = np.mean(image_changes, 0)
         else:
@@ -288,8 +288,8 @@ class LatentShift(GradientAttribution):
         
         for idx, img in enumerate(towrite):
                 
-            px = 1/plt.rcParams['figure.dpi']
-            full_frame(img[0].shape[0]*px, img[0].shape[1]*px)
+            px = 1 / plt.rcParams['figure.dpi']
+            full_frame(img[0].shape[0] * px, img[0].shape[1] * px)
             plt.imshow(img[0], interpolation='none')
 
             if watermark:
@@ -315,7 +315,9 @@ class LatentShift(GradientAttribution):
             plt.close()
 
         # Command for ffmpeg to generate an mp4
-        cmd = "{} -loglevel quiet -stats -y -i {}/image-%d.png -c:v libx264 -vf scale=-2:{} -profile:v baseline -level 3.0 -pix_fmt yuv420p '{}.mp4'".format(
+        cmd = "{} -loglevel quiet -stats -y -i {}/image-%d.png -c:v libx264 " \
+              "-vf scale=-2:{} -profile:v baseline -level 3.0 -pix_fmt " \
+              "yuv420p '{}.mp4'".format( 
             ffmpeg_path, temp_path, imgs[0][0].shape[0], target_filename
         )
 

--- a/captum/attr/_core/latent_shift.py
+++ b/captum/attr/_core/latent_shift.py
@@ -84,10 +84,15 @@ class LatentShift(GradientAttribution):
                         this will be the initial step size. This is similar to
                         a learning rate. Smaller values avoid jumping over the
                         ideal lambda but the search may take a long time.
+            search_max_steps (int): The max steps to take when doing the search.
+                        Sometimes steps make a tiny improvement and can go on
+                        forever. This just bounds the time and gives up the
+                        search.
             search_max_pixel_diff (float): When searching stop of the pixel
                         difference is larger than this amount. This will
                         prevent large  artifacts being introduced into the
                         image.
+            lambda_sweep_steps (int): How many frames to generate for the video.
             heatmap_method:  Default: 'int'. Possible methods: 'int': Average
                         per frame differences. 'mean' : Average difference
                         between 0 and other lambda frames. 'mm': Difference
@@ -116,7 +121,7 @@ class LatentShift(GradientAttribution):
             >>> # Load image
             >>> input = torch.randn(1, 3, 1024, 1024)
             >>> 
-            >>> # Defining Saliency interpreter
+            >>> # Defining Latent Shift module
             >>> attr = captum.attr.LatentShift(model, ae)
             >>> 
             >>> # Computes counterfactual for class 3.

--- a/captum/attr/_core/latent_shift.py
+++ b/captum/attr/_core/latent_shift.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+
+from typing import Any, Callable, Tuple
+
+import torch
+from torch import Tensor
+from captum._utils.common import _format_output, _format_tensor_into_tuples, _is_tuple
+from captum._utils.gradient import (
+    apply_gradient_requirements,
+    undo_gradient_requirements,
+)
+from captum._utils.typing import TargetType
+from captum.attr._utils.attribution import GradientAttribution
+from captum.log import log_usage
+
+
+class LatentShift(GradientAttribution):
+    r"""An implementation of the Latent Shift method to generate 
+    counterfactual explainations. This method uses an audoencoder to restrict
+    the possible  adverserial examples to remain in the dataspace by adjusting 
+    the latent space of the autoencoder using dy/dz instead of dy/dx in order 
+    to change the classifier's prediction.
+    
+    This class implements a search strategy to determine the lambda needed 
+    to change the prediction of the classifier by a specific amount as well
+    as the code to generate a video and construct a heatmap representing 
+    the image changes for viewing as an image.
+    
+    Publication:
+    Cohen, J. P., et al. Gifsplanation via Latent Shift: A Simple Autoencoder 
+    Approach to Counterfactual Generation for Chest X-rays. Medical Imaging 
+    with Deep Learning. https://arxiv.org/abs/2102.09475
+    """
+
+    def __init__(self, forward_func: Callable, autoencoder) -> None:
+        r"""
+        Args:
+
+            forward_func (callable): The forward function of the model or
+                        any modification of it
+            autoencoder: An object with an encode and decode function which
+                        maintains a gradient tape.
+        """
+        GradientAttribution.__init__(self, forward_func)
+        self.ae = autoencoder
+        
+        # check if ae has encode and decode
+        assert hasattr(self.ae, 'encode')
+        assert hasattr(self.ae, 'decode')
+        
+
+    @log_usage()
+    def attribute(
+        self,
+        inputs: Tensor,
+        target: TargetType = None,
+        fix_range: Tuple = None,
+        pred_diff: float = 0.8,
+        shift_step_size: float = 10.0,
+        max_pixel_diff: float = 5000.0,
+        aggregrate_method: str = 'int',
+    ) -> dict:
+        r"""
+        Args:
+
+            inputs (tensor):  Input for which the counterfactual is computed.
+            target (int):  Output indices for which dydz is computed (for
+                        classification cases, this is usually the target class).
+            fix_range (tuple): Overrides searching and directly specifies the
+                        lambda range to use. e.g. [-100,0].
+            pred_diff (float): The desired change in the classifiers prediction.
+                        For example if the classifer predicts 0.9 and 
+                        pred_diff=0.8 the search will try to generate a  
+                        counterfactual where the prediction is 0.1. 
+            shift_step_size (float): When searching for the right lambda to use 
+                        this will be the initial step size. This is similar to 
+                        a learning rate. Smaller values avoid jumping over the 
+                        ideal lambda but the search may take a long time.
+            max_pixel_diff (float): When searching stop of the pixel difference
+                        is larger than this amount. This will prevent large 
+                        artifacts being introduced into the image.
+            aggregate_method:  Default: 'int'. Possible methods: 'int': Average 
+                        per frame differences. 'mean' : Average difference 
+                        between 0 and other lambda frames. 'mm': Difference 
+                        between first and last frames. 'max': Max difference 
+                        from lambda 0 frame
+
+        Returns:
+            dict containing the follow keys:
+                generated_images: A list of images generated at each step along
+                    the dydz vector from the smallest lambda to the largest. By 
+                    default the smallest lambda represents the counterfactual 
+                    image and the largest lambda is 0 (representing no change).
+                lambdas: A list of the lambda values for each generated image.
+                preds: A list of the predictions of the model for each generated 
+                    image.
+                heatmap: A heatmap indicating the pixels which change in the 
+                    video sequence of images.
+
+
+        Examples::
+
+            >>> # Load classifier and autoencoder
+            >>> model = classifiers.FaceAttribute()
+            >>> ae = autoencoders.Transformer(weights="celeba")
+            >>> 
+            >>> # Load image
+            >>> input = torch.randn(1, 3, 1024, 1024)
+            >>> 
+            >>> # Defining Saliency interpreter
+            >>> attr = captum.attr.LatentShift(model, ae)
+            >>> 
+            >>> # Computes counterfactual for class 3.
+            >>> output = attr.attribute(input, target=3)
+
+        """
+        z = self.ae.encode(inputs).detach()
+        z.requires_grad = True
+        x_lambda0 = self.ae.decode(z)
+        pred = torch.sigmoid(self.forward_func(x_lambda0))[:,target]
+        dzdxp = torch.autograd.grad((pred), z)[0]
+        
+        # Cache so we can reuse at sweep stage
+        cache = {}
+        def compute_shift(lam):
+            """Compute the shift for a specific lambda"""
+            if lam not in cache:
+                x_lambdax = self.ae.decode(z+dzdxp*lam).detach()
+                pred1 = torch.sigmoid(self.forward_func(x_lambdax))[:,target]
+                pred1 = pred1.detach().cpu().numpy() 
+                cache[lam] = x_lambdax, pred1
+                print(f'Shift: {lam} , Prediction: {pred1}')
+            return cache[lam]
+        
+        _, initial_pred = compute_shift(0)
+        
+        if fix_range:
+            lbound, rbound = fix_range
+        else:
+            # Left range
+            lbound = 0
+            last_pred = initial_pred
+            while True:
+                x_lambdax, cur_pred = compute_shift(lbound)
+                pixel_diff = torch.abs(x_lambda0-x_lambdax).sum().detach()
+                
+                # If we stop decreasing the prediction
+                if last_pred < cur_pred:
+                    break
+                # If the prediction becomes very low
+                if cur_pred < 0.05:
+                    break
+                # If we have decreased the prediction by pred_diff
+                if initial_pred - pred_diff > cur_pred:
+                    break
+                # If we are moving in the latent space too much
+                if lbound <= -3000:
+                    break
+                # If we move too far we will distort the image
+                if pixel_diff > max_pixel_diff:
+                    break
+                    
+                last_pred = cur_pred
+                lbound = lbound - shift_step_size + lbound//10
+
+            # Right range search not implemented
+            rbound = 0
+        
+        print('Selected bounds: ', lbound, rbound)
+        
+        # Sweep over the range of lambda values to create a sequence
+        lambdas = np.arange(lbound, rbound, np.abs((lbound-rbound)/lambda_sweep_steps))
+        
+        preds = []
+        generated_images = []
+        
+        for lam in lambdas:
+            x_lambdax, pred = compute_shift(lam)
+            generated_images.append(x_lambdax.cpu().numpy())
+            preds.append(pred)
+            
+        params = {}
+        params['generated_images'] = generated_images
+        params['lambdas'] = lambdas
+        params['preds'] = preds
+        
+        
+        x_lambda0 = x_lambda0.detach().cpu().numpy()
+        if heatmap_method == 'max':
+            # Max difference from lambda 0 frame
+            heatmap = np.max(np.abs(x_lambda0[0][0] - generated_images[0][0]),0)
+        
+        elif heatmap_method == 'mean':
+            # Average difference between 0 and other lambda frames
+            heatmap = np.mean(np.abs(x_lambda0[0][0] - generated_images[0][0]),0)
+        
+        elif heatmap_method == 'mm':
+            # Difference between first and last frames
+            heatmap = np.abs(generated_images[0][0][0] - generated_images[-1][0][0])
+        
+        elif heatmap_method == 'int':
+            # Average per frame differences 
+            image_changes = []
+            for i in range(len(generated_images)-1):
+                image_changes.append(np.abs(generated_images[i][0][0] - generated_images[i+1][0][0]))
+            heatmap = np.mean(image_changes, 0)
+        else:
+            raise Exception('Unknown heatmap_method for 2d image')
+            
+        params["heatmap"] = heatmap
+        
+        return params

--- a/captum/attr/_core/latent_shift.py
+++ b/captum/attr/_core/latent_shift.py
@@ -22,20 +22,22 @@ import matplotlib.pyplot as plt
 
 class LatentShift(GradientAttribution):
     r"""An implementation of the Latent Shift method to generate 
-    counterfactual explainations. This method uses an audoencoder to restrict
-    the possible  adverserial examples to remain in the dataspace by adjusting 
-    the latent space of the autoencoder using dy/dz instead of dy/dx in order 
-    to change the classifier's prediction.
+    counterfactual explainations. This method uses an audoencoder 
+    to restrict the possible  adverserial examples to remain in 
+    the dataspace by adjusting the latent space of the autoencoder 
+    using dy/dz instead of dy/dx in order  to change the classifier's 
+    prediction.
     
-    This class implements a search strategy to determine the lambda needed 
-    to change the prediction of the classifier by a specific amount as well
-    as the code to generate a video and construct a heatmap representing 
-    the image changes for viewing as an image.
+    This class implements a search strategy to determine the lambda 
+    needed to change the prediction of the classifier by a specific 
+    amount as well  as the code to generate a video and construct a 
+    heatmap representing the image changes for viewing as an image.
     
     Publication:
-    Cohen, J. P., et al. Gifsplanation via Latent Shift: A Simple Autoencoder 
-    Approach to Counterfactual Generation for Chest X-rays. Medical Imaging 
-    with Deep Learning. https://arxiv.org/abs/2102.09475
+    Cohen, J. P., et al. Gifsplanation via Latent Shift: A Simple 
+    Autoencoder Approach to Counterfactual Generation for Chest 
+    X-rays. Medical Imaging with Deep Learning. 
+    https://arxiv.org/abs/2102.09475
     """
 
     def __init__(self, forward_func: Callable, autoencoder) -> None:

--- a/captum/attr/_core/latent_shift.py
+++ b/captum/attr/_core/latent_shift.py
@@ -252,8 +252,24 @@ class LatentShift(GradientAttribution):
         watermark: bool = True,
         ffmpeg_path: str = "ffmpeg",
         temp_path: str = "/tmp/gifsplanation",
-        show=True,
+        show: bool = True,
     ):
+        """Generate a video from the generated images.
+
+            Args:
+                params: The dict returned from the call to `attribute`.
+                target_filename: The filename to write the video to. `.mp4` will
+                    be added to the end of the string.
+                watermark: To add the probability output and the name of the
+                    method.
+                ffmpeg_path: The path to call `ffmpeg`
+                temp_path: A temp path to write images.
+                show: To try and show the video in a jupyter notebook.
+
+            Returns:
+                The filename of the video if show=False, otherwise it will
+                return a video to show in a jupyter notebook.
+        """
                     
         if not target_filename:
             target_filename = f'video-{params["target"]}'
@@ -265,6 +281,7 @@ class LatentShift(GradientAttribution):
         os.mkdir(temp_path)
         
         imgs = [h.transpose(0, 2, 3, 1) for h in params["generated_images"]]
+
         # Add reversed so we have an animation cycle
         towrite = list(reversed(imgs)) + list(imgs)
         ys = list(reversed(params['preds'])) + list(params['preds'])
@@ -298,7 +315,9 @@ class LatentShift(GradientAttribution):
             plt.close()
 
         # Command for ffmpeg to generate an mp4
-        cmd = "{} -loglevel quiet -stats -y -i {}/image-%d.png -c:v libx264 -vf scale=-2:{} -profile:v baseline -level 3.0 -pix_fmt yuv420p '{}.mp4'".format(ffmpeg_path, temp_path, imgs[0][0].shape[0], target_filename)
+        cmd = "{} -loglevel quiet -stats -y -i {}/image-%d.png -c:v libx264 -vf scale=-2:{} -profile:v baseline -level 3.0 -pix_fmt yuv420p '{}.mp4'".format(
+            ffmpeg_path, temp_path, imgs[0][0].shape[0], target_filename
+        )
 
         print(cmd)
         output = subprocess.check_output(cmd, shell=True)

--- a/captum/attr/_core/latent_shift.py
+++ b/captum/attr/_core/latent_shift.py
@@ -22,8 +22,8 @@ import matplotlib.pyplot as plt
 
 class LatentShift(GradientAttribution):
     r"""An implementation of the Latent Shift method to generate
-    counterfactual explainations. This method uses an audoencoder to restrict
-    the possible  adverserial examples to remain in the dataspace by
+    counterfactual explanations. This method uses an autoencoder to restrict
+    the possible  adversarial examples to remain in the data space by
     adjusting the latent space of the autoencoder using dy/dz instead of
     dy/dx in order  to change the classifier's prediction.
     
@@ -132,10 +132,11 @@ class LatentShift(GradientAttribution):
         z.requires_grad = True
         x_lambda0 = self.ae.decode(z)
         pred = torch.sigmoid(self.forward_func(x_lambda0))[:,target]
-        dzdxp = torch.autograd.grad((pred), z)[0]
+        dzdxp = torch.autograd.grad(pred, z)[0]
         
         # Cache so we can reuse at sweep stage
         cache = {}
+
         def compute_shift(lambdax):
             """Compute the shift for a specific lambda"""
             if lambdax not in cache:
@@ -198,8 +199,7 @@ class LatentShift(GradientAttribution):
         params['lambdas'] = lambdas
         params['preds'] = preds
         params['target'] = target
-        
-        
+
         x_lambda0 = x_lambda0.detach().cpu().numpy()
         if heatmap_method == 'max':
             # Max difference from lambda 0 frame

--- a/captum/attr/_core/latent_shift.py
+++ b/captum/attr/_core/latent_shift.py
@@ -284,10 +284,15 @@ class LatentShift(GradientAttribution):
         if show:
             # If we in a jupyter notebook then show the video.
             from IPython.core.display import Video
-            return Video(target_filename + ".mp4", 
-                         html_attributes = "controls loop autoplay muted",
-                         embed=True,
-                        )
+            try:
+                return Video(target_filename + ".mp4",
+                             html_attributes="controls loop autoplay muted",
+                             embed=True,
+                             )
+            except TypeError as e:
+                return Video(target_filename + ".mp4",
+                             embed=True
+                             )
         else:
             return target_filename + ".mp4"
         

--- a/captum/attr/_core/latent_shift.py
+++ b/captum/attr/_core/latent_shift.py
@@ -3,16 +3,10 @@
 from typing import Any, Callable, Tuple
 
 import os
-import sys
 import shutil
 import torch
 import numpy as np
 from torch import Tensor
-from captum._utils.common import _format_output, _format_tensor_into_tuples, _is_tuple
-from captum._utils.gradient import (
-    apply_gradient_requirements,
-    undo_gradient_requirements,
-)
 from captum._utils.typing import TargetType
 from captum.attr._utils.attribution import GradientAttribution
 from captum.log import log_usage
@@ -131,13 +125,13 @@ class LatentShift(GradientAttribution):
             >>> ae = autoencoders.Transformer(weights="faceshq")
             >>> 
             >>> # Load image
-            >>> input = torch.randn(1, 3, 1024, 1024)
+            >>> x = torch.randn(1, 3, 1024, 1024)
             >>> 
             >>> # Defining Latent Shift module
             >>> attr = captum.attr.LatentShift(model, ae)
             >>> 
             >>> # Computes counterfactual for class 3.
-            >>> output = attr.attribute(input, target=3)
+            >>> output = attr.attribute(x, target=3)
 
         """
         z = self.ae.encode(inputs).detach()

--- a/tests/attr/test_latent_shift.py
+++ b/tests/attr/test_latent_shift.py
@@ -1,0 +1,57 @@
+import torch
+import captum
+from tests.helpers.basic import BaseTest
+
+
+class TinyModel(torch.nn.Module):
+    def __init__(self):
+        super(TinyModel, self).__init__()
+
+        self.linear1 = torch.nn.Linear(100, 200)
+        self.activation = torch.nn.ReLU()
+        self.linear2 = torch.nn.Linear(200, 10)
+        self.sigmoid = torch.nn.Sigmoid()
+
+    def forward(self, x):
+        x = self.linear1(x)
+        x = self.activation(x)
+        x = self.linear2(x)
+        x = self.sigmoid(x)
+        return x
+
+
+class TinyAE(torch.nn.Module):
+
+    def __init__(self):
+        super(TinyAE, self).__init__()
+
+        self.linear1 = torch.nn.Linear(100, 10)
+        self.activation = torch.nn.ReLU()
+        self.linear2 = torch.nn.Linear(10, 100)
+
+    def encode(self, x):
+        x = self.linear1(x)
+        return self.activation(x)
+
+    def decode(self, z):
+        return self.linear2(z)
+
+    def forward(self, x):
+        return self.decode(self.encode(x))
+
+
+class Test(BaseTest):
+    def test_basic_setup(self):
+
+        model = TinyModel()
+        ae = TinyAE()
+        x = torch.randn(1, 100)
+
+        # Defining Latent Shift module
+        attr = captum.attr.LatentShift(model, ae)
+
+        # Computes counterfactual for class 3.
+        output = attr.attribute(x, target=3, lambda_sweep_steps=10)
+
+        assert 10 == len(output['generated_images'])
+        assert (1, 100) == output['generated_images'][0].shape

--- a/tests/attr/test_latent_shift.py
+++ b/tests/attr/test_latent_shift.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import torch
 import captum
 from tests.helpers.basic import BaseTest


### PR DESCRIPTION
(making a new PR to fix the CLA issue)
RE: https://github.com/pytorch/captum/issues/694
I got ahead of myself with the code here but I will use the PR as a design doc.

## Background
The Latent Shift method is an approach to explain neural networks by generating a counterfactual. What differentiates this approach from others is that it is modular and tries to be as simple as possible. To generate the counterfactual this method uses an autoencoder to restrict the possible adversarial examples to remain in the data space by adjusting the latent space of the autoencoder using dy/dz instead of dy/dx in order to change the classifier's prediction.

## Proposed Captum API Design
The proposed design is an attribution method which takes an autoencoder as well as the model as input. Here is the proposed interface.

```python3
# Load classifier and autoencoder
model = classifiers.FaceAttribute()
ae = autoencoders.Transformer(weights="faceshq")

# Load image
input = torch.randn(1, 3, 1024, 1024)

# Defining Latent Shift module
attr = captum.attr.LatentShift(model, ae)

# Computes counterfactual for class 3.
output = attr.attribute(input, target=3)
```
This example corresponds to tutorial code and models provided in this repo: https://github.com/ieee8023/latentshift and available as a colab notebook https://colab.research.google.com/github/ieee8023/latentshift/blob/main/example.ipynb.

The call to `attr.attribute` returns a dictionary with multiple aspects of the search that can be used later. The basic output being a heatmap in `output['heatmap']` and a sequence of images in `output['generated_images']`. 

The generated_images can be stitched together into a video using a provided `attr.generate_video(output, "filename")` function that will take the images and use ffmpeg to combine them into a video. It will also add the output probability of the model in the upper left hand corner to make it easier to interpret.

To generate the attribution and heatmaps there are many parameters which have defaults set. The search that is performed is an iterative heuristic based search and will likely need to be tuned when new autoencoders and models are used. The search determines the correct lambda values to generate the shift. The search starts by stepping by `search_step_size` in the negative direction while trying to determine if the output of the classifier has changed by `search_pred_diff` or when the change in the predict in stops going down. In order to avoid artifacts if the shift is too large or in the wrong direction an extra stop conditions is added `search_max_pixel_diff` if the change in the image is too large. To avoid the search from taking too long a `search_max_steps` will prevent the search from going on endlessly.

Also here is a side by side comparison of this method to other methods in captum for the target of pointy_nose 
![Screen Shot 2022-09-11 at 13 09 25](https://user-images.githubusercontent.com/446367/189546983-df3ff3be-b1a8-4ee6-b7ab-eef84d7bc56d.png)


