### PR TITLE
Support Cache Class for Even Newer Versions of Transformers Library

### DIFF
--- a/captum/_utils/transformers_typing.py
+++ b/captum/_utils/transformers_typing.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+# pyre-strict
+
+from typing import Optional, Protocol, Tuple, Type
+
+import torch
+
+
+class CacheLike(Protocol):
+    """Protocol for cache-like objects."""
+
+
+class DynamicCacheLike(CacheLike, Protocol):
+    """Protocol for dynamic cache-like objects."""
+
+    @classmethod
+    def from_legacy_cache(
+        cls: Type["DynamicCacheLike"],
+        past_key_values: Optional[Tuple[Tuple[torch.Tensor]]] = None,
+    ) -> "DynamicCacheLike": ...
+
+
+try:
+    # pyre-ignore[21]: Could not find a module corresponding to import
+    #  `transformers.cache_utils`
+    from transformers.cache_utils import Cache as _Cache, DynamicCache as _DynamicCache
+except ImportError:
+    _Cache = _DynamicCache = None
+
+Cache: Optional[Type[CacheLike]] = _Cache
+DynamicCache: Optional[Type[DynamicCacheLike]] = _DynamicCache

--- a/captum/_utils/transformers_typing.py
+++ b/captum/_utils/transformers_typing.py
@@ -2,9 +2,12 @@
 
 # pyre-strict
 
-from typing import Optional, Protocol, Tuple, Type
+from typing import Any, Dict, Optional, Protocol, Tuple, Type
 
 import torch
+
+from packaging.version import Version
+from torch import nn
 
 
 class CacheLike(Protocol):
@@ -21,12 +24,96 @@ class DynamicCacheLike(CacheLike, Protocol):
     ) -> "DynamicCacheLike": ...
 
 
-try:
-    # pyre-ignore[21]: Could not find a module corresponding to import
-    #  `transformers.cache_utils`
-    from transformers.cache_utils import Cache as _Cache, DynamicCache as _DynamicCache
-except ImportError:
-    _Cache = _DynamicCache = None
+transformers_installed: bool
+Cache: Optional[Type[CacheLike]]
+DynamicCache: Optional[Type[DynamicCacheLike]]
 
-Cache: Optional[Type[CacheLike]] = _Cache
-DynamicCache: Optional[Type[DynamicCacheLike]] = _DynamicCache
+try:
+    # pyre-ignore[21]: Could not find a module corresponding to import `transformers`.
+    import transformers  # noqa: F401
+
+    transformers_installed = True
+except ImportError:
+    transformers_installed = False
+
+if transformers_installed:
+    try:
+        # pyre-ignore[21]: Could not find a module corresponding to import
+        # `transformers.cache_utils`.
+        from transformers.cache_utils import (  # noqa: F401
+            Cache as _Cache,
+            DynamicCache as _DynamicCache,
+        )
+
+        Cache = _Cache
+        # pyre-ignore[9]: Incompatible variable type: DynamicCache is declared to have
+        # type `Optional[Type[DynamicCacheLike]]` but is used as type
+        # `Type[_DynamicCache]`
+        DynamicCache = _DynamicCache
+    except ImportError:
+        Cache = DynamicCache = None
+else:
+    Cache = DynamicCache = None
+
+# GenerationMixin._update_model_kwargs_for_generation
+# "cache_position" at v4.39.0 (only needed for models that support cache class)
+# "use_cache" at v4.41.0 (optional, default is True)
+# "cache_position" is mandatory at v4.43.0 ("use_cache" is still optional, default True)
+_transformers_version: Optional[Version]
+if transformers_installed:
+    _transformers_version = Version(transformers.__version__)
+else:
+    _transformers_version = None
+
+_mandated_cache_version = Version("4.43.0")
+_use_cache_version = Version("4.41.0")
+_cache_position_version = Version("4.39.0")
+
+
+def update_model_kwargs(
+    model_kwargs: Dict[str, Any],
+    model: nn.Module,
+    input_ids: torch.Tensor,
+    caching: bool,
+) -> None:
+    if not supports_caching(model):
+        return
+    assert _transformers_version is not None
+    if caching:
+        # Enable caching
+        if _transformers_version >= _cache_position_version:
+            cache_position = torch.arange(
+                input_ids.shape[1], dtype=torch.int64, device=input_ids.device
+            )
+            model_kwargs["cache_position"] = cache_position
+        # pyre-ignore[58]: Unsupported operand `>=` is not supported for operand types
+        # `Optional[Version]` and `Version`.
+        if _transformers_version >= _use_cache_version:
+            model_kwargs["use_cache"] = True
+    else:
+        # Disable caching
+        if _transformers_version >= _use_cache_version:
+            model_kwargs["use_cache"] = False
+
+
+def supports_caching(model: nn.Module) -> bool:
+    if not transformers_installed:
+        # Not a transformers model
+        return False
+    # Cache may be optional or unsupported depending on model/version
+    try:
+        # pyre-ignore[21]: Could not find a module corresponding to import
+        # `transformers.generation.utils`.
+        from transformers.generation.utils import GenerationMixin
+    except ImportError:
+        return False
+    if not isinstance(model, GenerationMixin):
+        # Model isn't a GenerationMixin, we don't support additional caching logic
+        # for it
+        return False
+    assert _transformers_version is not None
+    if _transformers_version >= _mandated_cache_version:
+        # Cache is mandatory
+        return True
+    # Fallback on _supports_cache_class attribute
+    return getattr(model, "_supports_cache_class", False)

--- a/captum/attr/_core/llm_attr.py
+++ b/captum/attr/_core/llm_attr.py
@@ -7,6 +7,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 import torch
+from captum._utils.transformers_typing import Cache, DynamicCache
 from captum._utils.typing import TokenizerLike
 from captum.attr._core.feature_ablation import FeatureAblation
 from captum.attr._core.kernel_shap import KernelShap
@@ -27,8 +28,12 @@ from captum.attr._utils.interpretable_input import (
 )
 from torch import nn, Tensor
 
-
-DEFAULT_GEN_ARGS = {"max_new_tokens": 25, "do_sample": False}
+DEFAULT_GEN_ARGS: Dict[str, Any] = {
+    "max_new_tokens": 25,
+    "do_sample": False,
+    "temperature": None,
+    "top_p": None,
+}
 
 
 class LLMAttributionResult:
@@ -258,8 +263,9 @@ class LLMAttribution(Attribution):
         init_model_inp = perturbed_input
 
         model_inp = init_model_inp
-        attention_mask = torch.tensor([[1] * model_inp.shape[1]])
-        attention_mask = attention_mask.to(model_inp.device)
+        attention_mask = torch.ones(
+            [1, model_inp.shape[1]], dtype=torch.long, device=model_inp.device
+        )
         model_kwargs = {"attention_mask": attention_mask}
 
         log_prob_list = []
@@ -267,6 +273,15 @@ class LLMAttribution(Attribution):
         for target_token in target_tokens:
             if use_cached_outputs:
                 if outputs is not None:
+                    if (
+                        Cache is not None
+                        and DynamicCache is not None
+                        and getattr(self.model, "_supports_cache_class", False)
+                        and not isinstance(outputs.past_key_values, Cache)
+                    ):
+                        outputs.past_key_values = DynamicCache.from_legacy_cache(
+                            outputs.past_key_values
+                        )
                     model_kwargs = self.model._update_model_kwargs_for_generation(
                         outputs, model_kwargs
                     )
@@ -275,7 +290,7 @@ class LLMAttribution(Attribution):
                 )
                 outputs = self.model.forward(**model_inputs)
             else:
-                outputs = self.model.forward(model_inp, attention_mask=attention_mask)
+                outputs = self.model.forward(model_inp, **model_kwargs)
             new_token_logits = outputs.logits[:, -1]
             log_probs = torch.nn.functional.log_softmax(new_token_logits, dim=1)
 
@@ -345,7 +360,8 @@ class LLMAttribution(Attribution):
                     Defaults: 1.
             gen_args (dict, optional): arguments for generating the target. Only used if
                     target is not given. When None, the default arguments are used,
-                    {"max_length": 25, "do_sample": False}
+                    {"max_new_tokens": 25, "do_sample": False,
+                    "temperature": None, "top_p": None}
                     Defaults: None
             **kwargs (Any): any extra keyword arguments passed to the call of the
                     underlying attribute function of the given attribution instance
@@ -516,7 +532,8 @@ class LLMGradientAttribution(Attribution):
                     Default: None
             gen_args (dict, optional): arguments for generating the target. Only used if
                     target is not given. When None, the default arguments are used,
-                    {"max_length": 25, "do_sample": False}
+                    {"max_new_tokens": 25, "do_sample": False,
+                    "temperature": None, "top_p": None}
                     Defaults: None
             **kwargs (Any): any extra keyword arguments passed to the call of the
                     underlying attribute function of the given attribution instance

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,9 @@ DEV_REQUIRES = (
 
 # get version string from module
 with open(os.path.join(os.path.dirname(__file__), "captum/__init__.py"), "r") as f:
-    version = re.search(r"__version__ = ['\"]([^'\"]*)['\"]", f.read(), re.M).group(1)
+    version_match = re.search(r"__version__ = ['\"]([^'\"]*)['\"]", f.read(), re.M)
+    assert version_match is not None, "Unable to find version string."
+    version = version_match.group(1)
     report("-- Building version " + version)
 
 # read in README.md as the long description
@@ -147,7 +149,13 @@ if __name__ == "__main__":
         long_description=long_description,
         long_description_content_type="text/markdown",
         python_requires=">=3.8",
-        install_requires=["matplotlib", "numpy<2.0", "torch>=1.10", "tqdm"],
+        install_requires=[
+            "matplotlib",
+            "numpy<2.0",
+            "packaging",
+            "torch>=1.10",
+            "tqdm",
+        ],
         packages=find_packages(exclude=("tests", "tests.*")),
         extras_require={
             "dev": DEV_REQUIRES,


### PR DESCRIPTION
Summary: Supports multiple and newer versions of the transformers library. Adds the `packaging` dependency as well to more robustly check package versions.

Differential Revision: D62468332
