### PR TITLE
Resolve Pyre FixMe's in basic_models.py

### DIFF
--- a/captum/testing/helpers/basic_models.py
+++ b/captum/testing/helpers/basic_models.py
@@ -2,7 +2,7 @@
 
 # pyre-strict
 
-from typing import Dict, no_type_check, Optional, Tuple, Union
+from typing import Dict, List, no_type_check, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -20,16 +20,15 @@ the relevant type hints.
 
 
 class BasicLinearReLULinear(nn.Module):
-    # pyre-fixme[2]: Parameter must be annotated.
-    def __init__(self, in_features, out_features: int = 5, bias: bool = False) -> None:
+    def __init__(
+        self, in_features: int, out_features: int = 5, bias: bool = False
+    ) -> None:
         super().__init__()
         self.fc1 = nn.Linear(in_features, out_features, bias=bias)
         self.relu1 = nn.ReLU()
         self.fc2 = nn.Linear(out_features, 1, bias=bias)
 
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def forward(self, x):
+    def forward(self, x: Tensor) -> Tensor:
         x = self.fc1(x)
         x = self.relu1(x)
         x = self.fc2(x)
@@ -40,9 +39,7 @@ class MixedKwargsAndArgsModule(nn.Module):
     def __init__(self) -> None:
         super().__init__()
 
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def forward(self, x, y=None):
+    def forward(self, x: Tensor, y: Optional[Tensor] = None) -> Tensor:
         if y is not None:
             return x + y
         return x
@@ -52,8 +49,7 @@ class BasicModel(nn.Module):
     def __init__(self) -> None:
         super().__init__()
 
-    # pyre-fixme[3]: Return type must be annotated.
-    def forward(self, input: Tensor):
+    def forward(self, input: Tensor) -> Tensor:
         input = 1 - F.relu(1 - input)
         return input
 
@@ -86,8 +82,7 @@ class BasicModel3(nn.Module):
     def __init__(self) -> None:
         super().__init__()
 
-    # pyre-fixme[2]: Parameter must be annotated.
-    def forward(self, input1, input2: Tensor) -> Tensor:
+    def forward(self, input1: Tensor, input2: Tensor) -> Tensor:
         relu_out1 = F.relu(input1 - 1)
         relu_out2 = F.relu(input2)
         return F.relu(relu_out1 - relu_out2)
@@ -105,8 +100,7 @@ class BasicModel4_MultiArgs(nn.Module):
 
     def forward(
         self,
-        # pyre-fixme[2]: Parameter must be annotated.
-        input1,
+        input1: Tensor,
         input2: Tensor,
         additional_input1: Union[bool, float, int, Tensor],
         additional_input2: int = 0,
@@ -129,11 +123,9 @@ class BasicModel5_MultiArgs(nn.Module):
 
     def forward(
         self,
-        # pyre-fixme[2]: Parameter must be annotated.
-        input1,
+        input1: Tensor,
         input2: Tensor,
-        # pyre-fixme[2]: Parameter must be annotated.
-        additional_input1,
+        additional_input1: List[int],
         additional_input2: int = 0,
     ) -> Tensor:
         relu_out1 = F.relu(input1 - 1) * additional_input1[0]
@@ -146,11 +138,8 @@ class BasicModel6_MultiTensor(nn.Module):
     def __init__(self) -> None:
         super().__init__()
 
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def forward(self, input1, input2):
+    def forward(self, input1: Tensor, input2: Tensor) -> Tensor:
         input = input1 + input2
-        # pyre-fixme[6]: For 1st argument expected `Tensor` but got `int`.
         return 1 - F.relu(1 - input)[:, 1]
 
 
@@ -159,34 +148,26 @@ class BasicLinearModel(nn.Module):
         super().__init__()
         self.linear = nn.Linear(7, 1)
 
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def forward(self, x1, x2):
+    def forward(self, x1: Tensor, x2: Tensor) -> Tensor:
         return self.linear(torch.cat((x1, x2), dim=-1))
 
 
 class BasicLinearModel2(nn.Module):
-    # pyre-fixme[2]: Parameter must be annotated.
-    def __init__(self, in_features, out_features) -> None:
+    def __init__(self, in_features: int, out_features: int) -> None:
         super().__init__()
         self.linear = nn.Linear(in_features, out_features, bias=False)
 
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def forward(self, input):
+    def forward(self, input: Tensor) -> Tensor:
         return self.linear(input)
 
 
 class BasicLinearModel_Multilayer(nn.Module):
-    # pyre-fixme[2]: Parameter must be annotated.
-    def __init__(self, in_features, hidden_nodes, out_features) -> None:
+    def __init__(self, in_features: int, hidden_nodes: int, out_features: int) -> None:
         super().__init__()
         self.linear1 = nn.Linear(in_features, hidden_nodes, bias=False)
         self.linear2 = nn.Linear(hidden_nodes, out_features, bias=False)
 
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def forward(self, input):
+    def forward(self, input: Tensor) -> Tensor:
         x = self.linear1(input)
         return self.linear2(x)
 
@@ -201,8 +182,7 @@ class ReLUDeepLiftModel(nn.Module):
         self.relu1 = nn.ReLU()
         self.relu2 = nn.ReLU()
 
-    # pyre-fixme[2]: Parameter must be annotated.
-    def forward(self, x1, x2, x3: int = 2) -> int:
+    def forward(self, x1: Tensor, x2: Tensor, x3: int = 2) -> int:
         return 2 * self.relu1(x1) + x3 * self.relu2(x2 - 1.5)
 
 
@@ -216,9 +196,7 @@ class LinearMaxPoolLinearModel(nn.Module):
         self.lin2 = nn.Linear(1, 1, bias=False)
         self.lin2.weight = nn.Parameter(torch.ones(1, 1))
 
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def forward(self, x):
+    def forward(self, x: Tensor) -> Tensor:
         x = x.unsqueeze(1)
         return self.lin2(self.pool1(self.lin1(x))[:, 0, :])
 
@@ -230,9 +208,7 @@ class BasicModelWithReusedModules(nn.Module):
         self.relu = nn.ReLU()
         self.lin2 = nn.Linear(2, 2)
 
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def forward(self, inputs):
+    def forward(self, inputs: Tensor) -> Tensor:
         return self.relu(self.lin2(self.relu(self.lin1(inputs))))
 
 
@@ -242,9 +218,7 @@ class BasicModelWithReusedLinear(nn.Module):
         self.lin1 = nn.Linear(3, 3)
         self.relu = nn.ReLU()
 
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def forward(self, inputs):
+    def forward(self, inputs: Tensor) -> Tensor:
         return self.relu(self.lin1(self.relu(self.lin1(inputs))))
 
 
@@ -255,9 +229,7 @@ class BasicModelWithSparseInputs(nn.Module):
         self.lin1.weight = nn.Parameter(torch.tensor([[3.0, 1.0, 2.0]]))
         self.lin1.bias = nn.Parameter(torch.zeros(1))
 
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def forward(self, inputs, sparse_list: Tensor):
+    def forward(self, inputs: Tensor, sparse_list: Tensor) -> Tensor:
         return (
             self.lin1(inputs) + (sparse_list[0] if torch.numel(sparse_list) > 0 else 0)
         ).sum()
@@ -269,9 +241,7 @@ class BasicModel_MaxPool_ReLU(nn.Module):
         self.maxpool = nn.MaxPool1d(3)
         self.relu = nn.ReLU(inplace=inplace)
 
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def forward(self, x):
+    def forward(self, x: Tensor) -> Tensor:
         return self.relu(self.maxpool(x)).sum(dim=1)
 
 
@@ -286,8 +256,7 @@ class TanhDeepLiftModel(nn.Module):
         self.tanh1 = nn.Tanh()
         self.tanh2 = nn.Tanh()
 
-    # pyre-fixme[2]: Parameter must be annotated.
-    def forward(self, x1, x2) -> int:
+    def forward(self, x1: Tensor, x2: Tensor) -> int:
         return 2 * self.tanh1(x1) + 2 * self.tanh2(x2 - 1.5)
 
 
@@ -313,8 +282,7 @@ class ReLULinearModel(nn.Module):
 
 
 class SimpleLRPModel(nn.Module):
-    # pyre-fixme[2]: Parameter must be annotated.
-    def __init__(self, inplace) -> None:
+    def __init__(self, inplace: bool) -> None:
         super().__init__()
         self.linear = nn.Linear(3, 3, bias=False)
         self.linear.weight.data.fill_(2.0)
@@ -323,9 +291,7 @@ class SimpleLRPModel(nn.Module):
         self.linear2.weight.data.fill_(3.0)
         self.dropout = torch.nn.Dropout(p=0.01)
 
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def forward(self, x):
+    def forward(self, x: Tensor) -> Tensor:
         return self.dropout(self.linear2(self.relu(self.linear(x))))
 
 
@@ -334,9 +300,7 @@ class Conv1dSeqModel(nn.Module):
         super().__init__()
         self.seq = nn.Sequential(nn.Conv1d(4, 2, 1), nn.ReLU(), nn.Linear(1000, 1))
 
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def forward(self, inputs):
+    def forward(self, inputs: Tensor) -> Tensor:
         return self.seq(inputs)
 
 
@@ -348,22 +312,23 @@ class TextModule(nn.Module):
 
     def __init__(
         self,
-        # pyre-fixme[2]: Parameter must be annotated.
-        num_embeddings,
-        # pyre-fixme[2]: Parameter must be annotated.
-        embedding_dim,
+        num_embeddings: int,
+        embedding_dim: int,
         second_embedding: bool = False,
     ) -> None:
         super().__init__()
         self.inner_embedding = nn.Embedding(num_embeddings, embedding_dim)
         self.second_embedding = second_embedding
         if self.second_embedding:
-            # pyre-fixme[4]: Attribute must be annotated.
-            self.inner_embedding2 = nn.Embedding(num_embeddings, embedding_dim)
+            self.inner_embedding2: nn.Embedding = nn.Embedding(
+                num_embeddings, embedding_dim
+            )
 
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def forward(self, input=None, another_input=None):
+    def forward(
+        self,
+        input: Optional[Tensor] = None,
+        another_input: Optional[Tensor] = None,
+    ) -> Tensor:
         assert input is not None, "The inputs to embedding module must be specified"
         embedding = self.inner_embedding(input)
         if self.second_embedding:
@@ -409,9 +374,9 @@ class BasicEmbeddingModel(nn.Module):
         self.linear2 = nn.Linear(hidden_dim, output_dim)
         self.linear2.weight = nn.Parameter(torch.ones(output_dim, hidden_dim))
 
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def forward(self, input1, input2, input3=None):
+    def forward(
+        self, input1: Tensor, input2: Tensor, input3: Optional[Tensor] = None
+    ) -> Tensor:
         embedding1 = self.embedding1(input1)
         embedding2 = self.embedding2(input2, input3)
         embeddings = embedding1 + embedding2
@@ -543,13 +508,12 @@ class BasicModel_MultiLayer(nn.Module):
         self.linear2.bias = nn.Parameter(torch.tensor([-1.0, 1.0]))
 
     @no_type_check
-    # pyre-fixme[3]: Return type must be annotated.
     def forward(
         self,
         x: Tensor,
         add_input: Optional[Tensor] = None,
         multidim_output: bool = False,
-    ):
+    ) -> Tensor:
         input = x if add_input is None else x + add_input
         lin0_out = self.linear0(input)
         lin1_out = self.linear1(lin0_out)
@@ -595,13 +559,12 @@ class BasicModel_MultiLayer_with_Future(nn.Module):
         self.linear2.bias = nn.Parameter(torch.tensor([-1.0, 1.0]))
 
     @no_type_check
-    # pyre-fixme[3]: Return type must be annotated.
     def forward(
         self,
         x: Tensor,
         add_input: Optional[Tensor] = None,
         multidim_output: bool = False,
-    ):
+    ) -> Future[Tensor]:
         input = x if add_input is None else x + add_input
         lin0_out = self.linear0(input)
         lin1_out = self.linear1(lin0_out)
@@ -631,13 +594,12 @@ class BasicModelBoolInput_with_Future(nn.Module):
         super().__init__()
         self.mod = BasicModel_MultiLayer_with_Future()
 
-    # pyre-fixme[3]: Return type must be annotated.
     def forward(
         self,
         x: Tensor,
         add_input: Optional[Tensor] = None,
         mult: float = 10.0,
-    ):
+    ) -> Future[Tensor]:
         assert x.dtype is torch.bool, "Input must be boolean"
         return self.mod(x.float() * mult, add_input)
 
@@ -647,13 +609,12 @@ class BasicModelBoolInput(nn.Module):
         super().__init__()
         self.mod = BasicModel_MultiLayer()
 
-    # pyre-fixme[3]: Return type must be annotated.
     def forward(
         self,
         x: Tensor,
         add_input: Optional[Tensor] = None,
         mult: float = 10.0,
-    ):
+    ) -> Tensor:
         assert x.dtype is torch.bool, "Input must be boolean"
         return self.mod(x.float() * mult, add_input)
 
@@ -664,8 +625,7 @@ class BasicModel_MultiLayer_MultiInput(nn.Module):
         self.model = BasicModel_MultiLayer()
 
     @no_type_check
-    # pyre-fixme[3]: Return type must be annotated.
-    def forward(self, x1: Tensor, x2: Tensor, x3: Tensor, scale: int):
+    def forward(self, x1: Tensor, x2: Tensor, x3: Tensor, scale: int) -> Tensor:
         return self.model(scale * (x1 + x2 + x3))
 
 
@@ -685,8 +645,7 @@ class BasicModel_MultiLayer_MultiInput_with_Future(nn.Module):
         self.model = BasicModel_MultiLayer_with_Future()
 
     @no_type_check
-    # pyre-fixme[3]: Return type must be annotated.
-    def forward(self, x1: Tensor, x2: Tensor, x3: Tensor, scale: int):
+    def forward(self, x1: Tensor, x2: Tensor, x3: Tensor, scale: int) -> Future[Tensor]:
         return self.model(scale * (x1 + x2 + x3))
 
 
@@ -723,8 +682,7 @@ class BasicModel_ConvNet_One_Conv(nn.Module):
         self.relu2 = nn.ReLU(inplace=inplace)
 
     @no_type_check
-    # pyre-fixme[3]: Return type must be annotated.
-    def forward(self, x: Tensor, x2: Optional[Tensor] = None):
+    def forward(self, x: Tensor, x2: Optional[Tensor] = None) -> Tensor:
         if x2 is not None:
             x = x + x2
         x = self.relu1(self.conv1(x))
@@ -740,8 +698,7 @@ class BasicModel_ConvNetWithPaddingDilation(nn.Module):
         self.fc1 = nn.Linear(16, 4)
 
     @no_type_check
-    # pyre-fixme[3]: Return type must be annotated.
-    def forward(self, x: Tensor):
+    def forward(self, x: Tensor) -> Tensor:
         bsz = x.shape[0]
         x = self.relu1(self.conv1(x))
         x = x.reshape(bsz, 2, -1)
@@ -835,9 +792,7 @@ class BasicModel_ConvNet_MaxPool3d(nn.Module):
         self.fc1.weight = nn.Parameter(torch.ones(8, 4))
         self.fc2.weight = nn.Parameter(torch.ones(10, 8))
 
-    # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def forward(self, x):
+    def forward(self, x: Tensor) -> Tensor:
         x = self.relu1(self.conv1(x))
         x = self.pool1(x)
         x = self.relu2(self.conv2(x))


### PR DESCRIPTION
Summary:
This diff resolves pyre-fixme's in the `basic_models.py` file.

2 pyre-fixmes are not resolved since no need to explicitly handling.

1 .
```
# pyre-fixme[61]: `another_embedding` is undefined, or not always defined.
return embedding if another_input is None else embedding + another_embedding
```
2 . 
```
# pyre-fixme [29]: `typing.Type[Future]` is not a function
result = Future()
```

Differential Revision: D77327906


