### PR TITLE
Split the get_random_model_and_data() method [1/n]

### DIFF
--- a/tests/influence/_core/test_tracin_xor.py
+++ b/tests/influence/_core/test_tracin_xor.py
@@ -23,7 +23,7 @@ class TestTracInXOR(BaseTest):
 
     # TODO: Move test setup to use setUp and tearDown method overrides.
     def _test_tracin_xor_setup(self, tmpdir: str, use_gpu: bool = False):
-        net = BasicLinearNet(2, 2, 1)
+        net = BasicLinearNet(in_features=2, hidden_nodes=2, out_features=1)
 
         state = OrderedDict(
             [


### PR DESCRIPTION
Summary:
As titled. The get_random_model_and_data() method is used to construct testing data for influence and it is reported as too complex by flake8 (https://www.flake8rules.com/rules/C901.html). This series of diff will split the method and abstract the common parts.

This diff isolate the model part for different gpu usage settings. It also eliminate the mix usage of bool and str.

Differential Revision: D55165054


