### PR TITLE
Upgrade from Deprecated CircleCI Images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,8 @@ jobs:
 
   lint_py36:
     docker:
-      - image: circleci/python:3.6.8
+      - image: cimg
+      /python:3.6.8
     steps:
       - checkout
       - pip_install
@@ -147,7 +148,7 @@ jobs:
 
   test_py36_pip:
     docker:
-      - image: circleci/python:3.6.8
+      - image: cimg/python:3.6.8
     steps:
       - checkout
       - pip_install:
@@ -157,7 +158,7 @@ jobs:
 
   test_py36_pip_release:
     docker:
-      - image: circleci/python:3.6.8
+      - image: cimg/python:3.6.8
     steps:
       - checkout
       - pip_install
@@ -166,7 +167,7 @@ jobs:
 
   test_py36_pip_torch_1_6:
     docker:
-      - image: circleci/python:3.6.8
+      - image: cimg/python:3.6.8
     steps:
       - checkout
       - pip_install:
@@ -175,7 +176,7 @@ jobs:
 
   test_py36_pip_torch_1_7:
     docker:
-      - image: circleci/python:3.6.8
+      - image: cimg/python:3.6.8
     steps:
       - checkout
       - pip_install:
@@ -184,7 +185,7 @@ jobs:
 
   test_py36_pip_torch_1_8:
     docker:
-      - image: circleci/python:3.6.8
+      - image: cimg/python:3.6.8
     steps:
       - checkout
       - pip_install:
@@ -193,7 +194,7 @@ jobs:
 
   test_py36_pip_torch_1_9:
     docker:
-      - image: circleci/python:3.6.8
+      - image: cimg/python:3.6.8
     steps:
       - checkout
       - pip_install:
@@ -225,7 +226,7 @@ jobs:
 
   auto_deploy_site:
     docker:
-      - image: circleci/python:3.6.8-node
+      - image: cimg/python:3.6.8-node
     steps:
       - checkout
       - pip_install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,8 +137,7 @@ jobs:
 
   lint_py36:
     docker:
-      - image: cimg
-      /python:3.6.8
+      - image: cimg/python:3.6.8
     steps:
       - checkout
       - pip_install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
 
   lint_py36:
     docker:
-      - image: cimg/python:3.6.8
+      - image: cimg/python:3.6
     steps:
       - checkout
       - pip_install
@@ -147,7 +147,7 @@ jobs:
 
   test_py36_pip:
     docker:
-      - image: cimg/python:3.6.8
+      - image: cimg/python:3.6
     steps:
       - checkout
       - pip_install:
@@ -157,7 +157,7 @@ jobs:
 
   test_py36_pip_release:
     docker:
-      - image: cimg/python:3.6.8
+      - image: cimg/python:3.6
     steps:
       - checkout
       - pip_install
@@ -166,7 +166,7 @@ jobs:
 
   test_py36_pip_torch_1_6:
     docker:
-      - image: cimg/python:3.6.8
+      - image: cimg/python:3.6
     steps:
       - checkout
       - pip_install:
@@ -175,7 +175,7 @@ jobs:
 
   test_py36_pip_torch_1_7:
     docker:
-      - image: cimg/python:3.6.8
+      - image: cimg/python:3.6
     steps:
       - checkout
       - pip_install:
@@ -184,7 +184,7 @@ jobs:
 
   test_py36_pip_torch_1_8:
     docker:
-      - image: cimg/python:3.6.8
+      - image: cimg/python:3.6
     steps:
       - checkout
       - pip_install:
@@ -193,7 +193,7 @@ jobs:
 
   test_py36_pip_torch_1_9:
     docker:
-      - image: cimg/python:3.6.8
+      - image: cimg/python:3.6
     steps:
       - checkout
       - pip_install:
@@ -225,7 +225,7 @@ jobs:
 
   auto_deploy_site:
     docker:
-      - image: cimg/python:3.6.8-node
+      - image: cimg/python:3.6-node
     steps:
       - checkout
       - pip_install:

--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -34,36 +34,36 @@ sudo apt install yarn
 # yarn needs terminal info
 export TERM=xterm
 
-# NOTE: All of the below installs use sudo, b/c otherwise pip will get
+# NOTE: All of the below installs use sudo, b/c otherwise pip3 will get
 # permission errors installing in the docker container. An alternative would be
 # to use a virtualenv, but that would lead to bifurcation of the CircleCI config
 # since we'd need to source the environment in each step.
 
-# upgrade pip
-sudo pip install --upgrade pip
+# upgrade pip3
+sudo pip3 install --upgrade pip3
 
 # install captum with dev deps
-sudo pip install -e .[dev]
+sudo pip3 install -e .[dev]
 sudo BUILD_INSIGHTS=1 python setup.py develop
 
 # install other frameworks if asked for and make sure this is before pytorch
 if [[ $FRAMEWORKS == true ]]; then
-  sudo pip install pytext-nlp
+  sudo pip3 install pytext-nlp
 fi
 
 # install pytorch nightly if asked for
 if [[ $PYTORCH_NIGHTLY == true ]]; then
-  sudo pip install --upgrade --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+  sudo pip3 install --upgrade --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 else
   # If no version is specified, upgrade to the latest release.
   if [[ $CHOSEN_TORCH_VERSION == -1 ]]; then
-    sudo pip install --upgrade torch
+    sudo pip3 install --upgrade torch
   else
-    sudo pip install torch==$CHOSEN_TORCH_VERSION
+    sudo pip3 install torch==$CHOSEN_TORCH_VERSION
   fi
 fi
 
 # install deployment bits if asked for
 if [[ $DEPLOY == true ]]; then
-  sudo pip install beautifulsoup4 ipython nbconvert==5.6.1
+  sudo pip3 install beautifulsoup4 ipython nbconvert==5.6.1
 fi

--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -34,36 +34,31 @@ sudo apt install yarn
 # yarn needs terminal info
 export TERM=xterm
 
-# NOTE: All of the below installs use sudo, b/c otherwise pip3 will get
-# permission errors installing in the docker container. An alternative would be
-# to use a virtualenv, but that would lead to bifurcation of the CircleCI config
-# since we'd need to source the environment in each step.
-
-# upgrade pip3
-sudo pip3 install --upgrade pip3
+# upgrade pip
+pip install --upgrade pip
 
 # install captum with dev deps
-sudo pip3 install -e .[dev]
-sudo BUILD_INSIGHTS=1 python setup.py develop
+pip install -e .[dev]
+BUILD_INSIGHTS=1 python setup.py develop
 
 # install other frameworks if asked for and make sure this is before pytorch
 if [[ $FRAMEWORKS == true ]]; then
-  sudo pip3 install pytext-nlp
+  pip install pytext-nlp
 fi
 
 # install pytorch nightly if asked for
 if [[ $PYTORCH_NIGHTLY == true ]]; then
-  sudo pip3 install --upgrade --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+  pip install --upgrade --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 else
   # If no version is specified, upgrade to the latest release.
   if [[ $CHOSEN_TORCH_VERSION == -1 ]]; then
-    sudo pip3 install --upgrade torch
+    pip install --upgrade torch
   else
-    sudo pip3 install torch==$CHOSEN_TORCH_VERSION
+    pip install torch==$CHOSEN_TORCH_VERSION
   fi
 fi
 
 # install deployment bits if asked for
 if [[ $DEPLOY == true ]]; then
-  sudo pip3 install beautifulsoup4 ipython nbconvert==5.6.1
+  pip install beautifulsoup4 ipython nbconvert==5.6.1
 fi

--- a/tests/attr/test_gradient_shap.py
+++ b/tests/attr/test_gradient_shap.py
@@ -253,7 +253,7 @@ def _assert_attribution_delta(
     attributions: Union[Tensor, Tuple[Tensor, ...]],
     n_samples: int,
     delta: Tensor,
-    delta_thresh: Tensor = 0.0006,
+    delta_thresh: Union[float, Tensor] = 0.0006,
     is_layer: bool = False,
 ) -> None:
     if not is_layer:
@@ -269,7 +269,7 @@ def _assert_attribution_delta(
     _assert_delta(test, delta, delta_thresh)
 
 
-def _assert_delta(test: BaseTest, delta: Tensor, delta_thresh: Tensor = 0.0006) -> None:
+def _assert_delta(test: BaseTest, delta: Tensor, delta_thresh: Union[Tensor, float] = 0.0006) -> None:
     delta_condition = (delta.abs() < delta_thresh).all()
     test.assertTrue(
         delta_condition,

--- a/tests/attr/test_gradient_shap.py
+++ b/tests/attr/test_gradient_shap.py
@@ -269,7 +269,9 @@ def _assert_attribution_delta(
     _assert_delta(test, delta, delta_thresh)
 
 
-def _assert_delta(test: BaseTest, delta: Tensor, delta_thresh: Union[Tensor, float] = 0.0006) -> None:
+def _assert_delta(
+    test: BaseTest, delta: Tensor, delta_thresh: Union[Tensor, float] = 0.0006
+) -> None:
     delta_condition = (delta.abs() < delta_thresh).all()
     test.assertTrue(
         delta_condition,


### PR DESCRIPTION
Current images used (e.g. circleci/python3.6.8) seem to be deprecated and causing current test failures. Migrating to new machine images (cimg/python3.6.8). 

This also required updating pip calls to not use sudo due to changes to python virtualenv setup (see https://github.com/CircleCI-Public/cimg-python/issues/112 for more details).

Minor fixes to test_gradient_shap added to resolve mypy failures.