### PR TITLE
Fix failing kernel shap tests

### DIFF
--- a/tests/attr/test_kernel_shap.py
+++ b/tests/attr/test_kernel_shap.py
@@ -371,7 +371,6 @@ class Test(BaseTest):
     ) -> None:
         for batch_size in perturbations_per_eval:
             kernel_shap = KernelShap(model)
-            set_all_random_seeds(1234)
             attributions = kernel_shap.attribute(
                 test_input,
                 target=target,

--- a/tests/attr/test_kernel_shap.py
+++ b/tests/attr/test_kernel_shap.py
@@ -12,6 +12,7 @@ from tests.helpers.basic import (
     assertTensorAlmostEqual,
     assertTensorTuplesAlmostEqual,
     BaseTest,
+    set_all_random_seeds,
 )
 from tests.helpers.basic_models import (
     BasicLinearModel,
@@ -370,6 +371,7 @@ class Test(BaseTest):
     ) -> None:
         for batch_size in perturbations_per_eval:
             kernel_shap = KernelShap(model)
+            set_all_random_seeds(1234)
             attributions = kernel_shap.attribute(
                 test_input,
                 target=target,
@@ -386,6 +388,7 @@ class Test(BaseTest):
             )
 
             if expected_coefs is not None:
+                set_all_random_seeds(1234)
                 # Test with return_input_shape = False
                 attributions = kernel_shap.attribute(
                     test_input,


### PR DESCRIPTION
Kernel SHAP's tests have been failing with the new PyTorch's version 1.14.0 on master. This fix resets random seeds to bring determinism to the tests. 
Here is the link to the failing tests: 
https://app.circleci.com/pipelines/github/pytorch/captum/4445/workflows/0db80fcb-08c7-4111-81c9-8e68588c5750/jobs/25508