### PR TITLE
Disable pyre errors for metrics/_core

### DIFF
--- a/captum/metrics/_core/infidelity.py
+++ b/captum/metrics/_core/infidelity.py
@@ -499,6 +499,8 @@ def _generate_perturbations(
     repeated instances per example.
     """
 
+    # pyre-fixme[53]: Captured variable `baselines_expanded` is not annotated.
+    # pyre-fixme[53]: Captured variable `inputs_expanded` is not annotated.
     def call_perturb_func() -> (
         Tuple[TensorOrTupleOfTensorsGeneric, TensorOrTupleOfTensorsGeneric]
     ):

--- a/captum/metrics/_core/sensitivity.py
+++ b/captum/metrics/_core/sensitivity.py
@@ -232,6 +232,8 @@ def sensitivity_max(
     # pyre-fixme[33]: Given annotation cannot be `Any`.
     kwargs_copy: Any = None
 
+    # pyre-fixme[53]: Captured variable `bsz` is not annotated.
+    # pyre-fixme[53]: Captured variable `expl_inputs` is not annotated.
     def _next_sensitivity_max(current_n_perturb_samples: int) -> Tensor:
         inputs_perturbed = _generate_perturbations(current_n_perturb_samples)
 


### PR DESCRIPTION
Summary: A Pyre upgrade added a few more typing failures.

Differential Revision: D65606038


