### PR TITLE
Add support for list of tensors output in Layer Gradient Attributor

### DIFF
--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -759,10 +759,10 @@ def _reduce_list(
     Applies reduction function to given list. If each element in the list is
     a Tensor, applies reduction function to all elements of the list, and returns
     the output Tensor / value. If each element is a boolean, apply any method (or).
-    If each element is a tuple, applies reduction
-    function to corresponding elements of each tuple in the list, and returns
+    If each element is a tuple/list, applies reduction
+    function to corresponding elements of each tuple/list in the list, and returns
     tuple of reduction function outputs with length matching the length of tuple
-    val_list[0]. It is assumed that all tuples in the list have the same length
+    val_list[0]. It is assumed that all tuples/lists in the list have the same length
     and red_func can be applied to all elements in each corresponding position.
     """
     assert len(val_list) > 0, "Cannot reduce empty list!"
@@ -774,7 +774,7 @@ def _reduce_list(
     elif isinstance(val_list[0], bool):
         # pyre-fixme[7]: Expected `TupleOrTensorOrBoolGeneric` but got `bool`.
         return any(val_list)
-    elif isinstance(val_list[0], tuple):
+    elif isinstance(val_list[0], (tuple, list)):
         final_out = []
         # pyre-fixme[6]: For 1st argument expected `pyre_extensions.ReadOnly[Sized]`
         #  but got `TupleOrTensorOrBoolGeneric`.
@@ -786,7 +786,7 @@ def _reduce_list(
     else:
         raise AssertionError(
             "Elements to be reduced can only be"
-            "either Tensors or tuples containing Tensors."
+            "either Tensors or tuples/lists containing Tensors."
         )
     # pyre-fixme[7]: Expected `TupleOrTensorOrBoolGeneric` but got `Tuple[Any, ...]`.
     return tuple(final_out)

--- a/captum/testing/helpers/basic_models.py
+++ b/captum/testing/helpers/basic_models.py
@@ -432,6 +432,8 @@ class BasicModel_GradientLayerAttribution(nn.Module):
         self.linear3.weight = nn.Parameter(torch.ones(2, 4))
         self.linear3.bias = nn.Parameter(torch.tensor([-1.0, 1.0]))
 
+        self.list_output_layer = PassThroughLayerOutput()
+
         self.int_layer = PassThroughLayerOutput()  # sample layer with an int output
 
     @no_type_check
@@ -452,11 +454,13 @@ class BasicModel_GradientLayerAttribution(nn.Module):
 
         relu_out = self.relu(lin1_out)
         lin2_out = self.linear2(relu_out)
+        list_out = self.list_output_layer([nn.Linear(2, 2)(lin2_out) for _ in range(2)])
+        resized_list_out = torch.cat(list_out, dim=1)
 
         lin3_out = self.linear3(lin1_out_alt)
         int_output = self.int_layer(lin3_out.to(torch.int64))
 
-        output_tensors = torch.cat((lin2_out, int_output), dim=1)
+        output_tensors = torch.cat((resized_list_out, int_output), dim=1)
 
         return (
             output_tensors


### PR DESCRIPTION
Summary: As part of increasing % of layers supported, we want to extend Layer Gradient Attributor to support List of Tensor with grad outputs. This is fairly safe since we already support Tuple of Tensor with grad outputs, and iteration across both types behaves similarly.

Differential Revision: D79134965


