### PR TITLE
Use past_key_values to speed up multi-token target LLM Attribution

### DIFF
--- a/captum/attr/_core/llm_attr.py
+++ b/captum/attr/_core/llm_attr.py
@@ -239,14 +239,12 @@ class LLMAttribution(Attribution):
         init_model_inp = perturbed_input
 
         model_inp = init_model_inp
+        model_kwargs = {"attention_mask": torch.tensor([[1] * model_inp.shape[1]])}
 
         log_prob_list = []
         outputs = None
         for target_token in target_tokens:
             if use_cached_outputs:
-                model_kwargs = {
-                    "attention_mask": torch.tensor([[1] * model_inp.shape[1]])
-                }
                 if outputs is not None:
                     model_kwargs = self.model._update_model_kwargs_for_generation(
                         outputs, model_kwargs

--- a/captum/attr/_core/llm_attr.py
+++ b/captum/attr/_core/llm_attr.py
@@ -232,7 +232,8 @@ class LLMAttribution(Attribution):
         perturbed_tensor,
         inp,
         target_tokens,
-        _inspect_forward,
+        use_cached_outputs=False,
+        _inspect_forward=None,
     ):
         perturbed_input = self._format_model_input(inp.to_model_input(perturbed_tensor))
         init_model_inp = perturbed_input
@@ -240,11 +241,25 @@ class LLMAttribution(Attribution):
         model_inp = init_model_inp
 
         log_prob_list = []
+        outputs = None
         for target_token in target_tokens:
-            output_logits = self.model.forward(
-                model_inp, attention_mask=torch.tensor([[1] * model_inp.shape[1]])
-            )
-            new_token_logits = output_logits.logits[:, -1]
+            if use_cached_outputs:
+                model_kwargs = {
+                    "attention_mask": torch.tensor([[1] * model_inp.shape[1]])
+                }
+                if outputs is not None:
+                    model_kwargs = self.model._update_model_kwargs_for_generation(
+                        outputs, model_kwargs
+                    )
+                model_inputs = self.model.prepare_inputs_for_generation(
+                    model_inp, **model_kwargs
+                )
+                outputs = self.model.forward(**model_inputs)
+            else:
+                outputs = self.model.forward(
+                    model_inp, attention_mask=torch.tensor([[1] * model_inp.shape[1]])
+                )
+            new_token_logits = outputs.logits[:, -1]
             log_probs = torch.nn.functional.log_softmax(new_token_logits, dim=1)
 
             log_prob_list.append(log_probs[0][target_token].detach())
@@ -292,6 +307,7 @@ class LLMAttribution(Attribution):
         target: Union[str, torch.Tensor, None] = None,
         num_trials: int = 1,
         gen_args: Optional[Dict] = None,
+        use_cached_outputs: bool = True,
         # internal callback hook can be used for logging
         _inspect_forward: Optional[Callable] = None,
         **kwargs,
@@ -360,7 +376,12 @@ class LLMAttribution(Attribution):
 
             cur_attr = self.attr_method.attribute(
                 attr_input,
-                additional_forward_args=(inp, target_tokens, _inspect_forward),
+                additional_forward_args=(
+                    inp,
+                    target_tokens,
+                    use_cached_outputs,
+                    _inspect_forward,
+                ),
                 **kwargs,
             )
 


### PR DESCRIPTION
Default generation in transformers utilizes past_key_values to cache previous key values to speed up forward passes for subsequent tokens. This adds a flag and use of corresponding helpers from transformers generation utils to follow the same approach for using caching.