### PR TITLE
Enable pyre type checking in OSS

### DIFF
--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -1,7 +1,7 @@
 name: Rerun tests if failed
 on:
   workflow_run:
-    workflows: ["Unit-tests for Conda install", "Unit-tests for Pip install with mypy type checks", "Unit-tests for Pip install"]
+    workflows: ["Unit-tests for Conda install", "Unit-tests for Pip install with type checks", "Unit-tests for Pip install"]
     types: ["completed"]
 
 permissions:

--- a/.github/workflows/test-pip-cpu-with-type-checks.yml
+++ b/.github/workflows/test-pip-cpu-with-type-checks.yml
@@ -1,4 +1,4 @@
-name: Unit-tests for Pip install with mypy type checks
+name: Unit-tests for Pip install with type checks
 
 on:
   pull_request:
@@ -23,5 +23,6 @@ jobs:
         sudo chmod -R 777 .
         ./scripts/install_via_pip.sh ${{ matrix.pytorch_args }}
         ./scripts/run_mypy.sh
+        pyre check
         # Run Tests
         python3 -m pytest -ra --cov=. --cov-report term-missing

--- a/.pyre_configuration
+++ b/.pyre_configuration
@@ -1,0 +1,17 @@
+{
+  "exclude": [
+    ".*/build/.*",
+    ".*/docs/.*",
+    ".*/scripts/.*",
+    ".*/sphinx/.*",
+    ".*/website/.*",
+    ".*/fb/.*",
+    ".*/tests/.*",
+    ".*/setup.py"
+  ],
+  "site_package_search_strategy": "all",
+  "source_directories": [
+    "."
+  ],
+  "strict": true
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Github Actions will fail on your PR if it does not adhere to the ufmt or flake8 
 
 #### Type Hints
 
-Captum is fully typed using python 3.6+
+Captum is fully typed using Python 3.9+
 [type hints](https://www.python.org/dev/peps/pep-0484/).
 We expect any contributions to also use proper type annotations, and we enforce
 consistency of these in our continuous integration tests.
@@ -61,10 +61,16 @@ Then run this script from the repository root:
 ```bash
 ./scripts/run_mypy.sh
 ```
-Note that we expect mypy to have version 0.760 or higher, and when type checking, use PyTorch 1.4 or
-higher due to fixes to PyTorch type hints available in 1.4. We also use the Literal feature which is
-available only in Python 3.9 or above. If type-checking using a previous version of Python, you will
-need to install the typing-extension package which can be done with pip using `pip install typing-extensions`.
+Note that we expect mypy to have version 0.760 or higher, and when type checking, use PyTorch 1.10 or
+higher due to fixes to the PyTorch type hints available. We also use the Literal feature which is
+available only in Python 3.9 or above.
+
+We also use [pyre](https://pyre-check.org/) for type checking. For contributors, the nightly version of
+pyre is used which can be installed with pip `pip install pyre-check-nightly`. To run pyre, you can
+use the following command from inside the repository root:
+```bash
+pyre check
+```
 
 #### Unit Tests
 

--- a/captum/_utils/transformers_typing.py
+++ b/captum/_utils/transformers_typing.py
@@ -29,8 +29,7 @@ Cache: Optional[Type[CacheLike]]
 DynamicCache: Optional[Type[DynamicCacheLike]]
 
 try:
-    # pyre-ignore[21]: Could not find a module corresponding to import `transformers`.
-    import transformers  # noqa: F401
+    import transformers  # noqa: F401  # type: ignore
 
     transformers_installed = True
 except ImportError:
@@ -38,9 +37,7 @@ except ImportError:
 
 if transformers_installed:
     try:
-        # pyre-ignore[21]: Could not find a module corresponding to import
-        # `transformers.cache_utils`.
-        from transformers.cache_utils import (  # noqa: F401
+        from transformers.cache_utils import (  # noqa: F401  # type: ignore
             Cache as _Cache,
             DynamicCache as _DynamicCache,
         )
@@ -99,9 +96,7 @@ def supports_caching(model: nn.Module) -> bool:
         return False
     # Cache may be optional or unsupported depending on model/version
     try:
-        # pyre-ignore[21]: Could not find a module corresponding to import
-        # `transformers.generation.utils`.
-        from transformers.generation.utils import GenerationMixin
+        from transformers.generation.utils import GenerationMixin  # type: ignore
     except ImportError:
         return False
     if not isinstance(model, GenerationMixin):
@@ -113,5 +108,4 @@ def supports_caching(model: nn.Module) -> bool:
         # Cache is mandatory
         return True
     # Fallback on _supports_cache_class attribute
-    # pyre-fixme[7]: Expected `bool` but got `Union[Module, Tensor]`.
-    return getattr(model, "_supports_cache_class", False)
+    return getattr(model, "_supports_cache_class", False)  # type: ignore

--- a/captum/attr/_core/deep_lift.py
+++ b/captum/attr/_core/deep_lift.py
@@ -409,8 +409,7 @@ class DeepLift(GradientAttribution):
         set necessary hooks on inputs there.
         """
         inputs = _format_tensor_into_tuples(inputs)
-        # pyre-fixme[16]: `Module` has no attribute `input`.
-        module.input = inputs[0].clone().detach()
+        module.input = inputs[0].clone().detach()  # type: ignore
 
     def _forward_hook(
         self,
@@ -423,8 +422,7 @@ class DeepLift(GradientAttribution):
         outputs of a neuron
         """
         outputs = _format_tensor_into_tuples(outputs)
-        # pyre-fixme[16]: `Module` has no attribute `output`.
-        module.output = outputs[0].clone().detach()
+        module.output = outputs[0].clone().detach()  # type: ignore
 
     def _backward_hook(
         self,
@@ -538,9 +536,7 @@ class DeepLift(GradientAttribution):
         ):
             return [
                 self.model.module.register_forward_pre_hook(pre_hook),  # type: ignore
-                # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no
-                #  attribute `register_forward_hook`.
-                self.model.module.register_forward_hook(forward_hook),
+                self.model.module.register_forward_hook(forward_hook),  # type: ignore
             ]  # type: ignore
         else:
             return [

--- a/captum/attr/_core/remote_provider.py
+++ b/captum/attr/_core/remote_provider.py
@@ -1,3 +1,5 @@
+# pyre-strict
+
 import logging
 import os
 from abc import ABC, abstractmethod
@@ -5,7 +7,7 @@ from typing import Any, List, Optional
 
 from captum._utils.typing import TokenizerLike
 
-logger = logging.getLogger(__name__)
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 class RemoteLLMProvider(ABC):
@@ -51,7 +53,9 @@ class RemoteLLMProvider(ABC):
 
 
 class VLLMProvider(RemoteLLMProvider):
-    def __init__(self, api_url: str, model_name: Optional[str] = None):
+    model_name: str
+
+    def __init__(self, api_url: str, model_name: Optional[str] = None) -> None:
         """
         Initialize a vLLM provider.
 
@@ -85,7 +89,7 @@ class VLLMProvider(RemoteLLMProvider):
         self.api_url = api_url
 
         try:
-            self.client = OpenAI(
+            self.client: OpenAI = OpenAI(
                 base_url=self.api_url, api_key=os.getenv("OPENAI_API_KEY", "EMPTY")
             )
 

--- a/captum/attr/_utils/visualization.py
+++ b/captum/attr/_utils/visualization.py
@@ -656,7 +656,12 @@ def _visualize_colored_graph(
         points = np.array([x_values, data[chan, :]]).T.reshape(-1, 1, 2)
         segments = np.concatenate([points[:-1], points[1:]], axis=1)
 
-        lc = LineCollection(segments, cmap=cmap, norm=cm_norm, **pyplot_kwargs)
+        lc = LineCollection(
+            segments,  # type: ignore
+            cmap=cmap,
+            norm=cm_norm,
+            **pyplot_kwargs,
+        )
         lc.set_array(norm_attr[chan, :])
         plt_axis_list[chan].add_collection(lc)
         plt_axis_list[chan].set_ylim(

--- a/captum/concept/_core/cav.py
+++ b/captum/concept/_core/cav.py
@@ -182,8 +182,12 @@ class CAV:
                     np.dtype,
                 ]
                 if hasattr(np, "dtypes"):
-                    # pyre-ignore[16]: Module `numpy` has no attribute `dtypes`.
-                    safe_globals.extend([np.dtypes.UInt32DType, np.dtypes.Int32DType])
+                    safe_globals.extend(
+                        [
+                            np.dtypes.UInt32DType,  # type: ignore
+                            np.dtypes.Int32DType,  # type: ignore
+                        ]
+                    )
                 ctx = torch.serialization.safe_globals(safe_globals)
             else:
                 # safe globals not in existence in this version of torch yet. Use a

--- a/captum/insights/attr_vis/app.py
+++ b/captum/insights/attr_vis/app.py
@@ -6,6 +6,7 @@ from itertools import cycle
 from typing import (
     Any,
     Callable,
+    cast,
     Dict,
     Iterable,
     List,
@@ -401,14 +402,12 @@ class AttributionVisualizer:
         single_model_index=None,
     ) -> Optional[List[VisualizationOutput]]:
         # Use all models, unless the user wants to render data for a particular one
-        models_used = (
+        models_used: List[Module] = (
             [self.models[single_model_index]]
             if single_model_index is not None
-            else self.models
+            else cast(List[Module], self.models)
         )
         results = []
-        # pyre-fixme[6]: For 1st argument expected `Iterable[_T]` but got
-        #  `Union[List[Any], Module]`.
         for model_index, model in enumerate(models_used):
             # Get list of model visualizations for each input
             actual_label_output = None

--- a/captum/insights/attr_vis/widget/widget.py
+++ b/captum/insights/attr_vis/widget/widget.py
@@ -23,7 +23,7 @@ class CaptumInsights(widgets.DOMWidget):
     _view_module_version = Unicode("^0.1.0").tag(sync=True)
     # pyre-fixme[4]: Attribute must be annotated.
     _model_module_version = Unicode("^0.1.0").tag(sync=True)
-
+    # pyre-fixme[4]: Attribute must be annotated.
     visualizer = Instance(klass=AttributionVisualizer)
 
     # pyre-fixme[4]: Attribute must be annotated.

--- a/captum/log/__init__.py
+++ b/captum/log/__init__.py
@@ -3,7 +3,7 @@
 # pyre-strict
 
 try:
-    from captum.log.fb.internal_log import (
+    from captum.log.fb.internal_log import (  # type: ignore
         disable_detailed_logging,
         log,
         log_usage,
@@ -11,16 +11,6 @@ try:
         set_environment,
         TimedLog,
     )
-
-    __all__ = [
-        "log",
-        "log_usage",
-        "TimedLog",
-        "set_environment",
-        "disable_detailed_logging",
-        "patch_methods",
-    ]
-
 except ImportError:
     # bug with mypy: https://github.com/python/mypy/issues/1153
     from captum.log.dummy_log import (  # type: ignore
@@ -31,3 +21,12 @@ except ImportError:
         set_environment,
         TimedLog,
     )
+
+__all__ = [
+    "log",
+    "log_usage",
+    "TimedLog",
+    "set_environment",
+    "disable_detailed_logging",
+    "patch_methods",
+]

--- a/captum/testing/helpers/__init__.py
+++ b/captum/testing/helpers/__init__.py
@@ -3,14 +3,18 @@
 # pyre-strict
 
 try:
-    from captum.testing.helpers.fb.internal_base import FbBaseTest as BaseTest
-
-    __all__ = [
-        "BaseTest",
-    ]
+    from captum.testing.helpers.fb.internal_base import (  # type: ignore
+        FbBaseTest as _BaseTest,
+    )
 
 except ImportError:
-    # tests/helpers/__init__.py:13: error: Incompatible import of "BaseTest"
+    # tests/helpers/__init__.py:13: error: Incompatible import of "_BaseTest"
     # (imported name has type "type[BaseTest]", local name has type
     # "type[FbBaseTest]")  [assignment]
-    from captum.testing.helpers.basic import BaseTest  # type: ignore
+    from captum.testing.helpers.basic import BaseTest as _BaseTest  # type: ignore
+
+BaseTest = _BaseTest
+
+__all__ = [
+    "BaseTest",
+]

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ TEST_REQUIRES = ["pytest", "pytest-cov", "parameterized", "flask", "flask-compre
 REMOTE_REQUIRES = ["openai"]
 
 DEV_REQUIRES = (
-    INSIGHTS_REQUIRES
+    TUTORIALS_REQUIRES
     + TEST_REQUIRES
     + REMOTE_REQUIRES
     + [
@@ -76,6 +76,7 @@ DEV_REQUIRES = (
         "sphinx-autodoc-typehints",
         "sphinxcontrib-katex",
         "mypy>=0.760",
+        "pyre-check-nightly",
         "usort==1.0.2",
         "ufmt",
         "scikit-learn",


### PR DESCRIPTION
Summary: This adds pyre type checking to OSS GitHub actions. This reduces the back and forth between OSS contributors and Captum team due to differing OSS and internal type checking. mypy is kept enabled as well for now since it handles some things that pyre doesn't, but this diff is needed as pyre catches things that mypy doesn't.

Differential Revision: D75113906
