### PR TITLE
Update config to allow running mypy on Captum in fbcode

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,3 +11,9 @@ exclude =
 omit =
     test/*
     setup.py
+
+[mypy]
+exclude = ^.*fb.*$
+
+[mypy-captum.log.fb.*]
+ignore_errors = True

--- a/tests/influence/_core/test_tracin_regression.py
+++ b/tests/influence/_core/test_tracin_regression.py
@@ -376,6 +376,7 @@ class TestTracInRegression(BaseTest):
                 DataInfluenceConstructor(
                     ArnoldiInfluenceFunction,
                     arnoldi_tol=1e-8,  # needs to be small to avoid empty arnoldi basis
+                    hessian_reg=2e-3,
                 ),
             ),
         ],


### PR DESCRIPTION
Summary:
Running mypy directly on Captum within fbcode results in errors due to fb only directories, which doesn't match the behavior of mypy in OSS.

Add appropriate excludes to setup.cfg to enable direct usage of mypy in fbcode

Differential Revision: D64576023


