### PR TITLE
Add layer support for TracInCP

### DIFF
--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -3,7 +3,7 @@ import threading
 import typing
 import warnings
 from collections import defaultdict
-from typing import Any, Callable, cast, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, cast, Dict, List, Optional, Sequence, Tuple, Union
 
 import torch
 from captum._utils.common import (
@@ -707,11 +707,26 @@ def construct_neuron_grad_fn(
     return grad_fn
 
 
+def _extract_parameters_from_layers(layer_modules):
+    layer_parameters = []
+    if layer_modules is not None:
+        layer_parameters = [
+            parameter
+            for layer_module in layer_modules
+            for parameter in layer_module.parameters()
+        ]
+        assert (
+            len(layer_parameters) > 0
+        ), "No parameters are available for modules for provided input `layers`"
+    return layer_parameters
+
+
 def _compute_jacobian_wrt_params(
     model: Module,
     inputs: Tuple[Any, ...],
     labels: Optional[Tensor] = None,
     loss_fn: Optional[Union[Module, Callable]] = None,
+    layer_modules: List[Module] = None,
 ) -> Tuple[Tensor, ...]:
     r"""
     Computes the Jacobian of a batch of test examples given a model, and optional
@@ -728,7 +743,8 @@ def _compute_jacobian_wrt_params(
                 defined loss function is provided, it would be expected to be a
                 torch.nn.Module. If a custom loss is provided, it can be either type,
                 but must behave as a library loss function would if `reduction='none'`.
-
+        layer_modules (List[torch.nn.Module]): A list of PyTorch modules w.r.t. which
+                jacobian gradients are computed.
     Returns:
         grads (tuple of Tensor): Returns the Jacobian for the minibatch as a
                 tuple of gradients corresponding to the tuple of trainable parameters
@@ -757,16 +773,20 @@ def _compute_jacobian_wrt_params(
                 assert out.shape[0] == loss.shape[0], msg1
             out = loss
 
+        if layer_modules is not None:
+            layer_parameters = _extract_parameters_from_layers(layer_modules)
         grads_list = [
             torch.autograd.grad(
                 outputs=out[i],
-                inputs=model.parameters(),  # type: ignore
+                inputs=cast(
+                    Union[Tensor, Sequence[Tensor]],
+                    model.parameters() if layer_modules is None else layer_parameters,
+                ),
                 grad_outputs=torch.ones_like(out[i]),
                 retain_graph=True,
             )
             for i in range(out.shape[0])
         ]
-
         grads = tuple([torch.stack(x) for x in zip(*grads_list)])
 
         return tuple(grads)
@@ -778,6 +798,7 @@ def _compute_jacobian_wrt_params_with_sample_wise_trick(
     labels: Optional[Tensor] = None,
     loss_fn: Optional[Union[Module, Callable]] = None,
     reduction_type: Optional[str] = "sum",
+    layer_modules: List[Module] = None,
 ) -> Tuple[Any, ...]:
     r"""
     Computes the Jacobian of a batch of test examples given a model, and optional
@@ -802,6 +823,8 @@ def _compute_jacobian_wrt_params_with_sample_wise_trick(
                 this should match `loss_fn.reduction`. Else if gradients are being
                 computed on direct model outputs (scores), then 'sum' should be used.
                 Defaults to 'sum'.
+        layer_modules (torch.nn.Module): A list of PyTorch modules w.r.t. which
+                jacobian gradients are computed.
 
     Returns:
         grads (tuple of Tensor): Returns the Jacobian for the minibatch as a
@@ -853,10 +876,13 @@ def _compute_jacobian_wrt_params_with_sample_wise_trick(
             sample_grad_wrapper.compute_param_sample_gradients(
                 out, loss_mode=reduction_type
             )
-
+            if layer_modules is not None:
+                layer_parameters = _extract_parameters_from_layers(layer_modules)
             grads = tuple(
                 param.sample_grad  # type: ignore
-                for param in model.parameters()
+                for param in (
+                    model.parameters() if layer_modules is None else layer_parameters
+                )
                 if hasattr(param, "sample_grad")
             )
         finally:

--- a/captum/influence/_core/tracincp.py
+++ b/captum/influence/_core/tracincp.py
@@ -18,7 +18,7 @@ from typing import (
 
 import torch
 from captum._utils.av import AV
-from captum._utils.common import _format_inputs
+from captum._utils.common import _format_inputs, _get_module_from_name
 from captum._utils.gradient import (
     _compute_jacobian_wrt_params,
     _compute_jacobian_wrt_params_with_sample_wise_trick,
@@ -141,11 +141,6 @@ class TracInCPBase(DataInfluence):
                     learning rate if it is saved. By default uses a utility to load a
                     model saved as a state dict.
                     Default: _load_flexible_state_dict
-            layers (list[str] or None, optional): A list of layer names for which
-                    gradients should be computed. If `layers` is None, gradients will
-                    be computed for all layers. Otherwise, they will only be computed
-                    for the layers specified in `layers`.
-                    Default: None
             loss_fn (Callable, optional): The loss function applied to model.
                     Default: None
             batch_size (int or None, optional): Batch size of the DataLoader created to
@@ -653,21 +648,25 @@ class TracInCP(TracInCPBase):
         within influence to restore after every influence call)? or make a copy so that
         changes to grad_requires aren't persistent after using TracIn.
         """
+        self.layer_modules = None
         if layers is not None:
             assert isinstance(layers, List), "`layers` should be a list!"
             assert len(layers) > 0, "`layers` cannot be empty!"
             assert isinstance(
                 layers[0], str
             ), "`layers` should contain str layer names."
-            layerstr = " ".join(layers)
-            gradset = False
-            for layer in layers:
-                for name, param in model.named_parameters():
-                    param.requires_grad = False
-                    if name in layerstr or layer in name:
+            self.layer_modules = [
+                _get_module_from_name(self.model, layer) for layer in layers
+            ]
+            for layer, layer_module in zip(layers, self.layer_modules):
+                for name, param in layer_module.named_parameters():
+                    if not param.requires_grad:
+                        warnings.warn(
+                            "Setting required grads for layer: {}, name: {}".format(
+                                ".".join(layer), name
+                            )
+                        )
                         param.requires_grad = True
-                        gradset = True
-            assert gradset, "At least one parameter of network must require gradient."
 
     @log_usage()
     def influence(  # type: ignore[override]
@@ -803,7 +802,6 @@ class TracInCP(TracInCPBase):
                 inputs,
                 targets,
             )
-
             return (
                 _gradient_dot_product(
                     input_jacobians,
@@ -1201,10 +1199,12 @@ class TracInCP(TracInCPBase):
                 targets,
                 self.loss_fn,
                 self.reduction_type,
+                self.layer_modules,
             )
         return _compute_jacobian_wrt_params(
             self.model,
             inputs,
             targets,
             self.loss_fn,
+            self.layer_modules,
         )

--- a/tests/influence/_core/test_tracin_k_most_influential.py
+++ b/tests/influence/_core/test_tracin_k_most_influential.py
@@ -4,10 +4,7 @@ from typing import Callable
 import torch
 import torch.nn as nn
 from captum.influence._core.tracincp import TracInCP
-from captum.influence._core.tracincp_fast_rand_proj import (
-    TracInCPFast,
-    TracInCPFastRandProj,
-)
+
 from parameterized import parameterized
 from tests.helpers.basic import assertTensorAlmostEqual, BaseTest
 from tests.influence._utils.common import (
@@ -31,19 +28,20 @@ class TestTracInGetKMostInfluential(BaseTest):
             for proponents in [True, False]:
                 for use_gpu in use_gpu_list:
                     for reduction, constr in [
-                        ("none", DataInfluenceConstructor(TracInCP)),
                         (
-                            "sum",
+                            "none",
                             DataInfluenceConstructor(
-                                TracInCP,
-                                name="TracInCPFastRandProjTests",
-                                sample_wise_grads_per_batch=True,
+                                TracInCP, name="TracInCP_all_layers"
                             ),
                         ),
-                        ("sum", DataInfluenceConstructor(TracInCPFast)),
-                        ("sum", DataInfluenceConstructor(TracInCPFastRandProj)),
-                        ("mean", DataInfluenceConstructor(TracInCPFast)),
-                        ("mean", DataInfluenceConstructor(TracInCPFastRandProj)),
+                        (
+                            "none",
+                            DataInfluenceConstructor(
+                                TracInCP,
+                                name="linear2",
+                                layers=["module.linear2"] if use_gpu else ["linear2"],
+                            ),
+                        ),
                     ]:
                         if not (
                             "sample_wise_grads_per_batch" in constr.kwargs
@@ -119,7 +117,6 @@ class TestTracInGetKMostInfluential(BaseTest):
                 proponents=proponents,
                 unpack_inputs=unpack_inputs,
             )
-
             for i in range(len(idx)):
                 # check that idx[i] is correct
                 assertTensorAlmostEqual(

--- a/tests/influence/_core/test_tracin_regression.py
+++ b/tests/influence/_core/test_tracin_regression.py
@@ -51,22 +51,62 @@ class TestTracInRegression(BaseTest):
     )
 
     param_list = []
-
     for use_gpu in use_gpu_list:
         for dim in [1, 20]:
             for (mode, reduction, constructor) in [
-                ("check_idx", "none", DataInfluenceConstructor(TracInCP)),
-                ("sample_wise_trick", None, DataInfluenceConstructor(TracInCP)),
-                ("check_idx", "sum", DataInfluenceConstructor(TracInCPFast)),
-                ("check_idx", "sum", DataInfluenceConstructor(TracInCPFastRandProj)),
-                ("check_idx", "mean", DataInfluenceConstructor(TracInCPFast)),
-                ("check_idx", "mean", DataInfluenceConstructor(TracInCPFastRandProj)),
+                (
+                    "check_idx",
+                    "none",
+                    DataInfluenceConstructor(TracInCP, name="TracInCP_all_layers"),
+                ),
+                (
+                    "check_idx",
+                    "none",
+                    DataInfluenceConstructor(
+                        TracInCP,
+                        name="TracInCP_fc1",
+                        layers=["module.fc1"] if use_gpu else ["fc1"],
+                    ),
+                ),
+                (
+                    "sample_wise_trick",
+                    None,
+                    DataInfluenceConstructor(TracInCP, name="TracInCP_fc1"),
+                ),
+                (
+                    "check_idx",
+                    "sum",
+                    DataInfluenceConstructor(
+                        TracInCPFast, name="TracInCPFast_last_fc_layer"
+                    ),
+                ),
+                (
+                    "check_idx",
+                    "sum",
+                    DataInfluenceConstructor(
+                        TracInCPFastRandProj, name="TracInCPFast_last_fc_layer"
+                    ),
+                ),
+                (
+                    "check_idx",
+                    "mean",
+                    DataInfluenceConstructor(
+                        TracInCPFast, name="TracInCPFast_last_fc_layer"
+                    ),
+                ),
+                (
+                    "check_idx",
+                    "mean",
+                    DataInfluenceConstructor(
+                        TracInCPFastRandProj, name="TracInCPFastRandProj_last_fc_layer"
+                    ),
+                ),
                 (
                     "check_idx",
                     "sum",
                     DataInfluenceConstructor(
                         TracInCPFastRandProj,
-                        name="TracInCPFastRandProj1DimensionalProjection",
+                        name="TracInCPFastRandProj1DimensionalProjection_last_fc_layer",
                         projection_dim=1,
                     ),
                 ),
@@ -271,7 +311,13 @@ class TestTracInRegression(BaseTest):
     @parameterized.expand(
         [
             ("check_idx", "none", DataInfluenceConstructor(TracInCP)),
+            ("check_idx", "none", DataInfluenceConstructor(TracInCP, layers=["fc1"])),
             ("sample_wise_trick", None, DataInfluenceConstructor(TracInCP)),
+            (
+                "sample_wise_trick",
+                None,
+                DataInfluenceConstructor(TracInCP, layers=["fc1"]),
+            ),
             ("check_idx", "sum", DataInfluenceConstructor(TracInCPFast)),
             ("check_idx", "sum", DataInfluenceConstructor(TracInCPFastRandProj)),
             ("check_idx", "mean", DataInfluenceConstructor(TracInCPFast)),

--- a/tests/influence/_core/test_tracin_xor.py
+++ b/tests/influence/_core/test_tracin_xor.py
@@ -167,26 +167,54 @@ class TestTracInXOR(BaseTest):
     parametrized_list = [
         (
             "none",
-            DataInfluenceConstructor(TracInCP),
+            DataInfluenceConstructor(
+                TracInCP, name="TracInCP_linear1", layers=["linear1"]
+            ),
+            "check_idx",
+            False,
+        ),
+        (
+            "none",
+            DataInfluenceConstructor(TracInCP, name="TracInCP_all_layers"),
             "check_idx",
             False,
         ),
         (
             None,
-            DataInfluenceConstructor(TracInCP),
+            DataInfluenceConstructor(TracInCP, name="TracInCP_all_layers"),
+            "sample_wise_trick",
+            False,
+        ),
+        (
+            None,
+            DataInfluenceConstructor(
+                TracInCP, name="TracInCP_linear1_linear2", layers=["linear1", "linear2"]
+            ),
             "sample_wise_trick",
             False,
         ),
     ]
 
     if torch.cuda.is_available() and torch.cuda.device_count() != 0:
-        parametrized_list.append(
-            (
-                "none",
-                DataInfluenceConstructor(TracInCP),
-                "check_idx",
-                True,
-            )
+        parametrized_list.extend(
+            [
+                (
+                    "none",
+                    DataInfluenceConstructor(TracInCP, name="TracInCP_all_layers"),
+                    "check_idx",
+                    True,
+                ),
+                (
+                    "none",
+                    DataInfluenceConstructor(
+                        TracInCP,
+                        name="TracInCP_linear1_linear2",
+                        layers=["module.linear1", "module.linear2"],
+                    ),
+                    "check_idx",
+                    True,
+                ),
+            ],
         )
 
     @parameterized.expand(
@@ -201,8 +229,6 @@ class TestTracInXOR(BaseTest):
         use_gpu: bool,
     ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
-            # net = BasicLinearNet(2, 2, 1)
-            # net = wrap_model_in_dataparallel(net) if use_gpu else net
             batch_size = 4
 
             net, dataset = self._test_tracin_xor_setup(tmpdir, use_gpu)


### PR DESCRIPTION
Summary:
1. This PR adds support for layers in the TracInCP. Originally we were passing this argument but we weren't using it. Now it is being propagated further to gradient computation functions.

 2. `assert gradset, "At least one parameter of network must require gradient."` was also confusing and didn't bring much. Removed it and warn the user whenever require grad is not set and we have to set it ourselves.

 3. Added test cases in relevant places.

Reviewed By: 99warriors

Differential Revision: D39247117

