### PR TITLE
let `SampleGradientWrapper` accept `layer_modules`

### DIFF
--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -836,7 +836,7 @@ def _compute_jacobian_wrt_params_with_sample_wise_trick(
                 parameters of the i-th layer, for the j-th member of the minibatch.
     """
     with torch.autograd.set_grad_enabled(True):
-        sample_grad_wrapper = SampleGradientWrapper(model)
+        sample_grad_wrapper = SampleGradientWrapper(model, layer_modules)
         try:
             sample_grad_wrapper.add_hooks()
 


### PR DESCRIPTION
Summary:
This diff adds the option for `SampleGradsWrapper` to compute sample grads only for a specified set of modules, which is specified by the new `layer_modules` initialization argument.  There are 2 reasons to add this:
- computational savings: in `_compute_jacobian_wrt_params_with_sample_wise_trick`, we request sample grads for only a specified set of modules, but compute them for all modules
- to avoid bugs: there are modules that it does not make sense to compute sample grads for, because in the same forward pass, they may be called with different batch sizes (for example in multple instance learning, we may apply a linear layer to bags with different number of examples).  in this case, there will be a bug when we try to accumulate different sample grads for the same parameter.  So we need a way to avoid computing sampel grads for those modules.

A simple test is added to check that only the sample grads of the specified layers were actually calculated.

Reviewed By: vivekmig

Differential Revision: D39610414

