### PR TITLE
Support permuting across input tensors in FeaturePermutation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ DEV_REQUIRES = (
     + [
         "black",
         "flake8",
-        "sphinx",
+        "sphinx<8.2.0",
         "sphinx-autodoc-typehints",
         "sphinxcontrib-katex",
         "mypy>=0.760",


### PR DESCRIPTION
Summary: Most of the logic is in the parent class `FeatureAblation`, but to support feature grouping across input tensors we need to update the permutation utils too

Differential Revision: D69867208


