### PR TITLE
Add logprobs to LLMAttributionResult

### DIFF
--- a/captum/attr/_core/llm_attr.py
+++ b/captum/attr/_core/llm_attr.py
@@ -55,6 +55,7 @@ class LLMAttributionResult:
     token_attr: Optional[Tensor]
     input_tokens: List[str]
     output_tokens: List[str]
+    output_probs: Optional[Tensor] = None
 
     @property
     def seq_attr_dict(self) -> Dict[str, float]:


### PR DESCRIPTION
Summary: Logprobs are now added to results which can help better understand attribution scores.

Differential Revision: D78491492


