### PR TITLE
check sphinx build in ci & remove pytext rst

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ commands:
     steps:
       - run:
           name: "Run sphinx"
-          command: sphinx-build -T --keep-going sphinx/source sphinx/build
+          command: sphinx-build -WT --keep-going sphinx/source sphinx/build
 
   configure_github_bot:
     description: "Configure Docusaurus GitHub bot"

--- a/sphinx/source/pytext.rst
+++ b/sphinx/source/pytext.rst
@@ -1,8 +1,0 @@
-Captum.Models
-==========================
-
-.. autoclass:: captum.attr._models.pytext.PyTextInterpretableEmbedding
-    :members:
-
-.. autoclass:: captum.attr._models.pytext.BaselineGenerator
-    :members:


### PR DESCRIPTION
- Require successful sphinx build in CI. Previously sphinx build will always pass even with errors (example below)
![image](https://user-images.githubusercontent.com/5113450/191642234-66e4a90a-6410-4371-899e-f9f6941e263d.png)

- Fixed the remaining error sphinx build: remove `pytext.rst`. We never really opensourced pytext model yet and its doc can never be built due to missing pytext (which is deprecated now); we can later migrate to torchtext and re-opensource it if needed
