### PR TITLE
Add auto retries for Captum OSS GitHub Actions

### DIFF
--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -1,0 +1,19 @@
+name: Retry Test
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        required: true
+jobs:
+  rerun-on-failure:
+    permissions: write-all
+    runs-on: ubuntu-latest
+    steps:
+      - name: rerun ${{ inputs.run_id }}
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          GH_DEBUG: api
+        run: |
+          gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
+          gh run rerun ${{ inputs.run_id }} --failed


### PR DESCRIPTION
Summary:
We frequently see sporadic failures in Captum GitHub actions test workflows, often related to package download, http errors, conda environment setup, etc.

We add auto-retries to automatically retry failed workflows rather than needing to do this manually.

Differential Revision: D64693773


