### PR TITLE
fix docstring - multiple or

### DIFF
--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -738,12 +738,12 @@ def _compute_jacobian_wrt_params(
         inputs (tuple[Any, ...]): The minibatch for which the forward pass is computed.
                 It is unpacked before passing to `model`, so it must be a tuple.  The
                 individual elements of `inputs` can be anything.
-        labels (Tensor or None): Labels for input if computing a loss function.
+        labels (Tensor, optional): Labels for input if computing a loss function.
         loss_fn (torch.nn.Module or Callable, optional): The loss function. If a library
                 defined loss function is provided, it would be expected to be a
                 torch.nn.Module. If a custom loss is provided, it can be either type,
                 but must behave as a library loss function would if `reduction='none'`.
-        layer_modules (List[torch.nn.Module]): A list of PyTorch modules w.r.t. which
+        layer_modules (List[torch.nn.Module], optional): A list of PyTorch modules w.r.t. which
                 jacobian gradients are computed.
     Returns:
         grads (tuple[Tensor, ...]): Returns the Jacobian for the minibatch as a

--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -813,17 +813,17 @@ def _compute_jacobian_wrt_params_with_sample_wise_trick(
         inputs (tuple[Any, ...]): The minibatch for which the forward pass is computed.
                 It is unpacked before passing to `model`, so it must be a tuple.  The
                 individual elements of `inputs` can be anything.
-        labels (Tensor or None): Labels for input if computing a loss function.
+        labels (Tensor, optional): Labels for input if computing a loss function.
         loss_fn (torch.nn.Module or Callable, optional): The loss function. If a library
                 defined loss function is provided, it would be expected to be a
                 torch.nn.Module. If a custom loss is provided, it can be either type,
                 but must behave as a library loss function would if `reduction='sum'` or
                 `reduction='mean'`.
-        reduction_type (str): The type of reduction applied. If a loss_fn is passed,
+        reduction_type (str, optional): The type of reduction applied. If a loss_fn is passed,
                 this should match `loss_fn.reduction`. Else if gradients are being
                 computed on direct model outputs (scores), then 'sum' should be used.
                 Defaults to 'sum'.
-        layer_modules (torch.nn.Module): A list of PyTorch modules w.r.t. which
+        layer_modules (torch.nn.Module, optional): A list of PyTorch modules w.r.t. which
                 jacobian gradients are computed.
 
     Returns:

--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -820,8 +820,9 @@ def _compute_jacobian_wrt_params_with_sample_wise_trick(
                 but must behave as a library loss function would if `reduction='sum'` or
                 `reduction='mean'`.
         reduction_type (str, optional): The type of reduction applied. If a loss_fn is
-                 passed, this should match `loss_fn.reduction`. Else if gradients are being
-                computed on direct model outputs (scores), then 'sum' should be used.
+                passed, this should match `loss_fn.reduction`. Else if gradients are
+                being computed on direct model outputs (scores), then 'sum' should be
+                used.
                 Defaults to 'sum'.
         layer_modules (torch.nn.Module, optional): A list of PyTorch modules w.r.t.
                  which jacobian gradients are computed.

--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -724,7 +724,7 @@ def _compute_jacobian_wrt_params(
                 It is unpacked before passing to `model`, so it must be a tuple.  The
                 individual elements of `inputs` can be anything.
         labels (Tensor or None): Labels for input if computing a loss function.
-        loss_fn (torch.nn.Module or Callable or None): The loss function. If a library
+        loss_fn (torch.nn.Module or Callable, optional): The loss function. If a library
                 defined loss function is provided, it would be expected to be a
                 torch.nn.Module. If a custom loss is provided, it can be either type,
                 but must behave as a library loss function would if `reduction='none'`.
@@ -793,7 +793,7 @@ def _compute_jacobian_wrt_params_with_sample_wise_trick(
                 It is unpacked before passing to `model`, so it must be a tuple.  The
                 individual elements of `inputs` can be anything.
         labels (Tensor or None): Labels for input if computing a loss function.
-        loss_fn (torch.nn.Module or Callable or None): The loss function. If a library
+        loss_fn (torch.nn.Module or Callable, optional): The loss function. If a library
                 defined loss function is provided, it would be expected to be a
                 torch.nn.Module. If a custom loss is provided, it can be either type,
                 but must behave as a library loss function would if `reduction='sum'` or

--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -743,8 +743,8 @@ def _compute_jacobian_wrt_params(
                 defined loss function is provided, it would be expected to be a
                 torch.nn.Module. If a custom loss is provided, it can be either type,
                 but must behave as a library loss function would if `reduction='none'`.
-        layer_modules (List[torch.nn.Module], optional): A list of PyTorch modules w.r.t. which
-                jacobian gradients are computed.
+        layer_modules (List[torch.nn.Module], optional): A list of PyTorch modules
+                 w.r.t. which jacobian gradients are computed.
     Returns:
         grads (tuple[Tensor, ...]): Returns the Jacobian for the minibatch as a
                 tuple of gradients corresponding to the tuple of trainable parameters
@@ -819,12 +819,12 @@ def _compute_jacobian_wrt_params_with_sample_wise_trick(
                 torch.nn.Module. If a custom loss is provided, it can be either type,
                 but must behave as a library loss function would if `reduction='sum'` or
                 `reduction='mean'`.
-        reduction_type (str, optional): The type of reduction applied. If a loss_fn is passed,
-                this should match `loss_fn.reduction`. Else if gradients are being
+        reduction_type (str, optional): The type of reduction applied. If a loss_fn is
+                 passed, this should match `loss_fn.reduction`. Else if gradients are being
                 computed on direct model outputs (scores), then 'sum' should be used.
                 Defaults to 'sum'.
-        layer_modules (torch.nn.Module, optional): A list of PyTorch modules w.r.t. which
-                jacobian gradients are computed.
+        layer_modules (torch.nn.Module, optional): A list of PyTorch modules w.r.t.
+                 which jacobian gradients are computed.
 
     Returns:
         grads (tuple[Tensor, ...]): Returns the Jacobian for the minibatch as a

--- a/captum/attr/_core/layer/layer_activation.py
+++ b/captum/attr/_core/layer/layer_activation.py
@@ -88,7 +88,7 @@ class LayerActivation(LayerAttribution):
 
         Returns:
             *Tensor* or *tuple[Tensor, ...]* or list of **attributions**:
-            - **attributions** (*Tensor* or *tuple[Tensor, ...]* or *list*):
+            - **attributions** (*Tensor*, *tuple[Tensor, ...]*, or *list*):
                         Activation of each neuron in given layer output.
                         Attributions will always be the same size as the
                         output of the given layer.

--- a/captum/attr/_core/layer/layer_gradient_x_activation.py
+++ b/captum/attr/_core/layer/layer_gradient_x_activation.py
@@ -135,7 +135,7 @@ class LayerGradientXActivation(LayerAttribution, GradientAttribution):
 
         Returns:
             *Tensor* or *tuple[Tensor, ...]* or list of **attributions**:
-            - **attributions** (*Tensor* or *tuple[Tensor, ...]* or *list*):
+            - **attributions** (*Tensor*, *tuple[Tensor, ...]*, or *list*):
                         Product of gradient and activation for each
                         neuron in given layer output.
                         Attributions will always be the same size as the

--- a/captum/attr/_core/occlusion.py
+++ b/captum/attr/_core/occlusion.py
@@ -80,7 +80,7 @@ class Occlusion(FeatureAblation):
                             this must be a tuple containing one tuple for each input
                             tensor defining the dimensions of the patch for that
                             input tensor, as described for the single tensor case.
-                strides (int or tuple or tuple[int] or tuple[tuple], optional):
+                strides (int, tuple, tuple[int], or tuple[tuple], optional):
                             This defines the step by which the occlusion hyperrectangle
                             should be shifted by in each direction for each iteration.
                             For a single tensor input, this can be either a single

--- a/captum/influence/_utils/common.py
+++ b/captum/influence/_utils/common.py
@@ -86,7 +86,7 @@ def _jacobian_loss_wrt_inputs(
     batch).
 
     Args:
-        loss_fn (torch.nn.Module or Callable or None): The loss function. If a library
+        loss_fn (torch.nn.Module, Callable, or None): The loss function. If a library
                 defined loss function is provided, it would be expected to be a
                 torch.nn.Module. If a custom loss is provided, it can be either type,
                 but must behave as a library loss function would if `reduction='sum'`


### PR DESCRIPTION
use only one `or` for multiple types