### PR TITLE
Fix incompatible type breaking OSS tests

### DIFF
--- a/captum/attr/_core/dataloader_attr.py
+++ b/captum/attr/_core/dataloader_attr.py
@@ -3,7 +3,7 @@
 # pyre-strict
 from collections import defaultdict
 from copy import copy
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Callable, cast, Dict, Iterable, List, Optional, Tuple, Union
 
 import torch
 from captum._utils.common import (
@@ -193,8 +193,7 @@ class DataLoaderAttribution(Attribution):
         feature_mask: Tuple[Tensor, ...],
         # pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.
         reduce: Callable,
-        # pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.
-        to_metric: Optional[Callable],
+        to_metric: Optional[Callable[[Tensor], Tensor]],
         show_progress: bool,
         feature_idx_to_mask_idx: Dict[int, List[int]],
     ) -> Tensor:
@@ -243,7 +242,8 @@ class DataLoaderAttribution(Attribution):
 
                 accum_states[i] = reduce(accum_states[i], output, perturbed_inputs)
 
-        accum_results = [
+        accum_states = cast(List[Tensor], accum_states)
+        accum_results: List[Tensor] = [
             to_metric(accum) if to_metric else accum for accum in accum_states
         ]
 
@@ -276,7 +276,7 @@ class DataLoaderAttribution(Attribution):
         Args:
 
             dataloader (torch.Dataloader): the dataloader to attribute, which should
-                        return a tuple of consistant size for every iteration
+                        return a tuple of consistent size for every iteration
             input_roles (tuple[int, ...], optional): a tuple of integers to define the
                         role of each element returned from the dataloader. It should
                         have the same size as the return of the dataloader.
@@ -326,7 +326,7 @@ class DataLoaderAttribution(Attribution):
                         traverses needed is
                         ceil(n_perturbations / perturbations_per_pass).
 
-                        This arguement offers control of the trade-off between memory
+                        This argument offers control of the trade-off between memory
                         and efficiency. If the dataloader involves slow operations like
                         remote request or file I/O, multiple traversals can be
                         inefficient. On the other hand, each perturbation needs to

--- a/captum/attr/_core/lime.py
+++ b/captum/attr/_core/lime.py
@@ -522,7 +522,10 @@ class LimeBase(PerturbationAttribution):
             if show_progress:
                 attr_progress.close()
 
-            combined_interp_inps = torch.cat(interpretable_inps).float()
+            # Argument 1 to "cat" has incompatible type
+            # "list[Tensor | tuple[Tensor, ...]]";
+            # expected "tuple[Tensor, ...] | list[Tensor]"  [arg-type]
+            combined_interp_inps = torch.cat(interpretable_inps).float()  # type: ignore
             combined_outputs = (
                 torch.cat(outputs)
                 if len(outputs[0].shape) > 0

--- a/captum/concept/_utils/classifier.py
+++ b/captum/concept/_utils/classifier.py
@@ -186,7 +186,9 @@ class DefaultClassifier(Classifier):
         x_train, x_test, y_train, y_test = _train_test_split(
             torch.cat(inputs), torch.cat(labels), test_split=test_split_ratio
         )
-        self.lm.device = device
+        # error: Incompatible types in assignment (expression has type "str | Any",
+        # variable has type "Tensor | Module")  [assignment]
+        self.lm.device = device  # type: ignore
         self.lm.fit(DataLoader(TensorDataset(x_train, y_train)))
 
         predict = self.lm(x_test)

--- a/captum/log/__init__.py
+++ b/captum/log/__init__.py
@@ -24,7 +24,7 @@ try:
 except ImportError:
     from functools import wraps
 
-    def log(*args: Any, **kwargs: Any) -> None:
+    def log(*args: Any, **kwargs: Any) -> None:  # type: ignore
         pass
 
     # bug with mypy: https://github.com/python/mypy/issues/1153
@@ -56,12 +56,12 @@ except ImportError:
         return _log_usage
 
     # pyre-fixme[2]: Parameter must be annotated.
-    def set_environment(env) -> None:
+    def set_environment(env) -> None:  # type: ignore
         pass
 
     def disable_detailed_logging() -> None:
         pass
 
     # pyre-fixme[2]: Parameter must be annotated.
-    def patch_methods(tester, patch_log: bool = True) -> None:
+    def patch_methods(tester, patch_log: bool = True) -> None:  # type: ignore
         pass

--- a/captum/module/gaussian_stochastic_gates.py
+++ b/captum/module/gaussian_stochastic_gates.py
@@ -81,7 +81,7 @@ class GaussianStochasticGates(StochasticGatesBase):
             mask=mask,
             # pyre-fixme[6]: For 3rd argument expected `float` but got
             #  `Optional[float]`.
-            reg_weight=reg_weight,
+            reg_weight=reg_weight,  # type: ignore
             reg_reduction=reg_reduction,
         )
 
@@ -91,7 +91,7 @@ class GaussianStochasticGates(StochasticGatesBase):
 
         # pyre-fixme[58]: `<` is not supported for operand types `int` and
         #  `Optional[float]`.
-        assert 0 < std, f"the standard deviation should be positive, received {std}"
+        assert 0 < std, f"the standard deviation should be positive, received {std}"  # type: ignore  # noqa: E501 line too long
         self.std = std
 
     def _sample_gate_values(self, batch_size: int) -> Tensor:
@@ -109,7 +109,7 @@ class GaussianStochasticGates(StochasticGatesBase):
             n = torch.empty(batch_size, self.n_gates, device=self.mu.device)
             # pyre-fixme[6]: For 2nd argument expected `float` but got
             #  `Optional[float]`.
-            n.normal_(mean=0, std=self.std)
+            n.normal_(mean=0, std=self.std)  # type: ignore
             return self.mu + n
 
         return self.mu.expand(batch_size, self.n_gates)

--- a/tests/attr/helpers/gen_test_utils.py
+++ b/tests/attr/helpers/gen_test_utils.py
@@ -41,7 +41,7 @@ def parse_test_config(
     baseline_distr = (
         test_config["baseline_distr"] if "baseline_distr" in test_config else False
     )
-    return algorithms, model, args, layer, noise_tunnel, baseline_distr
+    return algorithms, model, args, layer, noise_tunnel, baseline_distr  # type: ignore
 
 
 def should_create_generated_test(algorithm: Type[Attribution]) -> bool:

--- a/tests/attr/layer/test_layer_gradient_shap.py
+++ b/tests/attr/layer/test_layer_gradient_shap.py
@@ -201,7 +201,7 @@ class Test(BaseTest):
         if expected_delta is None:
             assert_attribution_delta(
                 # pyre-fixme[6]: For 1st argument expected `FbBaseTest` but got `Test`.
-                self,
+                self,  # type: ignore
                 inputs,
                 attrs,
                 n_samples,

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -10,4 +10,7 @@ try:
     ]
 
 except ImportError:
-    from tests.helpers.basic import BaseTest
+    # tests/helpers/__init__.py:13: error: Incompatible import of "BaseTest"
+    # (imported name has type "type[BaseTest]", local name has type
+    # "type[FbBaseTest]")  [assignment]
+    from tests.helpers.basic import BaseTest  # type: ignore

--- a/tests/helpers/influence/common.py
+++ b/tests/helpers/influence/common.py
@@ -409,6 +409,7 @@ def get_random_model_and_data(
         in_features, out_features, num_samples, use_gpu, unpack_inputs
     )
 
+    net: Union[BasicLinearNet, MultLinearNet, Linear, UnpackLinear]
     if model_type == "random":
         net = (
             BasicLinearNet(in_features, hidden_nodes, out_features)

--- a/tests/influence/_core/test_tracin_regression.py
+++ b/tests/influence/_core/test_tracin_regression.py
@@ -31,7 +31,7 @@ from torch import Tensor
 class TestTracInRegression(BaseTest):
     def _test_tracin_regression_setup(
         self, tmpdir: str, features: int, use_gpu: bool = False
-    ) -> Tuple[RangeDataset, Dict[str, Any]]:
+    ) -> Tuple[RangeDataset, Dict[str, Any]]:  # fixme (return type)
         low = 1
         high = 17
         dataset = RangeDataset(low, high, features, use_gpu)
@@ -49,7 +49,7 @@ class TestTracInRegression(BaseTest):
             torch.save(net_adjusted.state_dict(), os.path.join(tmpdir, checkpoint_name))
 
         # pyre-fixme[61]: `net_adjusted` is undefined, or not always defined.
-        return dataset, net_adjusted
+        return dataset, net_adjusted  # type: ignore
 
     use_gpu_list = (
         [True, False]

--- a/tests/influence/_core/test_tracin_xor.py
+++ b/tests/influence/_core/test_tracin_xor.py
@@ -167,7 +167,7 @@ class TestTracInXOR(BaseTest):
 
         dataset = BinaryDataset(use_gpu)
 
-        return net_adjusted, dataset
+        return net_adjusted, dataset  # type: ignore
 
     parametrized_list: List[
         Tuple[Optional[str], DataInfluenceConstructor, str, bool]

--- a/tests/module/test_binary_concrete_stochastic_gates.py
+++ b/tests/module/test_binary_concrete_stochastic_gates.py
@@ -18,6 +18,9 @@ from tests.helpers.basic import assertTensorAlmostEqual
     ]
 )
 class TestBinaryConcreteStochasticGates(BaseTest):
+    # pyre-fixme[13]: Attribute `testing_device` is never initialized.
+    testing_device: str
+
     def setUp(self) -> None:
         super().setUp()
         # pyre-fixme[16]: `TestBinaryConcreteStochasticGates` has no attribute

--- a/tests/module/test_gaussian_stochastic_gates.py
+++ b/tests/module/test_gaussian_stochastic_gates.py
@@ -19,6 +19,9 @@ from tests.helpers.basic import assertTensorAlmostEqual
     ]
 )
 class TestGaussianStochasticGates(BaseTest):
+    # pyre-fixme[13]: Attribute `testing_device` is never initialized.
+    testing_device: str
+
     def setUp(self) -> None:
         super().setUp()
         # pyre-fixme[16]: `TestGaussianStochasticGates` has no attribute


### PR DESCRIPTION
Summary: Correct typing in dataloader attr to prevent tests from breaking

Differential Revision: D64412835


