### PR TITLE
Fix titanic tutorial to convert datatypes to float

### DIFF
--- a/tutorials/Titanic_Basic_Interpret.ipynb
+++ b/tutorials/Titanic_Basic_Interpret.ipynb
@@ -136,9 +136,9 @@
     "# Separate training and test sets using \n",
     "train_indices = np.random.choice(len(labels), int(0.7*len(labels)), replace=False)\n",
     "test_indices = list(set(range(len(labels))) - set(train_indices))\n",
-    "train_features = data[train_indices]\n",
+    "train_features = np.array(data[train_indices], dtype=float)\n",
     "train_labels = labels[train_indices]\n",
-    "test_features = data[test_indices]\n",
+    "test_features = np.array(data[test_indices], dtype=float)\n",
     "test_labels = labels[test_indices]"
    ]
   },
@@ -823,7 +823,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -837,9 +837,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/tutorials/Titanic_Basic_Interpret.ipynb
+++ b/tutorials/Titanic_Basic_Interpret.ipynb
@@ -823,7 +823,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -837,9 +837,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 2
 }


### PR DESCRIPTION
Currently, the Titanic tutorial for Captum leads to an error due to mismatched datatypes within the training data. Explicitly converting to a numpy array with floats resolves this issue.