### PR TITLE
Fix mypy error in transformer_typing.py

### DIFF
--- a/captum/_utils/transformers_typing.py
+++ b/captum/_utils/transformers_typing.py
@@ -2,7 +2,7 @@
 
 # pyre-strict
 
-from typing import Any, Dict, Optional, Protocol, Tuple, Type
+from typing import Any, cast, Dict, Optional, Protocol, Tuple, Type
 
 import torch
 
@@ -46,10 +46,7 @@ if transformers_installed:
         )
 
         Cache = _Cache
-        # pyre-ignore[9]: Incompatible variable type: DynamicCache is declared to have
-        # type `Optional[Type[DynamicCacheLike]]` but is used as type
-        # `Type[_DynamicCache]`
-        DynamicCache = _DynamicCache
+        DynamicCache = cast(Optional[Type[DynamicCacheLike]], _DynamicCache)
     except ImportError:
         Cache = DynamicCache = None
 else:


### PR DESCRIPTION
Summary:
Example failure: https://github.com/pytorch/captum/actions/runs/14346024555/job/40216163528
```
captum/_utils/transformers_typing.py:52: error: Incompatible types in assignment (expression has type "type[DynamicCache]", variable has type "type[DynamicCacheLike] | None")  [assignment]

```

Differential Revision: D72685659


