### PR TITLE
Fix flake8 F824 violations

### DIFF
--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -863,10 +863,8 @@ def _register_backward_hook(
         inp: Union[Tensor, Tuple[Tensor, ...]],
         out: Union[Tensor, Tuple[Tensor, ...]],
     ) -> None:
-        nonlocal grad_out
 
         def output_tensor_hook(output_grad: Tensor) -> None:
-            nonlocal grad_out
             grad_out[output_grad.device] = output_grad
 
         if isinstance(out, tuple):
@@ -881,7 +879,6 @@ def _register_backward_hook(
         def input_tensor_hook(
             input_grad: Tensor,
         ) -> Union[None, Tensor, Tuple[Tensor, ...]]:
-            nonlocal grad_out
 
             if len(grad_out) == 0:
                 return None

--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -306,7 +306,6 @@ def _forward_layer_distributed_eval(
             if require_layer_grads:
                 apply_gradient_requirements(eval_tsrs, warn=False)
             with lock:
-                nonlocal saved_layer
                 # Note that cloning behaviour of `eval_tsr` is different
                 # when `forward_hook_with_return` is set to True. This is because
                 # otherwise `backward()` on the last output layer won't execute.

--- a/captum/influence/_core/influence_function.py
+++ b/captum/influence/_core/influence_function.py
@@ -1054,7 +1054,6 @@ class NaiveInfluenceFunction(IntermediateQuantitiesInfluenceFunction):
         # define a helper function that returns the embeddings for a batch
         # pyre-fixme[53]: Captured variable `loss_fn` is not annotated.
         def get_batch_embeddings(batch: Tuple[Tensor, ...]) -> Tensor:
-            nonlocal loss_fn, reduction_type, return_device
             # if `self.R` is on cpu, and `self.model_device` was not cpu, this implies
             # `self.R` was too large to fit in gpu memory, and we should do the matrix
             # multiplication of the batch jacobians with `self.R` separately for each

--- a/captum/influence/_core/tracincp.py
+++ b/captum/influence/_core/tracincp.py
@@ -878,7 +878,6 @@ class TracInCP(TracInCPBase):
         f_inputs: DataLoader = _format_inputs_dataset(inputs)
 
         def get_checkpoint_contribution(checkpoint: str) -> Tensor:
-            nonlocal f_inputs
             assert (
                 checkpoint is not None
             ), "None returned from `checkpoints`, cannot load."
@@ -1246,7 +1245,6 @@ class TracInCP(TracInCPBase):
             )
 
         def get_checkpoint_contribution(checkpoint: str) -> Tensor:
-            nonlocal inputs_len
             # This function returns a 1D tensor representing the contribution to the
             # self influence score for the given checkpoint, for all batches in
             # `inputs`. The length of the 1D tensor is the total number of

--- a/tests/attr/test_input_layer_wrapper.py
+++ b/tests/attr/test_input_layer_wrapper.py
@@ -45,7 +45,6 @@ layer_methods_to_test_with_equiv = [
 
 class InputLayerMeta(type):
     def __new__(metacls, name: str, bases: Tuple, attrs: Dict):
-        global layer_methods_to_test_with_equiv
         for (
             layer_method,
             equiv_method,


### PR DESCRIPTION
Summary:
flake8 released a new version on 3/29. Now one of the GitHub checks is failing on existing Captum code and blocking PR merges

Failed job: https://github.com/pytorch/captum/actions/runs/14163071093/job/39671582852

```
+ flake8
./captum/_utils/common.py:866:9: F824 `nonlocal grad_out` is unused: name is never assigned in scope
./captum/_utils/common.py:869:13: F824 `nonlocal grad_out` is unused: name is never assigned in scope
./captum/_utils/common.py:884:13: F824 `nonlocal grad_out` is unused: name is never assigned in scope
./captum/_utils/gradient.py:309:17: F824 `nonlocal saved_layer` is unused: name is never assigned in scope
./captum/attr/_core/feature_ablation.py:425:89: E501 line too long (109 > 88 characters)
./captum/influence/_core/influence_function.py:1057:13: F824 `nonlocal loss_fn` is unused: name is never assigned in scope
./captum/influence/_core/influence_function.py:1057:13: F824 `nonlocal reduction_type` is unused: name is never assigned in scope
./captum/influence/_core/influence_function.py:1057:13: F824 `nonlocal return_device` is unused: name is never assigned in scope
./captum/influence/_core/tracincp.py:881:13: F824 `nonlocal f_inputs` is unused: name is never assigned in scope
./captum/influence/_core/tracincp.py:1249:13: F824 `nonlocal inputs_len` is unused: name is never assigned in scope
./tests/attr/test_input_layer_wrapper.py:48:9: F824 `global layer_methods_to_test_with_equiv` is unused: name is never assigned in scope

```

Differential Revision: D72190516


