### PR TITLE
Added attribute_future to Attribution parent interface

### DIFF
--- a/captum/attr/_core/dataloader_attr.py
+++ b/captum/attr/_core/dataloader_attr.py
@@ -467,3 +467,14 @@ class DataLoaderAttribution(Attribution):
             )
 
             return _format_output(is_inputs_tuple, attr)
+
+    # pyre-fixme[3]: Return type must be annotated.
+    def attribute_future(
+        self,
+    ):
+        r"""
+        This method is not implemented for DataLoaderAttribution.
+        """
+        raise NotImplementedError(
+            "attribute_future is not implemented for DataLoaderAttribution"
+        )

--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -388,6 +388,15 @@ class DeepLift(GradientAttribution):
             is_inputs_tuple,
         )
 
+    # pyre-fixme[3]: Return type must be annotated.
+    def attribute_future(
+        self,
+    ):
+        r"""
+        This method is not implemented for DeepLift.
+        """
+        raise NotImplementedError("attribute_future is not implemented for DeepLift")
+
     def _construct_forward_func(
         self,
         # pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.

--- a/captum/attr/_core/gradient_shap.py
+++ b/captum/attr/_core/gradient_shap.py
@@ -301,6 +301,17 @@ class GradientShap(GradientAttribution):
 
         return attributions
 
+    # pyre-fixme[3]: Return type must be annotated.
+    def attribute_future(
+        self,
+    ):
+        r"""
+        This method is not implemented for GradientShap.
+        """
+        raise NotImplementedError(
+            "attribute_future is not implemented for GradientShap"
+        )
+
     def has_convergence_delta(self) -> bool:
         return True
 
@@ -424,6 +435,17 @@ class InputBaselineXGradient(GradientAttribution):
             additional_forward_args,
             target,
             is_inputs_tuple,
+        )
+
+    # pyre-fixme[3]: Return type must be annotated.
+    def attribute_future(
+        self,
+    ):
+        r"""
+        This method is not implemented for InputBaseLineXGradient.
+        """
+        raise NotImplementedError(
+            "attribute_future is not implemented for InputBaseLineXGradient"
         )
 
     def has_convergence_delta(self) -> bool:

--- a/captum/attr/_core/guided_backprop_deconvnet.py
+++ b/captum/attr/_core/guided_backprop_deconvnet.py
@@ -90,6 +90,16 @@ class ModifiedReluGradientAttribution(GradientAttribution):
         #  `Tuple[Tensor, ...]`.
         return _format_output(is_inputs_tuple, gradients)
 
+    def attribute_future(
+        self,
+    ) -> None:
+        r"""
+        This method is not implemented for ModifiedReluGradientAttribution.
+        """
+        raise NotImplementedError(
+            "attribute_future is not implemented for ModifiedReluGradientAttribution"
+        )
+
     # pyre-fixme[3]: Return type must be annotated.
     def _register_hooks(self, module: Module):
         if isinstance(module, torch.nn.ReLU):

--- a/captum/attr/_core/input_x_gradient.py
+++ b/captum/attr/_core/input_x_gradient.py
@@ -139,6 +139,17 @@ class InputXGradient(GradientAttribution):
         #  `Tuple[Tensor, ...]`.
         return _format_output(is_inputs_tuple, attributions)
 
+    # pyre-fixme[3]: Return type must be annotated.
+    def attribute_future(
+        self,
+    ):
+        r"""
+        This method is not implemented for InputXGradient.
+        """
+        raise NotImplementedError(
+            "attribute_future is not implemented for InputXGradient"
+        )
+
     @property
     # pyre-fixme[3]: Return type must be annotated.
     def multiplies_by_inputs(self):

--- a/captum/attr/_core/integrated_gradients.py
+++ b/captum/attr/_core/integrated_gradients.py
@@ -329,6 +329,17 @@ class IntegratedGradients(GradientAttribution):
         #  <: [Tensor, typing.Tuple[Tensor, ...]]]]` but got `Tuple[Tensor, ...]`.
         return _format_output(is_inputs_tuple, attributions)
 
+    # pyre-fixme[3]: Return type must be annotated.
+    def attribute_future(
+        self,
+    ):
+        r"""
+        This method is not implemented for IntegratedGradients.
+        """
+        raise NotImplementedError(
+            "attribute_future is not implemented for IntegratedGradients"
+        )
+
     def _attribute(
         self,
         inputs: Tuple[Tensor, ...],

--- a/captum/attr/_core/kernel_shap.py
+++ b/captum/attr/_core/kernel_shap.py
@@ -294,6 +294,15 @@ class KernelShap(Lime):
             show_progress=show_progress,
         )
 
+    # pyre-fixme[3]: Return type must be annotated.
+    def attribute_future(
+        self,
+    ):
+        r"""
+        This method is not implemented for KernelShap.
+        """
+        raise NotImplementedError("attribute_future is not implemented for KernelShap")
+
     def kernel_shap_similarity_kernel(
         self,
         _,

--- a/captum/attr/_core/lime.py
+++ b/captum/attr/_core/lime.py
@@ -540,6 +540,17 @@ class LimeBase(PerturbationAttribution):
             return self.interpretable_model.representation()
 
     # pyre-fixme[3]: Return type must be annotated.
+    def attribute_future(
+        self,
+    ):
+        r"""
+        This method is not implemented for LimeBase.
+        """
+        raise NotImplementedError(
+            "LimeBase does not support attribution of future samples."
+        )
+
+    # pyre-fixme[3]: Return type must be annotated.
     def _evaluate_batch(
         self,
         curr_model_inputs: List[TensorOrTupleOfTensorsGeneric],
@@ -1099,6 +1110,10 @@ class Lime(LimeBase):
             return_input_shape=return_input_shape,
             show_progress=show_progress,
         )
+
+    # pyre-fixme[3]: Return type must be annotated.
+    def attribute_future(self):
+        return super().attribute_future()
 
     def _attribute_kwargs(  # type: ignore
         self,

--- a/captum/attr/_core/llm_attr.py
+++ b/captum/attr/_core/llm_attr.py
@@ -435,6 +435,17 @@ class LLMAttribution(Attribution):
             self.tokenizer.convert_ids_to_tokens(target_tokens),
         )
 
+    # pyre-fixme[3]: Return type must be annotated.
+    def attribute_future(
+        self,
+    ):
+        r"""
+        This method is not implemented for LLMAttribution.
+        """
+        raise NotImplementedError(
+            "attribute_future is not implemented for LLMAttribution"
+        )
+
 
 class LLMGradientAttribution(Attribution):
     """
@@ -644,4 +655,15 @@ class LLMGradientAttribution(Attribution):
             inp.values,
             # pyre-fixme[61]: `target_tokens` is undefined, or not always defined.
             self.tokenizer.convert_ids_to_tokens(target_tokens),
+        )
+
+    # pyre-fixme[3]: Return type must be annotated.
+    def attribute_future(
+        self,
+    ):
+        r"""
+        This method is not implemented for LLMGradientAttribution.
+        """
+        raise NotImplementedError(
+            "attribute_future is not implemented for LLMGradientAttribution"
         )

--- a/captum/attr/_core/lrp.py
+++ b/captum/attr/_core/lrp.py
@@ -257,6 +257,15 @@ class LRP(GradientAttribution):
         else:
             return _format_output(is_inputs_tuple, relevances)  # type: ignore
 
+    # pyre-fixme[3]: Return type must be annotated.
+    def attribute_future(
+        self,
+    ):
+        r"""
+        This method is not implemented for LRP.
+        """
+        raise NotImplementedError("attribute_future is not implemented for LRP")
+
     def has_convergence_delta(self) -> bool:
         return True
 

--- a/captum/attr/_core/noise_tunnel.py
+++ b/captum/attr/_core/noise_tunnel.py
@@ -460,6 +460,14 @@ class NoiseTunnel(Attribution):
             delta,
         )
 
+    def attribute_future(
+        self,
+    ) -> None:
+        r"""
+        This method is not implemented for NoiseTunnel.
+        """
+        raise NotImplementedError("attribute_future is not implemented for NoiseTunnel")
+
     def _apply_checks_and_return_attributions(
         self,
         attributions: Tuple[Tensor, ...],

--- a/captum/attr/_core/occlusion.py
+++ b/captum/attr/_core/occlusion.py
@@ -271,6 +271,15 @@ class Occlusion(FeatureAblation):
             show_progress=show_progress,
         )
 
+    # pyre-fixme[3]: Return type must be annotated.
+    def attribute_future(
+        self,
+    ):
+        r"""
+        This method is not implemented for Occlusion.
+        """
+        raise NotImplementedError("attribute_future is not implemented for Occlusion")
+
     def _construct_ablated_input(
         self,
         expanded_input: Tensor,

--- a/captum/attr/_core/saliency.py
+++ b/captum/attr/_core/saliency.py
@@ -150,3 +150,12 @@ class Saliency(GradientAttribution):
         # pyre-fixme[7]: Expected `TensorOrTupleOfTensorsGeneric` but got
         #  `Tuple[Tensor, ...]`.
         return _format_output(is_inputs_tuple, attributions)
+
+    # pyre-fixme[3]: Return type must be annotated.
+    def attribute_future(
+        self,
+    ):
+        r"""
+        This method is not implemented for Saliency.
+        """
+        raise NotImplementedError("attribute_future is not implemented for Saliency")

--- a/captum/attr/_core/shapley_value.py
+++ b/captum/attr/_core/shapley_value.py
@@ -485,6 +485,17 @@ class ShapleyValueSampling(PerturbationAttribution):
         #  `Tuple[Tensor, ...]`.
         return formatted_attr
 
+    # pyre-fixme[3]: Return type must be annotated.
+    def attribute_future(
+        self,
+    ):
+        r"""
+        This method is not implemented for ShapleyValueSampling.
+        """
+        raise NotImplementedError(
+            "attribute_future is not implemented for ShapleyValueSampling"
+        )
+
     # pyre-fixme[3]: Return annotation cannot contain `Any`.
     def _perturbation_generator(
         self,

--- a/captum/attr/_utils/attribution.py
+++ b/captum/attr/_utils/attribution.py
@@ -73,6 +73,37 @@ class Attribution:
 
     """
 
+    # pyre-fixme[24] Callable needs 2 type parameters
+    attribute_future: Callable
+
+    r"""
+    This method computes and returns a Future of attribution values for each input
+    tensor. Deriving classes are responsible for implementing its logic accordingly.
+
+    Specific attribution algorithms that extend this class take relevant
+    arguments.
+
+    Args:
+
+        inputs (Tensor or tuple[Tensor, ...]): Input for which attribution
+                    is computed. It can be provided as a single tensor or
+                    a tuple of multiple tensors. If multiple input tensors
+                    are provided, the batch sizes must be aligned across all
+                    tensors.
+
+
+    Returns:
+
+        *Future[Tensor]* or *Future[tuple[Tensor, ...]]* of **attributions**:
+        - **attributions** (*Future[Tensor]* or *Future[tuple[Tensor, ...]]*):
+                    Future of attribution values for each input tensor.
+                    The results should be the same as the attribute
+                    method, except that the results are returned as a Future.
+                    If a single tensor is provided as inputs, a single Future tensor
+                    is returned. If a tuple is provided for inputs, a Future of a
+                    tuple of corresponding sized tensors is returned.
+    """
+
     @property
     # pyre-fixme[3]: Return type must be annotated.
     def multiplies_by_inputs(self):

--- a/tests/attr/test_dataloader_attr.py
+++ b/tests/attr/test_dataloader_attr.py
@@ -371,3 +371,12 @@ class Test(BaseTest):
         )
 
         assertAttributionComparision(self, dl_attributions, expected_attr)
+
+    def test_futures_not_implemented(self) -> None:
+        forward = sum_forward
+        fa = FeatureAblation(forward)
+        dl_fa = DataLoaderAttribution(fa)
+        attributions = None
+        with self.assertRaises(NotImplementedError):
+            attributions = dl_fa.attribute_future()
+        self.assertEqual(attributions, None)

--- a/tests/attr/test_deeplift_basic.py
+++ b/tests/attr/test_deeplift_basic.py
@@ -295,6 +295,14 @@ class Test(BaseTest):
         assertTensorAlmostEqual(self, attrs, expected, 0.0001)
         assertTensorAlmostEqual(self, delta, expected_delta, 0.0001)
 
+    def test_futures_not_implemented(self) -> None:
+        model = ReLUDeepLiftModel()
+        dl = DeepLift(model, multiply_by_inputs=False)
+        attributions = None
+        with self.assertRaises(NotImplementedError):
+            attributions = dl.attribute_future()
+        self.assertEqual(attributions, None)
+
     def _deeplift_assert(
         self,
         model: Module,

--- a/tests/attr/test_gradient_shap.py
+++ b/tests/attr/test_gradient_shap.py
@@ -244,6 +244,14 @@ class Test(BaseTest):
         attributions_ig = ig.attribute(inputs, baselines=baselines)
         self._assert_shap_ig_comparision(attributions, attributions_ig)
 
+    def test_futures_not_implemented(self) -> None:
+        model = BasicModel2()
+        gs = GradientShap(model)
+        attributions = None
+        with self.assertRaises(NotImplementedError):
+            attributions = gs.attribute_future()
+        self.assertEqual(attributions, None)
+
     def _assert_shap_ig_comparision(
         self, attributions1: Tuple[Tensor, ...], attributions2: Tuple[Tensor, ...]
     ) -> None:

--- a/tests/attr/test_input_x_gradient.py
+++ b/tests/attr/test_input_x_gradient.py
@@ -48,6 +48,14 @@ class Test(BaseTest):
     def test_input_x_gradient_classification_vargrad(self) -> None:
         self._input_x_gradient_classification_assert(nt_type="vargrad")
 
+    def test_futures_not_implemented(self) -> None:
+        model = SoftmaxModel(5, 20, 10)
+        input_x_grad = InputXGradient(model.forward)
+        attributions = None
+        with self.assertRaises(NotImplementedError):
+            attributions = input_x_grad.attribute_future()
+        self.assertEqual(attributions, None)
+
     def _input_x_gradient_base_assert(
         self,
         model: Module,

--- a/tests/attr/test_integrated_gradients_basic.py
+++ b/tests/attr/test_integrated_gradients_basic.py
@@ -154,6 +154,14 @@ class Test(BaseTest):
     def test_batched_multi_input_smoothgrad_sq_batch_size_3(self) -> None:
         self._assert_batched_tensor_multi_input("vargrad", "riemann_trapezoid", 3)
 
+    def test_futures_not_implemented(self) -> None:
+        model = BasicModel2()
+        ig = IntegratedGradients(model, multiply_by_inputs=True)
+        attributions = None
+        with self.assertRaises(NotImplementedError):
+            attributions = ig.attribute_future()
+        self.assertEqual(attributions, None)
+
     def _assert_multi_variable(
         self,
         type: str,

--- a/tests/attr/test_kernel_shap.py
+++ b/tests/attr/test_kernel_shap.py
@@ -330,6 +330,14 @@ class Test(BaseTest):
             lambda *inp: torch.sum(net(*inp)).item()
         )
 
+    def test_futures_not_implemented(self) -> None:
+        net = BasicModel_MultiLayer_MultiInput()
+        kernel_shap = KernelShap(net)
+        attributions = None
+        with self.assertRaises(NotImplementedError):
+            attributions = kernel_shap.attribute_future()
+        self.assertEqual(attributions, None)
+
     def _multi_input_scalar_kernel_shap_assert(self, func: Callable) -> None:
         inp1 = torch.tensor([[23.0, 100.0, 0.0], [20.0, 50.0, 30.0]])
         inp2 = torch.tensor([[20.0, 50.0, 30.0], [0.0, 100.0, 0.0]])

--- a/tests/attr/test_lime.py
+++ b/tests/attr/test_lime.py
@@ -49,12 +49,13 @@ def alt_perturb_func(
         binary_mask = curr_sample[0][feature_mask]
         return binary_mask * original_inp + (1 - binary_mask) * kwargs["baselines"]
     else:
-        binary_mask = tuple(
+        binary_mask_tuple = tuple(
             curr_sample[0][feature_mask[j]] for j in range(len(feature_mask))
         )
+        # pyre-fixme[7] Incompatible return type
         return tuple(
-            binary_mask[j] * original_inp[j]
-            + (1 - binary_mask[j]) * kwargs["baselines"][j]
+            binary_mask_tuple[j] * original_inp[j]
+            + (1 - binary_mask_tuple[j]) * kwargs["baselines"][j]
             for j in range(len(feature_mask))
         )
 
@@ -460,6 +461,20 @@ class Test(BaseTest):
     def test_multi_inp_lime_scalar_float(self) -> None:
         net = BasicModel_MultiLayer_MultiInput()
         self._multi_input_scalar_lime_assert(lambda *inp: torch.sum(net(*inp)).item())
+
+    def test_futures_not_implemented(self) -> None:
+        net = BasicLinearModel()
+
+        # no mask
+        lime = Lime(
+            net,
+            similarity_func=get_exp_kernel_similarity_function("cosine", 10.0),
+            interpretable_model=(SkLearnLasso(alpha=1.0)),
+        )
+        attributions = None
+        with self.assertRaises(NotImplementedError):
+            attributions = lime.attribute_future()
+        self.assertEqual(attributions, None)
 
     def _multi_input_scalar_lime_assert(self, func: Callable) -> None:
         inp1 = torch.tensor([[23.0, 100.0, 0.0], [20.0, 50.0, 30.0]])

--- a/tests/attr/test_llm_attr.py
+++ b/tests/attr/test_llm_attr.py
@@ -330,7 +330,6 @@ class TestLLMAttr(BaseTest):
         self.assertEqual(res.token_attr, None)
         self.assertEqual(res.input_tokens, ["a", "c", "d", "f"])
         self.assertEqual(res.output_tokens, ["m", "n", "o", "p", "q"])
-
         assertTensorAlmostEqual(
             self,
             actual=res.seq_attr,
@@ -338,6 +337,17 @@ class TestLLMAttr(BaseTest):
             delta=delta,
             mode="max",
         )
+
+    def test_futures_not_implemented(self) -> None:
+        llm = DummyLLM()
+        llm.to(self.device)
+        tokenizer = DummyTokenizer()
+        fa = FeatureAblation(llm)
+        llm_fa = LLMAttribution(fa, tokenizer)
+        attributions = None
+        with self.assertRaises(NotImplementedError):
+            attributions = llm_fa.attribute_future()
+        self.assertEqual(attributions, None)
 
 
 @parameterized_class(

--- a/tests/attr/test_lrp.py
+++ b/tests/attr/test_lrp.py
@@ -327,3 +327,11 @@ class Test(BaseTest):
         lrp = LRP(model)
         with self.assertRaisesRegex(RuntimeError, "more than once"):
             lrp.attribute(inp, target=0)
+
+    def test_futures_not_implemented(self) -> None:
+        model = BasicModelWithReusedLinear()
+        lrp = LRP(model)
+        attributions = None
+        with self.assertRaises(NotImplementedError):
+            attributions = lrp.attribute_future()
+        self.assertEqual(attributions, None)

--- a/tests/attr/test_occlusion.py
+++ b/tests/attr/test_occlusion.py
@@ -280,6 +280,14 @@ class Test(BaseTest):
             strides=((1, 2, 1), (1, 1, 2)),
         )
 
+    def test_futures_not_implemented(self) -> None:
+        net = BasicModel_ConvNet_One_Conv()
+        occ = Occlusion(net)
+        attributions = None
+        with self.assertRaises(NotImplementedError):
+            attributions = occ.attribute_future()
+        self.assertEqual(attributions, None)
+
     @unittest.mock.patch("sys.stderr", new_callable=io.StringIO)
     def test_simple_input_with_show_progress(self, mock_stderr) -> None:
         net = BasicModel_MultiLayer()

--- a/tests/attr/test_saliency.py
+++ b/tests/attr/test_saliency.py
@@ -105,6 +105,14 @@ class Test(BaseTest):
         self._saliency_base_assert(model, inp, grads, add_args)
         assertTensorTuplesAlmostEqual(self, inp.grad, grad, delta=0.0)
 
+    def test_futures_not_implemented(self) -> None:
+        model, inp, grads, add_args = get_basic_config()
+        saliency = Saliency(model)
+        attributions = None
+        with self.assertRaises(NotImplementedError):
+            attributions = saliency.attribute_future()
+        self.assertEqual(attributions, None)
+
     def _saliency_base_assert(
         self,
         model: Module,

--- a/tests/attr/test_shapley.py
+++ b/tests/attr/test_shapley.py
@@ -386,6 +386,15 @@ class Test(BaseTest):
             mock_stderr.seek(0)
             mock_stderr.truncate(0)
 
+    def test_futures_not_implemented(self) -> None:
+        net = BasicModel_MultiLayer()
+
+        attributions = None
+        shapley_samp = ShapleyValueSampling(net)
+        with self.assertRaises(NotImplementedError):
+            attributions = shapley_samp.attribute_future()
+        self.assertEqual(attributions, None)
+
     def _single_input_one_sample_batch_scalar_shapley_assert(
         self, func: Callable
     ) -> None:


### PR DESCRIPTION
Summary: This diff adds the attribute_future interface method to the Base attribution interface and throws a not implmented error if it has not been implemented yet

Differential Revision: D61233441


