### PR TITLE
Fix pytext lint error

### DIFF
--- a/tests/attr/models/test_pytext.py
+++ b/tests/attr/models/test_pytext.py
@@ -20,7 +20,7 @@ try:
     from pytext.config.doc_classification import ModelInputConfig, TargetConfig
     from pytext.config.field_config import FeatureConfig, WordFeatConfig
     from pytext.data import CommonMetadata
-    from pytext.data.doc_classification_data_handler import (  # @manual=//pytext:main_lib
+    from pytext.data.doc_classification_data_handler import (  # @manual=//pytext:main_lib  # noqa
         DocClassificationDataHandler,
     )
     from pytext.data.featurizer import SimpleFeaturizer


### PR DESCRIPTION
Flake8 is currently failing on master due to a flake8 error in test_pytext due to a line exceeding limit, resolving error.