### PR TITLE
Unblock NumPy 2.x

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -16,7 +16,7 @@ requirements:
     - python>=3.9
     - setuptools
   run:
-    - numpy<2.0
+    - numpy
     - pytorch>=1.10
     - matplotlib-base
     - tqdm

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: captum
 channels:
   - pytorch
 dependencies:
-  - numpy<2.0
+  - numpy
   - pytorch>=1.10
   - matplotlib-base
   - tqdm

--- a/setup.py
+++ b/setup.py
@@ -162,7 +162,7 @@ if __name__ == "__main__":
         ),
         install_requires=[
             "matplotlib",
-            "numpy<2.0",
+            "numpy",
             "packaging",
             "torch>=1.10",
             "tqdm",


### PR DESCRIPTION
NumPy 2.x has been around for almost a year, and the latest release is [2.3.0](https://github.com/numpy/numpy/releases/tag/v2.3.0). Most Python data science packages have finished migrating. According to the [NumPy 2.0 migration guide](https://numpy.org/devdocs/numpy_2_0_migration_guide.html), the following are the major changes in NumPy 2.0:
- [x] [Changes to NumPy data type promotion](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#changes-to-numpy-data-type-promotion): None-breaking for Captum, as none of the Captum code restricts to machine-dependent integer data types
- [x] [Windows default integer](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#windows-default-integer): Same as above
- [x] [C-API Changes](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#c-api-changes): Not related to Captum
- [x] [Changes to namespaces](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#changes-to-namespaces): Could be breaking changes for Captum, but can be checked using Ruff:
```
$ git clone https://github.com/pytorch/captum.git
$ ruff check ./captum/ --select NPY201
All checks passed!
```
Therefore, it is now safe to unblock NumPy 2.x.