### PR TITLE
Adjust hessian_reg to fix Arnoldi test case

### DIFF
--- a/tests/influence/_core/test_tracin_regression.py
+++ b/tests/influence/_core/test_tracin_regression.py
@@ -376,6 +376,7 @@ class TestTracInRegression(BaseTest):
                 DataInfluenceConstructor(
                     ArnoldiInfluenceFunction,
                     arnoldi_tol=1e-8,  # needs to be small to avoid empty arnoldi basis
+                    hessian_reg=2e-3,
                 ),
             ),
         ],


### PR DESCRIPTION
Summary: Increase hessian regularization term for Arnoldi test to ensure that highest self-influence datapoint / proponent match the corresponding example

Differential Revision: D64584502


