### PR TITLE
Reduce the running time for test_simple_batch_kernel_shap

### DIFF
--- a/tests/attr/test_kernel_shap.py
+++ b/tests/attr/test_kernel_shap.py
@@ -116,7 +116,7 @@ class Test(BaseTest):
             inp,
             [[7.0, 32.5, 10.5], [76.66666, 196.66666, 116.66666]],
             perturbations_per_eval=(1, 2, 3),
-            n_samples=20000,
+            n_samples=2000,
         )
 
     def test_simple_batch_kernel_shap_with_mask(self) -> None:


### PR DESCRIPTION
Summary: Reduce the time taken to run `test_simple_batch_kernel_shap` test by reducing the number of samples from 20000 to 2000. This was an order of magnitud greater than the rest of the tests, so it was probably a typo and not intended.

Differential Revision: D59009750
