### PR TITLE
Exit on errors in build_docs

### DIFF
--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # run this script from the project root using `./scripts/build_docs.sh`
 

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -51,8 +51,6 @@ mkdir -p $WEBSITE_SPHINX_DIR
 
 # move static files from /sphinx/build/html/_static/*:
 for sphinx_static_file in 'documentation_options.js' \
-               'jquery.js' \
-               'underscore.js' \
                'doctools.js' \
                'language_data.js' \
                'searchtools.js' \


### PR DESCRIPTION
Currently, build_docs completes successfully even if commands fail, which could cause problematic website deployments and inaccurate signal from the test website deployment. Adds -e to exit script if any command fails.