### PR TITLE
Address instances of "Overloaded function signature x will never be matched" + minor typing fixes

### DIFF
--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -73,17 +73,17 @@ def safe_div(
 @typing.overload
 # pyre-fixme[43]: The return type of overloaded function `_is_tuple` (`Literal[]`)
 #  is incompatible with the return type of the implementation (`bool`).
-# pyre-fixme[31]: Expression `Literal[False]` is not a valid type.
+# pyre-fixme[31]: Expression `Literal[True]` is not a valid type.
 # pyre-fixme[24]: Non-generic type `typing.Literal` cannot take parameters.
-def _is_tuple(inputs: Tensor) -> Literal[False]: ...
+def _is_tuple(inputs: Tuple[Tensor, ...]) -> Literal[True]: ...
 
 
 @typing.overload
 # pyre-fixme[43]: The return type of overloaded function `_is_tuple` (`Literal[]`)
 #  is incompatible with the return type of the implementation (`bool`).
-# pyre-fixme[31]: Expression `Literal[True]` is not a valid type.
+# pyre-fixme[31]: Expression `Literal[False]` is not a valid type.
 # pyre-fixme[24]: Non-generic type `typing.Literal` cannot take parameters.
-def _is_tuple(inputs: Tuple[Tensor, ...]) -> Literal[True]: ...
+def _is_tuple(inputs: Tensor) -> Literal[False]: ...
 
 
 def _is_tuple(inputs: Union[Tensor, Tuple[Tensor, ...]]) -> bool:
@@ -277,7 +277,7 @@ def _format_additional_forward_args(
 
 
 @overload
-def _format_additional_forward_args(
+def _format_additional_forward_args(  # type: ignore
     # pyre-fixme[2]: Parameter annotation cannot be `Any`.
     additional_forward_args: Any,
     # pyre-fixme[24]: Generic type `tuple` expects at least 1 type parameter.
@@ -780,10 +780,10 @@ def _reduce_list(
     """
     assert len(val_list) > 0, "Cannot reduce empty list!"
     if isinstance(val_list[0], torch.Tensor):
-        # pyre-fixme[16]: `bool` has no attribute `device`.
-        first_device = val_list[0].device
-        # pyre-fixme[16]: `bool` has no attribute `to`.
-        return red_func([elem.to(first_device) for elem in val_list])
+        first_device = cast(Tensor, val_list[0]).device
+        return red_func(
+            [elem.to(first_device) for elem in cast(List[Tensor], val_list)]
+        )
     elif isinstance(val_list[0], bool):
         # pyre-fixme[7]: Expected `TupleOrTensorOrBoolGeneric` but got `bool`.
         return any(val_list)

--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -159,6 +159,22 @@ def _neuron_gradients(
 
 @typing.overload
 # pyre-fixme[43]: The implementation of `_forward_layer_eval` does not accept all
+#  possible arguments of overload defined on line `170`.
+def _forward_layer_eval(
+    # pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.
+    forward_fn: Callable,
+    inputs: Union[Tensor, Tuple[Tensor, ...]],
+    layer: List[Module],
+    # pyre-fixme[2]: Parameter annotation cannot be `Any`.
+    additional_forward_args: Any = None,
+    device_ids: Union[None, List[int]] = None,
+    attribute_to_layer_input: bool = False,
+    grad_enabled: bool = False,
+) -> List[Tuple[Tensor, ...]]: ...
+
+
+@typing.overload
+# pyre-fixme[43]: The implementation of `_forward_layer_eval` does not accept all
 #  possible arguments of overload defined on line `158`.
 def _forward_layer_eval(
     # pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.
@@ -171,21 +187,6 @@ def _forward_layer_eval(
     attribute_to_layer_input: bool = False,
     grad_enabled: bool = False,
 ) -> Tuple[Tensor, ...]: ...
-
-
-@typing.overload
-# pyre-fixme[43]: The implementation of `_forward_layer_eval` does not accept all
-#  possible arguments of overload defined on line `170`.
-def _forward_layer_eval(
-    # pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.
-    forward_fn: Callable,
-    inputs: Union[Tensor, Tuple[Tensor, ...]],
-    layer: List[Module],
-    additional_forward_args: Any = None,
-    device_ids: Union[None, List[int]] = None,
-    attribute_to_layer_input: bool = False,
-    grad_enabled: bool = False,
-) -> List[Tuple[Tensor, ...]]: ...
 
 
 def _forward_layer_eval(
@@ -434,22 +435,6 @@ def _forward_layer_eval_with_neuron_grads(
 
 @typing.overload
 # pyre-fixme[43]: The implementation of `_forward_layer_eval_with_neuron_grads` does
-#  not accept all possible arguments of overload defined on line `392`.
-def _forward_layer_eval_with_neuron_grads(
-    # pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.
-    forward_fn: Callable,
-    inputs: Union[Tensor, Tuple[Tensor, ...]],
-    layer: Module,
-    additional_forward_args: Any = None,
-    gradient_neuron_selector: None = None,
-    grad_enabled: bool = False,
-    device_ids: Union[None, List[int]] = None,
-    attribute_to_layer_input: bool = False,
-) -> Tuple[Tensor, ...]: ...
-
-
-@typing.overload
-# pyre-fixme[43]: The implementation of `_forward_layer_eval_with_neuron_grads` does
 #  not accept all possible arguments of overload defined on line `405`.
 def _forward_layer_eval_with_neuron_grads(
     # pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.
@@ -462,6 +447,22 @@ def _forward_layer_eval_with_neuron_grads(
     device_ids: Union[None, List[int]] = None,
     attribute_to_layer_input: bool = False,
 ) -> List[Tuple[Tensor, ...]]: ...
+
+
+@typing.overload
+# pyre-fixme[43]: The implementation of `_forward_layer_eval_with_neuron_grads` does
+#  not accept all possible arguments of overload defined on line `392`.
+def _forward_layer_eval_with_neuron_grads(
+    # pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.
+    forward_fn: Callable,
+    inputs: Union[Tensor, Tuple[Tensor, ...]],
+    layer: Module,
+    additional_forward_args: Any = None,
+    gradient_neuron_selector: None = None,
+    grad_enabled: bool = False,
+    device_ids: Union[None, List[int]] = None,
+    attribute_to_layer_input: bool = False,
+) -> Tuple[Tensor, ...]: ...
 
 
 def _forward_layer_eval_with_neuron_grads(

--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -118,6 +118,23 @@ class DeepLift(GradientAttribution):
 
     @typing.overload
     # pyre-fixme[43]: The implementation of `attribute` does not accept all possible
+    #  arguments of overload defined on line `131`.
+    def attribute(
+        self,
+        inputs: TensorOrTupleOfTensorsGeneric,
+        baselines: BaselineType = None,
+        target: TargetType = None,
+        # pyre-fixme[2]: Parameter annotation cannot be `Any`.
+        additional_forward_args: Any = None,
+        *,
+        # pyre-fixme[31]: Expression `Literal[True]` is not a valid type.
+        # pyre-fixme[24]: Non-generic type `typing.Literal` cannot take parameters.
+        return_convergence_delta: Literal[True],
+        custom_attribution_func: Union[None, Callable[..., Tuple[Tensor, ...]]] = None,
+    ) -> Tuple[TensorOrTupleOfTensorsGeneric, Tensor]: ...
+
+    @typing.overload
+    # pyre-fixme[43]: The implementation of `attribute` does not accept all possible
     #  arguments of overload defined on line `120`.
     def attribute(
         self,
@@ -132,22 +149,6 @@ class DeepLift(GradientAttribution):
         return_convergence_delta: Literal[False] = False,
         custom_attribution_func: Union[None, Callable[..., Tuple[Tensor, ...]]] = None,
     ) -> TensorOrTupleOfTensorsGeneric: ...
-
-    @typing.overload
-    # pyre-fixme[43]: The implementation of `attribute` does not accept all possible
-    #  arguments of overload defined on line `131`.
-    def attribute(
-        self,
-        inputs: TensorOrTupleOfTensorsGeneric,
-        baselines: BaselineType = None,
-        target: TargetType = None,
-        additional_forward_args: Any = None,
-        *,
-        # pyre-fixme[31]: Expression `Literal[True]` is not a valid type.
-        # pyre-fixme[24]: Non-generic type `typing.Literal` cannot take parameters.
-        return_convergence_delta: Literal[True],
-        custom_attribution_func: Union[None, Callable[..., Tuple[Tensor, ...]]] = None,
-    ) -> Tuple[TensorOrTupleOfTensorsGeneric, Tensor]: ...
 
     @log_usage()
     def attribute(  # type: ignore
@@ -636,6 +637,25 @@ class DeepLiftShap(DeepLift):
     # DeepLiftShap.attribute, so we ignore typing here
     @typing.overload  # type: ignore
     # pyre-fixme[43]: The implementation of `attribute` does not accept all possible
+    #  arguments of overload defined on line `597`.
+    def attribute(
+        self,
+        inputs: TensorOrTupleOfTensorsGeneric,
+        baselines: Union[
+            TensorOrTupleOfTensorsGeneric, Callable[..., TensorOrTupleOfTensorsGeneric]
+        ],
+        target: TargetType = None,
+        # pyre-fixme[2]: Parameter annotation cannot be `Any`.
+        additional_forward_args: Any = None,
+        *,
+        # pyre-fixme[31]: Expression `Literal[True]` is not a valid type.
+        # pyre-fixme[24]: Non-generic type `typing.Literal` cannot take parameters.
+        return_convergence_delta: Literal[True],
+        custom_attribution_func: Union[None, Callable[..., Tuple[Tensor, ...]]] = None,
+    ) -> Tuple[TensorOrTupleOfTensorsGeneric, Tensor]: ...
+
+    @typing.overload
+    # pyre-fixme[43]: The implementation of `attribute` does not accept all possible
     #  arguments of overload defined on line `584`.
     def attribute(
         self,
@@ -652,24 +672,6 @@ class DeepLiftShap(DeepLift):
         return_convergence_delta: Literal[False] = False,
         custom_attribution_func: Union[None, Callable[..., Tuple[Tensor, ...]]] = None,
     ) -> TensorOrTupleOfTensorsGeneric: ...
-
-    @typing.overload
-    # pyre-fixme[43]: The implementation of `attribute` does not accept all possible
-    #  arguments of overload defined on line `597`.
-    def attribute(
-        self,
-        inputs: TensorOrTupleOfTensorsGeneric,
-        baselines: Union[
-            TensorOrTupleOfTensorsGeneric, Callable[..., TensorOrTupleOfTensorsGeneric]
-        ],
-        target: TargetType = None,
-        additional_forward_args: Any = None,
-        *,
-        # pyre-fixme[31]: Expression `Literal[True]` is not a valid type.
-        # pyre-fixme[24]: Non-generic type `typing.Literal` cannot take parameters.
-        return_convergence_delta: Literal[True],
-        custom_attribution_func: Union[None, Callable[..., Tuple[Tensor, ...]]] = None,
-    ) -> Tuple[TensorOrTupleOfTensorsGeneric, Tensor]: ...
 
     @log_usage()
     def attribute(  # type: ignore

--- a/captum/attr/_core/integrated_gradients.py
+++ b/captum/attr/_core/integrated_gradients.py
@@ -81,6 +81,25 @@ class IntegratedGradients(GradientAttribution):
     # a tuple with both attributions and deltas.
     @typing.overload
     # pyre-fixme[43]: The implementation of `attribute` does not accept all possible
+    #  arguments of overload defined on line `95`.
+    def attribute(
+        self,
+        inputs: TensorOrTupleOfTensorsGeneric,
+        baselines: BaselineType = None,
+        target: TargetType = None,
+        # pyre-fixme[2]: Parameter annotation cannot be `Any`.
+        additional_forward_args: Any = None,
+        n_steps: int = 50,
+        method: str = "gausslegendre",
+        internal_batch_size: Union[None, int] = None,
+        *,
+        # pyre-fixme[31]: Expression `Literal[True]` is not a valid type.
+        # pyre-fixme[24]: Non-generic type `typing.Literal` cannot take parameters.
+        return_convergence_delta: Literal[True],
+    ) -> Tuple[TensorOrTupleOfTensorsGeneric, Tensor]: ...
+
+    @typing.overload
+    # pyre-fixme[43]: The implementation of `attribute` does not accept all possible
     #  arguments of overload defined on line `82`.
     def attribute(
         self,
@@ -97,24 +116,6 @@ class IntegratedGradients(GradientAttribution):
         # pyre-fixme[24]: Non-generic type `typing.Literal` cannot take parameters.
         return_convergence_delta: Literal[False] = False,
     ) -> TensorOrTupleOfTensorsGeneric: ...
-
-    @typing.overload
-    # pyre-fixme[43]: The implementation of `attribute` does not accept all possible
-    #  arguments of overload defined on line `95`.
-    def attribute(
-        self,
-        inputs: TensorOrTupleOfTensorsGeneric,
-        baselines: BaselineType = None,
-        target: TargetType = None,
-        additional_forward_args: Any = None,
-        n_steps: int = 50,
-        method: str = "gausslegendre",
-        internal_batch_size: Union[None, int] = None,
-        *,
-        # pyre-fixme[31]: Expression `Literal[True]` is not a valid type.
-        # pyre-fixme[24]: Non-generic type `typing.Literal` cannot take parameters.
-        return_convergence_delta: Literal[True],
-    ) -> Tuple[TensorOrTupleOfTensorsGeneric, Tensor]: ...
 
     @log_usage()
     def attribute(  # type: ignore

--- a/captum/attr/_core/layer/layer_activation.py
+++ b/captum/attr/_core/layer/layer_activation.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # pyre-strict
-from typing import Any, Callable, List, Tuple, Union
+from typing import Any, Callable, cast, List, Tuple, Union
 
 import torch
 from captum._utils.common import _format_output
@@ -128,7 +128,9 @@ class LayerActivation(LayerAttribution):
                 attribute_to_layer_input=attribute_to_layer_input,
             )
         if isinstance(self.layer, Module):
-            return _format_output(len(layer_eval) > 1, layer_eval)
+            return _format_output(
+                len(layer_eval) > 1, cast(Tuple[Tensor, ...], layer_eval)
+            )
         else:
             return [
                 # pyre-fixme[6]: For 2nd argument expected `Tuple[Tensor, ...]` but

--- a/captum/attr/_core/layer/layer_deep_lift.py
+++ b/captum/attr/_core/layer/layer_deep_lift.py
@@ -102,6 +102,25 @@ class LayerDeepLift(LayerAttribution, DeepLift):
     # Ignoring mypy error for inconsistent signature with DeepLift
     @typing.overload  # type: ignore
     # pyre-fixme[43]: The implementation of `attribute` does not accept all possible
+    #  arguments of overload defined on line `117`.
+    def attribute(
+        self,
+        inputs: Union[Tensor, Tuple[Tensor, ...]],
+        baselines: BaselineType = None,
+        target: TargetType = None,
+        # pyre-fixme[2]: Parameter annotation cannot be `Any`.
+        additional_forward_args: Any = None,
+        *,
+        # pyre-fixme[31]: Expression `Literal[True]` is not a valid type.
+        # pyre-fixme[24]: Non-generic type `typing.Literal` cannot take parameters.
+        return_convergence_delta: Literal[True],
+        attribute_to_layer_input: bool = False,
+        custom_attribution_func: Union[None, Callable[..., Tuple[Tensor, ...]]] = None,
+        grad_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[Union[Tensor, Tuple[Tensor, ...]], Tensor]: ...
+
+    @typing.overload
+    # pyre-fixme[43]: The implementation of `attribute` does not accept all possible
     #  arguments of overload defined on line `104`.
     def attribute(
         self,
@@ -118,24 +137,6 @@ class LayerDeepLift(LayerAttribution, DeepLift):
         custom_attribution_func: Union[None, Callable[..., Tuple[Tensor, ...]]] = None,
         grad_kwargs: Optional[Dict[str, Any]] = None,
     ) -> Union[Tensor, Tuple[Tensor, ...]]: ...
-
-    @typing.overload
-    # pyre-fixme[43]: The implementation of `attribute` does not accept all possible
-    #  arguments of overload defined on line `117`.
-    def attribute(
-        self,
-        inputs: Union[Tensor, Tuple[Tensor, ...]],
-        baselines: BaselineType = None,
-        target: TargetType = None,
-        additional_forward_args: Any = None,
-        *,
-        # pyre-fixme[31]: Expression `Literal[True]` is not a valid type.
-        # pyre-fixme[24]: Non-generic type `typing.Literal` cannot take parameters.
-        return_convergence_delta: Literal[True],
-        attribute_to_layer_input: bool = False,
-        custom_attribution_func: Union[None, Callable[..., Tuple[Tensor, ...]]] = None,
-        grad_kwargs: Optional[Dict[str, Any]] = None,
-    ) -> Tuple[Union[Tensor, Tuple[Tensor, ...]], Tensor]: ...
 
     @log_usage()
     # pyre-fixme[43]: This definition does not have the same decorators as the
@@ -452,6 +453,26 @@ class LayerDeepLiftShap(LayerDeepLift, DeepLiftShap):
     # Ignoring mypy error for inconsistent signature with DeepLiftShap
     @typing.overload  # type: ignore
     # pyre-fixme[43]: The implementation of `attribute` does not accept all possible
+    #  arguments of overload defined on line `453`.
+    def attribute(
+        self,
+        inputs: Union[Tensor, Tuple[Tensor, ...]],
+        baselines: Union[
+            Tensor, Tuple[Tensor, ...], Callable[..., Union[Tensor, Tuple[Tensor, ...]]]
+        ],
+        target: TargetType = None,
+        # pyre-fixme[2]: Parameter annotation cannot be `Any`.
+        additional_forward_args: Any = None,
+        *,
+        # pyre-fixme[31]: Expression `Literal[True]` is not a valid type.
+        # pyre-fixme[24]: Non-generic type `typing.Literal` cannot take parameters.
+        return_convergence_delta: Literal[True],
+        attribute_to_layer_input: bool = False,
+        custom_attribution_func: Union[None, Callable[..., Tuple[Tensor, ...]]] = None,
+    ) -> Tuple[Union[Tensor, Tuple[Tensor, ...]], Tensor]: ...
+
+    @typing.overload
+    # pyre-fixme[43]: The implementation of `attribute` does not accept all possible
     #  arguments of overload defined on line `439`.
     def attribute(
         self,
@@ -469,25 +490,6 @@ class LayerDeepLiftShap(LayerDeepLift, DeepLiftShap):
         attribute_to_layer_input: bool = False,
         custom_attribution_func: Union[None, Callable[..., Tuple[Tensor, ...]]] = None,
     ) -> Union[Tensor, Tuple[Tensor, ...]]: ...
-
-    @typing.overload
-    # pyre-fixme[43]: The implementation of `attribute` does not accept all possible
-    #  arguments of overload defined on line `453`.
-    def attribute(
-        self,
-        inputs: Union[Tensor, Tuple[Tensor, ...]],
-        baselines: Union[
-            Tensor, Tuple[Tensor, ...], Callable[..., Union[Tensor, Tuple[Tensor, ...]]]
-        ],
-        target: TargetType = None,
-        additional_forward_args: Any = None,
-        *,
-        # pyre-fixme[31]: Expression `Literal[True]` is not a valid type.
-        # pyre-fixme[24]: Non-generic type `typing.Literal` cannot take parameters.
-        return_convergence_delta: Literal[True],
-        attribute_to_layer_input: bool = False,
-        custom_attribution_func: Union[None, Callable[..., Tuple[Tensor, ...]]] = None,
-    ) -> Tuple[Union[Tensor, Tuple[Tensor, ...]], Tensor]: ...
 
     @log_usage()
     # pyre-fixme[43]: This definition does not have the same decorators as the

--- a/captum/attr/_core/layer/layer_gradient_shap.py
+++ b/captum/attr/_core/layer/layer_gradient_shap.py
@@ -393,6 +393,24 @@ class LayerInputBaselineXGradient(LayerAttribution, GradientAttribution):
 
     @typing.overload
     # pyre-fixme[43]: The implementation of `attribute` does not accept all possible
+    #  arguments of overload defined on line `385`.
+    def attribute(
+        self,
+        inputs: Union[Tensor, Tuple[Tensor, ...]],
+        baselines: Union[Tensor, Tuple[Tensor, ...]],
+        target: TargetType = None,
+        # pyre-fixme[2]: Parameter annotation cannot be `Any`.
+        additional_forward_args: Any = None,
+        *,
+        # pyre-fixme[31]: Expression `Literal[True]` is not a valid type.
+        # pyre-fixme[24]: Non-generic type `typing.Literal` cannot take parameters.
+        return_convergence_delta: Literal[True],
+        attribute_to_layer_input: bool = False,
+        grad_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[Union[Tensor, Tuple[Tensor, ...]], Tensor]: ...
+
+    @typing.overload
+    # pyre-fixme[43]: The implementation of `attribute` does not accept all possible
     #  arguments of overload defined on line `373`.
     def attribute(
         self,
@@ -408,23 +426,6 @@ class LayerInputBaselineXGradient(LayerAttribution, GradientAttribution):
         attribute_to_layer_input: bool = False,
         grad_kwargs: Optional[Dict[str, Any]] = None,
     ) -> Union[Tensor, Tuple[Tensor, ...]]: ...
-
-    @typing.overload
-    # pyre-fixme[43]: The implementation of `attribute` does not accept all possible
-    #  arguments of overload defined on line `385`.
-    def attribute(
-        self,
-        inputs: Union[Tensor, Tuple[Tensor, ...]],
-        baselines: Union[Tensor, Tuple[Tensor, ...]],
-        target: TargetType = None,
-        additional_forward_args: Any = None,
-        *,
-        # pyre-fixme[31]: Expression `Literal[True]` is not a valid type.
-        # pyre-fixme[24]: Non-generic type `typing.Literal` cannot take parameters.
-        return_convergence_delta: Literal[True],
-        attribute_to_layer_input: bool = False,
-        grad_kwargs: Optional[Dict[str, Any]] = None,
-    ) -> Tuple[Union[Tensor, Tuple[Tensor, ...]], Tensor]: ...
 
     @log_usage()
     def attribute(  # type: ignore
@@ -481,7 +482,11 @@ class LayerInputBaselineXGradient(LayerAttribution, GradientAttribution):
 
         if self.multiplies_by_inputs:
             input_baseline_diffs = tuple(
-                input - baseline for input, baseline in zip(attr_inputs, attr_baselines)
+                # pyre-fixme[58]: `-` is not supported for operand types
+                # `typing.Tuple[torch._tensor.Tensor, ...]` and
+                # `typing.Tuple[torch._tensor.Tensor, ...]`.
+                input - baseline
+                for input, baseline in zip(attr_inputs, attr_baselines)
             )
             attributions = tuple(
                 input_baseline_diff * grad

--- a/captum/attr/_core/layer/layer_integrated_gradients.py
+++ b/captum/attr/_core/layer/layer_integrated_gradients.py
@@ -131,11 +131,12 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
     @overload
     # pyre-fixme[43]: The implementation of `attribute` does not accept all possible
     #  arguments of overload defined on line `126`.
-    def attribute(
+    def attribute(  # type: ignore
         self,
         inputs: Union[Tensor, Tuple[Tensor, ...]],
         baselines: BaselineType,
         target: TargetType,
+        # pyre-fixme[2]: Parameter annotation cannot be `Any`.
         additional_forward_args: Any,
         n_steps: int,
         method: str,

--- a/captum/attr/_core/layer/layer_lrp.py
+++ b/captum/attr/_core/layer/layer_lrp.py
@@ -65,6 +65,26 @@ class LayerLRP(LRP, LayerAttribution):
 
     @typing.overload  # type: ignore
     # pyre-fixme[43]: The implementation of `attribute` does not accept all possible
+    #  arguments of overload defined on line `77`.
+    def attribute(
+        self,
+        inputs: TensorOrTupleOfTensorsGeneric,
+        target: TargetType = None,
+        # pyre-fixme[2]: Parameter annotation cannot be `Any`.
+        additional_forward_args: Any = None,
+        *,
+        # pyre-fixme[31]: Expression `Literal[True]` is not a valid type.
+        # pyre-fixme[24]: Non-generic type `typing.Literal` cannot take parameters.
+        return_convergence_delta: Literal[True],
+        attribute_to_layer_input: bool = False,
+        verbose: bool = False,
+    ) -> Tuple[
+        Union[Tensor, Tuple[Tensor, ...], List[Union[Tensor, Tuple[Tensor, ...]]]],
+        Union[Tensor, List[Tensor]],
+    ]: ...
+
+    @typing.overload
+    # pyre-fixme[43]: The implementation of `attribute` does not accept all possible
     #  arguments of overload defined on line `66`.
     def attribute(
         self,
@@ -79,25 +99,6 @@ class LayerLRP(LRP, LayerAttribution):
         attribute_to_layer_input: bool = False,
         verbose: bool = False,
     ) -> Union[Tensor, Tuple[Tensor, ...], List[Union[Tensor, Tuple[Tensor, ...]]]]: ...
-
-    @typing.overload
-    # pyre-fixme[43]: The implementation of `attribute` does not accept all possible
-    #  arguments of overload defined on line `77`.
-    def attribute(
-        self,
-        inputs: TensorOrTupleOfTensorsGeneric,
-        target: TargetType = None,
-        additional_forward_args: Any = None,
-        *,
-        # pyre-fixme[31]: Expression `Literal[True]` is not a valid type.
-        # pyre-fixme[24]: Non-generic type `typing.Literal` cannot take parameters.
-        return_convergence_delta: Literal[True],
-        attribute_to_layer_input: bool = False,
-        verbose: bool = False,
-    ) -> Tuple[
-        Union[Tensor, Tuple[Tensor, ...], List[Union[Tensor, Tuple[Tensor, ...]]]],
-        Union[Tensor, List[Tensor]],
-    ]: ...
 
     def attribute(
         self,

--- a/captum/attr/_core/lime.py
+++ b/captum/attr/_core/lime.py
@@ -1275,7 +1275,7 @@ class Lime(LimeBase):
     @typing.overload
     # pyre-fixme[43]: The implementation of `_convert_output_shape` does not accept
     #  all possible arguments of overload defined on line `1211`.
-    def _convert_output_shape(
+    def _convert_output_shape(  # type: ignore
         self,
         formatted_inp: Tuple[Tensor, ...],
         feature_mask: Tuple[Tensor, ...],

--- a/captum/attr/_core/lrp.py
+++ b/captum/attr/_core/lrp.py
@@ -63,6 +63,22 @@ class LRP(GradientAttribution):
 
     @typing.overload
     # pyre-fixme[43]: The implementation of `attribute` does not accept all possible
+    #  arguments of overload defined on line `75`.
+    def attribute(
+        self,
+        inputs: TensorOrTupleOfTensorsGeneric,
+        target: TargetType = None,
+        # pyre-fixme[2]: Parameter annotation cannot be `Any`.
+        additional_forward_args: Any = None,
+        *,
+        # pyre-fixme[31]: Expression `Literal[True]` is not a valid type.
+        # pyre-fixme[24]: Non-generic type `typing.Literal` cannot take parameters.
+        return_convergence_delta: Literal[True],
+        verbose: bool = False,
+    ) -> Tuple[TensorOrTupleOfTensorsGeneric, Tensor]: ...
+
+    @typing.overload
+    # pyre-fixme[43]: The implementation of `attribute` does not accept all possible
     #  arguments of overload defined on line `65`.
     def attribute(
         self,
@@ -76,21 +92,6 @@ class LRP(GradientAttribution):
         return_convergence_delta: Literal[False] = False,
         verbose: bool = False,
     ) -> TensorOrTupleOfTensorsGeneric: ...
-
-    @typing.overload
-    # pyre-fixme[43]: The implementation of `attribute` does not accept all possible
-    #  arguments of overload defined on line `75`.
-    def attribute(
-        self,
-        inputs: TensorOrTupleOfTensorsGeneric,
-        target: TargetType = None,
-        additional_forward_args: Any = None,
-        *,
-        # pyre-fixme[31]: Expression `Literal[True]` is not a valid type.
-        # pyre-fixme[24]: Non-generic type `typing.Literal` cannot take parameters.
-        return_convergence_delta: Literal[True],
-        verbose: bool = False,
-    ) -> Tuple[TensorOrTupleOfTensorsGeneric, Tensor]: ...
 
     @log_usage()
     # pyre-fixme[43]: This definition does not have the same decorators as the

--- a/captum/attr/_core/neuron/neuron_feature_ablation.py
+++ b/captum/attr/_core/neuron/neuron_feature_ablation.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # pyre-strict
-from typing import Any, Callable, List, Tuple, Union
+from typing import Any, Callable, cast, List, Tuple, Union
 
 import torch
 from captum._utils.common import _verify_select_neuron
@@ -10,6 +10,7 @@ from captum._utils.typing import BaselineType, TensorOrTupleOfTensorsGeneric
 from captum.attr._core.feature_ablation import FeatureAblation
 from captum.attr._utils.attribution import NeuronAttribution, PerturbationAttribution
 from captum.log import log_usage
+from torch import Tensor
 from torch.nn import Module
 
 
@@ -260,7 +261,9 @@ class NeuronFeatureAblation(NeuronAttribution, PerturbationAttribution):
                     device_ids=self.device_ids,
                     attribute_to_layer_input=attribute_to_neuron_input,
                 )
-                return _verify_select_neuron(layer_eval, neuron_selector)
+                return _verify_select_neuron(
+                    cast(Tuple[Tensor, ...], layer_eval), neuron_selector
+                )
 
         ablator = FeatureAblation(neuron_forward_func)
 

--- a/captum/attr/_utils/common.py
+++ b/captum/attr/_utils/common.py
@@ -77,7 +77,7 @@ def _format_input_baseline(
 
 
 @typing.overload
-def _format_input_baseline(
+def _format_input_baseline(  # type: ignore
     inputs: Union[Tensor, Tuple[Tensor, ...]], baselines: BaselineType
 ) -> Tuple[Tuple[Tensor, ...], Tuple[Union[Tensor, int, float], ...]]: ...
 
@@ -201,6 +201,24 @@ def _format_and_verify_sliding_window_shapes(
 
 @typing.overload
 # pyre-fixme[43]: The implementation of `_compute_conv_delta_and_format_attrs` does
+#  not accept all possible arguments of overload defined on line `212`.
+def _compute_conv_delta_and_format_attrs(
+    attr_algo: "GradientAttribution",
+    return_convergence_delta: bool,
+    attributions: Tuple[Tensor, ...],
+    start_point: Union[int, float, Tensor, Tuple[Union[int, float, Tensor], ...]],
+    end_point: Union[Tensor, Tuple[Tensor, ...]],
+    # pyre-fixme[2]: Parameter annotation cannot be `Any`.
+    additional_forward_args: Any,
+    target: TargetType,
+    # pyre-fixme[31]: Expression `Literal[True]` is not a valid type.
+    # pyre-fixme[24]: Non-generic type `typing.Literal` cannot take parameters.
+    is_inputs_tuple: Literal[True],
+) -> Union[Tuple[Tensor, ...], Tuple[Tuple[Tensor, ...], Tensor]]: ...
+
+
+@typing.overload
+# pyre-fixme[43]: The implementation of `_compute_conv_delta_and_format_attrs` does
 #  not accept all possible arguments of overload defined on line `199`.
 def _compute_conv_delta_and_format_attrs(
     attr_algo: "GradientAttribution",
@@ -216,23 +234,6 @@ def _compute_conv_delta_and_format_attrs(
     # pyre-fixme[24]: Non-generic type `typing.Literal` cannot take parameters.
     is_inputs_tuple: Literal[False] = False,
 ) -> Union[Tensor, Tuple[Tensor, Tensor]]: ...
-
-
-@typing.overload
-# pyre-fixme[43]: The implementation of `_compute_conv_delta_and_format_attrs` does
-#  not accept all possible arguments of overload defined on line `212`.
-def _compute_conv_delta_and_format_attrs(
-    attr_algo: "GradientAttribution",
-    return_convergence_delta: bool,
-    attributions: Tuple[Tensor, ...],
-    start_point: Union[int, float, Tensor, Tuple[Union[int, float, Tensor], ...]],
-    end_point: Union[Tensor, Tuple[Tensor, ...]],
-    additional_forward_args: Any,
-    target: TargetType,
-    # pyre-fixme[31]: Expression `Literal[True]` is not a valid type.
-    # pyre-fixme[24]: Non-generic type `typing.Literal` cannot take parameters.
-    is_inputs_tuple: Literal[True],
-) -> Union[Tuple[Tensor, ...], Tuple[Tuple[Tensor, ...], Tensor]]: ...
 
 
 # FIXME: GradientAttribution is provided as a string due to a circular import.

--- a/tests/metrics/test_infidelity.py
+++ b/tests/metrics/test_infidelity.py
@@ -38,17 +38,17 @@ def _local_perturb_func_default(
 
 
 @typing.overload
-# pyre-fixme[43]: The implementation of `_local_perturb_func` does not accept all
-#  possible arguments of overload defined on line `35`.
-def _local_perturb_func(inputs: Tensor) -> Tuple[Tensor, Tensor]: ...
-
-
-@typing.overload
-# pyre-fixme[43]: The implementation of `_local_perturb_func` does not accept all
-#  possible arguments of overload defined on line `39`.
+# pyre-ignore[43]: The implementation of `_local_perturb_func` does not accept all
+#  possible arguments of overload defined on line `43`.
 def _local_perturb_func(
     inputs: Tuple[Tensor, ...]
 ) -> Tuple[Tuple[Tensor, ...], Tuple[Tensor, ...]]: ...
+
+
+@typing.overload
+# pyre-ignore[43]: The implementation of `_local_perturb_func` does not accept all
+#  possible arguments of overload defined on line `51`.
+def _local_perturb_func(inputs: Tensor) -> Tuple[Tensor, Tensor]: ...
 
 
 def _local_perturb_func(
@@ -81,16 +81,16 @@ def _global_perturb_func1_default(
 
 @typing.overload
 # pyre-fixme[43]: The implementation of `_global_perturb_func1` does not accept all
-#  possible arguments of overload defined on line `70`.
-def _global_perturb_func1(inputs: Tensor) -> Tuple[Tensor, Tensor]: ...
-
-
-@typing.overload
-# pyre-fixme[43]: The implementation of `_global_perturb_func1` does not accept all
 #  possible arguments of overload defined on line `74`.
 def _global_perturb_func1(
     inputs: Tuple[Tensor, ...]
 ) -> Tuple[Tuple[Tensor, ...], Tuple[Tensor, ...]]: ...
+
+
+@typing.overload
+# pyre-fixme[43]: The implementation of `_global_perturb_func1` does not accept all
+#  possible arguments of overload defined on line `70`.
+def _global_perturb_func1(inputs: Tensor) -> Tuple[Tensor, Tensor]: ...
 
 
 # sensitivity-N, N = #input features

--- a/tests/metrics/test_sensitivity.py
+++ b/tests/metrics/test_sensitivity.py
@@ -29,14 +29,14 @@ from torch import Tensor
 
 @typing.overload
 # pyre-fixme[43]: The implementation of `_perturb_func` does not accept all possible
-#  arguments of overload defined on line `28`.
-def _perturb_func(inputs: Tensor) -> Tensor: ...
+#  arguments of overload defined on line `32`.
+def _perturb_func(inputs: Tuple[Tensor, ...]) -> Tuple[Tensor, ...]: ...
 
 
 @typing.overload
 # pyre-fixme[43]: The implementation of `_perturb_func` does not accept all possible
-#  arguments of overload defined on line `32`.
-def _perturb_func(inputs: Tuple[Tensor, ...]) -> Tuple[Tensor, ...]: ...
+#  arguments of overload defined on line `28`.
+def _perturb_func(inputs: Tensor) -> Tensor: ...
 
 
 def _perturb_func(


### PR DESCRIPTION
Summary: Many overloads produced false positives or required changing order due to mypy breaking ties by picking the first matching variant (https://mypy.readthedocs.io/en/stable/more_types.html). This fixes or suppresses these errors. Created T204932142 to address Literal-related issues.

Differential Revision: D64517613


