### PR TITLE
Ensure autograd graphs are freed between attribute calls

### DIFF
--- a/captum/attr/_core/llm_attr.py
+++ b/captum/attr/_core/llm_attr.py
@@ -574,9 +574,10 @@ class LLMGradientAttribution(Attribution):
             if not gen_args:
                 gen_args = DEFAULT_GEN_ARGS
 
-            model_inp = self._format_model_input(inp.to_model_input())
-            output_tokens = self.model.generate(model_inp, **gen_args)
-            target_tokens = output_tokens[0][model_inp.size(1) :]
+            with torch.no_grad():
+                model_inp = self._format_model_input(inp.to_model_input())
+                output_tokens = self.model.generate(model_inp, **gen_args)
+                target_tokens = output_tokens[0][model_inp.size(1) :]
         else:
             assert gen_args is None, "gen_args must be None when target is given"
 
@@ -605,7 +606,7 @@ class LLMGradientAttribution(Attribution):
                     cur_target_idx,
                 ),
                 **kwargs,
-            )
+            ).detach()
             attr = cast(Tensor, attr)
 
             # will have the attr for previous output tokens


### PR DESCRIPTION
Summary:
Some attributions returned by gradient-based methods still have a `grad_fn` from autograd (e.g. `LayerGradientXActivation`). This diff ensures that the autograd graph is freed between attribute calls within `LLMGradientAttribution` to eliminate this as a potential source of VRAM accumulation.

Also wrapped `model.generate` with a `no_grad` context to avoid unecessary memory usage.

Differential Revision: D62671994
