### PR TITLE
Migrate to linux job v2 for captum CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   tests:
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       runner: linux.12xlarge
       docker-image: cimg/python:3.11

--- a/.github/workflows/test-pip-cpu-with-type-checks.yml
+++ b/.github/workflows/test-pip-cpu-with-type-checks.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         pytorch_args: ["", "-n"]
       fail-fast: false
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       runner: linux.12xlarge
       docker-image: cimg/python:3.11

--- a/.github/workflows/test-pip-cpu.yml
+++ b/.github/workflows/test-pip-cpu.yml
@@ -37,7 +37,7 @@ jobs:
           - pytorch_args: "-v 2.1.0"
             docker_img: "cimg/python:3.12"
       fail-fast: false
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       runner: linux.12xlarge
       docker-image: ${{ matrix.docker_img }}

--- a/.github/workflows/test-pip-gpu.yml
+++ b/.github/workflows/test-pip-gpu.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         cuda_arch_version: ["12.1"]
       fail-fast: false
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       runner: linux.4xlarge.nvidia.gpu
       repository: pytorch/captum


### PR DESCRIPTION
Summary: Migrates to linux v2 job type from PyTorch test infra to resolve current OSS CI failures related to libcst

Reviewed By: sarahtranfb

Differential Revision: D76736664
