### PR TITLE
chore: add missing test dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ INSIGHTS_FILE_SUBDIRS = [
 
 TUTORIALS_REQUIRES = INSIGHTS_REQUIRES + ["torchtext", "torchvision"]
 
-TEST_REQUIRES = ["pytest", "pytest-cov", "parameterized"]
+TEST_REQUIRES = ["pytest", "pytest-cov", "parameterized", "flask", "flask-compress"]
 
 DEV_REQUIRES = (
     INSIGHTS_REQUIRES


### PR DESCRIPTION
While packaging this module for Nix (https://github.com/NixOS/nixpkgs/pull/356087), I noticed during the tests that `flask` and `flask-compress` modules were missing from the `setup.py` file.