### PR TITLE
Quiet conda install & remove conda solver

### DIFF
--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -22,8 +22,8 @@ conda update -q --all --yes
 conda install -qy conda-build
 
 # Use faster conda solver
-conda install -q -n base conda-libmamba-solver
-conda config --set solver libmamba
+# conda install -q -n base conda-libmamba-solver
+# conda config --set solver libmamba
 
 # install other frameworks if asked for and make sure this is before pytorch
 if [[ $FRAMEWORKS == true ]]; then

--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -16,31 +16,31 @@ while getopts 'nf' flag; do
 # update conda
 # removing due to setuptools error during update
 #conda update -y -n base -c defaults conda
-conda update --all --yes
+conda update -q --all --yes
 
 # required to use conda develop
-conda install -y conda-build
+conda install -qy conda-build
 
 # Use faster conda solver
-conda install -n base conda-libmamba-solver
+conda install -q -n base conda-libmamba-solver
 conda config --set solver libmamba
 
 # install other frameworks if asked for and make sure this is before pytorch
 if [[ $FRAMEWORKS == true ]]; then
-  pip install pytext-nlp
+  pip install -q pytext-nlp
 fi
 
 if [[ $PYTORCH_NIGHTLY == true ]]; then
   # install CPU version for much smaller download
-  conda install -y pytorch cpuonly -c pytorch-nightly
+  conda install -q -y pytorch cpuonly -c pytorch-nightly
 else
  # install CPU version for much smaller download
- conda install -y -c pytorch pytorch-cpu
+ conda install -q -y -c pytorch pytorch-cpu
 fi
 
 # install other deps
-conda install -y pytest ipywidgets ipython scikit-learn parameterized
-conda install -y -c conda-forge matplotlib pytest-cov flask flask-compress
+conda install -q -y pytest ipywidgets ipython scikit-learn parameterized
+conda install -q -y -c conda-forge matplotlib pytest-cov flask flask-compress
 
 # install captum
 python setup.py develop

--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -19,7 +19,7 @@ while getopts 'nf' flag; do
 conda update -q --all --yes
 
 # required to use conda develop
-conda install -qy conda-build
+conda install -q -y conda-build
 
 # install other frameworks if asked for and make sure this is before pytorch
 if [[ $FRAMEWORKS == true ]]; then

--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -21,10 +21,6 @@ conda update -q --all --yes
 # required to use conda develop
 conda install -qy conda-build
 
-# Use faster conda solver
-# conda install -q -n base conda-libmamba-solver
-# conda config --set solver libmamba
-
 # install other frameworks if asked for and make sure this is before pytorch
 if [[ $FRAMEWORKS == true ]]; then
   pip install -q pytext-nlp


### PR DESCRIPTION
Fix the failed conda ci job which is caused by the dependencies conflicts of libmamba-solver
- remove the libmamba-solver and use the default solver instead

Also "quietly" execute `conda install` to disable progressbar, which pollutes the CircleCI logs