### PR TITLE
improve error msg of invalid input types

### DIFF
--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -177,7 +177,8 @@ def _format_tensor_into_tuples(
     if not isinstance(inputs, tuple):
         assert isinstance(
             inputs, torch.Tensor
-        ), "`inputs` must have type " "torch.Tensor but {} found: ".format(type(inputs))
+        ), "`inputs` must be a torch.Tensor or a tuple[torch.Tensor] " \
+            f"but found: {type(inputs)}"
         inputs = (inputs,)
     return inputs
 

--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -175,10 +175,10 @@ def _format_tensor_into_tuples(
     if inputs is None:
         return None
     if not isinstance(inputs, tuple):
-        assert isinstance(
-            inputs, torch.Tensor
-        ), "`inputs` must be a torch.Tensor or a tuple[torch.Tensor] " \
+        assert isinstance(inputs, torch.Tensor), (
+            "`inputs` must be a torch.Tensor or a tuple[torch.Tensor] "
             f"but found: {type(inputs)}"
+        )
         inputs = (inputs,)
     return inputs
 


### PR DESCRIPTION
Discussed in https://github.com/pytorch/captum/pull/1077#issuecomment-1329668409 , improving the error message of invalid `inputs` to tell the two types we allow: `Tensor` and `tuple[Tensor]`