### PR TITLE
make clamp optional in STG's get_gate_values

### DIFF
--- a/captum/module/binary_concrete_stochastic_gates.py
+++ b/captum/module/binary_concrete_stochastic_gates.py
@@ -166,7 +166,8 @@ class BinaryConcreteStochasticGates(StochasticGatesBase):
 
     def _get_gate_values(self) -> Tensor:
         """
-        Get the gate values derived from learned log_alpha_param after model is trained
+        Get the raw gate values, which are the means of the underneath gate
+        distributions, derived from learned log_alpha_param
 
         Returns:
             gate_values (Tensor): value of each gate after model is trained
@@ -175,7 +176,7 @@ class BinaryConcreteStochasticGates(StochasticGatesBase):
             torch.sigmoid(self.log_alpha_param) * (self.upper_bound - self.lower_bound)
             + self.lower_bound
         )
-        return torch.clamp(gate_values, min=0, max=1)
+        return gate_values
 
     def _get_gate_active_probs(self) -> Tensor:
         """

--- a/captum/module/gaussian_stochastic_gates.py
+++ b/captum/module/gaussian_stochastic_gates.py
@@ -103,12 +103,13 @@ class GaussianStochasticGates(StochasticGatesBase):
 
     def _get_gate_values(self) -> Tensor:
         """
-        Get the gate values derived from learned mu after model is trained
+        Get the raw gate values, which are the means of the underneath gate
+        distributions, the learned mu
 
         Returns:
             gate_values (Tensor): value of each gate after model is trained
         """
-        return torch.clamp(self.mu, min=0, max=1)
+        return self.mu
 
     def _get_gate_active_probs(self) -> Tensor:
         """

--- a/tests/module/test_binary_concrete_stochastic_gates.py
+++ b/tests/module/test_binary_concrete_stochastic_gates.py
@@ -260,6 +260,25 @@ class TestBinaryConcreteStochasticGates(BaseTest):
 
         assertTensorAlmostEqual(self, gate_values, expected_gate_values, mode="max")
 
+    def test_get_gate_values_clamp(self) -> None:
+        dim = 3
+        # enlarge the bounds & extremify log_alpha to mock gate  values beyond 0 & 1
+        bcstg = BinaryConcreteStochasticGates(dim, lower_bound=-2, upper_bound=2).to(
+            self.testing_device
+        )
+        mocked_log_alpha = torch.tensor([10.0, -10.0, 10.0])
+        bcstg.load_state_dict({"log_alpha_param": mocked_log_alpha})
+
+        clamped_gate_values = bcstg.get_gate_values().cpu().tolist()
+        assert clamped_gate_values == [1.0, 0.0, 1.0]
+
+        unclamped_gate_values = bcstg.get_gate_values(clamp=False).cpu().tolist()
+        assert (
+            unclamped_gate_values[0] > 1
+            and unclamped_gate_values[1] < 0
+            and unclamped_gate_values[2] > 1
+        )
+
     def test_get_gate_values_2d_input_with_mask(self) -> None:
 
         dim = 3

--- a/tests/module/test_gaussian_stochastic_gates.py
+++ b/tests/module/test_gaussian_stochastic_gates.py
@@ -284,6 +284,23 @@ class TestGaussianStochasticGates(BaseTest):
         expected_gate_values = [0.5005, 0.5040, 0.4899]
         assertTensorAlmostEqual(self, gate_values, expected_gate_values, mode="max")
 
+    def test_get_gate_values_clamp(self) -> None:
+        dim = 3
+
+        gstg = GaussianStochasticGates(dim).to(self.testing_device)
+        mocked_mu = torch.tensor([2.0, -2.0, 2.0])
+        gstg.load_state_dict({"mu": mocked_mu})
+
+        clamped_gate_values = gstg.get_gate_values().cpu().tolist()
+        assert clamped_gate_values == [1.0, 0.0, 1.0]
+
+        unclamped_gate_values = gstg.get_gate_values(clamp=False).cpu().tolist()
+        assert (
+            unclamped_gate_values[0] > 1
+            and unclamped_gate_values[1] < 0
+            and unclamped_gate_values[2] > 1
+        )
+
     def test_get_gate_active_probs_1d_input(self) -> None:
 
         dim = 3


### PR DESCRIPTION
Summary:
add a flag in `get_gate_values` indicating if clamping the gate values. As smoothed Bernoulli variables, gate values are clamped withn 0 and 1 by defautl.

But turning this off to get the raw means of the underneath distribution (e.g., conrete, gaussian) can be useful to differentiate the gates' relative importance when multiple gate values are beyond 0 or 1.

Reviewed By: cyrjano

Differential Revision: D41013197

