### PR TITLE
Fix socket timeout in test_data_parallel

### DIFF
--- a/tests/attr/test_data_parallel.py
+++ b/tests/attr/test_data_parallel.py
@@ -41,7 +41,7 @@ schema described there.
 """
 
 # Distributed Data Parallel env setup
-os.environ["MASTER_ADDR"] = "127.0.0.1"
+os.environ["MASTER_ADDR"] = "localhost"
 os.environ["MASTER_PORT"] = "29500"
 dist.init_process_group(backend="gloo", rank=0, world_size=1)
 


### PR DESCRIPTION
Summary:
Example failure:
https://www.internalfb.com/intern/testinfra/testconsole/testrun/4785074873255877/
Passed and failed on rev 3c307b1e123f2007d69464836099b12fa4656423, so not due to a code change

Running locally at least, I see:
```
E0305 00:39:14.685009 1133092 socket.cpp:1019] [c10d] The client socket has timed out after 600000ms while trying to connect to (127.0.0.1, 29500).
```

Related thread: https://fb.workplace.com/groups/319878845696681/permalink/1241443370206886/

There's only one process in this test (`world_size=1`) so should be ok to use `localhost` instead of `127.0.0.1`

Differential Revision: D70637306


