### PR TITLE
Remove Llama2 tutorial path append

### DIFF
--- a/tutorials/Llama2_LLM_Attribution.ipynb
+++ b/tutorials/Llama2_LLM_Attribution.ipynb
@@ -27,7 +27,6 @@
     "import random\n",
     "import sys\n",
     "\n",
-    "sys.path.append(\"/home/aoboyang/local/captum\")\n",
     "from captum.attr import (\n",
     "    FeatureAblation, \n",
     "    ShapleyValues,\n",


### PR DESCRIPTION
Remove unnecessary line
    "sys.path.append(\"/home/aoboyang/local/captum\")\n",
from Llama2 tutorial