### PR TITLE
Fix broken unittests.

### DIFF
--- a/tests/attr/test_feature_ablation.py
+++ b/tests/attr/test_feature_ablation.py
@@ -571,7 +571,7 @@ class Test(BaseTest):
         self._ablation_test_assert(
             ablation_algo,
             inp,
-            torch.tensor([[82.0, 82.0, 24.0]], dtype=dtype),
+            torch.tensor([[82.0, 82.0, 24.0]], dtype=torch.float32).to(dtype),
             feature_mask=mask,
             perturbations_per_eval=(1,),
             target=None,
@@ -588,7 +588,7 @@ class Test(BaseTest):
         self._ablation_test_assert(
             ablation_algo,
             inp,
-            torch.tensor([[642.0, 642.0, 264.0]], dtype=dtype),
+            torch.tensor([[642.0, 642.0, 264.0]], dtype=torch.float32).to(dtype),
             feature_mask=mask,
             perturbations_per_eval=(1,),
             target=None,

--- a/tests/concept/test_tcav.py
+++ b/tests/concept/test_tcav.py
@@ -4,6 +4,7 @@ import glob
 import os
 import tempfile
 from collections import defaultdict, OrderedDict
+import unittest
 from typing import (
     Any,
     Callable,
@@ -1191,6 +1192,12 @@ class Test(BaseTest):
 
     # Testing TCAV with default classifier and experimental sets of varying lengths
     def test_exp_sets_with_diffent_lengths(self) -> None:
+        try:
+            import sklearn
+            import sklearn.linear_model
+            import sklearn.svm  # noqa: F401
+        except ImportError:
+            raise unittest.SkipTest("sklearn is not available.")
         # Create Concepts
         concepts_dict = create_concepts()
 

--- a/tests/concept/test_tcav.py
+++ b/tests/concept/test_tcav.py
@@ -3,8 +3,8 @@
 import glob
 import os
 import tempfile
-from collections import defaultdict, OrderedDict
 import unittest
+from collections import defaultdict, OrderedDict
 from typing import (
     Any,
     Callable,


### PR DESCRIPTION
Summary:
There were a few unittest broken on my local run this fixes all of them.
 Broken tests,
test_multi_sample_ablation_batch\
 _scalar_tensor_int  test_single_ablation_batch_scalar_tensor_int
test_exp_sets_with_diffent_lengths
Test Plan:
pytest -ra

Comes clean.

Reviewers:

Subscribers:

Tasks:

Tags: