### PR TITLE
let tracincp aggregate influence

### DIFF
--- a/captum/influence/_utils/common.py
+++ b/captum/influence/_utils/common.py
@@ -188,7 +188,7 @@ def _load_flexible_state_dict(model: Module, path: str) -> float:
 def _get_k_most_influential_helper(
     influence_src_dataloader: DataLoader,
     influence_batch_fn: Callable,
-    inputs: Tuple[Any, ...],
+    inputs: Any,
     k: int = 5,
     proponents: bool = True,
     show_progress: bool = False,
@@ -205,10 +205,10 @@ def _get_k_most_influential_helper(
         influence_batch_fn (Callable): A callable that will be called via
                 `influence_batch_fn(inputs, batch)`, where `batch` is a batch
                 in the `influence_src_dataloader` argument.
-        inputs (tuple[Any, ...]): This argument represents the test batch, and is a
-                single tuple of any, where the last element is assumed to be the labels
-                for the batch. That is, `model(*batch[0:-1])` produces the output for
-                `model`, and `batch[-1]` are the labels, if any.
+        inputs (any): This argument represents the test batch, and can be of any type.
+                It is passed as the first argument to `influence_batch_fn`, and thus
+                needs to be compatible with it. It is not necessarily the test batch
+                itself, but can be some quantity derived from it, i.e. its jacobians.
         k (int, optional): The number of proponents or opponents to return per test
                 instance.
                 Default: 5

--- a/tests/influence/_core/test_tracin_aggregate_influence.py
+++ b/tests/influence/_core/test_tracin_aggregate_influence.py
@@ -1,0 +1,147 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import tempfile
+from typing import Callable
+
+import torch
+
+import torch.nn as nn
+from captum.influence._core.tracincp import TracInCP
+from parameterized import parameterized
+from tests.helpers.basic import assertTensorAlmostEqual, BaseTest
+from tests.influence._utils.common import (
+    build_test_name_func,
+    DataInfluenceConstructor,
+    get_random_model_and_data,
+)
+from torch.utils.data import DataLoader
+
+
+class TestTracInAggregateInfluence(BaseTest):
+    @parameterized.expand(
+        [
+            (reduction, constructor, unpack_inputs)
+            for unpack_inputs in [True, False]
+            for (reduction, constructor) in [
+                ("none", DataInfluenceConstructor(TracInCP)),
+                (
+                    "sum",
+                    DataInfluenceConstructor(
+                        TracInCP, sample_wise_grads_per_batch=True
+                    ),
+                ),
+            ]
+        ],
+        name_func=build_test_name_func(),
+    )
+    def test_tracin_aggregate_influence(
+        self, reduction: str, tracin_constructor: Callable, unpack_inputs: bool
+    ) -> None:
+        """
+        tests that calling `influence` with `aggregate=True`
+        does give the same result as calling it with `aggregate=False`, and then
+        summing
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (net, train_dataset,) = get_random_model_and_data(
+                tmpdir,
+                unpack_inputs,
+                return_test_data=False,
+            )
+
+            # create a dataloader that yields batches from the dataset
+            train_dataset = DataLoader(train_dataset, batch_size=5)
+
+            # create tracin instance
+            criterion = nn.MSELoss(reduction=reduction)
+            batch_size = 5
+
+            tracin = tracin_constructor(
+                net,
+                train_dataset,
+                tmpdir,
+                batch_size,
+                criterion,
+            )
+
+            train_scores = tracin.influence(train_dataset, aggregate=False)
+            aggregated_train_scores = tracin.influence(train_dataset, aggregate=True)
+
+            assertTensorAlmostEqual(
+                self,
+                torch.sum(train_scores, dim=0, keepdim=True),
+                aggregated_train_scores,
+                delta=1e-3,  # due to numerical issues, we can't set this to 0.0
+                mode="max",
+            )
+
+    @parameterized.expand(
+        [
+            (reduction, constructor, unpack_inputs)
+            for unpack_inputs in [True, False]
+            for (reduction, constructor) in [
+                ("none", DataInfluenceConstructor(TracInCP)),
+                (
+                    "sum",
+                    DataInfluenceConstructor(
+                        TracInCP, sample_wise_grads_per_batch=True
+                    ),
+                ),
+            ]
+        ],
+        name_func=build_test_name_func(),
+    )
+    def test_tracin_aggregate_influence_api(
+        self, reduction: str, tracin_constructor: Callable, unpack_inputs: bool
+    ) -> None:
+        """
+        tests that the result of calling the public method
+        `influence` when `aggregate` is true for a DataLoader of batches is the same as
+        when the batches are collated into a single batch
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (net, train_dataset,) = get_random_model_and_data(
+                tmpdir,
+                unpack_inputs,
+                return_test_data=False,
+            )
+
+            # create a single batch representing the entire dataset
+            single_batch = next(
+                iter(DataLoader(train_dataset, batch_size=len(train_dataset)))
+            )
+
+            # create a dataloader that yields batches from the dataset
+            dataloader = DataLoader(train_dataset, batch_size=5)
+
+            # create tracin instance
+            criterion = nn.MSELoss(reduction=reduction)
+            batch_size = 5
+            tracin = tracin_constructor(
+                net,
+                train_dataset,
+                tmpdir,
+                batch_size,
+                criterion,
+            )
+
+            # compute influence scores using `influence`
+            # when passing in a single batch
+            single_batch_aggregated_train_scores = tracin.influence(
+                single_batch, aggregate=True
+            )
+
+            # compute influence scores using `influence`
+            # when passing in a dataloader with the same examples
+            dataloader_aggregated_train_scores = tracin.influence(
+                dataloader, aggregate=True
+            )
+
+            # the two influence scores should be equal
+            assertTensorAlmostEqual(
+                self,
+                single_batch_aggregated_train_scores,
+                dataloader_aggregated_train_scores,
+                delta=0.01,  # due to numerical issues, we can't set this to 0.0
+                mode="max",
+            )

--- a/tests/influence/_core/test_tracin_k_most_influential.py
+++ b/tests/influence/_core/test_tracin_k_most_influential.py
@@ -28,12 +28,20 @@ class TestTracInGetKMostInfluential(BaseTest):
         for unpack_inputs in [True, False]:
             for proponents in [True, False]:
                 for use_gpu in use_gpu_list:
-                    for reduction, constr in [
+                    for (reduction, constr, aggregate) in [
                         (
                             "none",
                             DataInfluenceConstructor(
                                 TracInCP, name="TracInCP_all_layers"
                             ),
+                            False,
+                        ),
+                        (
+                            "none",
+                            DataInfluenceConstructor(
+                                TracInCP, name="TracInCP_all_layers"
+                            ),
+                            True,
                         ),
                         (
                             "none",
@@ -42,6 +50,7 @@ class TestTracInGetKMostInfluential(BaseTest):
                                 name="linear2",
                                 layers=["module.linear2"] if use_gpu else ["linear2"],
                             ),
+                            False,
                         ),
                     ]:
                         if not (
@@ -58,6 +67,7 @@ class TestTracInGetKMostInfluential(BaseTest):
                                     batch_size,
                                     k,
                                     use_gpu,
+                                    aggregate,
                                 )
                             )
 
@@ -74,6 +84,7 @@ class TestTracInGetKMostInfluential(BaseTest):
         batch_size: int,
         k: int,
         use_gpu: bool,
+        aggregate: bool,
     ) -> None:
         """
         This test constructs a random BasicLinearNet, and checks that the proponents
@@ -110,12 +121,14 @@ class TestTracInGetKMostInfluential(BaseTest):
             train_scores = tracin.influence(
                 _format_batch_into_tuple(test_samples, test_labels, unpack_inputs),
                 k=None,
+                aggregate=aggregate,
             )
             sort_idx = torch.argsort(train_scores, dim=1, descending=proponents)[:, 0:k]
             idx, _train_scores = tracin.influence(
                 _format_batch_into_tuple(test_samples, test_labels, unpack_inputs),
                 k=k,
                 proponents=proponents,
+                aggregate=aggregate,
             )
             for i in range(len(idx)):
                 # check that idx[i] is correct


### PR DESCRIPTION
Summary:
This diff adds an "aggregate" option to `TracInCP.influence`. The "aggregate" influence score of a training example on a test dataset is the sum of the influence of the training example on all examples in the test dataset. When `aggregate` is True, `influence` in influence score mode returns a 2D tensor of shape (1, training dataset size) containing aggregate influence scores of all training examples.  When `aggregate` is True, `influence` in k most influential mode returns a 2D tensor of shape (1, k) of proponents (or opponents), and a 2D tensor containing the corresponding aggregate influence scores, of the same shape.

This option is only added for `TracInCP`, because for it, aggregate influence can be computed more quickly than naively computing the influence score of all training examples on all test examples, and then summing across test examples. In particular, we can first sum the jacobians across all test examples, and then take the dot-product of the sum with the jacobians of training examples.  (all this is done across checkpoints).

Since computing aggregate influence scores is efficient, even if the test dataset is large, we now allow `inputs` for `influence` to be a dataloader, so that it does not need to fit in memory.

One use case of aggregate influence is to compute the influence of a training example on some validation metric, i.e. fairness metric.

We add the following tests:
- in newly added `test_tracin_aggregate_influence`, `test_tracin_aggregate_influence` tests that calling `influence` with `aggregate=True`does give the same result as calling it with `aggregate=False`, and then summing.
- in newly added `test_tracin_aggregate_influence`, `test_tracin_aggregate_influence_api` tests that the result of calling `influence` when `aggregate` is true for a DataLoader of batches is the same as when the batches are collated into a single batch.
- in `test_tracin_k_most_influential`, we modify the test to allow `aggregate` to be true, which tests that the proponents computed with the memory saving approach by `influence` are the same proponents computed via calculating all aggregate influence scores, and then sorting (not memory efficient).ar

Differential Revision: D41830245

