### PR TITLE
Enable multi-task attribution for Shapley

### DIFF
--- a/captum/attr/_utils/common.py
+++ b/captum/attr/_utils/common.py
@@ -318,6 +318,7 @@ def _find_output_mode_and_verify(
     num_examples: int,
     perturbations_per_eval: int,
     feature_mask: Union[None, TensorOrTupleOfTensorsGeneric],
+    allow_multi_outputs: bool = False,
 ) -> bool:
     """
     This method identifies whether the model outputs a single output for a batch
@@ -346,9 +347,10 @@ def _find_output_mode_and_verify(
                 )
     else:
         agg_output_mode = False
-        assert (
-            isinstance(initial_eval, torch.Tensor) and initial_eval[0].numel() == 1
-        ), "Target should identify a single element in the model output."
+        if not allow_multi_outputs:
+            assert (
+                isinstance(initial_eval, torch.Tensor) and initial_eval[0].numel() == 1
+            ), "Target should identify a single element in the model output."
     return agg_output_mode
 
 

--- a/tests/attr/test_shapley.py
+++ b/tests/attr/test_shapley.py
@@ -151,6 +151,43 @@ class Test(BaseTest):
             perturbations_per_eval=(1, 2, 3),
         )
 
+    def test_shapley_sampling_multi_task_output(self) -> None:
+        # return shape (batch size, 2)
+        net1 = BasicModel_MultiLayer()
+
+        # return shape (batch size, 4)
+        def forward_func(*args, **kwargs):
+            net_output = net1(*args, **kwargs)
+            batch_size = net_output.size(0)
+            constant = torch.ones(batch_size, 2)
+            output = torch.cat(
+                [
+                    net_output,
+                    constant,
+                ],
+                dim=-1,
+            )
+            return output
+
+        inp = torch.tensor([[20.0, 50.0, 30.0]], requires_grad=True)
+
+        self._shapley_test_assert(
+            forward_func,
+            inp,
+            [
+                [
+                    [76.66666, 196.66666, 116.66666],
+                    [76.66666, 196.66666, 116.66666],
+                    [0, 0, 0],
+                    [0, 0, 0],
+                ]
+            ],
+            target=None,  # no target, multi-task output for all classes
+            perturbations_per_eval=(1, 2, 3),
+            n_samples=150,
+            test_true_shapley=True,
+        )
+
     # Remaining tests are for cases where forward function returns a scalar
     # per batch, as either a float, integer, 0d tensor or 1d tensor.
     def test_single_shapley_batch_scalar_float(self) -> None:


### PR DESCRIPTION
Summary:
Support multi-task attribution in `ShapleyValues` and `ShapleyValueSampling`.

Assuming the return of `forward_fun` is in (*output_shape), the attribution result will be in (*output_shape, *input_shape[1:]). Existing use cases becomes just special cases where output_shape is (1,) or (batch_size,)

Differential Revision: D48696578

