### PR TITLE
Add min_examples_per_batch to FeatureAblation/FeaturePermutation

### DIFF
--- a/captum/attr/_core/feature_permutation.py
+++ b/captum/attr/_core/feature_permutation.py
@@ -92,6 +92,10 @@ class FeaturePermutation(FeatureAblation):
         """
         FeatureAblation.__init__(self, forward_func=forward_func)
         self.perm_func = perm_func
+        # Minimum number of elements needed in each input tensor, otherwise the
+        # attribution for the tensor will be skipped. Set to 1 to throw if any
+        # input tensors only have one example
+        self._min_examples_per_batch = 2
 
     # suppressing error caused by the child class not having a matching
     # signature to the parent

--- a/tests/attr/test_feature_permutation.py
+++ b/tests/attr/test_feature_permutation.py
@@ -112,6 +112,23 @@ class Test(BaseTest):
             assertTensorAlmostEqual(self, attribs[:, 0], zeros, delta=0.05, mode="max")
             self.assertTrue((attribs[:, 1 : input_size[0]].abs() > 0).all())
 
+    def test_simple_input_with_min_examples(self) -> None:
+        def forward_func(x: Tensor) -> Tensor:
+            return x.sum(dim=-1)
+
+        feature_importance = FeaturePermutation(forward_func=forward_func)
+        inp = torch.tensor([[1.0, 2.0]])
+        assertTensorAlmostEqual(
+            self,
+            feature_importance.attribute(inp),
+            torch.tensor([[0.0, 0.0]]),
+            delta=0.0,
+        )
+
+        feature_importance._min_examples_per_batch = 1
+        with self.assertRaises(AssertionError):
+            feature_importance.attribute(inp)
+
     def test_single_input_with_future(
         self,
     ) -> None:


### PR DESCRIPTION
Summary:
For sparse features, the 0th dim is not always the batch size.
Currently for FeatureAblation, we skip the input tensor if there are no elements in it. For FeaturePermutation, we throw if we cannot permute across the "batch" (i.e. the tensor has only one element).
`min_examples_per_batch` parameterizes the above behavior. For FeaturePermutation, the default is set to 2, meaning we no longer throw by default, but return an attribution score of 0

Differential Revision: D71980024


