### PR TITLE
Update conda build file with required build and run dependencies

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -14,10 +14,13 @@ build:
 requirements:
   host:
     - python>=3.9
+    - setuptools
   run:
     - numpy<2.0
     - pytorch>=1.10
     - matplotlib-base
+    - tqdm
+    - packaging
 
 test:
   imports:


### PR DESCRIPTION
`setuptools` is no longer an automatically included dependency of any `host` packages, so it needs to be included. `run` needs to be updated with additional new baseline dependencies of captum as well.