### PR TITLE
Implement serialization of Summarizer

### DIFF
--- a/captum/attr/__init__.py
+++ b/captum/attr/__init__.py
@@ -75,7 +75,7 @@ from captum.attr._utils.stat import (
     Sum,
     Var,
 )
-from captum.attr._utils.summarizer import Summarizer
+from captum.attr._utils.summarizer import Summarizer, SummarizerSingleTensor
 
 __all__ = [
     "Attribution",
@@ -147,4 +147,5 @@ __all__ = [
     "Max",
     "Sum",
     "Count",
+    "SummarizerSingleTensor",
 ]


### PR DESCRIPTION
Summary:
To save a checkpoint of a Feature Importance job, we will need to persistent below fields in https://www.internalfb.com/code/fbsource/[5e3ebcd68e0c]/fbcode/model_understanding/feature_importance/summarizer.py?lines=89-99 in order save the state of the job:
```
        # Initialize summarizers
        self.input_attr_summarizer = Summarizer([Mean(), StdDev(order=0)])
        self.input_coverage_summarizer = Summarizer([Mean()])
        self.derived_attr_summarizer = Summarizer([Mean(), StdDev(order=0)])
        self.derived_coverage_summarizer = Summarizer([Mean()])
        self.neuron_attr_summarizer = Summarizer([Mean(), StdDev(order=0)])

        # Initialize batch counts
        self.input_batch_count = 0
        self.derived_batch_count = 0
        self.neuron_batch_count = 0
```

This diff implements (de)serialization of Summarizer.

### future diffs include:
 - save FI checkpoints to manifold
 - add the hook to Mast graceful preemption to save the checkpoint of Feature Importance Job
 - load checkpoint when initializing the Feature Importance Job

Differential Revision: D58227186


