### PR TITLE
Added skip_bos Argument to LLM Attribution To Enable Wider Model Support for Attributing Against a Single Token

### DIFF
--- a/captum/attr/_core/llm_attr.py
+++ b/captum/attr/_core/llm_attr.py
@@ -296,6 +296,7 @@ class LLMAttribution(Attribution):
                 ).unsqueeze(0)
             except TypeError:
                 print("It seems like you got an empty list of target tokens. If you are attributing only one target token (a single character / word) try using the skip_bos argument in the attribute function.")
+                exit()
         else:
             target_log_probs = total_log_prob
         # pyre-fixme[6]: For 1st argument expected `Tensor` but got `Union[int,

--- a/captum/attr/_core/llm_attr.py
+++ b/captum/attr/_core/llm_attr.py
@@ -290,9 +290,12 @@ class LLMAttribution(Attribution):
         # 1st element is the total prob, rest are the target tokens
         # add a leading dim for batch even we only support single instance for now
         if self.include_per_token_attr:
-            target_log_probs = torch.stack(
-                [total_log_prob, *log_prob_list], dim=0
-            ).unsqueeze(0)
+            try:
+                target_log_probs = torch.stack(
+                    [total_log_prob, *log_prob_list], dim=0
+                ).unsqueeze(0)
+            except TypeError:
+                print("It seems like you got an empty list of target tokens. If you are attributing only one target token (a single character / word) try using the skip_bos argument in the attribute function.")
         else:
             target_log_probs = total_log_prob
         # pyre-fixme[6]: For 1st argument expected `Tensor` but got `Union[int,

--- a/captum/attr/_core/llm_attr.py
+++ b/captum/attr/_core/llm_attr.py
@@ -327,6 +327,7 @@ class LLMAttribution(Attribution):
         inp: InterpretableInput,
         target: Union[str, torch.Tensor, None] = None,
         num_trials: int = 1,
+        skip_bos: bool = True,
         # pyre-fixme[24]: Generic type `dict` expects 2 type parameters, use
         #  `typing.Dict[<key type>, <value type>]` to avoid runtime subscripting
         #  errors.
@@ -382,8 +383,11 @@ class LLMAttribution(Attribution):
             assert gen_args is None, "gen_args must be None when target is given"
 
             if type(target) is str:
-                # exclude sos
-                target_tokens = self.tokenizer.encode(target)[1:]
+                # exclude sos / bos
+                if skip_bos:
+                    target_tokens = self.tokenizer.encode(target)[1:]
+                else:
+                    target_tokens = self.tokenizer.encode(target)
                 target_tokens = torch.tensor(target_tokens)
             elif type(target) is torch.Tensor:
                 target_tokens = target


### PR DESCRIPTION
Some models do not generate a bos, so when trying to attribute a single token the code crashes. I added a `skip_bos` argument (that defaults to True to not change anything in the system) and some minor error handling to tell the user when to use the argument.

Here's my error handling so far:

```
if self.include_per_token_attr:
    try:
        target_log_probs = torch.stack(
            [total_log_prob, *log_prob_list], dim=0
        ).unsqueeze(0)
    except TypeError:
        print("It seems like you got an empty list of target tokens. If you are attributing only one target token (a single character / word) try using the skip_bos argument in the attribute function.")
        exit()
else:
    target_log_probs = total_log_prob
```

This allowed me to attribute multiple choice question answers (a single token) with models (like microsoft/Phi-3-mini-4k-instruct) that don't generate a bos token when the target is predefined.

The error that would pop up without this change is the following:

```
Traceback (most recent call last):
  File "/Users/sultan/Documents/Github/idk-what-this-is-yet/test.py", line 86, in <module>
    attr_res = llm_attr.attribute(inp, target=target)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sultan/miniconda3/envs/generalai/lib/python3.11/site-packages/captum/attr/_core/llm_attr.py", line 360, in attribute
    cur_attr = self.attr_method.attribute(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sultan/miniconda3/envs/generalai/lib/python3.11/site-packages/captum/log/__init__.py", line 42, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sultan/miniconda3/envs/generalai/lib/python3.11/site-packages/captum/attr/_core/feature_ablation.py", line 289, in attribute
    initial_eval = self._strict_run_forward(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sultan/miniconda3/envs/generalai/lib/python3.11/site-packages/captum/attr/_core/feature_ablation.py", line 599, in _strict_run_forward
    forward_output = _run_forward(*args, **kwargs)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sultan/miniconda3/envs/generalai/lib/python3.11/site-packages/captum/_utils/common.py", line 531, in _run_forward
    output = forward_func(
             ^^^^^^^^^^^^^
  File "/Users/sultan/miniconda3/envs/generalai/lib/python3.11/site-packages/captum/attr/_core/llm_attr.py", line 259, in _forward_func
    target_log_probs = torch.stack(
                       ^^^^^^^^^^^^
TypeError: expected Tensor as element 0 in argument 0, but got int
```