### PR TITLE
Add ipython_genutils to pip dependencies

### DIFF
--- a/.github/workflows/test-website-depoy.yml
+++ b/.github/workflows/test-website-depoy.yml
@@ -17,6 +17,6 @@ jobs:
           sudo chmod -R 777 .
           python3 -m pip install --upgrade pip --progress-bar off
           python3 -m pip install -e .[dev] --progress-bar off
-          python3 -m pip install beautifulsoup4 ipython jinja2==3.0.0 nbconvert==5.6.1 --progress-bar off
+          python3 -m pip install beautifulsoup4 ipython jinja2==3.0.0 nbconvert==5.6.1 ipython_genutils --progress-bar off
           ./scripts/build_docs.sh -b
           cd website

--- a/.github/workflows/website-depoy.yml
+++ b/.github/workflows/website-depoy.yml
@@ -23,7 +23,7 @@ jobs:
           sudo chmod -R 777 .
           python3 -m pip install --upgrade pip --progress-bar off
           python3 -m pip install -e .[dev] --progress-bar off
-          python3 -m pip install beautifulsoup4 ipython jinja2==3.0.0 nbconvert==5.6.1 --progress-bar off
+          python3 -m pip install beautifulsoup4 ipython jinja2==3.0.0 nbconvert==5.6.1 ipython_genutils --progress-bar off
           ./scripts/build_docs.sh -b
           cd website
 


### PR DESCRIPTION
Tutorial generation is currently failing due to ipython_genutils not being found. Adding this dependency for website publishing.