### PR TITLE
[captum] Add additional gradient-based attribution methods to LLM Attribution

### DIFF
--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -110,7 +110,7 @@ class DeepLift(GradientAttribution):
                         Default: 1e-10
         """
         GradientAttribution.__init__(self, model)
-        self.model = cast(nn.Module, model)
+        self.model: nn.Module = model
         self.eps = eps
         self.forward_handles: List[RemovableHandle] = []
         self.backward_handles: List[RemovableHandle] = []
@@ -324,7 +324,8 @@ class DeepLift(GradientAttribution):
         warnings.warn(
             """Setting forward, backward hooks and attributes on non-linear
                activations. The hooks and attributes will be removed
-            after the attribution is finished"""
+            after the attribution is finished""",
+            stacklevel=2,
         )
         # pyre-fixme[6]: For 1st argument expected `Tuple[Tensor, ...]` but got
         #  `TensorOrTupleOfTensorsGeneric`.

--- a/captum/attr/_core/layer/layer_deep_lift.py
+++ b/captum/attr/_core/layer/layer_deep_lift.py
@@ -351,9 +351,9 @@ class LayerDeepLift(LayerAttribution, DeepLift):
                 grad_kwargs=grad_kwargs,
             )
 
-            attr_inputs = tuple(map(lambda attr: attr[0], attrs))
-            attr_baselines = tuple(map(lambda attr: attr[1], attrs))
-            gradients = tuple(map(lambda grad: grad[0], gradients))
+            attr_inputs = tuple(attr[0] for attr in attrs)
+            attr_baselines = tuple(attr[1] for attr in attrs)
+            gradients = tuple(grad[0] for grad in gradients)
 
             if custom_attribution_func is None:
                 if self.multiplies_by_inputs:

--- a/captum/attr/_core/llm_attr.py
+++ b/captum/attr/_core/llm_attr.py
@@ -457,7 +457,7 @@ class LLMGradientAttribution(Attribution):
     SUPPORTED_METHODS = (
         LayerGradientShap,
         LayerGradientXActivation,
-        LayerIntegratedGradients
+        LayerIntegratedGradients,
     )
     SUPPORTED_INPUTS = (TextTokenInput,)
 
@@ -624,14 +624,11 @@ class GradientForwardFunc(nn.Module):
     A wrapper class for the forward function of a model in LLMGradientAttribution
     """
 
-    def __init__(
-        self,
-        attr: LLMGradientAttribution
-    ) -> None:
+    def __init__(self, attr: LLMGradientAttribution) -> None:
         super().__init__()
         self.attr = attr
         self.model = attr.model
-    
+
     def forward(
         self,
         perturbed_tensor: Tensor,
@@ -639,7 +636,9 @@ class GradientForwardFunc(nn.Module):
         target_tokens: Tensor,  # 1D tensor of target token ids
         cur_target_idx: int,  # current target index
     ) -> Tensor:
-        perturbed_input = self.attr._format_model_input(inp.to_model_input(perturbed_tensor))
+        perturbed_input = self.attr._format_model_input(
+            inp.to_model_input(perturbed_tensor)
+        )
 
         if cur_target_idx:
             # the input batch size can be expanded by attr method

--- a/captum/attr/_core/llm_attr.py
+++ b/captum/attr/_core/llm_attr.py
@@ -627,7 +627,7 @@ class GradientForwardFunc(nn.Module):
     def __init__(self, attr: LLMGradientAttribution) -> None:
         super().__init__()
         self.attr = attr
-        self.model = attr.model
+        self.model: nn.Module = attr.model
 
     def forward(
         self,

--- a/tests/attr/test_llm_attr.py
+++ b/tests/attr/test_llm_attr.py
@@ -399,7 +399,7 @@ class TestLLMGradAttr(BaseTest):
 
         attr_kws: Dict[str, Any] = {}
         if baselines is not None:
-            attr_kws["baselines"] = baselines
+            attr_kws["baselines"] = baselines.to(self.device)
 
         inp = TextTokenInput("a b c", tokenizer)
         res = llm_attr.attribute(inp, "m n o p q", **attr_kws)
@@ -435,7 +435,7 @@ class TestLLMGradAttr(BaseTest):
 
         attr_kws: Dict[str, Any] = {}
         if baselines is not None:
-            attr_kws["baselines"] = baselines
+            attr_kws["baselines"] = baselines.to(self.device)
 
         inp = TextTokenInput("a b c", tokenizer)
         res = llm_attr.attribute(inp, gen_args={"mock_response": "x y z"}, **attr_kws)
@@ -470,7 +470,7 @@ class TestLLMGradAttr(BaseTest):
 
         attr_kws: Dict[str, Any] = {}
         if baselines is not None:
-            attr_kws["baselines"] = baselines
+            attr_kws["baselines"] = baselines.to(self.device)
 
         inp = TextTokenInput("a b c", tokenizer, skip_tokens=[0])
         res = llm_attr.attribute(inp, "m n o p q", **attr_kws)

--- a/tests/attr/test_llm_attr.py
+++ b/tests/attr/test_llm_attr.py
@@ -385,13 +385,11 @@ class TestLLMGradAttr(BaseTest):
         [
             (LayerIntegratedGradients, None),
             (LayerGradientXActivation, None),
-            (LayerGradientShap, (torch.tensor([[1, 0, 1, 0]]),))
+            (LayerGradientShap, (torch.tensor([[1, 0, 1, 0]]),)),
         ]
     )
     def test_llm_attr(
-        self,
-        AttrClass: Type[GradientAttribution],
-        baselines: Optional[Tuple[Tensor]]
+        self, AttrClass: Type[GradientAttribution], baselines: Optional[Tuple[Tensor]]
     ) -> None:
         llm = DummyLLM()
         llm.to(self.device)
@@ -401,7 +399,7 @@ class TestLLMGradAttr(BaseTest):
 
         attr_kws = {}
         if baselines is not None:
-            attr_kws['baselines'] = baselines
+            attr_kws["baselines"] = baselines
 
         inp = TextTokenInput("a b c", tokenizer)
         res = llm_attr.attribute(inp, "m n o p q", **attr_kws)
@@ -423,13 +421,11 @@ class TestLLMGradAttr(BaseTest):
         [
             (LayerIntegratedGradients, None),
             (LayerGradientXActivation, None),
-            (LayerGradientShap, (torch.tensor([[1, 0, 1, 0]]),))
+            (LayerGradientShap, (torch.tensor([[1, 0, 1, 0]]),)),
         ]
     )
     def test_llm_attr_without_target(
-        self,
-        AttrClass: Type[GradientAttribution],
-        baselines: Optional[Tuple[Tensor]]
+        self, AttrClass: Type[GradientAttribution], baselines: Optional[Tuple[Tensor]]
     ) -> None:
         llm = DummyLLM()
         llm.to(self.device)
@@ -439,11 +435,10 @@ class TestLLMGradAttr(BaseTest):
 
         attr_kws = {}
         if baselines is not None:
-            attr_kws['baselines'] = baselines
+            attr_kws["baselines"] = baselines
 
         inp = TextTokenInput("a b c", tokenizer)
-        res = llm_attr.attribute(inp, gen_args={"mock_response": "x y z"},
-                                 **attr_kws)
+        res = llm_attr.attribute(inp, gen_args={"mock_response": "x y z"}, **attr_kws)
 
         self.assertEqual(res.seq_attr.shape, (4,))
         assert res.token_attr is not None  # make pyre/mypy happy
@@ -457,18 +452,15 @@ class TestLLMGradAttr(BaseTest):
         assert res.token_attr is not None  # make pyre/mypy happy
         self.assertEqual(token_attr.device.type, self.device)  # type: ignore
 
-
     @parameterized.expand(
         [
             (LayerIntegratedGradients, None),
             (LayerGradientXActivation, None),
-            (LayerGradientShap, (torch.tensor([[1, 0, 1]]),))
+            (LayerGradientShap, (torch.tensor([[1, 0, 1]]),)),
         ]
     )
     def test_llm_attr_with_skip_tokens(
-        self,
-        AttrClass: Type[GradientAttribution],
-        baselines: Optional[Tuple[Tensor]]
+        self, AttrClass: Type[GradientAttribution], baselines: Optional[Tuple[Tensor]]
     ) -> None:
         llm = DummyLLM()
         llm.to(self.device)
@@ -478,7 +470,7 @@ class TestLLMGradAttr(BaseTest):
 
         attr_kws = {}
         if baselines is not None:
-            attr_kws['baselines'] = baselines
+            attr_kws["baselines"] = baselines
 
         inp = TextTokenInput("a b c", tokenizer, skip_tokens=[0])
         res = llm_attr.attribute(inp, "m n o p q", **attr_kws)

--- a/tests/attr/test_llm_attr.py
+++ b/tests/attr/test_llm_attr.py
@@ -400,7 +400,8 @@ class TestLLMGradAttr(BaseTest):
         attr_kws: Dict[str, Any] = {}
         if baselines is not None:
             attr_kws["baselines"] = tuple(
-                baseline.to(self.device) for baseline in baselines)
+                baseline.to(self.device) for baseline in baselines
+            )
 
         inp = TextTokenInput("a b c", tokenizer)
         res = llm_attr.attribute(inp, "m n o p q", **attr_kws)
@@ -437,7 +438,8 @@ class TestLLMGradAttr(BaseTest):
         attr_kws: Dict[str, Any] = {}
         if baselines is not None:
             attr_kws["baselines"] = tuple(
-                baseline.to(self.device) for baseline in baselines)
+                baseline.to(self.device) for baseline in baselines
+            )
 
         inp = TextTokenInput("a b c", tokenizer)
         res = llm_attr.attribute(inp, gen_args={"mock_response": "x y z"}, **attr_kws)
@@ -473,7 +475,8 @@ class TestLLMGradAttr(BaseTest):
         attr_kws: Dict[str, Any] = {}
         if baselines is not None:
             attr_kws["baselines"] = tuple(
-                baseline.to(self.device) for baseline in baselines)
+                baseline.to(self.device) for baseline in baselines
+            )
 
         inp = TextTokenInput("a b c", tokenizer, skip_tokens=[0])
         res = llm_attr.attribute(inp, "m n o p q", **attr_kws)

--- a/tests/attr/test_llm_attr.py
+++ b/tests/attr/test_llm_attr.py
@@ -399,7 +399,8 @@ class TestLLMGradAttr(BaseTest):
 
         attr_kws: Dict[str, Any] = {}
         if baselines is not None:
-            attr_kws["baselines"] = baselines.to(self.device)
+            attr_kws["baselines"] = tuple(
+                baseline.to(self.device) for baseline in baselines)
 
         inp = TextTokenInput("a b c", tokenizer)
         res = llm_attr.attribute(inp, "m n o p q", **attr_kws)
@@ -435,7 +436,8 @@ class TestLLMGradAttr(BaseTest):
 
         attr_kws: Dict[str, Any] = {}
         if baselines is not None:
-            attr_kws["baselines"] = baselines.to(self.device)
+            attr_kws["baselines"] = tuple(
+                baseline.to(self.device) for baseline in baselines)
 
         inp = TextTokenInput("a b c", tokenizer)
         res = llm_attr.attribute(inp, gen_args={"mock_response": "x y z"}, **attr_kws)
@@ -470,7 +472,8 @@ class TestLLMGradAttr(BaseTest):
 
         attr_kws: Dict[str, Any] = {}
         if baselines is not None:
-            attr_kws["baselines"] = baselines.to(self.device)
+            attr_kws["baselines"] = tuple(
+                baseline.to(self.device) for baseline in baselines)
 
         inp = TextTokenInput("a b c", tokenizer, skip_tokens=[0])
         res = llm_attr.attribute(inp, "m n o p q", **attr_kws)

--- a/tests/attr/test_llm_attr.py
+++ b/tests/attr/test_llm_attr.py
@@ -6,9 +6,7 @@ import copy
 from typing import Any, cast, Dict, List, NamedTuple, Optional, Tuple, Type, Union
 
 import torch
-from captum._utils.models.linear_model import (  # @manual=//pytorch/captum/captum/_utils/models/linear_model:linear_model  # noqa: E501
-    SkLearnLasso,
-)
+from captum._utils.models.linear_model import SkLearnLasso
 from captum.attr._core.feature_ablation import FeatureAblation
 from captum.attr._core.kernel_shap import KernelShap
 from captum.attr._core.layer.layer_gradient_shap import LayerGradientShap

--- a/tests/attr/test_llm_attr.py
+++ b/tests/attr/test_llm_attr.py
@@ -394,10 +394,10 @@ class TestLLMGradAttr(BaseTest):
         llm = DummyLLM()
         llm.to(self.device)
         tokenizer = DummyTokenizer()
-        attr = AttrClass(llm, llm.emb)
+        attr = AttrClass(llm, llm.emb)  # type: ignore[call-arg]
         llm_attr = LLMGradientAttribution(attr, tokenizer)
 
-        attr_kws = {}
+        attr_kws: Dict[str, Any] = {}
         if baselines is not None:
             attr_kws["baselines"] = baselines
 
@@ -430,10 +430,10 @@ class TestLLMGradAttr(BaseTest):
         llm = DummyLLM()
         llm.to(self.device)
         tokenizer = DummyTokenizer()
-        attr = AttrClass(llm, llm.emb)
+        attr = AttrClass(llm, llm.emb)  # type: ignore[call-arg]
         llm_attr = LLMGradientAttribution(attr, tokenizer)
 
-        attr_kws = {}
+        attr_kws: Dict[str, Any] = {}
         if baselines is not None:
             attr_kws["baselines"] = baselines
 
@@ -465,10 +465,10 @@ class TestLLMGradAttr(BaseTest):
         llm = DummyLLM()
         llm.to(self.device)
         tokenizer = DummyTokenizer()
-        attr = AttrClass(llm, llm.emb)
+        attr = AttrClass(llm, llm.emb)  # type: ignore[call-arg]
         llm_attr = LLMGradientAttribution(attr, tokenizer)
 
-        attr_kws = {}
+        attr_kws: Dict[str, Any] = {}
         if baselines is not None:
             attr_kws["baselines"] = baselines
 


### PR DESCRIPTION
Summary:
Add `LayerGradientXActivation` and `LayerGradientShap` to the supported gradient-based LLM attribution methods.

Test Plan:
`pytest tests/attr -k TestLLMGradAttr` with new test cases via parameterized library

Reviewers: #captum