### PR TITLE
check ufmt before flake8 in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,8 +141,8 @@ jobs:
     steps:
       - checkout
       - pip_install
-      - lint_flake8
       - ufmt_check
+      - lint_flake8
       - sphinx
 
   test_py36_pip:


### PR DESCRIPTION
`ufmt` (`black + usort`) overlaps with many rules of `flake8`. 
`ufmt` can automatically fix many violations given by `flake8`. So we should screen if any errors can be auto fixed by `ufmt` at first to avoid wasting people's time. And only show the rest `flake8` errors that require manual fixes.