### PR TITLE
Update Documentation to Refer to model instead of forward_func

### DIFF
--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -155,9 +155,9 @@ class DeepLift(GradientAttribution):
         Args:
 
             inputs (Tensor or tuple[Tensor, ...]): Input for which
-                        attributions are computed. If forward_func takes a single
+                        attributions are computed. If model takes a single
                         tensor as input, a single input tensor should be provided.
-                        If forward_func takes multiple tensors as input, a tuple
+                        If model takes multiple tensors as input, a tuple
                         of the input tensors should be provided. It is assumed
                         that for all given input tensors, dimension 0 corresponds
                         to the number of examples (aka batch size), and if
@@ -227,7 +227,7 @@ class DeepLift(GradientAttribution):
                         argument of a Tensor or arbitrary (non-tuple) type or a tuple
                         containing multiple additional arguments including tensors
                         or any arbitrary python types. These arguments are provided to
-                        forward_func in order, following the arguments in inputs.
+                        model in order, following the arguments in inputs.
                         Note that attributions are not computed with respect
                         to these arguments.
                         Default: None
@@ -267,7 +267,7 @@ class DeepLift(GradientAttribution):
                 corresponding sized tensors is returned.
             - **delta** (*Tensor*, returned if return_convergence_delta=True):
                 This is computed using the property that
-                the total sum of forward_func(inputs) - forward_func(baselines)
+                the total sum of model(inputs) - model(baselines)
                 must equal the total sum of the attributions computed
                 based on DeepLift's rescale rule.
                 Delta is calculated per example, meaning that the number of
@@ -627,9 +627,9 @@ class DeepLiftShap(DeepLift):
         Args:
 
             inputs (Tensor or tuple[Tensor, ...]): Input for which
-                        attributions are computed. If forward_func takes a single
+                        attributions are computed. If model takes a single
                         tensor as input, a single input tensor should be provided.
-                        If forward_func takes multiple tensors as input, a tuple
+                        If model takes multiple tensors as input, a tuple
                         of the input tensors should be provided. It is assumed
                         that for all given input tensors, dimension 0 corresponds
                         to the number of examples (aka batch size), and if
@@ -692,7 +692,7 @@ class DeepLiftShap(DeepLift):
                         argument of a Tensor or arbitrary (non-tuple) type or a tuple
                         containing multiple additional arguments including tensors
                         or any arbitrary python types. These arguments are provided to
-                        forward_func in order, following the arguments in inputs.
+                        model in order, following the arguments in inputs.
                         Note that attributions are not computed with respect
                         to these arguments.
                         Default: None
@@ -731,7 +731,7 @@ class DeepLiftShap(DeepLift):
                         corresponding sized tensors is returned.
             - **delta** (*Tensor*, returned if return_convergence_delta=True):
                         This is computed using the property that the
-                        total sum of forward_func(inputs) - forward_func(baselines)
+                        total sum of model(inputs) - model(baselines)
                         must be very close to the total sum of attributions
                         computed based on approximated SHAP values using
                         Deeplift's rescale rule.

--- a/captum/attr/_core/guided_backprop_deconvnet.py
+++ b/captum/attr/_core/guided_backprop_deconvnet.py
@@ -138,9 +138,9 @@ class GuidedBackprop(ModifiedReluGradientAttribution):
         Args:
 
             inputs (Tensor or tuple[Tensor, ...]): Input for which
-                        attributions are computed. If forward_func takes a single
+                        attributions are computed. If model takes a single
                         tensor as input, a single input tensor should be provided.
-                        If forward_func takes multiple tensors as input, a tuple
+                        If model takes multiple tensors as input, a tuple
                         of the input tensors should be provided. It is assumed
                         that for all given input tensors, dimension 0 corresponds
                         to the number of examples (aka batch size), and if
@@ -178,7 +178,7 @@ class GuidedBackprop(ModifiedReluGradientAttribution):
                         argument of a Tensor or arbitrary (non-tuple) type or a tuple
                         containing multiple additional arguments including tensors
                         or any arbitrary python types. These arguments are provided to
-                        forward_func in order, following the arguments in inputs.
+                        model in order, following the arguments in inputs.
                         Note that attributions are not computed with respect
                         to these arguments.
                         Default: None
@@ -247,9 +247,9 @@ class Deconvolution(ModifiedReluGradientAttribution):
         Args:
 
             inputs (Tensor or tuple[Tensor, ...]): Input for which
-                        attributions are computed. If forward_func takes a single
+                        attributions are computed. If model takes a single
                         tensor as input, a single input tensor should be provided.
-                        If forward_func takes multiple tensors as input, a tuple
+                        If model takes multiple tensors as input, a tuple
                         of the input tensors should be provided. It is assumed
                         that for all given input tensors, dimension 0 corresponds
                         to the number of examples (aka batch size), and if
@@ -287,7 +287,7 @@ class Deconvolution(ModifiedReluGradientAttribution):
                         argument of a Tensor or arbitrary (non-tuple) type or a tuple
                         containing multiple additional arguments including tensors
                         or any arbitrary python types. These arguments are provided to
-                        forward_func in order, following the arguments in inputs.
+                        model in order, following the arguments in inputs.
                         Note that attributions are not computed with respect
                         to these arguments.
                         Default: None

--- a/captum/attr/_core/guided_grad_cam.py
+++ b/captum/attr/_core/guided_grad_cam.py
@@ -55,10 +55,10 @@ class GuidedGradCam(GradientAttribution):
             layer (torch.nn.Module): Layer for which GradCAM attributions are computed.
                           Currently, only layers with a single tensor output are
                           supported.
-            device_ids (list[int]): Device ID list, necessary only if forward_func
-                          applies a DataParallel model. This allows reconstruction of
+            device_ids (list[int]): Device ID list, necessary only if model
+                          is a DataParallel model. This allows reconstruction of
                           intermediate outputs from batched results across devices.
-                          If forward_func is given as the DataParallel model itself,
+                          If model is given as the DataParallel model itself,
                           then it is not necessary to provide this argument.
         """
         GradientAttribution.__init__(self, model)
@@ -78,9 +78,9 @@ class GuidedGradCam(GradientAttribution):
         Args:
 
             inputs (Tensor or tuple[Tensor, ...]): Input for which attributions
-                        are computed. If forward_func takes a single
+                        are computed. If model takes a single
                         tensor as input, a single input tensor should be provided.
-                        If forward_func takes multiple tensors as input, a tuple
+                        If model takes multiple tensors as input, a tuple
                         of the input tensors should be provided. It is assumed
                         that for all given input tensors, dimension 0 corresponds
                         to the number of examples, and if multiple input tensors
@@ -117,7 +117,7 @@ class GuidedGradCam(GradientAttribution):
                         argument of a Tensor or arbitrary (non-tuple) type or a
                         tuple containing multiple additional arguments including
                         tensors or any arbitrary python types. These arguments
-                        are provided to forward_func in order following the
+                        are provided to model in order following the
                         arguments in inputs.
                         Note that attributions are not computed with respect
                         to these arguments.

--- a/captum/attr/_core/layer/layer_deep_lift.py
+++ b/captum/attr/_core/layer/layer_deep_lift.py
@@ -142,9 +142,9 @@ class LayerDeepLift(LayerAttribution, DeepLift):
         Args:
 
             inputs (Tensor or tuple[Tensor, ...]): Input for which layer
-                        attributions are computed. If forward_func takes a
+                        attributions are computed. If model takes a
                         single tensor as input, a single input tensor should be
-                        provided. If forward_func takes multiple tensors as input,
+                        provided. If model takes multiple tensors as input,
                         a tuple of the input tensors should be provided. It is
                         assumed that for all given input tensors, dimension 0
                         corresponds to the number of examples (aka batch size),
@@ -214,7 +214,7 @@ class LayerDeepLift(LayerAttribution, DeepLift):
                         argument of a Tensor or arbitrary (non-tuple) type or a tuple
                         containing multiple additional arguments including tensors
                         or any arbitrary python types. These arguments are provided to
-                        forward_func in order, following the arguments in inputs.
+                        model in order, following the arguments in inputs.
                         Note that attributions are not computed with respect
                         to these arguments.
                         Default: None
@@ -264,7 +264,7 @@ class LayerDeepLift(LayerAttribution, DeepLift):
                 of tensors is returned.
             - **delta** (*Tensor*, returned if return_convergence_delta=True):
                 This is computed using the property that the total sum of
-                forward_func(inputs) - forward_func(baselines) must equal the
+                model(inputs) - model(baselines) must equal the
                 total sum of the attributions computed based on DeepLift's
                 rescale rule.
                 Delta is calculated per example, meaning that the number of
@@ -477,9 +477,9 @@ class LayerDeepLiftShap(LayerDeepLift, DeepLiftShap):
         Args:
 
             inputs (Tensor or tuple[Tensor, ...]): Input for which layer
-                        attributions are computed. If forward_func takes a single
+                        attributions are computed. If model takes a single
                         tensor as input, a single input tensor should be provided.
-                        If forward_func takes multiple tensors as input, a tuple
+                        If model takes multiple tensors as input, a tuple
                         of the input tensors should be provided. It is assumed
                         that for all given input tensors, dimension 0 corresponds
                         to the number of examples (aka batch size), and if
@@ -542,7 +542,7 @@ class LayerDeepLiftShap(LayerDeepLift, DeepLiftShap):
                         argument of a Tensor or arbitrary (non-tuple) type or a tuple
                         containing multiple additional arguments including tensors
                         or any arbitrary python types. These arguments are provided to
-                        forward_func in order, following the arguments in inputs.
+                        model in order, following the arguments in inputs.
                         Note that attributions are not computed with respect
                         to these arguments.
                         Default: None
@@ -594,7 +594,7 @@ class LayerDeepLiftShap(LayerDeepLift, DeepLiftShap):
                         outputs of a single tensor are not.
             - **delta** (*Tensor*, returned if return_convergence_delta=True):
                         This is computed using the property that the
-                        total sum of forward_func(inputs) - forward_func(baselines)
+                        total sum of model(inputs) - model(baselines)
                         must be very close to the total sum of attributions
                         computed based on approximated SHAP values using
                         DeepLift's rescale rule.

--- a/captum/attr/_core/layer/layer_lrp.py
+++ b/captum/attr/_core/layer/layer_lrp.py
@@ -110,9 +110,9 @@ class LayerLRP(LRP, LayerAttribution):
 
             inputs (Tensor or tuple[Tensor, ...]): Input for which relevance is
                         propagated.
-                        If forward_func takes a single
+                        If model takes a single
                         tensor as input, a single input tensor should be provided.
-                        If forward_func takes multiple tensors as input, a tuple
+                        If model takes multiple tensors as input, a tuple
                         of the input tensors should be provided. It is assumed
                         that for all given input tensors, dimension 0 corresponds
                         to the number of examples, and if multiple input tensors
@@ -149,7 +149,7 @@ class LayerLRP(LRP, LayerAttribution):
                     argument of a Tensor or arbitrary (non-tuple) type or a tuple
                     containing multiple additional arguments including tensors
                     or any arbitrary python types. These arguments are provided to
-                    forward_func in order, following the arguments in inputs.
+                    model in order, following the arguments in inputs.
                     Note that attributions are not computed with respect
                     to these arguments.
                     Default: None

--- a/captum/attr/_core/lrp.py
+++ b/captum/attr/_core/lrp.py
@@ -97,9 +97,9 @@ class LRP(GradientAttribution):
         Args:
 
             inputs (Tensor or tuple[Tensor, ...]): Input for which relevance is
-                        propagated. If forward_func takes a single
+                        propagated. If model takes a single
                         tensor as input, a single input tensor should be provided.
-                        If forward_func takes multiple tensors as input, a tuple
+                        If model takes multiple tensors as input, a tuple
                         of the input tensors should be provided. It is assumed
                         that for all given input tensors, dimension 0 corresponds
                         to the number of examples, and if multiple input tensors
@@ -137,7 +137,7 @@ class LRP(GradientAttribution):
                     argument of a Tensor or arbitrary (non-tuple) type or a tuple
                     containing multiple additional arguments including tensors
                     or any arbitrary python types. These arguments are provided to
-                    forward_func in order, following the arguments in inputs.
+                    model in order, following the arguments in inputs.
                     Note that attributions are not computed with respect
                     to these arguments.
                     Default: None

--- a/captum/attr/_core/neuron/neuron_deep_lift.py
+++ b/captum/attr/_core/neuron/neuron_deep_lift.py
@@ -87,9 +87,9 @@ class NeuronDeepLift(NeuronAttribution, GradientAttribution):
         Args:
 
             inputs (Tensor or tuple[Tensor, ...]): Input for which layer
-                        attributions are computed. If forward_func takes a
+                        attributions are computed. If model takes a
                         single tensor as input, a single input tensor should be
-                        provided. If forward_func takes multiple tensors as input,
+                        provided. If model takes multiple tensors as input,
                         a tuple of the input tensors should be provided. It is
                         assumed that for all given input tensors, dimension 0
                         corresponds to the number of examples (aka batch size),
@@ -168,7 +168,7 @@ class NeuronDeepLift(NeuronAttribution, GradientAttribution):
                         argument of a Tensor or arbitrary (non-tuple) type or a tuple
                         containing multiple additional arguments including tensors
                         or any arbitrary python types. These arguments are provided
-                        to forward_func in order, following the arguments in inputs.
+                        to model in order, following the arguments in inputs.
                         Note that attributions are not computed with respect
                         to these arguments.
                         Default: None
@@ -318,9 +318,9 @@ class NeuronDeepLiftShap(NeuronAttribution, GradientAttribution):
         Args:
 
             inputs (Tensor or tuple[Tensor, ...]): Input for which layer
-                        attributions are computed. If forward_func takes a
+                        attributions are computed. If model takes a
                         single tensor as input, a single input tensor should be
-                        provided. If forward_func takes multiple tensors as input,
+                        provided. If model takes multiple tensors as input,
                         a tuple of the input tensors should be provided. It is
                         assumed that for all given input tensors, dimension 0
                         corresponds to the number of examples (aka batch size),
@@ -392,7 +392,7 @@ class NeuronDeepLiftShap(NeuronAttribution, GradientAttribution):
                         argument of a Tensor or arbitrary (non-tuple) type or a tuple
                         containing multiple additional arguments including tensors
                         or any arbitrary python types. These arguments are provided
-                        to forward_func in order, following the arguments in inputs.
+                        to model in order, following the arguments in inputs.
                         Note that attributions are not computed with respect
                         to these arguments.
                         Default: None

--- a/captum/attr/_core/neuron/neuron_guided_backprop_deconvnet.py
+++ b/captum/attr/_core/neuron/neuron_guided_backprop_deconvnet.py
@@ -44,10 +44,10 @@ class NeuronDeconvolution(NeuronAttribution, GradientAttribution):
                           Currently, it is assumed that the inputs or the outputs
                           of the layer, depending on which one is used for
                           attribution, can only be a single tensor.
-            device_ids (list[int]): Device ID list, necessary only if forward_func
+            device_ids (list[int]): Device ID list, necessary only if model
                           applies a DataParallel model. This allows reconstruction of
                           intermediate outputs from batched results across devices.
-                          If forward_func is given as the DataParallel model itself,
+                          If model is given as the DataParallel model itself,
                           then it is not necessary to provide this argument.
         """
         NeuronAttribution.__init__(self, model, layer, device_ids)
@@ -66,9 +66,9 @@ class NeuronDeconvolution(NeuronAttribution, GradientAttribution):
         Args:
 
             inputs (Tensor or tuple[Tensor, ...]): Input for which
-                        attributions are computed. If forward_func takes a single
+                        attributions are computed. If model takes a single
                         tensor as input, a single input tensor should be provided.
-                        If forward_func takes multiple tensors as input, a tuple
+                        If model takes multiple tensors as input, a tuple
                         of the input tensors should be provided. It is assumed
                         that for all given input tensors, dimension 0 corresponds
                         to the number of examples (aka batch size), and if
@@ -114,7 +114,7 @@ class NeuronDeconvolution(NeuronAttribution, GradientAttribution):
                         argument of a Tensor or arbitrary (non-tuple) type or a tuple
                         containing multiple additional arguments including tensors
                         or any arbitrary python types. These arguments are provided to
-                        forward_func in order, following the arguments in inputs.
+                        model in order, following the arguments in inputs.
                         Note that attributions are not computed with respect
                         to these arguments.
                         Default: None
@@ -198,10 +198,10 @@ class NeuronGuidedBackprop(NeuronAttribution, GradientAttribution):
                           in the attribute method.
                           Currently, only layers with a single tensor output are
                           supported.
-            device_ids (list[int]): Device ID list, necessary only if forward_func
+            device_ids (list[int]): Device ID list, necessary only if model
                           applies a DataParallel model. This allows reconstruction of
                           intermediate outputs from batched results across devices.
-                          If forward_func is given as the DataParallel model itself,
+                          If model is given as the DataParallel model itself,
                           then it is not necessary to provide this argument.
         """
         NeuronAttribution.__init__(self, model, layer, device_ids)
@@ -220,9 +220,9 @@ class NeuronGuidedBackprop(NeuronAttribution, GradientAttribution):
         Args:
 
             inputs (Tensor or tuple[Tensor, ...]): Input for which
-                        attributions are computed. If forward_func takes a single
+                        attributions are computed. If model takes a single
                         tensor as input, a single input tensor should be provided.
-                        If forward_func takes multiple tensors as input, a tuple
+                        If model takes multiple tensors as input, a tuple
                         of the input tensors should be provided. It is assumed
                         that for all given input tensors, dimension 0 corresponds
                         to the number of examples (aka batch size), and if
@@ -268,7 +268,7 @@ class NeuronGuidedBackprop(NeuronAttribution, GradientAttribution):
                         argument of a Tensor or arbitrary (non-tuple) type or a tuple
                         containing multiple additional arguments including tensors
                         or any arbitrary python types. These arguments are provided to
-                        forward_func in order, following the arguments in inputs.
+                        model in order, following the arguments in inputs.
                         Note that attributions are not computed with respect
                         to these arguments.
                         Default: None


### PR DESCRIPTION
Update documentation to refer to model instead of forward_func for methods which require access to the model and document constructor argument as model