### PR TITLE
move STG to captum module

### DIFF
--- a/captum/module/__init__.py
+++ b/captum/module/__init__.py
@@ -1,0 +1,5 @@
+from captum.module.binary_concrete_stochastic_gates import (  # noqa
+    BinaryConcreteStochasticGates,
+)
+from captum.module.gaussian_stochastic_gates import GaussianStochasticGates  # noqa
+from captum.module.stochastic_gates_base import StochasticGatesBase  # noqa

--- a/captum/module/binary_concrete_stochastic_gates.py
+++ b/captum/module/binary_concrete_stochastic_gates.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+import math
+from typing import Optional
+
+import torch
+from captum.module.stochastic_gates_base import StochasticGatesBase
+from torch import nn, Tensor
+
+
+def _torch_empty(batch_size: int, n_gates: int, device: torch.device) -> Tensor:
+    return torch.empty(batch_size, n_gates, device=device)
+
+
+# torch.fx is introduced in 1.8.0
+if hasattr(torch, "fx"):
+    torch.fx.wrap(_torch_empty)
+
+
+def _logit(inp):
+    # torch.logit is introduced in 1.7.0
+    if hasattr(torch, "logit"):
+        return torch.logit(inp)
+    else:
+        return torch.log(inp) - torch.log(1 - inp)
+
+
+class BinaryConcreteStochasticGates(StochasticGatesBase):
+    """
+    Stochastic Gates with binary concrete distribution.
+
+    Stochastic Gates is a practical solution to add L0 norm regularization for neural
+    networks. L0 regularization, which explicitly penalizes any present (non-zero)
+    parameters, can help network pruning and feature selection, but directly optimizing
+    L0 is a non-differentiable combinatorial problem. To surrogate L0, Stochastic Gate
+    uses certain continuous probability distributions (e.g., Concrete, Gaussian) with
+    hard-sigmoid rectification as a continuous smoothed Bernoulli distribution
+    determining the weight of a parameter, i.e., gate. Then L0 is equal to the gates's
+    non-zero probability represented by the parameters of the continuous probability
+    distribution. The gate value can also be reparameterized to the distribution
+    parameters with a noise. So the expected L0 can be optimized through learning
+    the distribution parameters via stochastic gradients.
+
+    BinaryConcreteStochasticGates adopts a "stretched" binary concrete distribution as
+    the smoothed Bernoulli distribution of gate. The binary concrete distribution does
+    not include its lower and upper boundaries, 0 and 1, which are required by a
+    Bernoulli distribution, so it needs to be linearly stretched beyond both boundaries.
+    Then use hard-sigmoid rectification to "fold" the parts smaller than 0 or larger
+    than 1 back to 0 and 1.
+
+    More details can be found in the
+    `original paper <https://arxiv.org/abs/1712.01312>`.
+    """
+
+    def __init__(
+        self,
+        n_gates: int,
+        mask: Optional[Tensor] = None,
+        reg_weight: float = 1.0,
+        temperature: float = 2.0 / 3,
+        lower_bound: float = -0.1,
+        upper_bound: float = 1.1,
+        eps: float = 1e-8,
+    ):
+        """
+        Args:
+            n_gates (int): number of gates.
+
+            mask (Optional[Tensor]): If provided, this allows grouping multiple
+                input tensor elements to share the same stochastic gate.
+                This tensor should be broadcastable to match the input shape
+                and contain integers in the range 0 to n_gates - 1.
+                Indices grouped to the same stochastic gate should have the same value.
+                If not provided, each element in the input tensor
+                (on dimensions other than dim 0 - batch dim) is gated separately.
+                Default: None
+
+            reg_weight (Optional[float]): rescaling weight for L0 regularization term.
+                Default: 1.0
+
+            temperature (float): temperature of the concrete distribution, controls
+                the degree of approximation, as 0 means the original Bernoulli
+                without relaxation. The value should be between 0 and 1.
+                Default: 2/3
+
+            lower_bound (float): the lower bound to "stretch" the binary concrete
+                distribution
+                Default: -0.1
+
+            upper_bound (float): the upper bound to "stretch" the binary concrete
+                distribution
+                Default: 1.1
+
+            eps (float): term to improve numerical stability in binary concerete
+                sampling
+                Default: 1e-8
+        """
+        super().__init__(n_gates, mask=mask, reg_weight=reg_weight)
+
+        # avoid changing the tensor's variable name
+        # when the module is used after compilation,
+        # users may directly access this tensor by name
+        log_alpha_param = torch.empty(n_gates)
+        nn.init.normal_(log_alpha_param, mean=0.0, std=0.01)
+        self.log_alpha_param = nn.Parameter(log_alpha_param)
+
+        assert (
+            0 < temperature < 1
+        ), f"the temperature should be bwteen 0 and 1, received {temperature}"
+        self.temperature = temperature
+
+        assert (
+            lower_bound < 0
+        ), f"the stretch lower bound should smaller than 0, received {lower_bound}"
+        self.lower_bound = lower_bound
+        assert (
+            upper_bound > 1
+        ), f"the stretch upper bound should larger than 1, received {upper_bound}"
+        self.upper_bound = upper_bound
+
+        self.eps = eps
+
+        # pre-calculate the fixed term used in active prob
+        self.active_prob_offset = temperature * math.log(-lower_bound / upper_bound)
+
+    def forward(self, *args, **kwargs):
+        """
+        Args:
+            input_tensor (Tensor): Tensor to be gated with stochastic gates
+
+
+        Outputs:
+            gated_input (Tensor): Tensor of the same shape weighted by the sampled
+                gate values
+
+            l0_reg (Tensor): L0 regularization term to be optimized together with
+                model loss,
+                e.g. loss(model_out, target) + l0_reg
+        """
+        return super().forward(*args, **kwargs)
+
+    def _sample_gate_values(self, batch_size: int) -> Tensor:
+        """
+        Sample gate values for each example in the batch from the binary concrete
+        distributions
+
+        Args:
+            batch_size (int): input batch size
+
+        Returns:
+            gate_values (Tensor): gate value tensor of shape(batch_size, n_gates)
+        """
+        if self.training:
+            u = _torch_empty(
+                batch_size, self.n_gates, device=self.log_alpha_param.device
+            )
+            u.uniform_(self.eps, 1 - self.eps)
+            s = torch.sigmoid((_logit(u) + self.log_alpha_param) / self.temperature)
+
+        else:
+            s = torch.sigmoid(self.log_alpha_param)
+            s = s.expand(batch_size, self.n_gates)
+
+        s_bar = s * (self.upper_bound - self.lower_bound) + self.lower_bound
+
+        return s_bar
+
+    def _get_gate_values(self) -> Tensor:
+        """
+        Get the gate values derived from learned log_alpha_param after model is trained
+
+        Returns:
+            gate_values (Tensor): value of each gate after model is trained
+        """
+        gate_values = (
+            torch.sigmoid(self.log_alpha_param) * (self.upper_bound - self.lower_bound)
+            + self.lower_bound
+        )
+        return torch.clamp(gate_values, min=0, max=1)
+
+    def _get_gate_active_probs(self) -> Tensor:
+        """
+        Get the active probability of each gate, i.e, gate value > 0, in the binary
+        concrete distributions
+
+        Returns:
+            probs (Tensor): probabilities tensor of the gates are active
+                in shape(n_gates)
+        """
+        return torch.sigmoid(self.log_alpha_param - self.active_prob_offset)

--- a/captum/module/gaussian_stochastic_gates.py
+++ b/captum/module/gaussian_stochastic_gates.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+import math
+from typing import Optional
+
+import torch
+from captum.module.stochastic_gates_base import StochasticGatesBase
+from torch import nn, Tensor
+
+
+class GaussianStochasticGates(StochasticGatesBase):
+    """
+    Stochastic Gates with Gaussian distribution.
+
+    Stochastic Gates is a practical solution to add L0 norm regularization for neural
+    networks. L0 regularization, which explicitly penalizes any present (non-zero)
+    parameters, can help network pruning and feature selection, but directly optimizing
+    L0 is a non-differentiable combinatorial problem. To surrogate L0, Stochastic Gate
+    uses certain continuous probability distributions (e.g., Concrete, Gaussian) with
+    hard-sigmoid rectification as a continuous smoothed Bernoulli distribution
+    determining the weight of a parameter, i.e., gate. Then L0 is equal to the gates's
+    non-zero probability represented by the parameters of the continuous probability
+    distribution. The gate value can also be reparameterized to the distribution
+    parameters with a noise. So the expected L0 can be optimized through learning
+    the distribution parameters via stochastic gradients.
+
+    GaussianStochasticGates adopts a gaussian distribution as the smoothed Bernoulli
+    distribution of gate. While the smoothed Bernoulli distribution should be
+    within 0 and 1, gaussian does not have boundaries. So hard-sigmoid rectification
+    is used to "fold" the parts smaller than 0 or larger than 1 back to 0 and 1.
+
+    More details can be found in the
+    `original paper <https://arxiv.org/abs/1810.04247>`.
+    """
+
+    def __init__(
+        self,
+        n_gates: int,
+        mask: Optional[Tensor] = None,
+        reg_weight: Optional[float] = 1.0,
+        std: Optional[float] = 0.5,
+    ):
+        """
+        Args:
+            n_gates (int): number of gates.
+
+            mask (Optional[Tensor]): If provided, this allows grouping multiple
+                input tensor elements to share the same stochastic gate.
+                This tensor should be broadcastable to match the input shape
+                and contain integers in the range 0 to n_gates - 1.
+                Indices grouped to the same stochastic gate should have the same value.
+                If not provided, each element in the input tensor
+                (on dimensions other than dim 0 - batch dim) is gated separately.
+                Default: None
+
+            reg_weight (Optional[float]): rescaling weight for L0 regularization term.
+                Default: 1.0
+
+            std (Optional[float]): standard deviation that will be fixed throughout.
+                Default: 0.5 (by paper reference)
+
+        """
+        super().__init__(n_gates, mask=mask, reg_weight=reg_weight)
+
+        mu = torch.empty(n_gates)
+        nn.init.normal_(mu, mean=0.5, std=0.01)
+        self.mu = nn.Parameter(mu)
+
+        assert 0 < std, f"the standard deviation should be positive, received {std}"
+        self.std = std
+
+    def forward(self, *args, **kwargs):
+        """
+        Args:
+            input_tensor (Tensor): Tensor to be gated with stochastic gates
+
+        Outputs:
+            gated_input (Tensor): Tensor of the same shape weighted by the sampled
+                gate values
+
+            l0_reg (Tensor): L0 regularization term to be optimized together with
+                model loss,
+                e.g. loss(model_out, target) + l0_reg
+        """
+        return super().forward(*args, **kwargs)
+
+    def _sample_gate_values(self, batch_size: int) -> Tensor:
+        """
+        Sample gate values for each example in the batch from the Gaussian distribution
+
+        Args:
+            batch_size (int): input batch size
+
+        Returns:
+            gate_values (Tensor): gate value tensor of shape(batch_size, n_gates)
+        """
+
+        if self.training:
+            n = torch.empty(batch_size, self.n_gates, device=self.mu.device)
+            n.normal_(mean=0, std=self.std)
+            return self.mu + n
+
+        return self.mu.expand(batch_size, self.n_gates)
+
+    def _get_gate_values(self) -> Tensor:
+        """
+        Get the gate values derived from learned mu after model is trained
+
+        Returns:
+            gate_values (Tensor): value of each gate after model is trained
+        """
+        return torch.clamp(self.mu, min=0, max=1)
+
+    def _get_gate_active_probs(self) -> Tensor:
+        """
+        Get the active probability of each gate, i.e, gate value > 0, in the
+        Gaussian distribution
+
+        Returns:
+            probs (Tensor): probabilities tensor of the gates are active
+                in shape(n_gates)
+        """
+        x = self.mu / self.std
+        return 0.5 * (1 + torch.erf(x / math.sqrt(2)))

--- a/captum/module/stochastic_gates_base.py
+++ b/captum/module/stochastic_gates_base.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+from abc import ABC, abstractmethod
+from typing import Optional, Tuple
+
+import torch
+from torch import Tensor
+from torch.nn import Module
+
+
+class StochasticGatesBase(Module, ABC):
+    """
+    Abstract module for Stochastic Gates.
+
+    Stochastic Gates is a practical solution to add L0 norm regularization for neural
+    networks. L0 regularization, which explicitly penalizes any present (non-zero)
+    parameters, can help network pruning and feature selection, but directly optimizing
+    L0 is a non-differentiable combinatorial problem. To surrogate L0, Stochastic Gate
+    uses certain continuous probability distributions (e.g., Concrete, Gaussian) with
+    hard-sigmoid rectification as a continuous smoothed Bernoulli distribution
+    determining the weight of a parameter, i.e., gate. Then L0 is equal to the gates's
+    non-zero probability represented by the parameters of the continuous probability
+    distribution. The gate value can also be reparameterized to the distribution
+    parameters with a noise. So the expected L0 can be optimized through learning
+    the distribution parameters via stochastic gradients.
+
+    This base class defines the shared variables and forward logic of how the input is
+    gated regardless of the underneath distribution. The actual implementation should
+    extend this class and implement the distribution specific functions.
+    """
+
+    def __init__(
+        self, n_gates: int, mask: Optional[Tensor] = None, reg_weight: float = 1.0
+    ):
+        """
+        Args:
+            n_gates (int): number of gates.
+
+            mask (Optional[Tensor]): If provided, this allows grouping multiple
+                input tensor elements to share the same stochastic gate.
+                This tensor should be broadcastable to match the input shape
+                and contain integers in the range 0 to n_gates - 1.
+                Indices grouped to the same stochastic gate should have the same value.
+                If not provided, each element in the input tensor
+                (on dimensions other than dim 0 - batch dim) is gated separately.
+                Default: None
+
+            reg_weight (Optional[float]): rescaling weight for L0 regularization term.
+                Default: 1.0
+        """
+        super().__init__()
+
+        if mask is not None:
+            max_mask_ind = mask.max().item()
+            assert max_mask_ind == n_gates - 1, (
+                f"the maximum mask index (received {max_mask_ind}) should be equal to"
+                f" the number of gates - 1 (received {n_gates}) since each mask"
+                " should correspond to a gate"
+            )
+
+        self.n_gates = n_gates
+        self.register_buffer(
+            "mask", mask.detach().clone() if mask is not None else None
+        )
+        self.reg_weight = reg_weight
+
+    def forward(self, input_tensor: Tensor) -> Tuple[Tensor, Tensor]:
+        """
+        Args:
+            input_tensor (Tensor): Tensor to be gated with stochastic gates
+
+
+        Outputs:
+            gated_input (Tensor): Tensor of the same shape weighted by the sampled
+                gate values
+
+            l0_reg (Tensor): L0 regularization term to be optimized together with
+                model loss,
+                e.g. loss(model_out, target) + l0_reg
+        """
+        if self.mask is None:
+            n_ele = self._get_numel_of_input(input_tensor)
+            assert n_ele == self.n_gates, (
+                "if mask is not given, each example in the input batch should have the"
+                " same number of elements"
+                f" (received {n_ele}) as gates ({self.n_gates})"
+            )
+
+        input_size = input_tensor.size()
+        batch_size = input_size[0]
+
+        gate_values = self._sample_gate_values(batch_size)
+
+        # hard-sigmoid rectification z=min(1,max(0,_z))
+        gate_values = torch.clamp(gate_values, min=0, max=1)
+
+        if self.mask is not None:
+            # use expand_as not expand/broadcast_to which do not work with torch.fx
+            input_mask = self.mask.expand_as(input_tensor)
+
+            # flatten all dim except batch to gather from gate values
+            flattened_mask = input_mask.reshape(batch_size, -1)
+            gate_values = torch.gather(gate_values, 1, flattened_mask)
+
+        # reshape gates(batch_size, n_elements) into input_size for point-wise mul
+        gate_values = gate_values.reshape(input_size)
+        gated_input = input_tensor * gate_values
+
+        prob_density = self._get_gate_active_probs()
+        l0_reg = self.reg_weight * prob_density.mean()
+
+        return gated_input, l0_reg
+
+    def get_gate_values(self) -> Tensor:
+        """
+        Get the gate values after model is trained. These values are derived from
+        the learned distribution parameters used during reparameterization.
+
+        Returns:
+            gate_values (Tensor): value of each gate after model is trained
+                in shape(n_gates)
+        """
+        return self._get_gate_values().detach()
+
+    def get_gate_active_probs(self) -> Tensor:
+        """
+        Get the active probability of each gate, i.e, gate value > 0
+
+        Returns:
+            probs (Tensor): probabilities tensor of the gates are active
+                in shape(n_gates)
+        """
+        return self._get_gate_active_probs().detach()
+
+    @abstractmethod
+    def _get_gate_values(self) -> Tensor:
+        """
+        Protected method to be override in the child depending on the chosen
+        distribution. Get the gate values derived from the learned parameters of
+        the according distribution.
+
+        Returns:
+            gate_values (Tensor): gate value tensor of shape(n_gates)
+        """
+        pass
+
+    @abstractmethod
+    def _sample_gate_values(self, batch_size: int) -> Tensor:
+        """
+        Protected method to be override in the child depending on the chosen
+        distribution. Sample gate values for each example in the batch from a
+        probability distribution
+
+        Args:
+            batch_size (int): input batch size
+
+        Returns:
+            gate_values (Tensor): gate value tensor of shape(batch_size, n_gates)
+        """
+        pass
+
+    @abstractmethod
+    def _get_gate_active_probs(self) -> Tensor:
+        """
+        Protected method to be override in the child depending on the chosen
+        distribution. Get the active probability of each gate, i.e, gate value > 0
+
+        Returns:
+            probs (Tensor): probabilities tensor of the gates are active
+                in shape(n_gates)
+        """
+        pass
+
+    def _get_numel_of_input(self, input_tensor: Tensor) -> int:
+        """
+        Get the number of elements of a single example in the batched input tensor
+        """
+        assert input_tensor.dim() > 1, (
+            "The input tensor must have more than 1 dimension with the 1st dimention"
+            " being batch size;"
+            f" received input tensor shape {input_tensor.size()}"
+        )
+        return input_tensor[0].numel()

--- a/tests/module/test_binary_concrete_stochastic_gates.py
+++ b/tests/module/test_binary_concrete_stochastic_gates.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+
+import unittest
+
+import torch
+from captum.module.binary_concrete_stochastic_gates import BinaryConcreteStochasticGates
+from parameterized import parameterized_class
+from tests.helpers.basic import assertTensorAlmostEqual, BaseTest
+
+
+@parameterized_class(
+    [
+        {"testing_device": "cpu"},
+        {"testing_device": "cuda"},
+    ]
+)
+class TestBinaryConcreteStochasticGates(BaseTest):
+    def setUp(self):
+        super().setUp()
+        if self.testing_device == "cuda" and not torch.cuda.is_available():
+            raise unittest.SkipTest("Skipping GPU test since CUDA not available.")
+
+    def test_bcstg_1d_input(self) -> None:
+
+        dim = 3
+        bcstg = BinaryConcreteStochasticGates(dim).to(self.testing_device)
+        input_tensor = torch.tensor(
+            [
+                [0.0, 0.1, 0.2],
+                [0.3, 0.4, 0.5],
+            ]
+        ).to(self.testing_device)
+
+        gated_input, reg = bcstg(input_tensor)
+        expected_reg = 0.8316
+
+        if self.testing_device == "cpu":
+            expected_gated_input = [[0.0000, 0.0212, 0.1892], [0.1839, 0.3753, 0.4937]]
+        elif self.testing_device == "cuda":
+            expected_gated_input = [[0.0000, 0.0985, 0.1149], [0.2329, 0.0497, 0.5000]]
+
+        assertTensorAlmostEqual(self, gated_input, expected_gated_input, mode="max")
+        assertTensorAlmostEqual(self, reg, expected_reg)
+
+    def test_bcstg_1d_input_with_n_gates_error(self) -> None:
+
+        dim = 3
+        bcstg = BinaryConcreteStochasticGates(dim).to(self.testing_device)
+        input_tensor = torch.tensor([0.0, 0.1, 0.2]).to(self.testing_device)
+
+        with self.assertRaises(AssertionError):
+            bcstg(input_tensor)
+
+    def test_bcstg_num_mask_not_equal_dim_error(self) -> None:
+        dim = 3
+        mask = torch.tensor([0, 0, 1])  # only two distinct masks, but given dim is 3
+
+        with self.assertRaises(AssertionError):
+            BinaryConcreteStochasticGates(dim, mask=mask).to(self.testing_device)
+
+    def test_gates_values_matching_dim_when_eval(self) -> None:
+        dim = 3
+        bcstg = BinaryConcreteStochasticGates(dim).to(self.testing_device)
+        input_tensor = torch.tensor(
+            [
+                [0.0, 0.1, 0.2],
+                [0.3, 0.4, 0.5],
+            ]
+        ).to(self.testing_device)
+
+        bcstg.train(False)
+        gated_input, reg = bcstg(input_tensor)
+        assert gated_input.shape == input_tensor.shape
+
+    def test_bcstg_1d_input_with_mask(self) -> None:
+
+        dim = 2
+        mask = torch.tensor([0, 0, 1]).to(self.testing_device)
+        bcstg = BinaryConcreteStochasticGates(dim, mask=mask).to(self.testing_device)
+        input_tensor = torch.tensor(
+            [
+                [0.0, 0.1, 0.2],
+                [0.3, 0.4, 0.5],
+            ]
+        ).to(self.testing_device)
+
+        gated_input, reg = bcstg(input_tensor)
+        expected_reg = 0.8321
+
+        if self.testing_device == "cpu":
+            expected_gated_input = [[0.0000, 0.0000, 0.1679], [0.0000, 0.0000, 0.2223]]
+        elif self.testing_device == "cuda":
+            expected_gated_input = [[0.0000, 0.0000, 0.1971], [0.1737, 0.2317, 0.3888]]
+
+        assertTensorAlmostEqual(self, gated_input, expected_gated_input, mode="max")
+        assertTensorAlmostEqual(self, reg, expected_reg)
+
+    def test_bcstg_2d_input(self) -> None:
+
+        dim = 3 * 2
+        bcstg = BinaryConcreteStochasticGates(dim).to(self.testing_device)
+
+        # shape(2,3,2)
+        input_tensor = torch.tensor(
+            [
+                [
+                    [0.0, 0.1],
+                    [0.2, 0.3],
+                    [0.4, 0.5],
+                ],
+                [
+                    [0.6, 0.7],
+                    [0.8, 0.9],
+                    [1.0, 1.1],
+                ],
+            ]
+        ).to(self.testing_device)
+
+        gated_input, reg = bcstg(input_tensor)
+
+        expected_reg = 0.8317
+        if self.testing_device == "cpu":
+            expected_gated_input = [
+                [[0.0000, 0.0990], [0.0261, 0.2431], [0.0551, 0.3863]],
+                [[0.0476, 0.6177], [0.5400, 0.1530], [0.0984, 0.8013]],
+            ]
+        elif self.testing_device == "cuda":
+            expected_gated_input = [
+                [[0.0000, 0.0985], [0.1149, 0.2331], [0.0486, 0.5000]],
+                [[0.1840, 0.1571], [0.4612, 0.7937], [0.2975, 0.7393]],
+            ]
+
+        assertTensorAlmostEqual(self, gated_input, expected_gated_input, mode="max")
+        assertTensorAlmostEqual(self, reg, expected_reg)
+
+    def test_bcstg_2d_input_with_n_gates_error(self) -> None:
+
+        dim = 5
+        bcstg = BinaryConcreteStochasticGates(dim).to(self.testing_device)
+        input_tensor = torch.tensor(
+            [
+                [
+                    [0.0, 0.1],
+                    [0.2, 0.3],
+                    [0.4, 0.5],
+                ],
+            ]
+        ).to(self.testing_device)
+
+        with self.assertRaises(AssertionError):
+            bcstg(input_tensor)
+
+    def test_bcstg_2d_input_with_mask(self) -> None:
+
+        dim = 3
+        mask = torch.tensor(
+            [
+                [0, 1],
+                [1, 1],
+                [0, 2],
+            ]
+        ).to(self.testing_device)
+        bcstg = BinaryConcreteStochasticGates(dim, mask=mask).to(self.testing_device)
+
+        # shape(2,3,2)
+        input_tensor = torch.tensor(
+            [
+                [
+                    [0.0, 0.1],
+                    [0.2, 0.3],
+                    [0.4, 0.5],
+                ],
+                [
+                    [0.6, 0.7],
+                    [0.8, 0.9],
+                    [1.0, 1.1],
+                ],
+            ]
+        ).to(self.testing_device)
+
+        gated_input, reg = bcstg(input_tensor)
+        expected_reg = 0.8316
+
+        if self.testing_device == "cpu":
+            expected_gated_input = [
+                [[0.0000, 0.0212], [0.0424, 0.0636], [0.3191, 0.4730]],
+                [[0.3678, 0.6568], [0.7507, 0.8445], [0.6130, 1.0861]],
+            ]
+        elif self.testing_device == "cuda":
+            expected_gated_input = [
+                [[0.0000, 0.0985], [0.1971, 0.2956], [0.0000, 0.2872]],
+                [[0.4658, 0.0870], [0.0994, 0.1119], [0.7764, 1.1000]],
+            ]
+
+        assertTensorAlmostEqual(self, gated_input, expected_gated_input, mode="max")
+        assertTensorAlmostEqual(self, reg, expected_reg)
+
+    def test_get_gate_values_1d_input(self) -> None:
+
+        dim = 3
+        bcstg = BinaryConcreteStochasticGates(dim).to(self.testing_device)
+        input_tensor = torch.tensor(
+            [
+                [0.0, 0.1, 0.2],
+                [0.3, 0.4, 0.5],
+            ]
+        ).to(self.testing_device)
+
+        bcstg(input_tensor)
+        gate_values = bcstg.get_gate_values()
+
+        expected_gate_values = [0.5001, 0.5012, 0.4970]
+
+        assertTensorAlmostEqual(self, gate_values, expected_gate_values, mode="max")
+
+    def test_get_gate_values_1d_input_with_mask(self) -> None:
+
+        dim = 2
+        mask = torch.tensor([0, 1, 1])
+        bcstg = BinaryConcreteStochasticGates(dim, mask=mask).to(self.testing_device)
+        input_tensor = torch.tensor(
+            [
+                [0.0, 0.1, 0.2],
+                [0.3, 0.4, 0.5],
+            ]
+        ).to(self.testing_device)
+
+        bcstg(input_tensor)
+        gate_values = bcstg.get_gate_values()
+
+        expected_gate_values = [0.5001, 0.5012]
+
+        assertTensorAlmostEqual(self, gate_values, expected_gate_values, mode="max")
+
+    def test_get_gate_values_2d_input(self) -> None:
+
+        dim = 3 * 2
+        bcstg = BinaryConcreteStochasticGates(dim).to(self.testing_device)
+
+        # shape(2,3,2)
+        input_tensor = torch.tensor(
+            [
+                [
+                    [0.0, 0.1],
+                    [0.2, 0.3],
+                    [0.4, 0.5],
+                ],
+                [
+                    [0.6, 0.7],
+                    [0.8, 0.9],
+                    [1.0, 1.1],
+                ],
+            ]
+        ).to(self.testing_device)
+
+        bcstg(input_tensor)
+        gate_values = bcstg.get_gate_values()
+
+        expected_gate_values = [0.5001, 0.5012, 0.4970, 0.5007, 0.4982, 0.5015]
+
+        assertTensorAlmostEqual(self, gate_values, expected_gate_values, mode="max")
+
+    def test_get_gate_values_2d_input_with_mask(self) -> None:
+
+        dim = 3
+        mask = torch.tensor(
+            [
+                [0, 1],
+                [1, 1],
+                [0, 2],
+            ]
+        )
+        bcstg = BinaryConcreteStochasticGates(dim, mask=mask).to(self.testing_device)
+
+        input_tensor = torch.tensor(
+            [
+                [
+                    [0.0, 0.1],
+                    [0.2, 0.3],
+                    [0.4, 0.5],
+                ],
+                [
+                    [0.6, 0.7],
+                    [0.8, 0.9],
+                    [1.0, 1.1],
+                ],
+            ]
+        ).to(self.testing_device)
+
+        bcstg(input_tensor)
+        gate_values = bcstg.get_gate_values()
+
+        expected_gate_values = [0.5001, 0.5012, 0.4970]
+
+        assertTensorAlmostEqual(self, gate_values, expected_gate_values, mode="max")
+
+    def test_get_gate_active_probs_1d_input(self) -> None:
+
+        dim = 3
+        bcstg = BinaryConcreteStochasticGates(dim).to(self.testing_device)
+        input_tensor = torch.tensor(
+            [
+                [0.0, 0.1, 0.2],
+                [0.3, 0.4, 0.5],
+            ]
+        ).to(self.testing_device)
+
+        bcstg(input_tensor)
+        gate_active_probs = bcstg.get_gate_active_probs()
+
+        expected_gate_active_probs = [0.8319, 0.8324, 0.8304]
+
+        assertTensorAlmostEqual(
+            self, gate_active_probs, expected_gate_active_probs, mode="max"
+        )
+
+    def test_get_gate_active_probs_1d_input_with_mask(self) -> None:
+
+        dim = 2
+        mask = torch.tensor([0, 1, 1])
+        bcstg = BinaryConcreteStochasticGates(dim, mask=mask).to(self.testing_device)
+        input_tensor = torch.tensor(
+            [
+                [0.0, 0.1, 0.2],
+                [0.3, 0.4, 0.5],
+            ]
+        ).to(self.testing_device)
+
+        bcstg(input_tensor)
+        gate_active_probs = bcstg.get_gate_active_probs()
+
+        expected_gate_active_probs = [0.8319, 0.8324]
+
+        assertTensorAlmostEqual(
+            self, gate_active_probs, expected_gate_active_probs, mode="max"
+        )
+
+    def test_get_gate_active_probs_2d_input(self) -> None:
+
+        dim = 3 * 2
+        bcstg = BinaryConcreteStochasticGates(dim).to(self.testing_device)
+
+        # shape(2,3,2)
+        input_tensor = torch.tensor(
+            [
+                [
+                    [0.0, 0.1],
+                    [0.2, 0.3],
+                    [0.4, 0.5],
+                ],
+                [
+                    [0.6, 0.7],
+                    [0.8, 0.9],
+                    [1.0, 1.1],
+                ],
+            ]
+        ).to(self.testing_device)
+
+        bcstg(input_tensor)
+        gate_active_probs = bcstg.get_gate_active_probs()
+
+        expected_gate_active_probs = [0.8319, 0.8324, 0.8304, 0.8321, 0.8310, 0.8325]
+
+        assertTensorAlmostEqual(
+            self, gate_active_probs, expected_gate_active_probs, mode="max"
+        )
+
+    def test_get_gate_active_probs_2d_input_with_mask(self) -> None:
+
+        dim = 3
+        mask = torch.tensor(
+            [
+                [0, 1],
+                [1, 1],
+                [0, 2],
+            ]
+        )
+        bcstg = BinaryConcreteStochasticGates(dim, mask=mask).to(self.testing_device)
+
+        input_tensor = torch.tensor(
+            [
+                [
+                    [0.0, 0.1],
+                    [0.2, 0.3],
+                    [0.4, 0.5],
+                ],
+                [
+                    [0.6, 0.7],
+                    [0.8, 0.9],
+                    [1.0, 1.1],
+                ],
+            ]
+        ).to(self.testing_device)
+
+        bcstg(input_tensor)
+        gate_active_probs = bcstg.get_gate_active_probs()
+
+        expected_gate_active_probs = [0.8319, 0.8324, 0.8304]
+
+        assertTensorAlmostEqual(
+            self, gate_active_probs, expected_gate_active_probs, mode="max"
+        )

--- a/tests/module/test_gaussian_stochastic_gates.py
+++ b/tests/module/test_gaussian_stochastic_gates.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env fbpython
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import unittest
+
+import torch
+from captum.module.gaussian_stochastic_gates import GaussianStochasticGates
+from parameterized import parameterized_class
+from tests.helpers.basic import assertTensorAlmostEqual, BaseTest
+
+
+@parameterized_class(
+    [
+        {"testing_device": "cpu"},
+        {"testing_device": "cuda"},
+    ]
+)
+class TestGaussianStochasticGates(BaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        if self.testing_device == "cuda" and not torch.cuda.is_available():
+            raise unittest.SkipTest("Skipping GPU test since CUDA not available.")
+
+    def test_gstg_1d_input(self) -> None:
+
+        dim = 3
+        gstg = GaussianStochasticGates(dim).to(self.testing_device)
+        input_tensor = torch.tensor(
+            [
+                [0.0, 0.1, 0.2],
+                [0.3, 0.4, 0.5],
+            ]
+        ).to(self.testing_device)
+
+        gated_input, reg = gstg(input_tensor)
+        expected_reg = 0.8404
+
+        if self.testing_device == "cpu":
+            expected_gated_input = [[0.0000, 0.0198, 0.1483], [0.1848, 0.3402, 0.1782]]
+        elif self.testing_device == "cuda":
+            expected_gated_input = [[0.0000, 0.0788, 0.0470], [0.0134, 0.0000, 0.1884]]
+
+        assertTensorAlmostEqual(self, gated_input, expected_gated_input, mode="max")
+        assertTensorAlmostEqual(self, reg, expected_reg)
+
+    def test_gstg_1d_input_with_n_gates_error(self) -> None:
+
+        dim = 3
+        gstg = GaussianStochasticGates(dim).to(self.testing_device)
+        input_tensor = torch.tensor([0.0, 0.1, 0.2]).to(self.testing_device)
+
+        with self.assertRaises(AssertionError):
+            gstg(input_tensor)
+
+    def test_gstg_1d_input_with_mask(self) -> None:
+
+        dim = 2
+        mask = torch.tensor([0, 0, 1]).to(self.testing_device)
+        gstg = GaussianStochasticGates(dim, mask=mask).to(self.testing_device)
+        input_tensor = torch.tensor(
+            [
+                [0.0, 0.1, 0.2],
+                [0.3, 0.4, 0.5],
+            ]
+        ).to(self.testing_device)
+
+        gated_input, reg = gstg(input_tensor)
+        expected_reg = 0.8424
+
+        if self.testing_device == "cpu":
+            expected_gated_input = [[0.0000, 0.0000, 0.1225], [0.0583, 0.0777, 0.3779]]
+        elif self.testing_device == "cuda":
+            expected_gated_input = [[0.0000, 0.0000, 0.1577], [0.0736, 0.0981, 0.0242]]
+
+        assertTensorAlmostEqual(self, gated_input, expected_gated_input, mode="max")
+        assertTensorAlmostEqual(self, reg, expected_reg)
+
+    def test_gates_values_matching_dim_when_eval(self) -> None:
+        dim = 3
+        gstg = GaussianStochasticGates(dim).to(self.testing_device)
+        input_tensor = torch.tensor(
+            [
+                [0.0, 0.1, 0.2],
+                [0.3, 0.4, 0.5],
+            ]
+        ).to(self.testing_device)
+
+        gstg.train(False)
+        gated_input, reg = gstg(input_tensor)
+        assert gated_input.shape == input_tensor.shape
+
+    def test_gstg_2d_input(self) -> None:
+
+        dim = 3 * 2
+        gstg = GaussianStochasticGates(dim).to(self.testing_device)
+
+        # shape(2,3,2)
+        input_tensor = torch.tensor(
+            [
+                [
+                    [0.0, 0.1],
+                    [0.2, 0.3],
+                    [0.4, 0.5],
+                ],
+                [
+                    [0.6, 0.7],
+                    [0.8, 0.9],
+                    [1.0, 1.1],
+                ],
+            ]
+        ).to(self.testing_device)
+
+        gated_input, reg = gstg(input_tensor)
+        expected_reg = 0.8410
+
+        if self.testing_device == "cpu":
+            expected_gated_input = [
+                [[0.0000, 0.0851], [0.0713, 0.3000], [0.2180, 0.1878]],
+                [[0.2538, 0.0000], [0.3391, 0.8501], [0.3633, 0.8913]],
+            ]
+        elif self.testing_device == "cuda":
+            expected_gated_input = [
+                [[0.0000, 0.0788], [0.0470, 0.0139], [0.0000, 0.1960]],
+                [[0.0000, 0.7000], [0.1052, 0.2120], [0.5978, 0.0166]],
+            ]
+
+        assertTensorAlmostEqual(self, gated_input, expected_gated_input, mode="max")
+        assertTensorAlmostEqual(self, reg, expected_reg)
+
+    def test_gstg_2d_input_with_n_gates_error(self) -> None:
+
+        dim = 5
+        gstg = GaussianStochasticGates(dim).to(self.testing_device)
+        input_tensor = torch.tensor(
+            [
+                [
+                    [0.0, 0.1],
+                    [0.2, 0.3],
+                    [0.4, 0.5],
+                ],
+            ]
+        ).to(self.testing_device)
+
+        with self.assertRaises(AssertionError):
+            gstg(input_tensor)
+
+    def test_gstg_2d_input_with_mask(self) -> None:
+
+        dim = 3
+        mask = torch.tensor(
+            [
+                [0, 1],
+                [1, 1],
+                [0, 2],
+            ]
+        ).to(self.testing_device)
+        gstg = GaussianStochasticGates(dim, mask=mask).to(self.testing_device)
+
+        # shape(2,3,2)
+        input_tensor = torch.tensor(
+            [
+                [
+                    [0.0, 0.1],
+                    [0.2, 0.3],
+                    [0.4, 0.5],
+                ],
+                [
+                    [0.6, 0.7],
+                    [0.8, 0.9],
+                    [1.0, 1.1],
+                ],
+            ]
+        ).to(self.testing_device)
+
+        gated_input, reg = gstg(input_tensor)
+        expected_reg = 0.8404
+
+        if self.testing_device == "cpu":
+            expected_gated_input = [
+                [[0.0000, 0.0198], [0.0396, 0.0594], [0.2435, 0.3708]],
+                [[0.3696, 0.5954], [0.6805, 0.7655], [0.6159, 0.3921]],
+            ]
+        elif self.testing_device == "cuda":
+            expected_gated_input = [
+                [[0.0000, 0.0788], [0.1577, 0.2365], [0.0000, 0.1174]],
+                [[0.0269, 0.0000], [0.0000, 0.0000], [0.0448, 0.4145]],
+            ]
+
+        assertTensorAlmostEqual(self, gated_input, expected_gated_input, mode="max")
+        assertTensorAlmostEqual(self, reg, expected_reg)
+
+    def test_get_gate_values_1d_input(self) -> None:
+
+        dim = 3
+        gstg = GaussianStochasticGates(dim).to(self.testing_device)
+        input_tensor = torch.tensor(
+            [
+                [0.0, 0.1, 0.2],
+                [0.3, 0.4, 0.5],
+            ]
+        ).to(self.testing_device)
+
+        gstg(input_tensor)
+        gate_values = gstg.get_gate_values()
+
+        expected_gate_values = [0.5005, 0.5040, 0.4899]
+        assertTensorAlmostEqual(self, gate_values, expected_gate_values, mode="max")
+
+    def test_get_gate_values_1d_input_with_mask(self) -> None:
+
+        dim = 2
+        mask = torch.tensor([0, 1, 1])
+        gstg = GaussianStochasticGates(dim, mask=mask).to(self.testing_device)
+        input_tensor = torch.tensor(
+            [
+                [0.0, 0.1, 0.2],
+                [0.3, 0.4, 0.5],
+            ]
+        ).to(self.testing_device)
+
+        gstg(input_tensor)
+        gate_values = gstg.get_gate_values()
+
+        expected_gate_values = [0.5005, 0.5040]
+        assertTensorAlmostEqual(self, gate_values, expected_gate_values, mode="max")
+
+    def test_get_gate_values_2d_input(self) -> None:
+
+        dim = 3 * 2
+        gstg = GaussianStochasticGates(dim).to(self.testing_device)
+
+        # shape(2,3,2)
+        input_tensor = torch.tensor(
+            [
+                [
+                    [0.0, 0.1],
+                    [0.2, 0.3],
+                    [0.4, 0.5],
+                ],
+                [
+                    [0.6, 0.7],
+                    [0.8, 0.9],
+                    [1.0, 1.1],
+                ],
+            ]
+        ).to(self.testing_device)
+
+        gstg(input_tensor)
+        gate_values = gstg.get_gate_values()
+
+        expected_gate_values = [0.5005, 0.5040, 0.4899, 0.5022, 0.4939, 0.5050]
+        assertTensorAlmostEqual(self, gate_values, expected_gate_values, mode="max")
+
+    def test_get_gate_values_2d_input_with_mask(self) -> None:
+
+        dim = 3
+        mask = torch.tensor(
+            [
+                [0, 1],
+                [1, 1],
+                [0, 2],
+            ]
+        )
+        gstg = GaussianStochasticGates(dim, mask=mask).to(self.testing_device)
+
+        input_tensor = torch.tensor(
+            [
+                [
+                    [0.0, 0.1],
+                    [0.2, 0.3],
+                    [0.4, 0.5],
+                ],
+                [
+                    [0.6, 0.7],
+                    [0.8, 0.9],
+                    [1.0, 1.1],
+                ],
+            ]
+        ).to(self.testing_device)
+
+        gstg(input_tensor)
+        gate_values = gstg.get_gate_values()
+
+        expected_gate_values = [0.5005, 0.5040, 0.4899]
+        assertTensorAlmostEqual(self, gate_values, expected_gate_values, mode="max")
+
+    def test_get_gate_active_probs_1d_input(self) -> None:
+
+        dim = 3
+        gstg = GaussianStochasticGates(dim).to(self.testing_device)
+        input_tensor = torch.tensor(
+            [
+                [0.0, 0.1, 0.2],
+                [0.3, 0.4, 0.5],
+            ]
+        ).to(self.testing_device)
+
+        gstg(input_tensor)
+        gate_active_probs = gstg.get_gate_active_probs()
+
+        expected_gate_active_probs = [0.8416, 0.8433, 0.8364]
+        assertTensorAlmostEqual(
+            self, gate_active_probs, expected_gate_active_probs, mode="max"
+        )
+
+    def test_get_gate_active_probs_1d_input_with_mask(self) -> None:
+
+        dim = 2
+        mask = torch.tensor([0, 1, 1])
+        gstg = GaussianStochasticGates(dim, mask=mask).to(self.testing_device)
+        input_tensor = torch.tensor(
+            [
+                [0.0, 0.1, 0.2],
+                [0.3, 0.4, 0.5],
+            ]
+        ).to(self.testing_device)
+
+        gstg(input_tensor)
+        gate_active_probs = gstg.get_gate_active_probs()
+
+        expected_gate_active_probs = [0.8416, 0.8433]
+
+        assertTensorAlmostEqual(
+            self, gate_active_probs, expected_gate_active_probs, mode="max"
+        )
+
+    def test_get_gate_active_probs_2d_input(self) -> None:
+
+        dim = 3 * 2
+        gstg = GaussianStochasticGates(dim).to(self.testing_device)
+
+        # shape(2,3,2)
+        input_tensor = torch.tensor(
+            [
+                [
+                    [0.0, 0.1],
+                    [0.2, 0.3],
+                    [0.4, 0.5],
+                ],
+                [
+                    [0.6, 0.7],
+                    [0.8, 0.9],
+                    [1.0, 1.1],
+                ],
+            ]
+        ).to(self.testing_device)
+
+        gstg(input_tensor)
+        gate_active_probs = gstg.get_gate_active_probs()
+
+        expected_gate_active_probs = [0.8416, 0.8433, 0.8364, 0.8424, 0.8384, 0.8438]
+
+        assertTensorAlmostEqual(
+            self, gate_active_probs, expected_gate_active_probs, mode="max"
+        )
+
+    def test_get_gate_active_probs_2d_input_with_mask(self) -> None:
+
+        dim = 3
+        mask = torch.tensor(
+            [
+                [0, 1],
+                [1, 1],
+                [0, 2],
+            ]
+        )
+        gstg = GaussianStochasticGates(dim, mask=mask).to(self.testing_device)
+
+        input_tensor = torch.tensor(
+            [
+                [
+                    [0.0, 0.1],
+                    [0.2, 0.3],
+                    [0.4, 0.5],
+                ],
+                [
+                    [0.6, 0.7],
+                    [0.8, 0.9],
+                    [1.0, 1.1],
+                ],
+            ]
+        ).to(self.testing_device)
+
+        gstg(input_tensor)
+        gate_active_probs = gstg.get_gate_active_probs()
+
+        expected_gate_active_probs = [0.8416, 0.8433, 0.8364]
+
+        assertTensorAlmostEqual(
+            self, gate_active_probs, expected_gate_active_probs, mode="max"
+        )


### PR DESCRIPTION
Summary: move STGBase, BinaryConcreteSTG and GaussianSTG to path `captum/module`

Reviewed By: vivekmig

Differential Revision: D41000738

