### PR TITLE
Fix for automatic GitHub workflow reruns

### DIFF
--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -18,7 +18,7 @@ jobs:
           echo "event: ${{ github.event.workflow_run.conclusion }}"
           echo "event: ${{ github.event.workflow_run.event }}"
       - name: Rerun Failed Workflows
-        if: github.event.workflow_run.conclusion == 'failure' && github.event.run_attempt <= 3
+        if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt <= 3
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_ID: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
Summary: Slight bug in the retry GitHub workflow causes failing workflows to rerun indefinitely. This _should_ fix it

Differential Revision: D65008676


