### PR TITLE
Fix pyre typing in train.py

### DIFF
--- a/captum/testing/attr/helpers/test_config.py
+++ b/captum/testing/attr/helpers/test_config.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 # pyre-strict
+from typing import Any, Dict, List
 
 import torch
 from captum.attr._core.deep_lift import DeepLift, DeepLiftShap
@@ -89,8 +90,7 @@ config and creates relevant test cases based on the config.
 # Set random seeds to ensure deterministic behavior
 set_all_random_seeds(1234)
 
-# pyre-fixme[5]: Global expression must be annotated.
-config = [
+config: List[Dict[str, Any]] = [
     # Attribution Method Configs
     # Primary Methods (Generic Configs)
     {


### PR DESCRIPTION
Summary:
Fix type annotations in captum/_utils/models/linear_model/train.py and captum/testing/attr/helpers/test_config.py
This diff addresses all `pyre-fixme` comments in train.py by adding proper Python type annotations and removes the fixme comments. Additionally, a type annotation was added in test_config.py to ensure OSS mypy checks pass.
Verified with internal Pyre checks and OSS mypy tests.
The changes improve static type safety and align with Captum OSS development guidelines.

Differential Revision: D81624358


