### PR TITLE
move pred to cpu, which is the same device as lm.classes()

### DIFF
--- a/captum/concept/_utils/classifier.py
+++ b/captum/concept/_utils/classifier.py
@@ -178,7 +178,7 @@ class DefaultClassifier(Classifier):
 
         predict = self.lm(x_test)
 
-        predict = self.lm.classes()[torch.argmax(predict, dim=1)]  # type: ignore
+        predict = self.lm.classes()[torch.argmax(predict, dim=1).cpu()]  # type: ignore
         score = predict.long() == y_test.long().cpu()
 
         accs = score.float().mean()


### PR DESCRIPTION
without this `.cpu()` call there is an error when training the classifier using cuda, because the predictions will be on the gpu