### PR TITLE
Preserve template in InterpretableInputs

### DIFF
--- a/captum/attr/_utils/interpretable_input.py
+++ b/captum/attr/_utils/interpretable_input.py
@@ -286,6 +286,8 @@ class TextTemplateInput(InterpretableInput):
         self.n_features = n_features
         self.n_itp_features = n_itp_features
 
+        # preserve template before modification
+        self.template = template
         if isinstance(template, str):
             template = template.format
         else:


### PR DESCRIPTION
Summary: Preserve template in InterpretableInputs before replacing it with a formatting function. This allows original template strings to be fetched, if needed.

Differential Revision: D76426755
