### PR TITLE
Docstring typo in layer activation docstring

### DIFF
--- a/captum/attr/_core/layer/layer_activation.py
+++ b/captum/attr/_core/layer/layer_activation.py
@@ -112,7 +112,7 @@ class LayerActivation(LayerAttribution):
             >>> input = torch.randn(2, 3, 32, 32, requires_grad=True)
             >>> # Computes layer activation.
             >>> # attribution is layer output, with size Nx12x32x32
-            >>> attribution = layer_cond.attribute(input)
+            >>> attribution = layer_act.attribute(input)
         """
         with torch.no_grad():
             layer_eval = _forward_layer_eval(


### PR DESCRIPTION
There was a typo in the docstring of Layer Activation