### PR TITLE
Skip feature group when permuting features if any have batch size <= 1

### DIFF
--- a/captum/attr/_core/feature_permutation.py
+++ b/captum/attr/_core/feature_permutation.py
@@ -92,10 +92,17 @@ class FeaturePermutation(FeatureAblation):
         """
         FeatureAblation.__init__(self, forward_func=forward_func)
         self.perm_func = perm_func
-        # Minimum number of elements needed in each input tensor, otherwise the
+        # Minimum number of elements needed in each input tensor, when
+        # `enable_cross_tensor_attribution` is False, otherwise the
         # attribution for the tensor will be skipped. Set to 1 to throw if any
         # input tensors only have one example
         self._min_examples_per_batch = 2
+        # Similar to above, when `enable_cross_tensor_attribution` is True.
+        # Considering the case when we permute multiple input tensors at once
+        # through `feature_mask`, we disregard the feature group if the 0th
+        # dim of *any* input tensor in the group is less than
+        # `_min_examples_per_batch_grouped`.
+        self._min_examples_per_batch_grouped = 2
 
     # suppressing error caused by the child class not having a matching
     # signature to the parent

--- a/tests/attr/test_feature_permutation.py
+++ b/tests/attr/test_feature_permutation.py
@@ -129,6 +129,59 @@ class Test(BaseTest):
         with self.assertRaises(AssertionError):
             feature_importance.attribute(inp)
 
+    def test_simple_input_with_min_examples_in_group(self) -> None:
+        def forward_func(x: Tensor) -> Tensor:
+            return x.sum(dim=-1)
+
+        feature_importance = FeaturePermutation(forward_func=forward_func)
+        inp = torch.tensor([[1.0, 2.0]])
+        assertTensorAlmostEqual(
+            self,
+            feature_importance.attribute(inp, enable_cross_tensor_attribution=True),
+            torch.tensor([[0.0, 0.0]]),
+            delta=0.0,
+        )
+        assertTensorAlmostEqual(
+            self,
+            feature_importance.attribute(
+                torch.tensor([]), enable_cross_tensor_attribution=True
+            ),
+            torch.tensor([0.0]),
+            delta=0.0,
+        )
+
+        feature_importance._min_examples_per_batch_grouped = 1
+        with self.assertRaises(AssertionError):
+            feature_importance.attribute(inp, enable_cross_tensor_attribution=True)
+
+    def test_simple_input_custom_mask_with_min_examples_in_group(self) -> None:
+        def forward_func(x1: Tensor, x2: Tensor) -> Tensor:
+            return x1.sum(dim=-1)
+
+        feature_importance = FeaturePermutation(forward_func=forward_func)
+        inp = (
+            torch.tensor([[1.0, 2.0]]),
+            torch.tensor(([3.0, 4.0], [5.0, 6.0])),
+        )
+        mask = (
+            torch.tensor([0, 0]),
+            torch.tensor([[0, 0], [0, 0]]),
+        )
+        assertTensorAlmostEqual(
+            self,
+            feature_importance.attribute(
+                inp, feature_mask=mask, enable_cross_tensor_attribution=True
+            )[0],
+            torch.tensor([[0.0, 0.0]]),
+            delta=0.0,
+        )
+
+        feature_importance._min_examples_per_batch_grouped = 1
+        with self.assertRaises(AssertionError):
+            feature_importance.attribute(
+                inp, feature_mask=mask, enable_cross_tensor_attribution=True
+            )
+
     def test_single_input_with_future(
         self,
     ) -> None:


### PR DESCRIPTION
Summary:
Also if all of the associated input tensors are empty, for permutation and ablation.

Basically the same as the previous diff, but for `enable_cross_tensor_attribution=True`.

Differential Revision: D72253679


