### PR TITLE
Initialize parameterized test attributes

### DIFF
--- a/tests/attr/test_llm_attr.py
+++ b/tests/attr/test_llm_attr.py
@@ -191,9 +191,6 @@ class DummyLLM(nn.Module):
         assert mock_response, "must mock response to use DummyLLM to generate"
         response = self.tokenizer.encode(mock_response)[1:]
         return torch.cat(
-            # pyre-fixme[6]: In call `torch._C._VariableFunctions.cat`,
-            # for 1st positional argument, expected `Union[List[Tensor],
-            # typing.Tuple[Tensor, ...]]` but got `List[Union[List[int], Tensor]]`.
             [input_ids, torch.tensor([response], device=self.device)],  # type: ignore
             dim=1,
         )
@@ -236,13 +233,9 @@ class DummyLLM(nn.Module):
         else [("cpu", True), ("cpu", False)]
     ),
 )
-# pyre-fixme[13]: Attribute `device` is never initialized.
-# pyre-fixme[13]: Attribute `use_cached_outputs` is never initialized.
 class TestLLMAttr(BaseTest):
-    # pyre-fixme[13]: Attribute `device` is never initialized.
-    device: str
-    # pyre-fixme[13]: Attribute `use_cached_outputs` is never initialized.
-    use_cached_outputs: bool
+    device: Optional[str] = None
+    use_cached_outputs: bool = False
 
     # pyre-fixme[56]: Pyre was not able to infer the type of argument `comprehension
     @parameterized.expand(
@@ -509,8 +502,7 @@ class TestLLMAttr(BaseTest):
     ("device",), [("cpu",), ("cuda",)] if torch.cuda.is_available() else [("cpu",)]
 )
 class TestLLMGradAttr(BaseTest):
-    # pyre-fixme[13]: Attribute `device` is never initialized.
-    device: str
+    device: Optional[str] = None
 
     @parameterized.expand(
         [

--- a/tests/attr/test_llm_attr_hf_compatibility.py
+++ b/tests/attr/test_llm_attr_hf_compatibility.py
@@ -34,10 +34,8 @@ except ImportError:
     ),
 )
 class TestLLMAttrHFCompatibility(BaseTest):
-    # pyre-fixme[13]: Attribute `device` is never initialized.
-    device: str
-    # pyre-fixme[13]: Attribute `use_cached_outputs` is never initialized.
-    use_cached_outputs: bool
+    device: Optional[str] = None
+    use_cached_outputs: bool = False
 
     def setUp(self) -> None:
         if not HAS_HF:

--- a/tests/module/test_binary_concrete_stochastic_gates.py
+++ b/tests/module/test_binary_concrete_stochastic_gates.py
@@ -3,6 +3,7 @@
 # pyre-strict
 
 import unittest
+from typing import Optional
 
 import torch
 from captum.module.binary_concrete_stochastic_gates import BinaryConcreteStochasticGates
@@ -18,21 +19,16 @@ from parameterized import parameterized_class
     ]
 )
 class TestBinaryConcreteStochasticGates(BaseTest):
-    # pyre-fixme[13]: Attribute `testing_device` is never initialized.
-    testing_device: str
+    testing_device: Optional[str] = None
 
     def setUp(self) -> None:
         super().setUp()
-        # pyre-fixme[16]: `TestBinaryConcreteStochasticGates` has no attribute
-        #  `testing_device`.
         if self.testing_device == "cuda" and not torch.cuda.is_available():
             raise unittest.SkipTest("Skipping GPU test since CUDA not available.")
 
     def test_bcstg_1d_input(self) -> None:
 
         dim = 3
-        # pyre-fixme[16]: `TestBinaryConcreteStochasticGates` has no attribute
-        #  `testing_device`.
         bcstg = BinaryConcreteStochasticGates(dim).to(self.testing_device)
         input_tensor = torch.tensor(
             [
@@ -57,8 +53,6 @@ class TestBinaryConcreteStochasticGates(BaseTest):
 
         dim = 3
         mean_bcstg = BinaryConcreteStochasticGates(dim, reg_reduction="mean").to(
-            # pyre-fixme[16]: `TestBinaryConcreteStochasticGates` has no attribute
-            #  `testing_device`.
             self.testing_device
         )
         none_bcstg = BinaryConcreteStochasticGates(dim, reg_reduction="none").to(
@@ -82,8 +76,6 @@ class TestBinaryConcreteStochasticGates(BaseTest):
     def test_bcstg_1d_input_with_n_gates_error(self) -> None:
 
         dim = 3
-        # pyre-fixme[16]: `TestBinaryConcreteStochasticGates` has no attribute
-        #  `testing_device`.
         bcstg = BinaryConcreteStochasticGates(dim).to(self.testing_device)
         input_tensor = torch.tensor([0.0, 0.1, 0.2]).to(self.testing_device)
 
@@ -95,14 +87,10 @@ class TestBinaryConcreteStochasticGates(BaseTest):
         mask = torch.tensor([0, 0, 1])  # only two distinct masks, but given dim is 3
 
         with self.assertRaises(AssertionError):
-            # pyre-fixme[16]: `TestBinaryConcreteStochasticGates` has no attribute
-            #  `testing_device`.
             BinaryConcreteStochasticGates(dim, mask=mask).to(self.testing_device)
 
     def test_gates_values_matching_dim_when_eval(self) -> None:
         dim = 3
-        # pyre-fixme[16]: `TestBinaryConcreteStochasticGates` has no attribute
-        #  `testing_device`.
         bcstg = BinaryConcreteStochasticGates(dim).to(self.testing_device)
         input_tensor = torch.tensor(
             [
@@ -118,8 +106,6 @@ class TestBinaryConcreteStochasticGates(BaseTest):
     def test_bcstg_1d_input_with_mask(self) -> None:
 
         dim = 2
-        # pyre-fixme[16]: `TestBinaryConcreteStochasticGates` has no attribute
-        #  `testing_device`.
         mask = torch.tensor([0, 0, 1]).to(self.testing_device)
         bcstg = BinaryConcreteStochasticGates(dim, mask=mask).to(self.testing_device)
         input_tensor = torch.tensor(
@@ -144,8 +130,6 @@ class TestBinaryConcreteStochasticGates(BaseTest):
     def test_bcstg_2d_input(self) -> None:
 
         dim = 3 * 2
-        # pyre-fixme[16]: `TestBinaryConcreteStochasticGates` has no attribute
-        #  `testing_device`.
         bcstg = BinaryConcreteStochasticGates(dim).to(self.testing_device)
 
         # shape(2,3,2)
@@ -185,8 +169,6 @@ class TestBinaryConcreteStochasticGates(BaseTest):
     def test_bcstg_2d_input_with_n_gates_error(self) -> None:
 
         dim = 5
-        # pyre-fixme[16]: `TestBinaryConcreteStochasticGates` has no attribute
-        #  `testing_device`.
         bcstg = BinaryConcreteStochasticGates(dim).to(self.testing_device)
         input_tensor = torch.tensor(
             [
@@ -210,8 +192,6 @@ class TestBinaryConcreteStochasticGates(BaseTest):
                 [1, 1],
                 [0, 2],
             ]
-            # pyre-fixme[16]: `TestBinaryConcreteStochasticGates` has no attribute
-            #  `testing_device`.
         ).to(self.testing_device)
         bcstg = BinaryConcreteStochasticGates(dim, mask=mask).to(self.testing_device)
 
@@ -252,8 +232,6 @@ class TestBinaryConcreteStochasticGates(BaseTest):
     def test_get_gate_values_1d_input(self) -> None:
 
         dim = 3
-        # pyre-fixme[16]: `TestBinaryConcreteStochasticGates` has no attribute
-        #  `testing_device`.
         bcstg = BinaryConcreteStochasticGates(dim).to(self.testing_device)
         input_tensor = torch.tensor(
             [
@@ -273,8 +251,6 @@ class TestBinaryConcreteStochasticGates(BaseTest):
 
         dim = 2
         mask = torch.tensor([0, 1, 1])
-        # pyre-fixme[16]: `TestBinaryConcreteStochasticGates` has no attribute
-        #  `testing_device`.
         bcstg = BinaryConcreteStochasticGates(dim, mask=mask).to(self.testing_device)
         input_tensor = torch.tensor(
             [
@@ -293,8 +269,6 @@ class TestBinaryConcreteStochasticGates(BaseTest):
     def test_get_gate_values_2d_input(self) -> None:
 
         dim = 3 * 2
-        # pyre-fixme[16]: `TestBinaryConcreteStochasticGates` has no attribute
-        #  `testing_device`.
         bcstg = BinaryConcreteStochasticGates(dim).to(self.testing_device)
 
         # shape(2,3,2)
@@ -326,8 +300,6 @@ class TestBinaryConcreteStochasticGates(BaseTest):
             torch.tensor([10.0, -10.0, 10.0]),
             lower_bound=-2,
             upper_bound=2,
-            # pyre-fixme[16]: `TestBinaryConcreteStochasticGates` has no attribute
-            #  `testing_device`.
         ).to(self.testing_device)
 
         clamped_gate_values = bcstg.get_gate_values().cpu().tolist()
@@ -350,8 +322,6 @@ class TestBinaryConcreteStochasticGates(BaseTest):
                 [0, 2],
             ]
         )
-        # pyre-fixme[16]: `TestBinaryConcreteStochasticGates` has no attribute
-        #  `testing_device`.
         bcstg = BinaryConcreteStochasticGates(dim, mask=mask).to(self.testing_device)
 
         input_tensor = torch.tensor(
@@ -379,8 +349,6 @@ class TestBinaryConcreteStochasticGates(BaseTest):
     def test_get_gate_active_probs_1d_input(self) -> None:
 
         dim = 3
-        # pyre-fixme[16]: `TestBinaryConcreteStochasticGates` has no attribute
-        #  `testing_device`.
         bcstg = BinaryConcreteStochasticGates(dim).to(self.testing_device)
         input_tensor = torch.tensor(
             [
@@ -402,8 +370,6 @@ class TestBinaryConcreteStochasticGates(BaseTest):
 
         dim = 2
         mask = torch.tensor([0, 1, 1])
-        # pyre-fixme[16]: `TestBinaryConcreteStochasticGates` has no attribute
-        #  `testing_device`.
         bcstg = BinaryConcreteStochasticGates(dim, mask=mask).to(self.testing_device)
         input_tensor = torch.tensor(
             [
@@ -424,8 +390,6 @@ class TestBinaryConcreteStochasticGates(BaseTest):
     def test_get_gate_active_probs_2d_input(self) -> None:
 
         dim = 3 * 2
-        # pyre-fixme[16]: `TestBinaryConcreteStochasticGates` has no attribute
-        #  `testing_device`.
         bcstg = BinaryConcreteStochasticGates(dim).to(self.testing_device)
 
         # shape(2,3,2)
@@ -463,8 +427,6 @@ class TestBinaryConcreteStochasticGates(BaseTest):
                 [0, 2],
             ]
         )
-        # pyre-fixme[16]: `TestBinaryConcreteStochasticGates` has no attribute
-        #  `testing_device`.
         bcstg = BinaryConcreteStochasticGates(dim, mask=mask).to(self.testing_device)
 
         input_tensor = torch.tensor(

--- a/tests/module/test_gaussian_stochastic_gates.py
+++ b/tests/module/test_gaussian_stochastic_gates.py
@@ -4,6 +4,7 @@
 # pyre-strict
 
 import unittest
+from typing import Optional
 
 import torch
 from captum.module.gaussian_stochastic_gates import GaussianStochasticGates
@@ -19,21 +20,16 @@ from parameterized import parameterized_class
     ]
 )
 class TestGaussianStochasticGates(BaseTest):
-    # pyre-fixme[13]: Attribute `testing_device` is never initialized.
-    testing_device: str
+    testing_device: Optional[str] = None
 
     def setUp(self) -> None:
         super().setUp()
-        # pyre-fixme[16]: `TestGaussianStochasticGates` has no attribute
-        #  `testing_device`.
         if self.testing_device == "cuda" and not torch.cuda.is_available():
             raise unittest.SkipTest("Skipping GPU test since CUDA not available.")
 
     def test_gstg_1d_input(self) -> None:
 
         dim = 3
-        # pyre-fixme[16]: `TestGaussianStochasticGates` has no attribute
-        #  `testing_device`.
         gstg = GaussianStochasticGates(dim).to(self.testing_device)
 
         input_tensor = torch.tensor(
@@ -58,8 +54,6 @@ class TestGaussianStochasticGates(BaseTest):
     def test_gstg_1d_input_with_reg_reduction(self) -> None:
         dim = 3
         mean_gstg = GaussianStochasticGates(dim, reg_reduction="mean").to(
-            # pyre-fixme[16]: `TestGaussianStochasticGates` has no attribute
-            #  `testing_device`.
             self.testing_device
         )
         none_gstg = GaussianStochasticGates(dim, reg_reduction="none").to(
@@ -84,8 +78,6 @@ class TestGaussianStochasticGates(BaseTest):
     def test_gstg_1d_input_with_n_gates_error(self) -> None:
 
         dim = 3
-        # pyre-fixme[16]: `TestGaussianStochasticGates` has no attribute
-        #  `testing_device`.
         gstg = GaussianStochasticGates(dim).to(self.testing_device)
         input_tensor = torch.tensor([0.0, 0.1, 0.2]).to(self.testing_device)
 
@@ -95,8 +87,6 @@ class TestGaussianStochasticGates(BaseTest):
     def test_gstg_1d_input_with_mask(self) -> None:
 
         dim = 2
-        # pyre-fixme[16]: `TestGaussianStochasticGates` has no attribute
-        #  `testing_device`.
         mask = torch.tensor([0, 0, 1]).to(self.testing_device)
         gstg = GaussianStochasticGates(dim, mask=mask).to(self.testing_device)
         input_tensor = torch.tensor(
@@ -120,8 +110,6 @@ class TestGaussianStochasticGates(BaseTest):
 
     def test_gates_values_matching_dim_when_eval(self) -> None:
         dim = 3
-        # pyre-fixme[16]: `TestGaussianStochasticGates` has no attribute
-        #  `testing_device`.
         gstg = GaussianStochasticGates(dim).to(self.testing_device)
         input_tensor = torch.tensor(
             [
@@ -137,8 +125,6 @@ class TestGaussianStochasticGates(BaseTest):
     def test_gstg_2d_input(self) -> None:
 
         dim = 3 * 2
-        # pyre-fixme[16]: `TestGaussianStochasticGates` has no attribute
-        #  `testing_device`.
         gstg = GaussianStochasticGates(dim).to(self.testing_device)
 
         # shape(2,3,2)
@@ -178,8 +164,6 @@ class TestGaussianStochasticGates(BaseTest):
     def test_gstg_2d_input_with_n_gates_error(self) -> None:
 
         dim = 5
-        # pyre-fixme[16]: `TestGaussianStochasticGates` has no attribute
-        #  `testing_device`.
         gstg = GaussianStochasticGates(dim).to(self.testing_device)
         input_tensor = torch.tensor(
             [
@@ -203,8 +187,6 @@ class TestGaussianStochasticGates(BaseTest):
                 [1, 1],
                 [0, 2],
             ]
-            # pyre-fixme[16]: `TestGaussianStochasticGates` has no attribute
-            #  `testing_device`.
         ).to(self.testing_device)
         gstg = GaussianStochasticGates(dim, mask=mask).to(self.testing_device)
 
@@ -245,8 +227,6 @@ class TestGaussianStochasticGates(BaseTest):
     def test_get_gate_values_1d_input(self) -> None:
 
         dim = 3
-        # pyre-fixme[16]: `TestGaussianStochasticGates` has no attribute
-        #  `testing_device`.
         gstg = GaussianStochasticGates(dim).to(self.testing_device)
         input_tensor = torch.tensor(
             [
@@ -265,8 +245,6 @@ class TestGaussianStochasticGates(BaseTest):
 
         dim = 2
         mask = torch.tensor([0, 1, 1])
-        # pyre-fixme[16]: `TestGaussianStochasticGates` has no attribute
-        #  `testing_device`.
         gstg = GaussianStochasticGates(dim, mask=mask).to(self.testing_device)
         input_tensor = torch.tensor(
             [
@@ -284,8 +262,6 @@ class TestGaussianStochasticGates(BaseTest):
     def test_get_gate_values_2d_input(self) -> None:
 
         dim = 3 * 2
-        # pyre-fixme[16]: `TestGaussianStochasticGates` has no attribute
-        #  `testing_device`.
         gstg = GaussianStochasticGates(dim).to(self.testing_device)
 
         # shape(2,3,2)
@@ -320,8 +296,6 @@ class TestGaussianStochasticGates(BaseTest):
                 [0, 2],
             ]
         )
-        # pyre-fixme[16]: `TestGaussianStochasticGates` has no attribute
-        #  `testing_device`.
         gstg = GaussianStochasticGates(dim, mask=mask).to(self.testing_device)
 
         input_tensor = torch.tensor(
@@ -348,8 +322,6 @@ class TestGaussianStochasticGates(BaseTest):
     def test_get_gate_values_clamp(self) -> None:
         gstg = GaussianStochasticGates._from_pretrained(
             torch.tensor([2.0, -2.0, 2.0])
-            # pyre-fixme[16]: `TestGaussianStochasticGates` has no attribute
-            #  `testing_device`.
         ).to(self.testing_device)
 
         clamped_gate_values = gstg.get_gate_values().cpu().tolist()
@@ -365,8 +337,6 @@ class TestGaussianStochasticGates(BaseTest):
     def test_get_gate_active_probs_1d_input(self) -> None:
 
         dim = 3
-        # pyre-fixme[16]: `TestGaussianStochasticGates` has no attribute
-        #  `testing_device`.
         gstg = GaussianStochasticGates(dim).to(self.testing_device)
         input_tensor = torch.tensor(
             [
@@ -387,8 +357,6 @@ class TestGaussianStochasticGates(BaseTest):
 
         dim = 2
         mask = torch.tensor([0, 1, 1])
-        # pyre-fixme[16]: `TestGaussianStochasticGates` has no attribute
-        #  `testing_device`.
         gstg = GaussianStochasticGates(dim, mask=mask).to(self.testing_device)
         input_tensor = torch.tensor(
             [
@@ -409,8 +377,6 @@ class TestGaussianStochasticGates(BaseTest):
     def test_get_gate_active_probs_2d_input(self) -> None:
 
         dim = 3 * 2
-        # pyre-fixme[16]: `TestGaussianStochasticGates` has no attribute
-        #  `testing_device`.
         gstg = GaussianStochasticGates(dim).to(self.testing_device)
 
         # shape(2,3,2)
@@ -448,8 +414,6 @@ class TestGaussianStochasticGates(BaseTest):
                 [0, 2],
             ]
         )
-        # pyre-fixme[16]: `TestGaussianStochasticGates` has no attribute
-        #  `testing_device`.
         gstg = GaussianStochasticGates(dim, mask=mask).to(self.testing_device)
 
         input_tensor = torch.tensor(


### PR DESCRIPTION
Summary: Make Pyre happy. The actual values are overridden by parameterized_class args

Differential Revision: D73884605


