### PR TITLE
Add LLMAttribution

### DIFF
--- a/captum/attr/_core/llm_attr.py
+++ b/captum/attr/_core/llm_attr.py
@@ -1,0 +1,242 @@
+from copy import copy
+
+from typing import Callable, cast, Dict, List, Optional, Union
+
+import torch
+from captum.attr._core.feature_ablation import FeatureAblation
+from captum.attr._utils.attribution import Attribution
+from captum.attr._utils.interpretable_input import InterpretableInput, TextTemplateInput
+from torch import nn, Tensor
+
+
+SUPPORTED_METHODS = (FeatureAblation,)
+SUPPORTED_INPUTS = (TextTemplateInput,)
+
+DEFAULT_GEN_ARGS = {"max_new_tokens": 25, "do_sample": False}
+
+
+class LLMAttributionResult:
+    """
+    Data class for the return result of LLMAttribution,
+    which includes the necessary properties of the attribution.
+    It also provides utilities to help present and plot the result in different forms.
+    """
+
+    def __init__(
+        self,
+        seq_attr: Tensor,
+        token_attr: Tensor,
+        input_tokens: List[str],
+        output_tokens: List[str],
+    ):
+        self.seq_attr = seq_attr
+        self.token_attr = token_attr
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+
+    @property
+    def seq_attr_dict(self):
+        return {k: v for v, k in zip(self.seq_attr.cpu().tolist(), self.input_tokens)}
+
+    def plot_token_attr(self):
+        pass
+
+    def plot_seq_attr(self):
+        pass
+
+
+class LLMAttribution(Attribution):
+    """
+    Attribution class for large language models. It wraps a perturbation-based
+    attribution algorthm to produce commonly interested attribution
+    results for the use case of text generation.
+    The wrapped instance will calculate attribution in the
+    same way as configured in the original attribution algorthm, but it will provide a
+    new "attribute" function which accepts text-based inputs
+    and returns LLMAttributionResult
+    """
+
+    def __init__(
+        self,
+        attr_method: Attribution,
+        tokenizer,
+        attr_target: str = "log_prob",  # TODO: support callable attr_target
+    ):
+        """
+        Args:
+            attr_method (Attribution): instance of a supported perturbation attribution
+                    class created with the llm model that follows huggingface style
+                    interface convention
+            tokenizer (Tokenizer): tokenizer of the llm model used in the attr_method
+            attr_target (str): attribute towards log probability or probability.
+                    Available values ["log_prob", "prob"]
+                    Default: "log_prob"
+        """
+
+        assert isinstance(
+            attr_method, SUPPORTED_METHODS
+        ), f"LLMAttribution does not support {type(attr_method)}"
+
+        super().__init__(attr_method.forward_func)
+
+        # shallow copy is enough to avoid modifying original instance
+        self.attr_method = copy(attr_method)
+
+        self.attr_method.forward_func = self._forward_func
+
+        # alias, we really need a model and don't support wrapper functions
+        self.model = cast(nn.Module, self.forward_func)
+
+        self.tokenizer = tokenizer
+        self.device = (
+            cast(torch.device, self.model.device)
+            if hasattr(self.model, "device")
+            else next(self.model.parameters()).device
+        )
+
+        assert attr_target in (
+            "log_prob",
+            "prob",
+        ), "attr_target should be either 'log_prob' or 'prob'"
+        self.attr_target = attr_target
+
+    def _forward_func(
+        self,
+        perturbed_feature,
+        input_feature,
+        target_tokens,
+        _inspect_forward,
+    ):
+        perturbed_input = self._format_model_input(
+            input_feature.to_model_input(perturbed_feature)
+        )
+        init_model_inp = perturbed_input
+
+        model_inp = init_model_inp
+
+        log_prob_list = []
+        for target_token in target_tokens:
+            output_logits = self.model.forward(
+                model_inp, attention_mask=torch.tensor([[1] * model_inp.shape[1]])
+            )
+            new_token_logits = output_logits.logits[:, -1]
+            log_probs = torch.nn.functional.log_softmax(new_token_logits, dim=1)
+
+            log_prob_list.append(log_probs[0][target_token].detach())
+
+            model_inp = torch.cat(
+                (model_inp, torch.tensor([[target_token]]).to(self.device)), dim=1
+            )
+
+        total_log_prob = sum(log_prob_list)
+        # 1st dim is the total prob, rest are the target tokens
+        target_log_probs = torch.stack([total_log_prob, *log_prob_list], dim=0)
+        target_probs = torch.exp(target_log_probs)
+
+        if _inspect_forward:
+            prompt = self.tokenizer.decode(init_model_inp[0])
+            response = self.tokenizer.decode(target_tokens)
+
+            # callback for externals to inspect (prompt, response, seq_prob)
+            _inspect_forward(prompt, response, target_probs[0].item())
+
+        return target_probs if self.attr_target != "log_prob" else target_log_probs
+
+    def _format_model_input(self, model_input: Union[str, Tensor]):
+        """
+        Convert str to tokenized tensor
+        to make LLMAttribution work with model inputs of both
+        raw text and text token tensors
+        """
+        # return tensor(1, n_tokens)
+        if type(model_input) is str:
+            return self.tokenizer.encode(model_input, return_tensors="pt").to(
+                self.device
+            )
+        return model_input.to(self.device)
+
+    def attribute(
+        self,
+        inp: InterpretableInput,
+        target: Union[str, torch.Tensor, None] = None,
+        num_trials: int = 1,
+        gen_args: Optional[Dict] = None,
+        # internal callback hook can be used for logging
+        _inspect_forward: Optional[Callable] = None,
+        **kwargs,
+    ) -> LLMAttributionResult:
+        """
+        Args:
+            inp (InterpretableInput): input prompt for which attributions are computed
+            target (str or Tensor, optional): target response with respect to
+                    which attributions are computed. If None, it uses the model
+                    to generate the target based on the input and gen_args.
+                    Default: None
+            num_trials (int, optional): number of trials to run. Return is the average
+                    attribibutions over all the trials.
+                    Defaults: 1.
+            gen_args (dict, optional): arguments for generating the target. Only used if
+                    target is not given. When None, the default arguments are used,
+                    {"max_length": 25, "do_sample": False}
+                    Defaults: None
+            **kwargs (Any): any extra keyword arguments passed to the call of the
+                    underlying attribute function of the given attribution instance
+
+        Returns:
+
+            attr (LLMAttributionResult): attribution result
+        """
+
+        assert isinstance(
+            inp, SUPPORTED_INPUTS
+        ), f"LLMAttribution does not support input type {type(inp)}"
+
+        if target is None:
+            # generate when None
+            assert hasattr(self.model, "generate") and callable(self.model.generate), (
+                "The model does not have recognizable generate function."
+                "Target must be given for attribution"
+            )
+
+            if not gen_args:
+                gen_args = DEFAULT_GEN_ARGS
+
+            model_inp = self._format_model_input(inp.to_model_input())
+            output_tokens = self.model.generate(model_inp, **gen_args)
+            target_tokens = output_tokens[0][model_inp.size(1) :]
+        else:
+            assert gen_args is None, "gen_args must be None when target is given"
+
+            if type(target) is str:
+                # exclude sos
+                target_tokens = self.tokenizer.encode(target)[1:]
+            elif type(target) is torch.Tensor:
+                target_tokens = target
+
+        attr = torch.zeros(
+            [1 + len(target_tokens), inp.n_itp_features],
+            dtype=torch.float,
+            device=self.device,
+        )
+
+        for _ in range(num_trials):
+            attr_input = inp.to_tensor().to(self.device)
+
+            cur_attr = self.attr_method.attribute(
+                attr_input,
+                additional_forward_args=(inp, target_tokens, _inspect_forward),
+                **kwargs,
+            )
+
+            attr += cur_attr
+
+        attr = attr / num_trials
+
+        attr = inp.format_attr(attr)
+
+        return LLMAttributionResult(
+            attr[0],
+            attr[1:],  # shape(n_output_token, n_input_features)
+            inp.values,
+            self.tokenizer.convert_ids_to_tokens(target_tokens),
+        )

--- a/tests/attr/test_llm_attr.py
+++ b/tests/attr/test_llm_attr.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+
+from collections import namedtuple
+from typing import List, Optional, Union
+
+import torch
+from captum.attr._core.feature_ablation import FeatureAblation
+from captum.attr._core.llm_attr import LLMAttribution
+from captum.attr._utils.interpretable_input import TextTemplateInput
+from tests.helpers.basic import assertTensorAlmostEqual, BaseTest
+from torch import nn, Tensor
+
+
+class DummyTokenizer:
+    vocab_size = 256
+    sos, unk = [0, 1]
+    special_tokens = {sos: "<sos>", unk: "<unk>"}
+
+    def encode(self, text: str, return_tensors: Optional[str] = None):
+        tokens = text.split(" ")
+        tokens_ids = [ord(s[0]) if len(s) == 1 else self.unk for s in tokens]
+
+        # start with sos
+        tokens_ids: Union[List[int], Tensor] = [self.sos, *tokens_ids]
+
+        if return_tensors:
+            tokens_ids = torch.tensor([tokens_ids])
+
+        return tokens_ids
+
+    def convert_ids_to_tokens(self, token_ids):
+        return [
+            (self.special_tokens[tid] if tid in self.special_tokens else chr(tid))
+            for tid in token_ids
+        ]
+
+    def decode(self, token_ids):
+        return " ".join(self.convert_ids_to_tokens(token_ids))
+
+
+class DummyLLM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.tokenizer = DummyTokenizer()
+        self.emb = nn.Embedding(self.tokenizer.vocab_size, 10)
+        self.linear = nn.Linear(10, self.tokenizer.vocab_size)
+        self.trans = nn.TransformerEncoderLayer(d_model=10, nhead=2)
+
+    def forward(self, input_ids, *args, **kwargs):
+        emb = self.emb(input_ids)
+        logits = self.linear(self.trans(emb))
+        Result = namedtuple("Result", ["logits"])
+        return Result(logits=logits)
+
+    def generate(self, input_ids, *args, mock_response=None, **kwargs):
+        assert mock_response, "must mock response to use DummyLLM to geenrate"
+        response = self.tokenizer.encode(mock_response)[1:]
+        return torch.cat([input_ids, torch.tensor([response])], dim=1)
+
+    @property
+    def device(self):
+        return next(self.parameters()).device
+
+
+class TestLLMAttr(BaseTest):
+    def test_llm_attr(self) -> None:
+        llm = DummyLLM()
+        tokenizer = DummyTokenizer()
+        fa = FeatureAblation(llm)
+        llm_fa = LLMAttribution(fa, tokenizer)
+
+        inp = TextTemplateInput("{} b {} {} e {}", ["a", "c", "d", "f"])
+        res = llm_fa.attribute(inp, "m n o p q")
+
+        self.assertEqual(res.seq_attr.shape, (4,))
+        self.assertEqual(res.token_attr.shape, (5, 4))
+        self.assertEqual(res.input_tokens, ["a", "c", "d", "f"])
+        self.assertEqual(res.output_tokens, ["m", "n", "o", "p", "q"])
+
+    def test_llm_attr_without_target(self) -> None:
+        llm = DummyLLM()
+        tokenizer = DummyTokenizer()
+        fa = FeatureAblation(llm)
+        llm_fa = LLMAttribution(fa, tokenizer)
+
+        inp = TextTemplateInput("{} b {} {} e {}", ["a", "c", "d", "f"])
+        res = llm_fa.attribute(inp, gen_args={"mock_response": "x y z"})
+
+        self.assertEqual(res.seq_attr.shape, (4,))
+        self.assertEqual(res.token_attr.shape, (3, 4))
+        self.assertEqual(res.input_tokens, ["a", "c", "d", "f"])
+        self.assertEqual(res.output_tokens, ["x", "y", "z"])
+
+    def test_llm_attr_fa_log_prob(self) -> None:
+        llm = DummyLLM()
+        tokenizer = DummyTokenizer()
+        fa = FeatureAblation(llm)
+        llm_fa = LLMAttribution(fa, tokenizer, attr_target="log_prob")
+
+        inp = TextTemplateInput("{} b {} {} e {}", ["a", "c", "d", "f"])
+        res = llm_fa.attribute(inp, "m n o p q")
+
+        # With FeatureAblation, the seq attr in log_prob
+        # equals to the sum of each token attr
+        assertTensorAlmostEqual(self, res.seq_attr, res.token_attr.sum(0))


### PR DESCRIPTION
Summary: Add an attribution class leveraging existing perturbation-based instances to cater specific use cases for large language models

Differential Revision: D48615917

