### PR TITLE
Implement TextTemplateInput

### DIFF
--- a/captum/attr/_utils/interpretable_input.py
+++ b/captum/attr/_utils/interpretable_input.py
@@ -1,6 +1,48 @@
-from typing import Any, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
+import torch
 from torch import Tensor
+
+
+def _scatter_itp_attr_by_mask(
+    itp_attr: Tensor,
+    input_shape: Tuple[int, ...],
+    mask: Tensor,
+) -> Tensor:
+    """
+    Scatter the attribution of the interpretable features to the model input shape
+    by mask, if the interpretable features are the mask groups of the raw
+    input elements,
+    """
+
+    # itp_attr in shape(*output_dims, n_itp_features)
+    output_dims = itp_attr.shape[:-1]
+    n_itp_features = itp_attr.shape[-1]
+
+    # input_shape in shape(batch_size, *inp_feature_dims)
+    # attribute in shape(*output_dims, *inp_feature_dims)
+    attr_shape = (*output_dims, *input_shape[1:])
+
+    expanded_feature_indices = mask.expand(attr_shape)
+
+    if len(input_shape) > 2:
+        # exclude batch_size & last of actual value
+        extra_inp_dims = list(input_shape[1:-1])
+
+        # unsqueeze itp_attr to have same number of dims as input
+        # (*output_dims, 1..., 1, n_itp_features)
+        # then broadcast to (*output_dims, *inp.shape[1:-1], n_itp_features)
+        n_extra_dims = len(extra_inp_dims)
+        unsqueezed_shape = (*output_dims, *(1,) * n_extra_dims, n_itp_features)
+        expanded_shape = (*output_dims, *extra_inp_dims, n_itp_features)
+        expanded_itp_attr = itp_attr.reshape(unsqueezed_shape).expand(expanded_shape)
+    else:
+        expanded_itp_attr = itp_attr
+
+    # gather from (*output_dims, *inp.shape[1:-1], n_itp_features)
+    attr = torch.gather(expanded_itp_attr, -1, expanded_feature_indices)
+
+    return attr
 
 
 class InterpretableInput:
@@ -12,7 +54,7 @@ class InterpretableInput:
     is not always true in practice. First, the model may take inputs of formats other
     than tensor that also require attributions. For example, a model with encapsulated
     tokenizer can directly take string as input. Second, what is considered as
-    an interpretable feature is always depended on the actual application and the user's
+    an interpretable feature always depends on the actual application and the user's
     desire. For example, the interpretable feature of an image tensor can either be
     each pixel or some segments. For text, users may see the entire string as one
     interpretable feature or view each word as one interpretable feature. This class
@@ -81,7 +123,7 @@ class InterpretableInput:
         """
         pass
 
-    def format_attr(self, itp_attr) -> Tensor:
+    def format_attr(self, itp_attr: Tensor) -> Tensor:
         """
         Format the attribution of the interpretable feature if needed.
         The way of formatting depends on the specific interpretable input type.
@@ -98,3 +140,166 @@ class InterpretableInput:
                 attr (Tensor): formatted attribution
         """
         return itp_attr
+
+
+class TextTemplateInput(InterpretableInput):
+    """
+    TextTemplateInput is an implementation of InterpretableInput for text inputs, whose
+    interpretable features are certain segments (e.g., words, phrases) of the text.
+    It takes a template string (or function) to define the feature segmentats
+    of the input text. Its input format to the model will be the completed text,
+    while its interpretable representation will be a binary tensor of the number of
+    the segment features whose values indicates if the feature is
+    “presence” or “absence”.
+
+    Args:
+
+        template (str or Callable): template string or function that takes
+                the text segments and format them into the text input for the model
+        values (List[str] or Dict[str, str]): the values of the segments. it is
+                the input to the template.
+        baselines (List[str] or Dict[str, str] or Callable or None, optional): the
+                baseline values for the segment features. If it is None, emptry string
+                will be used as the baseline.
+                Default: None
+        mask (List[int] or Dict[str, int] or None, optional): the mask to group the
+                segment features. It must be in the same format as the values
+                and assign each segment a mask index. Segments with the same
+                index will be seen as a single interpretable feature, which means
+                they must be perturbed together and end with same attributions.
+                Default: None
+
+    Examples::
+
+        >>> text_inp = TextTemplateInput(
+        >>>     template="{} feels {} right now",
+        >>>     values=["He", "depressed"],
+        >>>     baselines=["It", "neutral"],
+        >>> )
+        >>>
+        >>> text_inp.to_tensor()
+        >>> # torch.tensor([[1, 1]])
+        >>>
+        >>> text_inp.to_model_input(torch.tensor([[0, 1]]))
+        >>> # "It feels depressed right now"
+
+    """
+
+    def __init__(
+        self,
+        template: Union[str, Callable],
+        values: Union[List[str], Dict[str, str]],
+        baselines: Union[List[str], Dict[str, str], Callable, None] = None,
+        mask: Union[List[int], Dict[str, int], None] = None,
+    ):
+        # convert values dict to list
+        if isinstance(values, dict):
+            dict_keys = list(values.keys())
+            values = [values[k] for k in dict_keys]
+        else:
+            assert isinstance(
+                values, list
+            ), f"the values must be either a list or a dict, received: {type(values)}"
+            dict_keys = []
+
+        self.values = values
+        self.dict_keys = dict_keys
+
+        n_features = len(values)
+
+        if baselines is None:
+            # default baseline is to remove the element
+            baselines = [""] * len(values)
+        elif dict_keys:
+            assert isinstance(baselines, dict), (
+                "if values is dict, the baselines must also be a dict, "
+                f"received: {type(baselines)}"
+            )
+
+            # convert dict to list
+            baselines = [baselines[k] for k in self.dict_keys]
+
+        if mask is None:
+            n_itp_features = n_features
+        else:
+            if self.dict_keys:
+                assert isinstance(mask, dict), (
+                    "if values is dict, the mask must also be a dict, "
+                    f"received: {type(mask)}"
+                )
+
+                # convert dict to list
+                mask = [mask[k] for k in self.dict_keys]
+
+            mask_ids = set(mask)
+            mask_id_to_idx = {mid: i for i, mid in enumerate(mask_ids)}
+
+            # internal compressed mask of continuous interpretable indices from 0
+            # cannot replace original mask of ids for grouping across values externally
+            self.formatted_mask = [mask_id_to_idx[mid] for mid in mask]
+
+            n_itp_features = len(mask_ids)
+
+        # number of raw features and intepretable features
+        self.n_features = n_features
+        self.n_itp_features = n_itp_features
+
+        if isinstance(template, str):
+            template = template.format
+        else:
+            assert isinstance(template, Callable), (
+                "the template must be either a string or a callable, "
+                f"received: {type(template)}"
+            )
+            template = template
+        self.format_fn = template
+
+        self.baselines = baselines
+        self.mask = mask
+
+    def to_tensor(self) -> torch.Tensor:
+        # Interpretable representation in shape(1, n_itp_features)
+        return torch.tensor([[1.0] * self.n_itp_features])
+
+    def to_model_input(self, perturbed_tensor: Optional[Tensor] = None) -> str:
+        values = list(self.values)  # clone
+
+        if perturbed_tensor is not None:
+            baselines = self.baselines
+            if isinstance(baselines, Callable):
+                # a placeholder for advanced baselines
+                # TODO: support callable baselines
+                baselines = self.baselines()
+                if self.dict_keys:
+                    baselines = [baselines[k] for k in self.dict_keys]
+
+            for i in range(len(values)):
+                itp_idx = i
+                if self.mask:
+                    itp_idx = self.formatted_mask[i]
+
+                itp_val = perturbed_tensor[0][itp_idx]
+
+                if not itp_val:
+                    values[i] = baselines[i]
+
+        if self.dict_keys:
+            values = dict(zip(self.dict_keys, values))
+            input_str = self.format_fn(**values)
+        else:
+            input_str = self.format_fn(*values)
+
+        return input_str
+
+    def format_attr(self, itp_attr: torch.Tensor) -> torch.Tensor:
+        if self.mask is None:
+            return itp_attr
+
+        device = itp_attr.device
+
+        formatted_attr = _scatter_itp_attr_by_mask(
+            itp_attr,  # shape(*output_dims, n_itp_features)
+            (1, self.n_features),
+            torch.tensor([self.formatted_mask], device=device),
+        )
+        return formatted_attr

--- a/tests/attr/test_interpretable_input.py
+++ b/tests/attr/test_interpretable_input.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+import torch
+from captum.attr._utils.interpretable_input import TextTemplateInput
+from parameterized import parameterized
+from tests.helpers.basic import assertTensorAlmostEqual, BaseTest
+
+
+class TestTextTemplateInput(BaseTest):
+    @parameterized.expand(
+        [
+            ("{} b {} {} e {}", ["a", "c", "d", "f"]),
+            (
+                "{arg1} b {arg2} {arg3} e {arg4}",
+                {"arg1": "a", "arg2": "c", "arg3": "d", "arg4": "f"},
+            ),
+        ]
+    )
+    def test_input(self, template, inputs) -> None:
+        tt_input = TextTemplateInput(template, inputs)
+
+        expected_tensor = torch.tensor([[1.0] * 4])
+        assertTensorAlmostEqual(self, tt_input.to_tensor(), expected_tensor)
+
+        self.assertEqual(tt_input.to_model_input(), "a b c d e f")
+
+        perturbed_tensor = torch.tensor([[1.0, 0.0, 1.0, 0.0]])
+        self.assertEqual(tt_input.to_model_input(perturbed_tensor), "a b  d e ")
+
+    @parameterized.expand(
+        [
+            ("{} b {} {} e {}", ["a", "c", "d", "f"], ["w", "x", "y", "z"]),
+            (
+                "{arg1} b {arg2} {arg3} e {arg4}",
+                {"arg1": "a", "arg2": "c", "arg3": "d", "arg4": "f"},
+                {"arg1": "w", "arg2": "x", "arg3": "y", "arg4": "z"},
+            ),
+        ]
+    )
+    def test_input_with_baselines(self, template, inputs, baselines) -> None:
+        perturbed_tensor = torch.tensor([[1.0, 0.0, 1.0, 0.0]])
+
+        # single instance baselines
+        tt_input = TextTemplateInput(template, inputs, baselines=baselines)
+        self.assertEqual(tt_input.to_model_input(perturbed_tensor), "a b x d e z")
+
+    @parameterized.expand(
+        [
+            ("{} b {} {} e {}", ["a", "c", "d", "f"], [0, 1, 0, 1]),
+            (
+                "{arg1} b {arg2} {arg3} e {arg4}",
+                {"arg1": "a", "arg2": "c", "arg3": "d", "arg4": "f"},
+                {"arg1": 0, "arg2": 1, "arg3": 0, "arg4": 1},
+            ),
+        ]
+    )
+    def test_input_with_mask(self, template, inputs, mask) -> None:
+        tt_input = TextTemplateInput(template, inputs, mask=mask)
+
+        expected_tensor = torch.tensor([[1.0] * 2])
+        assertTensorAlmostEqual(self, tt_input.to_tensor(), expected_tensor)
+
+        self.assertEqual(tt_input.to_model_input(), "a b c d e f")
+
+        perturbed_tensor = torch.tensor([[1.0, 0.0]])
+        self.assertEqual(tt_input.to_model_input(perturbed_tensor), "a b  d e ")
+
+    @parameterized.expand(
+        [
+            ("{} b {} {} e {}", ["a", "c", "d", "f"], [0, 1, 0, 1]),
+            (
+                "{arg1} b {arg2} {arg3} e {arg4}",
+                {"arg1": "a", "arg2": "c", "arg3": "d", "arg4": "f"},
+                {"arg1": 0, "arg2": 1, "arg3": 0, "arg4": 1},
+            ),
+        ]
+    )
+    def test_format_attr(self, template, inputs, mask) -> None:
+        tt_input = TextTemplateInput(template, inputs, mask=mask)
+
+        attr = torch.tensor([[0.1, 0.2]])
+
+        assertTensorAlmostEqual(
+            self, tt_input.format_attr(attr), torch.tensor([[0.1, 0.2, 0.1, 0.2]])
+        )


### PR DESCRIPTION
Summary: implement `TextTemplateInput`, a child of `InterpretableInput` whose interpretable features are text components of a piece of text based on a formatting template

Differential Revision: D48486817

