### PR TITLE
Separate out future logic from attribute method into attribute_future in Feature Ablation

### DIFF
--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -16,6 +16,7 @@ from captum._utils.typing import (
     TensorOrTupleOfTensorsGeneric,
     TupleOrTensorOrBoolGeneric,
 )
+
 from torch import device, Tensor
 
 from torch.futures import Future
@@ -567,6 +568,19 @@ def _format_outputs(
         if is_multiple_inputs
         else _format_output(len(outputs[0]) > 1, outputs[0])
     )
+
+
+# pyre-fixme[24] Callable requires 2 arguments
+def _construct_future_forward(original_forward: Callable) -> Callable:
+    # pyre-fixme[3] return type not specified
+    # pyre-ignore
+    def future_forward(*args, **kwargs):
+        # pyre-ignore
+        fut = torch.futures.Future()
+        fut.set_result(original_forward(*args, **kwargs))
+        return fut
+
+    return future_forward
 
 
 def _run_forward(

--- a/captum/attr/_core/feature_permutation.py
+++ b/captum/attr/_core/feature_permutation.py
@@ -93,7 +93,6 @@ class FeaturePermutation(FeatureAblation):
         """
         FeatureAblation.__init__(self, forward_func=forward_func)
         self.perm_func = perm_func
-        self.use_futures = False
 
     # suppressing error caused by the child class not having a matching
     # signature to the parent
@@ -293,7 +292,7 @@ class FeaturePermutation(FeatureAblation):
     ) -> Future[TensorOrTupleOfTensorsGeneric]:
         if isinstance(kwargs, dict) and "baselines" in kwargs:
             del kwargs["baselines"]
-        return FeatureAblation.attribute.__wrapped__(
+        return FeatureAblation.attribute_future.__wrapped__(
             self,
             inputs,
             baselines=None,
@@ -302,7 +301,6 @@ class FeaturePermutation(FeatureAblation):
             feature_mask=feature_mask,
             perturbations_per_eval=perturbations_per_eval,
             show_progress=show_progress,
-            use_futures=self.use_futures,
             **kwargs,
         )
 

--- a/tests/attr/test_feature_permutation.py
+++ b/tests/attr/test_feature_permutation.py
@@ -119,7 +119,6 @@ class Test(BaseTest):
         feature_importance = FeaturePermutation(
             forward_func=self.construct_future_forward(forward_func)
         )
-        feature_importance.use_futures = True
 
         inp = torch.randn((batch_size,) + input_size)
 
@@ -200,7 +199,6 @@ class Test(BaseTest):
         feature_importance = FeaturePermutation(
             forward_func=self.construct_future_forward(forward_func)
         )
-        feature_importance.use_futures = True
 
         inp = (
             torch.randn((batch_size,) + inp1_size),
@@ -280,7 +278,6 @@ class Test(BaseTest):
         feature_importance = FeaturePermutation(
             forward_func=self.construct_future_forward(forward_func)
         )
-        feature_importance.use_futures = True
 
         attribs = feature_importance.attribute_future(
             inp, perturbations_per_eval=perturbations_per_eval, target=target
@@ -354,7 +351,6 @@ class Test(BaseTest):
         feature_importance = FeaturePermutation(
             forward_func=self.construct_future_forward(forward_func)
         )
-        feature_importance.use_futures = True
 
         masks = [
             torch.tensor([0]),


### PR DESCRIPTION
Summary:
This diff separates the logic for futures in the FeatureAblation class into its own method, attribute_future. This method should only be used with forward functions that return a future, and additional test cases were added to ensure the proper usage of the attribute and the attribute_future methods.

the construct_future_forward helper method was also moved into the utils class to share with other method tests

Differential Revision: D60911353


