### PR TITLE
Add logging for captum.robust

### DIFF
--- a/captum/robust/_core/fgsm.py
+++ b/captum/robust/_core/fgsm.py
@@ -15,6 +15,7 @@ from captum._utils.gradient import (
     undo_gradient_requirements,
 )
 from captum._utils.typing import TensorOrTupleOfTensorsGeneric
+from captum.log import log_usage
 from captum.robust._core.perturbation import Perturbation
 from torch import Tensor
 
@@ -73,6 +74,7 @@ class FGSM(Perturbation):
         self.bound = lambda x: torch.clamp(x, min=lower_bound, max=upper_bound)
         self.zero_thresh = 10**-6
 
+    @log_usage()
     def perturb(
         self,
         inputs: TensorOrTupleOfTensorsGeneric,

--- a/captum/robust/_core/metrics/attack_comparator.py
+++ b/captum/robust/_core/metrics/attack_comparator.py
@@ -21,6 +21,7 @@ from captum._utils.common import (
     _reduce_list,
 )
 from captum.attr import Max, Mean, Min, Summarizer
+from captum.log import log_usage
 from captum.robust._core.perturbation import Perturbation
 from torch import Tensor
 
@@ -235,6 +236,7 @@ class AttackComparator(Generic[MetricResultType]):
                 batch_summarizers[key_list[i]].update(out_metric)
                 current_count += batch_size
 
+    @log_usage()
     def evaluate(
         self,
         inputs: Any,

--- a/captum/robust/_core/metrics/min_param_perturbation.py
+++ b/captum/robust/_core/metrics/min_param_perturbation.py
@@ -10,6 +10,7 @@ from captum._utils.common import (
     _reduce_list,
 )
 from captum._utils.typing import TargetType
+from captum.log import log_usage
 from captum.robust._core.perturbation import Perturbation
 from torch import Tensor
 
@@ -335,6 +336,7 @@ class MinParamPerturbation:
 
         return min_input, min_so_far
 
+    @log_usage()
     def evaluate(
         self,
         inputs: Any,

--- a/captum/robust/_core/pgd.py
+++ b/captum/robust/_core/pgd.py
@@ -5,6 +5,7 @@ import torch
 import torch.nn.functional as F
 from captum._utils.common import _format_output, _format_tensor_into_tuples, _is_tuple
 from captum._utils.typing import TensorOrTupleOfTensorsGeneric
+from captum.log import log_usage
 from captum.robust._core.fgsm import FGSM
 from captum.robust._core.perturbation import Perturbation
 from torch import Tensor
@@ -65,6 +66,7 @@ class PGD(Perturbation):
         self.fgsm = FGSM(forward_func, loss_func)
         self.bound = lambda x: torch.clamp(x, min=lower_bound, max=upper_bound)
 
+    @log_usage()
     def perturb(
         self,
         inputs: TensorOrTupleOfTensorsGeneric,


### PR DESCRIPTION
Summary: Add logging for methods in captum.robust and fix test target setup

Differential Revision: D39600745

