### PR TITLE
Resolve CUDA illegal memory access

### DIFF
--- a/captum/attr/_core/feature_ablation.py
+++ b/captum/attr/_core/feature_ablation.py
@@ -685,7 +685,7 @@ class FeatureAblation(PerturbationAttribution):
 
         for i, input_tensor in enumerate(inputs):
             if i not in tensor_idxs:
-                ablated_inputs.append(input_tensor)
+                ablated_inputs.append(input_tensor.clone())
                 current_masks.append(None)
                 continue
             tensor_mask = []

--- a/captum/attr/_core/feature_permutation.py
+++ b/captum/attr/_core/feature_permutation.py
@@ -20,6 +20,7 @@ def _permute_feature(x: Tensor, feature_mask: Tensor) -> Tensor:
     while (perm == no_perm).all():
         perm = torch.randperm(n)
 
+    perm = perm.to(x.device)
     return (x[perm] * feature_mask.to(dtype=x.dtype)) + (
         x * feature_mask.bitwise_not().to(dtype=x.dtype)
     )
@@ -391,7 +392,7 @@ class FeaturePermutation(FeatureAblation):
         for i, input_tensor in enumerate(inputs):
             if i not in tensor_idxs:
                 current_masks.append(None)
-                permuted_inputs.append(input_tensor)
+                permuted_inputs.append(input_tensor.clone())
                 continue
             tensor_mask = []
             permuted_input = input_tensor.clone()


### PR DESCRIPTION
Summary: Fix the CUDA illegal memory access issue, due to race condition caused by concurrently read/write to the feature index input_tensor. Copy the index input_tensor before use for all tensors, including permuted + non-permuted.

Differential Revision: D77902870


