### PR TITLE
Clean up pyre-fixme/ignore comments that are no longer suppressing errors

### DIFF
--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -682,8 +682,6 @@ def compute_layer_gradients_and_eval(
             " take gradient with respect to multiple outputs."
         )
 
-        # pyre-fixme[6]: For 2nd argument expected `Dict[Module, Dict[device,
-        #  typing.Tuple[Tensor, ...]]]` but got `Module`.
         device_ids = _extract_device_ids(forward_fn, saved_layer, device_ids)
 
         # Identifies correct device ordering based on device ids.
@@ -729,7 +727,6 @@ def compute_layer_gradients_and_eval(
             for layer_tensor in saved_layer[single_layer][device_id]
         )
         saved_grads = torch.autograd.grad(
-            # pyre-fixme[6]: For 1st argument expected `Tensor` but got `Module`.
             outputs=torch.unbind(output),
             inputs=grad_inputs,
             **grad_kwargs or {},

--- a/captum/_utils/models/linear_model/train.py
+++ b/captum/_utils/models/linear_model/train.py
@@ -275,7 +275,6 @@ class NormLayer(nn.Module):
         self.mean = mean
         # pyre-fixme[4]: Attribute must be annotated.
         self.std = std
-        # pyre-fixme[4]: Attribute must be annotated.
         self.eps = eps
 
     # pyre-fixme[3]: Return type must be annotated.

--- a/captum/attr/_core/integrated_gradients.py
+++ b/captum/attr/_core/integrated_gradients.py
@@ -88,8 +88,6 @@ class IntegratedGradients(GradientAttribution):
     ) -> Tuple[TensorOrTupleOfTensorsGeneric, Tensor]: ...
 
     @typing.overload
-    # pyre-fixme[43]: The implementation of `attribute` does not accept all possible
-    #  arguments of overload defined on line `82`.
     def attribute(
         self,
         inputs: TensorOrTupleOfTensorsGeneric,
@@ -262,14 +260,10 @@ class IntegratedGradients(GradientAttribution):
         # converting it into a tuple.
         is_inputs_tuple = _is_tuple(inputs)
 
-        # pyre-fixme[9]: inputs has type `TensorOrTupleOfTensorsGeneric`; used as
-        #  `Tuple[Tensor, ...]`.
         formatted_inputs, formatted_baselines = _format_input_baseline(
             inputs, baselines
         )
 
-        # pyre-fixme[6]: For 1st argument expected `Tuple[Tensor, ...]` but got
-        #  `TensorOrTupleOfTensorsGeneric`.
         _validate_input(formatted_inputs, formatted_baselines, n_steps, method)
 
         if internal_batch_size is not None:

--- a/captum/attr/_core/lime.py
+++ b/captum/attr/_core/lime.py
@@ -566,7 +566,6 @@ class LimeBase(PerturbationAttribution):
     ) -> Tensor:
         model_out = _run_forward(
             self.forward_func,
-            # pyre-fixme[6]: For 1st argument expected `Sequence[Variable[TupleOrTens...
             _reduce_list(curr_model_inputs),
             expanded_target,
             expanded_additional_args,

--- a/captum/attr/_core/occlusion.py
+++ b/captum/attr/_core/occlusion.py
@@ -323,8 +323,6 @@ class Occlusion(FeatureAblation):
                 torch.ones(1, dtype=torch.long, device=expanded_input.device)
                 - input_mask
             ).to(expanded_input.dtype)
-            # pyre-fixme[58]: `*` is not supported for operand types `Union[None, float,
-            #  Tensor]` and `Tensor`.
         ) + (baseline * input_mask.to(expanded_input.dtype))
         return ablated_tensor, input_mask
 

--- a/captum/attr/_utils/attribution.py
+++ b/captum/attr/_utils/attribution.py
@@ -24,8 +24,6 @@ from torch import Tensor
 from torch.nn import Module
 
 
-# pyre-fixme[13]: Attribute `attribute` is never initialized.
-# pyre-fixme[13]: Attribute `compute_convergence_delta` is never initialized.
 class Attribution:
     r"""
     All attribution algorithms extend this class. It enforces its child classes
@@ -471,7 +469,6 @@ class LayerAttribution(InternalAttribution):
         return F.interpolate(layer_attribution, interpolate_dims, mode=interpolate_mode)
 
 
-# pyre-fixme[13]: Attribute `attribute` is never initialized.
 # pyre-fixme[24]: Generic type `InternalAttribution` expects 1 type parameter.
 class NeuronAttribution(InternalAttribution):
     r"""

--- a/captum/attr/_utils/lrp_rules.py
+++ b/captum/attr/_utils/lrp_rules.py
@@ -68,7 +68,6 @@ class PropagationRule(ABC):
             device = grad.device
             # pyre-fixme[16]: `PropagationRule` has no attribute `_has_single_input`.
             if self._has_single_input:
-                # pyre-fixme[16]: `PropagationRule` has no attribute `relevance_input`.
                 self.relevance_input[device] = relevance.data
             else:
                 cast(List[Tensor], self.relevance_input[device]).append(relevance.data)
@@ -82,14 +81,12 @@ class PropagationRule(ABC):
 
     # pyre-fixme[3]: Return type must be annotated.
     def _create_backward_hook_output(self, outputs: torch.Tensor):
-        # pyre-fixme[53]: Captured variable `outputs` is not annotated.
         # pyre-fixme[3]: Return type must be annotated.
         # pyre-fixme[2]: Parameter must be annotated.
         def _backward_hook_output(grad):
             sign = torch.sign(outputs)
             sign[sign == 0] = 1
             relevance = grad / (outputs + sign * self.STABILITY_FACTOR)
-            # pyre-fixme[16]: `PropagationRule` has no attribute `relevance_output`.
             self.relevance_output[grad.device] = grad.data
             return relevance
 
@@ -138,7 +135,6 @@ class EpsilonRule(PropagationRule):
     """
 
     def __init__(self, epsilon: float = 1e-9) -> None:
-        # pyre-fixme[4]: Attribute must be annotated.
         self.STABILITY_FACTOR = epsilon
 
     # pyre-fixme[2]: Parameter must be annotated.
@@ -159,9 +155,7 @@ class GammaRule(PropagationRule):
     """
 
     def __init__(self, gamma: float = 0.25, set_bias_to_zero: bool = False) -> None:
-        # pyre-fixme[4]: Attribute must be annotated.
         self.gamma = gamma
-        # pyre-fixme[4]: Attribute must be annotated.
         self.set_bias_to_zero = set_bias_to_zero
 
     # pyre-fixme[2]: Parameter must be annotated.
@@ -188,7 +182,6 @@ class Alpha1_Beta0_Rule(PropagationRule):
     """
 
     def __init__(self, set_bias_to_zero: bool = False) -> None:
-        # pyre-fixme[4]: Attribute must be annotated.
         self.set_bias_to_zero = set_bias_to_zero
 
     # pyre-fixme[2]: Parameter must be annotated.
@@ -215,7 +208,6 @@ class IdentityRule(EpsilonRule):
         # pyre-fixme[3]: Return type must be annotated.
         # pyre-fixme[2]: Parameter must be annotated.
         def _backward_hook_input(grad):
-            # pyre-fixme[16]: `IdentityRule` has no attribute `relevance_output`.
             return self.relevance_output[grad.device]
 
         return _backward_hook_input

--- a/captum/concept/_core/concept.py
+++ b/captum/concept/_core/concept.py
@@ -58,7 +58,6 @@ class Concept:
         return "Concept(%r, %r)" % (self.id, self.name)
 
 
-# pyre-fixme[13]: Attribute `interpret` is never initialized.
 class ConceptInterpreter:
     r"""
     An abstract class that exposes an abstract interpret method

--- a/captum/insights/example.py
+++ b/captum/insights/example.py
@@ -3,7 +3,6 @@
 # pyre-strict
 import warnings
 
-# pyre-fixme[21]: Could not find name `Net` in `captum.insights.attr_vis.example`.
 from captum.insights.attr_vis.example import *  # noqa
 
 warnings.warn(

--- a/captum/robust/_core/fgsm.py
+++ b/captum/robust/_core/fgsm.py
@@ -156,8 +156,6 @@ class FGSM(Perturbation):
                         is returned. If a tuple is provided for inputs, a tuple of
                         corresponding sized tensors is returned.
         """
-        # pyre-fixme[6]: For 1st argument expected `Tensor` but got
-        #  `TensorOrTupleOfTensorsGeneric`.
         is_inputs_tuple = _is_tuple(inputs)
         # pyre-fixme[35]: Target cannot be annotated.
         inputs: Tuple[Tensor, ...] = _format_tensor_into_tuples(inputs)

--- a/captum/robust/_core/metrics/min_param_perturbation.py
+++ b/captum/robust/_core/metrics/min_param_perturbation.py
@@ -161,7 +161,6 @@ class MinParamPerturbation:
         assert (
             mode.upper() in MinParamPerturbationMode.__members__
         ), f"Provided perturb mode {mode} is not valid - must be linear or binary"
-        # pyre-fixme[4]: Attribute must be annotated.
         self.mode = MinParamPerturbationMode[mode.upper()]
 
     def _evaluate_batch(

--- a/captum/robust/_core/perturbation.py
+++ b/captum/robust/_core/perturbation.py
@@ -4,7 +4,6 @@
 from typing import Callable
 
 
-# pyre-fixme[13]: Attribute `perturb` is never initialized.
 class Perturbation:
     r"""
     All perturbation and attack algorithms extend this class. It enforces

--- a/captum/robust/_core/pgd.py
+++ b/captum/robust/_core/pgd.py
@@ -168,8 +168,6 @@ class PGD(Perturbation):
             else:
                 raise AssertionError("Norm constraint must be L2 or Linf.")
 
-        # pyre-fixme[6]: For 1st argument expected `Tensor` but got
-        #  `TensorOrTupleOfTensorsGeneric`.
         is_inputs_tuple = _is_tuple(inputs)
         formatted_inputs = _format_tensor_into_tuples(inputs)
         # pyre-fixme[9]: formatted_masks has type `Union[typing.Tuple[int, ...],

--- a/tests/attr/layer/test_layer_gradient_shap.py
+++ b/tests/attr/layer/test_layer_gradient_shap.py
@@ -47,7 +47,7 @@ class Test(BaseTest):
         inputs = torch.tensor([[1.0, -20.0, 10.0]])
         baselines = torch.zeros(3, 3)
         lgs = LayerGradientShap(model, model.linear2, multiply_by_inputs=False)
-        attrs = lgs.attribute(
+        attrs = lgs.attribute(  # type: ignore[has-type]
             inputs,
             baselines,
             target=0,
@@ -187,7 +187,7 @@ class Test(BaseTest):
         add_args: Any = None,
     ) -> None:
         lgs = LayerGradientShap(model, layer)
-        attrs, delta = lgs.attribute(
+        attrs, delta = lgs.attribute(  # type: ignore[has-type]
             inputs,
             baselines,
             target=target,

--- a/tests/attr/neuron/test_neuron_conductance.py
+++ b/tests/attr/neuron/test_neuron_conductance.py
@@ -273,13 +273,7 @@ class Test(BaseTest):
                     for n in range(attributions.shape[0]):
                         self.assertAlmostEqual(
                             torch.sum(neuron_vals[n]).item(),
-                            # pyre-fixme[6]: For 2nd argument expected
-                            #  `SupportsRSub[Variable[_T],
-                            #  SupportsAbs[SupportsRound[object]]]` but got
-                            #  `Union[bool, float, int]`.
                             attributions[n, i, j, k].item(),
-                            # pyre-fixme[6]: For 3rd argument expected `None` but
-                            #  got `float`.
                             delta=0.005,
                         )
 

--- a/tests/attr/test_llm_attr.py
+++ b/tests/attr/test_llm_attr.py
@@ -191,9 +191,6 @@ class DummyLLM(nn.Module):
         assert mock_response, "must mock response to use DummyLLM to generate"
         response = self.tokenizer.encode(mock_response)[1:]
         return torch.cat(
-            # pyre-fixme[6]: In call `torch._C._VariableFunctions.cat`,
-            # for 1st positional argument, expected `Union[List[Tensor],
-            # typing.Tuple[Tensor, ...]]` but got `List[Union[List[int], Tensor]]`.
             [input_ids, torch.tensor([response], device=self.device)],  # type: ignore
             dim=1,
         )
@@ -236,8 +233,6 @@ class DummyLLM(nn.Module):
         else [("cpu", True), ("cpu", False)]
     ),
 )
-# pyre-fixme[13]: Attribute `device` is never initialized.
-# pyre-fixme[13]: Attribute `use_cached_outputs` is never initialized.
 class TestLLMAttr(BaseTest):
     # pyre-fixme[13]: Attribute `device` is never initialized.
     device: str

--- a/tests/concept/test_tcav.py
+++ b/tests/concept/test_tcav.py
@@ -844,8 +844,6 @@ class Test(BaseTest):
                     self.assertAlmostEqual(
                         stats["accs"].item(),
                         acc,
-                        # pyre-fixme[6]: For 3rd argument expected `None` but got
-                        #  `float`.
                         delta=0.0001,
                     )
 

--- a/tests/utils/test_sample_gradient.py
+++ b/tests/utils/test_sample_gradient.py
@@ -100,8 +100,6 @@ class Test(BaseTest):
 
         # possible candidates for `layer_modules`, which are the modules whose
         # parameters we want to compute sample grads for
-        # pyre-fixme[9]: layer_moduless has type `List[List[Module]]`; used as
-        #  `List[Union[List[Union[Conv2d, Linear]], List[Conv2d], List[Linear]]]`.
         layer_moduless: List[List[Module]] = [
             [model.conv1],
             [model.fc1],


### PR DESCRIPTION
Summary: Clean up pyre-fixme/ignore comments that are no longer suppressing errors throughout the entire Captum library.

Differential Revision: D74049476


