### PR TITLE
Implement LLMGradientAttribution

### DIFF
--- a/captum/attr/_core/layer/layer_integrated_gradients.py
+++ b/captum/attr/_core/layer/layer_integrated_gradients.py
@@ -467,6 +467,8 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
 
                         hooks.append(hook)
 
+                    # the inputs is an empty tuple
+                    # coz it is prepended into additional_forward_args
                     output = _run_forward(
                         self.forward_func, tuple(), target_ind, additional_forward_args
                     )


### PR DESCRIPTION
Summary:
Implement the LLM attribution method wrapper for gradient-based algorithm

Only supported token-based attribution

Reviewed By: vivekmig

Differential Revision: D51224438


