### PR TITLE
Correct default `method` argument for captum.attr.visualization.visualize_t…

### DIFF
--- a/captum/attr/_utils/visualization.py
+++ b/captum/attr/_utils/visualization.py
@@ -448,7 +448,7 @@ def visualize_timeseries_attr(
     attr: ndarray,
     data: ndarray,
     x_values: Optional[ndarray] = None,
-    method: str = "individual_channels",
+    method: str = "overlay_individual",
     sign: str = "absolute_value",
     channel_labels: Optional[List[str]] = None,
     channels_last: bool = True,


### PR DESCRIPTION
The default argument for `method` in `captum.attr.visualization.visualize_timeseries_attr` is currently `"individual_channels"`, which is not a valid option, resulting in an exception if used. This PR changes the default method to `"overlay_individual"`, which is what the docs indicate the default should be.