### PR TITLE
Clean install_via_conda

### DIFF
--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -48,9 +48,9 @@ conda install -y -c conda-forge matplotlib pytest-cov mypy flask flask-compress
 # pip install sphinxcontrib-katex
 
 # install node/yarn for insights build
-conda install -y -c conda-forge yarn
+# conda install -y -c conda-forge yarn
 # nodejs should be last, otherwise other conda packages will downgrade node
-conda install -y --no-channel-priority -c conda-forge nodejs=14
+# conda install -y --no-channel-priority -c conda-forge nodejs=14
 
 # build insights and install captum
 # BUILD_INSIGHTS=1 python setup.py develop

--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -39,18 +39,8 @@ else
 fi
 
 # install other deps
-# conda install -y numpy sphinx pytest flake8 ipywidgets ipython scikit-learn parameterized
-# conda install -y -c conda-forge matplotlib pytest-cov sphinx-autodoc-typehints mypy flask flask-compress
-conda install -y pytest flake8 ipywidgets ipython scikit-learn parameterized
-conda install -y -c conda-forge matplotlib pytest-cov mypy flask flask-compress
-
-# deps not available in conda
-# pip install sphinxcontrib-katex
-
-# install node/yarn for insights build
-# conda install -y -c conda-forge yarn
-# nodejs should be last, otherwise other conda packages will downgrade node
-# conda install -y --no-channel-priority -c conda-forge nodejs=14
+conda install -y pytest ipywidgets ipython scikit-learn parameterized
+conda install -y -c conda-forge matplotlib pytest-cov flask flask-compress
 
 # build insights and install captum
-# BUILD_INSIGHTS=1 python setup.py develop
+python setup.py develop

--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -53,4 +53,4 @@ conda install -y -c conda-forge yarn
 conda install -y --no-channel-priority -c conda-forge nodejs=14
 
 # build insights and install captum
-BUILD_INSIGHTS=1 python setup.py develop
+# BUILD_INSIGHTS=1 python setup.py develop

--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -40,7 +40,7 @@ fi
 
 # install other deps
 conda install -y pytest ipywidgets ipython scikit-learn parameterized
-conda install -y -c conda-forge matplotlib pytest-cov
+conda install -y -c conda-forge matplotlib pytest-cov flask flask-compress
 
 # install captum
 python setup.py develop

--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -40,7 +40,7 @@ fi
 
 # install other deps
 conda install -y pytest ipywidgets ipython scikit-learn parameterized
-conda install -y -c conda-forge matplotlib pytest-cov flask flask-compress
+conda install -y -c conda-forge matplotlib pytest-cov
 
-# build insights and install captum
+# install captum
 python setup.py develop


### PR DESCRIPTION
Circle CI job `test_conda` is failing because of some missing dependencies, like
```
E   ImportError: libtiff.so.5: cannot open shared object file: No such file or directory
```

The cause is that when we install `nodejs`  through conda, it will upgrade some packages, like
```
> conda install -y --no-channel-priority -c conda-forge nodejs=14

...
libtiff                                  4.3.0-hf544144_1 --> 4.5.0-h82bc61c_0
```
The newer version is not be compatible with some python packages.

Downgrade those incompatible packages will fix the issue. But I made this PR to just drop the installations of `nodejs` and `yarn`  (and some other unused packages like `mypy` `flake8`). Also stop building `captum-insight`

I feel `nodejs` & `yarn` are used for building the website and Insight's frontend. However, this script is only used in for CircleCI's conda testing, which does not execute anything related to Insight frontend or build website, so it safe to remove them. 

(I am not sure why we include them in the 1st place. Let me know if I missed some use cases of this script)