### PR TITLE
check the length in assertTensorTuplesAlmostEqual test when expected is tuple

### DIFF
--- a/tests/helpers/basic.py
+++ b/tests/helpers/basic.py
@@ -59,6 +59,8 @@ def assertTensorAlmostEqual(test, actual, expected, delta=0.0001, mode="sum"):
 
 def assertTensorTuplesAlmostEqual(test, actual, expected, delta=0.0001, mode="sum"):
     if isinstance(expected, tuple):
+        assert len(actual) == len(expected)
+
         for i in range(len(expected)):
             assertTensorAlmostEqual(test, actual[i], expected[i], delta, mode)
     else:


### PR DESCRIPTION
Summary:
When `expected` is a tuple in `assertTensorhenTuplesAlmostEqual`, check if the `actual` has the same size before iterating the elements.

It should also check if `actual` is a tuple, but the existing code has heavily abused this func to compare `tensor` vs `tuple`, `list` vs `tuple`. Have to leave the fix to the future.

Reviewed By: skim9

Differential Revision: D46307992

