### PR TITLE
Add support for Lime and KernelShap in LLM Attribution

### DIFF
--- a/captum/attr/_core/llm_attr.py
+++ b/captum/attr/_core/llm_attr.py
@@ -4,6 +4,8 @@ from typing import Callable, cast, Dict, List, Optional, Union
 
 import torch
 from captum.attr._core.feature_ablation import FeatureAblation
+from captum.attr._core.lime import Lime
+from captum.attr._core.kernel_shap import KernelShap
 from captum.attr._core.layer.layer_integrated_gradients import LayerIntegratedGradients
 from captum.attr._core.shapley_value import ShapleyValues, ShapleyValueSampling
 from captum.attr._utils.attribution import Attribution
@@ -59,7 +61,8 @@ class LLMAttribution(Attribution):
     and returns LLMAttributionResult
     """
 
-    SUPPORTED_METHODS = (FeatureAblation, ShapleyValueSampling, ShapleyValues)
+    SUPPORTED_METHODS = (FeatureAblation, ShapleyValueSampling, ShapleyValues, Lime, KernelShap)
+    SUPPORTED_PER_TOKEN_ATTR_METHODS = (FeatureAblation, ShapleyValueSampling, ShapleyValues)
     SUPPORTED_INPUTS = (TextTemplateInput, TextTokenInput)
 
     def __init__(
@@ -87,6 +90,7 @@ class LLMAttribution(Attribution):
 
         # shallow copy is enough to avoid modifying original instance
         self.attr_method = copy(attr_method)
+        self.include_per_token_attr = isinstance(attr_method, self.SUPPORTED_PER_TOKEN_ATTR_METHODS)
 
         self.attr_method.forward_func = self._forward_func
 
@@ -136,9 +140,12 @@ class LLMAttribution(Attribution):
         total_log_prob = sum(log_prob_list)
         # 1st element is the total prob, rest are the target tokens
         # add a leading dim for batch even we only support single instance for now
-        target_log_probs = torch.stack(
-            [total_log_prob, *log_prob_list], dim=0
-        ).unsqueeze(0)
+        if self.include_per_token_attr:
+            target_log_probs = torch.stack(
+                [total_log_prob, *log_prob_list], dim=0
+            ).unsqueeze(0)
+        else:
+            target_log_probs = total_log_prob
         target_probs = torch.exp(target_log_probs)
 
         if _inspect_forward:
@@ -223,7 +230,7 @@ class LLMAttribution(Attribution):
                 target_tokens = target
 
         attr = torch.zeros(
-            [1 + len(target_tokens), inp.n_itp_features],
+            [1 + len(target_tokens) if self.include_per_token_attr else 1, inp.n_itp_features],
             dtype=torch.float,
             device=self.device,
         )
@@ -250,7 +257,7 @@ class LLMAttribution(Attribution):
 
         return LLMAttributionResult(
             attr[0],
-            attr[1:],  # shape(n_output_token, n_input_features)
+            attr[1:] if self.include_per_token_attr else None,  # shape(n_output_token, n_input_features)
             inp.values,
             self.tokenizer.convert_ids_to_tokens(target_tokens),
         )

--- a/tests/attr/test_llm_attr.py
+++ b/tests/attr/test_llm_attr.py
@@ -5,15 +5,15 @@ from typing import List, Optional, Union
 
 import torch
 from captum.attr._core.feature_ablation import FeatureAblation
+from captum.attr._core.kernel_shap import KernelShap
 from captum.attr._core.layer.layer_integrated_gradients import LayerIntegratedGradients
+from captum.attr._core.lime import Lime
 from captum.attr._core.llm_attr import LLMAttribution, LLMGradientAttribution
 from captum.attr._core.shapley_value import ShapleyValueSampling
 from captum.attr._utils.interpretable_input import TextTemplateInput, TextTokenInput
 from parameterized import parameterized
 from tests.helpers.basic import assertTensorAlmostEqual, BaseTest
 from torch import nn, Tensor
-from captum.attr._core.lime import Lime
-from captum.attr._core.kernel_shap import KernelShap
 
 
 class DummyTokenizer:
@@ -123,6 +123,7 @@ class TestLLMAttr(BaseTest):
         self.assertEqual(res.token_attr, None)
         self.assertEqual(res.input_tokens, ["a", "c", "d", "f"])
         self.assertEqual(res.output_tokens, ["m", "n", "o", "p", "q"])
+
 
 class TestLLMGradAttr(BaseTest):
     def test_llm_attr(self) -> None:


### PR DESCRIPTION
Adds support for Lime and KernelShap in LLM Attribution, which return None for token_attr.