### PR TITLE
Fix deeplift mypy error

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -13,7 +13,7 @@ build:
 
 requirements:
   host:
-    - python>=3.8
+    - python>=3.9
   run:
     - numpy<2.0
     - pytorch>=1.10

--- a/.github/workflows/test-conda-cpu.yml
+++ b/.github/workflows/test-conda-cpu.yml
@@ -15,7 +15,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11"]
+        python_version: ["3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:
@@ -28,7 +28,7 @@ jobs:
         # Create Conda Env
         conda create -yp ci_env python="${PYTHON_VERSION}"
         conda activate /pytorch/captum/ci_env
-        ./scripts/install_via_conda.sh -n
+        ./scripts/install_via_conda.sh
 
         # Run Tests
         python3 -m pytest -ra --cov=. --cov-report term-missing

--- a/.github/workflows/test-pip-cpu.yml
+++ b/.github/workflows/test-pip-cpu.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         pytorch_args: ["-v 1.10", "-v 1.11", "-v 1.12", "-v 1.13", "-v 2.0.0", "-v 2.1.0", "-v 2.2.0", "-v 2.3.0"]
         transformers_args: ["-t 4.38.0", "-t 4.39.0", "-t 4.41.0", "-t 4.43.0", "-t 4.45.2"]
-        docker_img: ["cimg/python:3.8", "cimg/python:3.9", "cimg/python:3.10", "cimg/python:3.11"]
+        docker_img: ["cimg/python:3.9", "cimg/python:3.10", "cimg/python:3.11", "cimg/python:3.12"]
         exclude:
           - pytorch_args: "-v 1.10"
             docker_img: "cimg/python:3.10"
@@ -24,6 +24,18 @@ jobs:
             docker_img: "cimg/python:3.11"
           - pytorch_args: "-v 1.12"
             docker_img: "cimg/python:3.11"
+          - pytorch_args: "-v 1.10"
+            docker_img: "cimg/python:3.12"
+          - pytorch_args: "-v 1.11"
+            docker_img: "cimg/python:3.12"
+          - pytorch_args: "-v 1.12"
+            docker_img: "cimg/python:3.12"
+          - pytorch_args: "-v 1.13"
+            docker_img: "cimg/python:3.12"
+          - pytorch_args: "-v 2.0.0"
+            docker_img: "cimg/python:3.12"
+          - pytorch_args: "-v 2.1.0"
+            docker_img: "cimg/python:3.12"
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Then run this script from the repository root:
 ```
 Note that we expect mypy to have version 0.760 or higher, and when type checking, use PyTorch 1.4 or
 higher due to fixes to PyTorch type hints available in 1.4. We also use the Literal feature which is
-available only in Python 3.8 or above. If type-checking using a previous version of Python, you will
+available only in Python 3.9 or above. If type-checking using a previous version of Python, you will
 need to install the typing-extension package which can be done with pip using `pip install typing-extensions`.
 
 #### Unit Tests

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Captum can also be used by application engineers who are using trained models in
 ## Installation
 
 **Installation Requirements**
-- Python >= 3.8
+- Python >= 3.9
 - PyTorch >= 1.10
 
 

--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -2,11 +2,8 @@
 
 set -e
 
-PYTORCH_NIGHTLY=false
-
 while getopts 'nf' flag; do
   case "${flag}" in
-    n) PYTORCH_NIGHTLY=true ;;
     f) FRAMEWORKS=true ;;
     *) echo "usage: $0 [-n] [-f]" >&2
        exit 1 ;;
@@ -18,25 +15,17 @@ while getopts 'nf' flag; do
 #conda update -y -n base -c defaults conda
 conda update -q --all --yes
 
-# required to use conda develop
-conda install -q -y conda-build
-
 # install other frameworks if asked for and make sure this is before pytorch
 if [[ $FRAMEWORKS == true ]]; then
   pip install -q pytext-nlp
 fi
 
-if [[ $PYTORCH_NIGHTLY == true ]]; then
-  # install CPU version for much smaller download
-  conda install -q -y pytorch cpuonly -c pytorch-nightly
-else
- # install CPU version for much smaller download
- conda install -q -y -c pytorch pytorch-cpu
-fi
+# install CPU version for much smaller download
+conda install -q -y pytorch cpuonly -c pytorch
 
 # install other deps
-conda install -q -y pytest ipywidgets ipython scikit-learn parameterized werkzeug==2.2.2
-conda install -q -y -c conda-forge matplotlib pytest-cov flask flask-compress
+conda install -q -y pytest ipywidgets ipython scikit-learn parameterized werkzeug
+conda install -q -y -c conda-forge matplotlib pytest-cov flask flask-compress conda-build
 conda install -q -y transformers
 
 # install captum

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import sys
 from setuptools import find_packages, setup
 
 REQUIRED_MAJOR = 3
-REQUIRED_MINOR = 8
+REQUIRED_MINOR = 9
 
 # Check for python version
 if sys.version_info < (REQUIRED_MAJOR, REQUIRED_MINOR):
@@ -148,7 +148,7 @@ if __name__ == "__main__":
         ],
         long_description=long_description,
         long_description_content_type="text/markdown",
-        python_requires=">=3.8",
+        python_requires=">=3.9",
         install_requires=[
             "matplotlib",
             "numpy<2.0",

--- a/tests/attr/test_deeplift_classification.py
+++ b/tests/attr/test_deeplift_classification.py
@@ -2,7 +2,7 @@
 
 # pyre-unsafe
 
-from typing import Union
+from typing import TypeVar, Union
 
 import torch
 from captum._utils.typing import TargetType
@@ -20,6 +20,8 @@ from tests.helpers.classification_models import (
 )
 from torch import Tensor
 from torch.nn import Module
+
+DeepLiftAttrMethod = TypeVar("DeepLiftAttrMethod", DeepLift, DeepLiftShap)
 
 
 class Test(BaseTest):
@@ -155,7 +157,7 @@ class Test(BaseTest):
     def softmax_classification(
         self,
         model: Module,
-        attr_method: Union[DeepLift, DeepLiftShap],
+        attr_method: DeepLiftAttrMethod,
         input: Tensor,
         baselines: Union[float, int, Tensor],
         target: TargetType,


### PR DESCRIPTION
Summary: Currently, Captum OSS tests are failing due to mypy failures (likely from new version) in DeepLift test cases. Adds fix for type failure caused by different signature between DeepLift and DeepLiftShap.

Differential Revision: D67538043


