### PR TITLE
Update Minimum PyTorch Version to 1.9

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -16,7 +16,7 @@ requirements:
     - python>=3.6
   run:
     - numpy
-    - pytorch>=1.6
+    - pytorch>=1.9
     - matplotlib-base
 
 test:

--- a/.github/workflows/test-pip-cpu.yml
+++ b/.github/workflows/test-pip-cpu.yml
@@ -12,7 +12,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        pytorch_args: ["-v 1.6", "-v 1.7", " -v 1.8", "-v 1.9"]
+        pytorch_args: ["-v 1.9", "-v 1.10", "-v 1.11", " -v 1.12", " -v 1.13", " -v 2.0.0"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:

--- a/.github/workflows/test-pip-cpu.yml
+++ b/.github/workflows/test-pip-cpu.yml
@@ -12,7 +12,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        pytorch_args: ["-v 1.9", "-v 1.10", "-v 1.11", " -v 1.12", " -v 1.13", " -v 2.0.0"]
+        pytorch_args: ["-v 1.9", "-v 1.10", "-v 1.11", " -v 1.12", " -v 1.13", " -v 2.0"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Captum can also be used by application engineers who are using trained models in
 
 **Installation Requirements**
 - Python >= 3.6
-- PyTorch >= 1.6
+- PyTorch >= 1.9
 
 
 ##### Installing the latest release

--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ if __name__ == "__main__":
         long_description=long_description,
         long_description_content_type="text/markdown",
         python_requires=">=3.6",
-        install_requires=["matplotlib", "numpy", "torch>=1.6", "tqdm"],
+        install_requires=["matplotlib", "numpy", "torch>=1.9", "tqdm"],
         packages=find_packages(exclude=("tests", "tests.*")),
         extras_require={
             "dev": DEV_REQUIRES,


### PR DESCRIPTION
Updates minimum version of PyTorch to 1.9 and updates GitHub actions tests accordingly to cover all versions after 1.9. This will also ensure torch.linalg.eig is available for influence implementations in all supported versions.