### PR TITLE
Address likely package mismatch issues

### DIFF
--- a/.github/workflows/test-pip-gpu.yml
+++ b/.github/workflows/test-pip-gpu.yml
@@ -12,7 +12,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        cuda_arch_version: ["12.1"]
+        cuda_arch_version: ["12.6"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
@@ -22,7 +22,9 @@ jobs:
       gpu-arch-version: ${{ matrix.cuda_arch_version }}
       script: |
         python3 -m pip install --upgrade pip --progress-bar off
-        python3 -m pip install -e .[dev] --progress-bar off
+        python3 -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cu126 --progress-bar off
+        python3 -m pip install -e .[dev] --extra-index-url https://download.pytorch.org/whl/cu126 --progress-bar off
+        python3 -m pip install transformers --progress-bar off
 
         # Build package
         python3 -m pip install build --progress-bar off

--- a/tests/attr/test_llm_attr_hf_compatibility.py
+++ b/tests/attr/test_llm_attr_hf_compatibility.py
@@ -73,7 +73,7 @@ class TestLLMAttrHFCompatibility(BaseTest):
             "hf-internal-testing/tiny-random-LlamaForCausalLM"
         )
 
-        llm.to(self.device)
+        llm.to(self.device)  # type: ignore[arg-type]
         llm.eval()
         llm_attr = LLMAttribution(AttrClass(llm), tokenizer)
 


### PR DESCRIPTION
Summary:
Previous CI runs were encountering issues:

1. https://github.com/.../runs/16867033035/job/47776474001

```
E           torch.AcceleratorError: CUDA error: no kernel image is available for execution on the device
E           CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
E           For debugging consider passing CUDA_LAUNCH_BLOCKING=1
E           Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
```

2. https://github.com/pytorch/captum/actions/runs/16867033037/job/47775775171

`tests/attr/test_llm_attr_hf_compatibility.py:76: error: Argument 1 to "__call__" of "_Wrapped" has incompatible type "str"; expected "PreTrainedModel" [arg-type]`

This is likely due to (1) mismatched pytorch versions vs the cuda version 12.1 specified in test-pip-gpu.yml, triggered by [new PyTorch release](https://github.com/pytorch/pytorch/releases) and (2) lack of full typing causing error thrown by `mypy`, triggered by loosely defined `mypy>=0.760` probably pulling [new MyPy release](https://pypi.org/project/mypy/#history)

Differential Revision: D80120024


