### PR TITLE
Pretty-print tokens in `llm_attr` methods

### DIFF
--- a/captum/_utils/typing.py
+++ b/captum/_utils/typing.py
@@ -2,7 +2,16 @@
 
 # pyre-strict
 
-from typing import List, Optional, Protocol, Tuple, TYPE_CHECKING, TypeVar, Union
+from typing import (
+    List,
+    Optional,
+    overload,
+    Protocol,
+    Tuple,
+    TYPE_CHECKING,
+    TypeVar,
+    Union,
+)
 
 from torch import Tensor
 from torch.nn import Module
@@ -10,7 +19,7 @@ from torch.nn import Module
 if TYPE_CHECKING:
     from typing import Literal
 else:
-    Literal = {True: bool, False: bool, (True, False): bool}
+    Literal = {True: bool, False: bool, (True, False): bool, "pt": str}
 
 TensorOrTupleOfTensorsGeneric = TypeVar(
     "TensorOrTupleOfTensorsGeneric", Tensor, Tuple[Tensor, ...]
@@ -39,8 +48,31 @@ class TokenizerLike(Protocol):
     """A protocol for tokenizer-like objects that can be used with Captum
     LLM attribution methods."""
 
+    @overload
+    def encode(self, text: str, return_tensors: None = None) -> List[int]: ...
+    @overload
+    def encode(self, text: str, return_tensors: Literal["pt"]) -> Tensor: ...
+
     def encode(
         self, text: str, return_tensors: Optional[str] = None
     ) -> Union[List[int], Tensor]: ...
+
     def decode(self, token_ids: Tensor) -> str: ...
-    def convert_ids_to_tokens(self, token_ids: Tensor) -> List[str]: ...
+
+    @overload
+    def convert_ids_to_tokens(self, token_ids: List[int]) -> List[str]: ...
+    @overload
+    def convert_ids_to_tokens(self, token_ids: int) -> str: ...
+
+    def convert_ids_to_tokens(
+        self, token_ids: Union[List[int], int]
+    ) -> Union[List[str], str]: ...
+
+    @overload
+    def convert_tokens_to_ids(self, tokens: str) -> int: ...
+    @overload
+    def convert_tokens_to_ids(self, tokens: List[str]) -> List[int]: ...
+
+    def convert_tokens_to_ids(
+        self, tokens: Union[List[str], str]
+    ) -> Union[List[int], int]: ...

--- a/captum/attr/_core/llm_attr.py
+++ b/captum/attr/_core/llm_attr.py
@@ -574,9 +574,10 @@ class LLMGradientAttribution(Attribution):
             if not gen_args:
                 gen_args = DEFAULT_GEN_ARGS
 
-            model_inp = self._format_model_input(inp.to_model_input())
-            output_tokens = self.model.generate(model_inp, **gen_args)
-            target_tokens = output_tokens[0][model_inp.size(1) :]
+            with torch.no_grad():
+                model_inp = self._format_model_input(inp.to_model_input())
+                output_tokens = self.model.generate(model_inp, **gen_args)
+                target_tokens = output_tokens[0][model_inp.size(1) :]
         else:
             assert gen_args is None, "gen_args must be None when target is given"
 
@@ -605,7 +606,7 @@ class LLMGradientAttribution(Attribution):
                     cur_target_idx,
                 ),
                 **kwargs,
-            )
+            ).detach()
             attr = cast(Tensor, attr)
 
             # will have the attr for previous output tokens

--- a/tests/attr/test_interpretable_input.py
+++ b/tests/attr/test_interpretable_input.py
@@ -2,7 +2,10 @@
 
 # pyre-unsafe
 
+from typing import List, Optional, overload, Union
+
 import torch
+from captum._utils.typing import Literal
 from captum.attr._utils.interpretable_input import TextTemplateInput, TextTokenInput
 from parameterized import parameterized
 from tests.helpers import BaseTest
@@ -16,19 +19,58 @@ class DummyTokenizer:
         self.id_to_token = vocab_list
         self.unk_idx = len(vocab_list) + 1
 
-    def encode(self, text, **kwargs) -> Tensor:
+    @overload
+    def encode(self, text: str, return_tensors: None = None) -> List[int]: ...
+    @overload
+    # pyre-fixme[43]: Incompatible overload. The implementation of
+    # `DummyTokenizer.encode` does not accept all possible arguments of overload.
+    # pyre-ignore[11]: Annotation `pt` is not defined as a type
+    def encode(self, text: str, return_tensors: Literal["pt"]) -> Tensor: ...
+
+    def encode(
+        self, text: str, return_tensors: Optional[str] = "pt"
+    ) -> Union[List[int], Tensor]:
+        assert return_tensors == "pt"
         return torch.tensor([self.convert_tokens_to_ids(text.split(" "))])
 
-    def convert_ids_to_tokens(self, ids):
+    @overload
+    def convert_ids_to_tokens(self, token_ids: List[int]) -> List[str]: ...
+    @overload
+    def convert_ids_to_tokens(self, token_ids: int) -> str: ...
+
+    def convert_ids_to_tokens(
+        self, token_ids: Union[List[int], int]
+    ) -> Union[List[str], str]:
+        if isinstance(token_ids, int):
+            return (
+                self.id_to_token[token_ids]
+                if token_ids < len(self.id_to_token)
+                else "[UNK]"
+            )
         return [
-            (self.id_to_token[i] if i < len(self.id_to_token) else "[UNK]") for i in ids
+            (self.id_to_token[i] if i < len(self.id_to_token) else "[UNK]")
+            for i in token_ids
         ]
 
-    def convert_tokens_to_ids(self, tokens):
+    @overload
+    def convert_tokens_to_ids(self, tokens: str) -> int: ...
+    @overload
+    def convert_tokens_to_ids(self, tokens: List[str]) -> List[int]: ...
+
+    def convert_tokens_to_ids(
+        self, tokens: Union[List[str], str]
+    ) -> Union[List[int], int]:
+        if isinstance(tokens, str):
+            return (
+                self.token_to_id[tokens] if tokens in self.token_to_id else self.unk_idx
+            )
         return [
             (self.token_to_id[t] if t in self.token_to_id else self.unk_idx)
             for t in tokens
         ]
+
+    def decode(self, token_ids: Tensor) -> str:
+        raise NotImplementedError
 
 
 class TestTextTemplateInput(BaseTest):

--- a/tests/attr/test_llm_attr.py
+++ b/tests/attr/test_llm_attr.py
@@ -3,10 +3,22 @@
 # pyre-strict
 
 import copy
-from typing import Any, cast, Dict, List, NamedTuple, Optional, Tuple, Type, Union
+from typing import (
+    Any,
+    cast,
+    Dict,
+    List,
+    NamedTuple,
+    Optional,
+    overload,
+    Tuple,
+    Type,
+    Union,
+)
 
 import torch
 from captum._utils.models.linear_model import SkLearnLasso
+from captum._utils.typing import Literal
 from captum.attr._core.feature_ablation import FeatureAblation
 from captum.attr._core.kernel_shap import KernelShap
 from captum.attr._core.layer.layer_gradient_shap import LayerGradientShap
@@ -29,6 +41,14 @@ class DummyTokenizer:
     unk: int = 1
     special_tokens: Dict[int, str] = {sos: "<sos>", unk: "<unk>"}
 
+    @overload
+    def encode(self, text: str, return_tensors: None = None) -> List[int]: ...
+    @overload
+    # pyre-fixme[43]: Incompatible overload. The implementation of
+    # `DummyTokenizer.encode` does not accept all possible arguments of overload.
+    # pyre-ignore[11]: Annotation `pt` is not defined as a type
+    def encode(self, text: str, return_tensors: Literal["pt"]) -> Tensor: ...
+
     def encode(
         self, text: str, return_tensors: Optional[str] = None
     ) -> Union[List[int], Tensor]:
@@ -45,14 +65,37 @@ class DummyTokenizer:
             return torch.tensor([tokens_ids])
         return tokens_ids
 
-    def convert_ids_to_tokens(self, token_ids: Tensor) -> List[str]:
+    @overload
+    def convert_ids_to_tokens(self, token_ids: List[int]) -> List[str]: ...
+    @overload
+    def convert_ids_to_tokens(self, token_ids: int) -> str: ...
+
+    def convert_ids_to_tokens(
+        self, token_ids: Union[List[int], int]
+    ) -> Union[List[str], str]:
+        if isinstance(token_ids, int):
+            return (
+                self.special_tokens[token_ids]
+                if token_ids in self.special_tokens
+                else chr(token_ids)
+            )
         return [
             (self.special_tokens[tid] if tid in self.special_tokens else chr(tid))
             for tid in token_ids
         ]
 
+    @overload
+    def convert_tokens_to_ids(self, tokens: str) -> int: ...
+    @overload
+    def convert_tokens_to_ids(self, tokens: List[str]) -> List[int]: ...
+
+    def convert_tokens_to_ids(
+        self, tokens: Union[List[str], str]
+    ) -> Union[List[int], int]:
+        raise NotImplementedError
+
     def decode(self, token_ids: Tensor) -> str:
-        return " ".join(self.convert_ids_to_tokens(token_ids))
+        return " ".join(self.convert_ids_to_tokens(token_ids.tolist()))
 
 
 class Result(NamedTuple):


### PR DESCRIPTION
Summary:
Convert ids to tokens without ugly unicode characters (e.g., Ġ). See:
 https://github.com/huggingface/transformers/issues/4786 and
https://discuss.huggingface.co/t/bpe-tokenizers-and-spaces-before-words/475/2

This is the preferred function over tokenizer.convert_ids_to_tokens() for user-facing data.

Quote from links:
    > Spaces are converted in a special character (the Ġ) in the tokenizer prior to
    > BPE splitting mostly to avoid digesting spaces since the standard BPE algorithm
    > used spaces in its process

Differential Revision: D62672912
