### PR TITLE
remove `clone` in `_compute_jacobian_wrt_params_with_sample_wise_trick`

### DIFF
--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -837,8 +837,6 @@ def _compute_jacobian_wrt_params_with_sample_wise_trick(
                 parameters of the i-th layer, for the j-th member of the minibatch.
     """
     with torch.autograd.set_grad_enabled(True):
-        inputs = tuple(inp.clone() for inp in inputs)
-        apply_gradient_requirements(inputs)
         sample_grad_wrapper = SampleGradientWrapper(model, layer_modules)
         try:
             sample_grad_wrapper.add_hooks()


### PR DESCRIPTION
Summary:
In https://www.internalfb.com/code/fbsource/[76c57d350097]/fbcode/pytorch/captum/captum/_utils/gradient.py?lines=840-841 we are calling `clone` on the elements of `inputs`.  However, since `inputs` is of type `Tuple[Any,...]`, those elements may not be Tensors, and thus may not have the clone method.
My understanding is that we call `clone` because in `apply_gradient_requirements`, we change `requires_grad=True` for all elements of `inputs`.  Even if those elements were Tensors, this would not be necessary, because in this function we seek gradients wrt to *parameters* of the model, and `inputs` refers to inputs to the model.  Furthermore, since `inputs` is not a tuple of tensors, it is not actually possible to call `apply_gradient_requirements` on `inputs`.

Also see discussion at https://www.internalfb.com/diff/D41687791 (https://github.com/pytorch/captum/commit/288cd3a6754d85cbcb0ce74784aa014876284b6c)?dst_version_fbid=1539905103125262&transaction_fbid=587574556076948

In summary, because `inputs` is of type `Tuple[Any,...]` and not `Tuple[Tensor,...]`, it does not make sense to call `clone` on the elements of `inputs`, nor call `apply_gradient_requirements(inputs)`.  And furthermore, we do not actually need to call the latter, because `inputs` is not parameters.  Thus, this diff simply removes those 2 calls.

Differential Revision: D43135296

