### PR TITLE
Fix pyre error in _generate_baseline_single_dict_feature

### DIFF
--- a/captum/attr/_models/pytext.py
+++ b/captum/attr/_models/pytext.py
@@ -160,8 +160,7 @@ class BaselineGenerator:
 
     def _generate_baseline_single_dict_feature(
         self,
-        # pyre-fixme[2]: Parameter `device` has no type specified.
-        device,
+        device: torch.device,
     ) -> Tuple[torch.Tensor, ...]:
         r"""Generate dict features based on Assistant's case study by using
          sia_transformer:
@@ -197,7 +196,7 @@ class BaselineGenerator:
                 ]
             )
             .unsqueeze(0)
-            .to(device)
+            .to(device=device)
         )
         gazetteer_feat_weights = (
             torch.tensor(gazetteer_feat_weights).unsqueeze(0).to(device)


### PR DESCRIPTION
Summary:
Fix the pyre error in `_generate_baseline_single_dict_feature`

The issue was that the device parameter didn't have a type annotation. It appears that the correct type is torch.device.

Also changed the call to `.to()` by adding the `device=` named parameter. If a named parameter is not used in this case, torch may assume this is a dtype (see: https://pytorch.org/docs/stable/generated/torch.Tensor.to.html). Adding the named parameter also clarifies the intent.

Reviewed By: jjuncho

Differential Revision: D65914877


