### PR TITLE
add util get_max_feature_index

### DIFF
--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -764,3 +764,15 @@ def _register_backward_hook(
         module.register_forward_pre_hook(pre_hook),
         module.register_forward_hook(forward_hook),
     ]
+
+
+def _get_max_feature_index(feature_mask: Tuple[Tensor, ...]):
+    """
+    Returns the max feature mask index
+    The feature mask should be formatted to tuple of tensors at first.
+
+    Note: This util is commonly used to identify the number of features (max_index + 1),
+    as we expect user to be resposible to ensure consecutive feature mask indices from 0
+    """
+
+    return int(max(torch.max(mask).item() for mask in feature_mask if mask.numel()))

--- a/captum/attr/_core/lime.py
+++ b/captum/attr/_core/lime.py
@@ -12,6 +12,7 @@ from captum._utils.common import (
     _flatten_tensor_or_tuple,
     _format_output,
     _format_tensor_into_tuples,
+    _get_max_feature_index,
     _is_tuple,
     _reduce_list,
     _run_forward,
@@ -673,14 +674,7 @@ def construct_feature_mask(feature_mask, formatted_inputs):
                 single_mask - min_interp_features for single_mask in feature_mask
             )
 
-        num_interp_features = int(
-            max(
-                torch.max(single_mask).item()
-                for single_mask in feature_mask
-                if single_mask.numel()
-            )
-            + 1
-        )
+        num_interp_features = _get_max_feature_index(feature_mask) + 1
     return feature_mask, num_interp_features
 
 

--- a/captum/attr/_core/shapley_value.py
+++ b/captum/attr/_core/shapley_value.py
@@ -13,6 +13,7 @@ from captum._utils.common import (
     _format_feature_mask,
     _format_output,
     _format_tensor_into_tuples,
+    _get_max_feature_index,
     _is_tuple,
     _run_forward,
 )
@@ -287,9 +288,7 @@ class ShapleyValueSampling(PerturbationAttribution):
             baselines = _tensorize_baseline(inputs, baselines)
             num_examples = inputs[0].shape[0]
 
-            total_features = int(
-                max(torch.max(single_mask).item() for single_mask in feature_mask) + 1
-            )
+            total_features = _get_max_feature_index(feature_mask) + 1
 
             if show_progress:
                 attr_progress = progress(

--- a/tests/utils/test_common.py
+++ b/tests/utils/test_common.py
@@ -5,6 +5,7 @@ from typing import cast, List, Tuple
 import torch
 from captum._utils.common import (
     _format_feature_mask,
+    _get_max_feature_index,
     _parse_version,
     _reduce_list,
     _select_targets,
@@ -160,6 +161,16 @@ class Test(BaseTest):
 
         self.assertEqual(type(formatted_none_mask), tuple)
         assertTensorTuplesAlmostEqual(self, formatted_none_mask, expected_mask)
+
+    def test_get_max_feature_index(self) -> None:
+        mask = (
+            torch.tensor([[0, 1], [2, 3]]),
+            torch.tensor([]),
+            torch.tensor([[4, 5], [6, 100]]),
+            torch.tensor([[0, 1], [2, 3]]),
+        )
+
+        assert _get_max_feature_index(mask) == 100
 
 
 class TestParseVersion(BaseTest):


### PR DESCRIPTION
Summary: Add a util function to get the maximum feature mask index from given feature masks. The util is extracted from some existing attribution methods and is commonly used to identify the number of features.

Reviewed By: armarkos

Differential Revision: D46322222

