### PR TITLE
Fix Tensor/float Pyre type issues

### DIFF
--- a/captum/influence/_core/arnoldi_influence_function.py
+++ b/captum/influence/_core/arnoldi_influence_function.py
@@ -304,12 +304,12 @@ class ArnoldiInfluenceFunction(IntermediateQuantitiesInfluenceFunction):
         # pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.
         checkpoints_load_func: Callable = _load_flexible_state_dict,
         layers: Optional[List[str]] = None,
-        # pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.
-        loss_fn: Optional[Union[Module, Callable]] = None,
+        loss_fn: Optional[Union[Module, Callable[[Tensor, Tensor], Tensor]]] = None,
         batch_size: Union[int, None] = 1,
         hessian_dataset: Optional[Union[Dataset, DataLoader]] = None,
-        # pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.
-        test_loss_fn: Optional[Union[Module, Callable]] = None,
+        test_loss_fn: Optional[
+            Union[Module, Callable[[Tensor, Tensor], Tensor]]
+        ] = None,
         sample_wise_grads_per_batch: bool = False,
         projection_dim: int = 50,
         seed: int = 0,
@@ -755,11 +755,12 @@ class ArnoldiInfluenceFunction(IntermediateQuantitiesInfluenceFunction):
             return_device = torch.device("cpu") if return_on_cpu else self.model_device
 
         # choose the correct loss function and reduction type based on `test`
-        loss_fn = self.test_loss_fn if test else self.loss_fn
+        loss_fn: Optional[Union[Module, Callable[[Tensor, Tensor], Tensor]]] = (
+            self.test_loss_fn if test else self.loss_fn
+        )
         reduction_type = self.test_reduction_type if test else self.reduction_type
 
         # define a helper function that returns the embeddings for a batch
-        # pyre-fixme[53]: Captured variable `loss_fn` is not annotated.
         # pyre-fixme[53]: Captured variable `reduction_type` is not annotated.
         # pyre-fixme[3]: Return type must be annotated.
         # pyre-fixme[2]: Parameter must be annotated.

--- a/captum/influence/_utils/common.py
+++ b/captum/influence/_utils/common.py
@@ -887,7 +887,9 @@ def _parameter_add(
     return tuple(param_1 + param_2 for (param_1, param_2) in zip(params_1, params_2))
 
 
-def _parameter_multiply(params: Tuple[Tensor, ...], c: Tensor) -> Tuple[Tensor, ...]:
+def _parameter_multiply(
+    params: Tuple[Tensor, ...], c: Union[Tensor, float]
+) -> Tuple[Tensor, ...]:
     """
     multiplies all tensors in a tuple of tensors by a given scalar
     """


### PR DESCRIPTION
Summary:
Fix the following:

```
# pyre-fixme[6]: For 2nd argument expected `Tensor` but got `float`.

# pyre-fixme[58]: `/` is not supported for operand types `float` and `Tensor`.
```

This is due to applying Python's math operators to floats and Tensors, resulting in type confusion. Use the equivalent torch functions instead, ex: `torch.pow` instead of `**`

Reviewed By: cyrjano

Differential Revision: D74025088


