### PR TITLE
Update Captum rerun workflow to operate directly on workflow completion

### DIFF
--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -1,19 +1,26 @@
-name: Retry Test
+name: Rerun tests if failed
 on:
-  workflow_dispatch:
-    inputs:
-      run_id:
-        required: true
+  workflow_run:
+    workflows: ["Unit-tests for Conda install", "Unit-tests for Pip install with mypy type checks", "Unit-tests for Pip install"]
+    types: ["completed"]
+
+permissions:
+  actions: write
+
 jobs:
-  rerun-on-failure:
-    permissions: write-all
+  rerun-tests:
     runs-on: ubuntu-latest
     steps:
-      - name: rerun ${{ inputs.run_id }}
-        env:
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ github.token }}
-          GH_DEBUG: api
+      - name: Log workflow metadata
         run: |
-          gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
-          gh run rerun ${{ inputs.run_id }} --failed
+          echo "ID: ${{ github.event.workflow_run.id }}"
+          echo "attempt: ${{ github.event.workflow_run.run_attempt }}"
+          echo "event: ${{ github.event.workflow_run.conclusion }}"
+          echo "event: ${{ github.event.workflow_run.event }}"
+      - name: Rerun Failed Workflows
+        if: github.event.workflow_run.conclusion == 'failure' && github.event.run_attempt <= 3
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          gh run rerun ${RUN_ID} --repo="${{ github.repository }}" --failed


### PR DESCRIPTION
Summary:
The initial rerun workflow cannot be triggered successfully for PRs created from forks, since the GitHub auth token  provided for PRs on forks doesn't provide write access.

This switches to a workflow completion trigger, which should run from the main repo and have write access to rerun the workflow.

Differential Revision: D64760527


