### PR TITLE
Reapply manual changes that I accidentally clobbered in D65826205

### DIFF
--- a/captum/attr/_core/feature_ablation.py
+++ b/captum/attr/_core/feature_ablation.py
@@ -806,11 +806,9 @@ class FeatureAblation(PerturbationAttribution):
             dim=0,
         ).long()
         current_mask = current_mask.to(expanded_input.device)
+        assert baseline is not None, "baseline must be provided"
         ablated_tensor = (
-            expanded_input
-            * (1 - current_mask).to(expanded_input.dtype)
-            # pyre-fixme[58]: `*` is not supported for operand types `Union[None, float,
-            #  Tensor]` and `Tensor`.
+            expanded_input * (1 - current_mask).to(expanded_input.dtype)
         ) + (baseline * current_mask.to(expanded_input.dtype))
         return ablated_tensor, current_mask
 

--- a/captum/attr/_core/occlusion.py
+++ b/captum/attr/_core/occlusion.py
@@ -316,14 +316,13 @@ class Occlusion(FeatureAblation):
             ],
             dim=0,
         ).long()
+        assert baseline is not None, "baseline should not be None"
         ablated_tensor = (
             expanded_input
             * (
                 torch.ones(1, dtype=torch.long, device=expanded_input.device)
                 - input_mask
             ).to(expanded_input.dtype)
-            # pyre-fixme[58]: `*` is not supported for operand types `Union[None, float,
-            #  Tensor]` and `Tensor`.
         ) + (baseline * input_mask.to(expanded_input.dtype))
         return ablated_tensor, input_mask
 

--- a/captum/module/gaussian_stochastic_gates.py
+++ b/captum/module/gaussian_stochastic_gates.py
@@ -133,9 +133,9 @@ class GaussianStochasticGates(StochasticGatesBase):
             probs (Tensor): probabilities tensor of the gates are active
                 in shape(n_gates)
         """
-        # pyre-fixme[58]: `/` is not supported for operand types `Parameter` and
-        #  `Optional[float]`.
-        x = self.mu / self.std
+        std = self.std
+        assert std is not None, "std should not be None"
+        x = self.mu / std
         return 0.5 * (1 + torch.erf(x / math.sqrt(2)))
 
     @classmethod

--- a/tests/attr/test_input_x_gradient.py
+++ b/tests/attr/test_input_x_gradient.py
@@ -117,9 +117,9 @@ class Test(BaseTest):
             attributions = input_x_grad.attribute(input, target)
             output = model(input)[:, target]
             output.backward()
-            # pyre-fixme[58]: `*` is not supported for operand types
-            #  `Optional[Tensor]` and `Tensor`.
-            expected = input.grad * input
+            input_grad = input.grad
+            assert input_grad is not None
+            expected = input_grad * input
             assertTensorAlmostEqual(self, attributions, expected, 0.00001, "max")
         else:
             nt = NoiseTunnel(input_x_grad)


### PR DESCRIPTION
Summary:
This diff was done by manually inspecting the bad diff and then running:

```
16676  hg diff -c D65826205 admarket/bidding_platform/simulation/pacer/pacer_utils/rl/policy_dualcontroller/calculator.py | patch -p2 -R
16677  hg diff -c D65826205 bc/facial_animation/dubbing/general_model/inference_v2/dubber.py | patch -p2 -R
16678  hg diff -c D65826205 frl/audio/cf/ml/hybridml/dataset/data_utils.py  | patch -p2 -R
16679  hg diff -c D65826205 frl/codec_avatar/CABody/ca_body/lbs/lbs.py  | patch -p2 -R
16680  hg diff -c D65826205 frl/codec_avatar/CABody/ca_body/models/gsplat_vae_relightable_drivable.py  | patch -p2 -R
16681  hg diff -c D65826205 frl/codec_avatar/CABody/ca_body/nn/layers.py  | patch -p2 -R
16682  hg diff -c D65826205 frl/codec_avatar/body_assets/visualization/body_skeleton_renderer.py  | patch -p2 -R
16683  hg diff -c D65826205 gen_ai/llm_inference/fb/llm/bench/llama_disagg.py  | patch -p2 -R
16684  hg diff -c D65826205 gen_ai/web_search/models/mac/textray/textray_deployment_wrapper.py  | patch -p2 -R
16685  hg diff -c D65826205 pytorch/captum/captum/attr/_core/feature_ablation.py  | patch -p2 -R
16686  hg diff -c D65826205 pytorch/captum/captum/attr/_core/occlusion.py  | patch -p2 -R
16687  hg diff -c D65826205 pytorch/captum/captum/module/gaussian_stochastic_gates.py  | patch -p2 -R
16688  hg diff -c D65826205 pytorch/captum/tests/attr/test_input_x_gradient.py  | patch -p2 -R
16689  hg diff -c D65826205 xiai/xi_genai/deploy/llm_model/src/models/mmllama.py  | patch -p2 -R
```

Differential Revision: D65881830


