### PR TITLE
Clean up enable_cross_tensor_attribution from FeaturePermutation

### DIFF
--- a/tests/attr/test_feature_permutation.py
+++ b/tests/attr/test_feature_permutation.py
@@ -103,31 +103,12 @@ class Test(BaseTest):
 
         inp[:, 0] = constant_value
         zeros = torch.zeros_like(inp[:, 0])
-        for enable_cross_tensor_attribution in (True, False):
-            attribs = feature_importance.attribute(
-                inp,
-                enable_cross_tensor_attribution=enable_cross_tensor_attribution,
-            )
-            self.assertTrue(attribs.squeeze(0).size() == (batch_size,) + input_size)
-            assertTensorAlmostEqual(self, attribs[:, 0], zeros, delta=0.05, mode="max")
-            self.assertTrue((attribs[:, 1 : input_size[0]].abs() > 0).all())
-
-    def test_simple_input_with_min_examples(self) -> None:
-        def forward_func(x: Tensor) -> Tensor:
-            return x.sum(dim=-1)
-
-        feature_importance = FeaturePermutation(forward_func=forward_func)
-        inp = torch.tensor([[1.0, 2.0]])
-        assertTensorAlmostEqual(
-            self,
-            feature_importance.attribute(inp, enable_cross_tensor_attribution=False),
-            torch.tensor([[0.0, 0.0]]),
-            delta=0.0,
+        attribs = feature_importance.attribute(
+            inp,
         )
-
-        feature_importance._min_examples_per_batch = 1
-        with self.assertRaises(AssertionError):
-            feature_importance.attribute(inp, enable_cross_tensor_attribution=False)
+        self.assertTrue(attribs.squeeze(0).size() == (batch_size,) + input_size)
+        assertTensorAlmostEqual(self, attribs[:, 0], zeros, delta=0.05, mode="max")
+        self.assertTrue((attribs[:, 1 : input_size[0]].abs() > 0).all())
 
     def test_simple_input_with_min_examples_in_group(self) -> None:
         def forward_func(x: Tensor) -> Tensor:
@@ -137,22 +118,20 @@ class Test(BaseTest):
         inp = torch.tensor([[1.0, 2.0]])
         assertTensorAlmostEqual(
             self,
-            feature_importance.attribute(inp, enable_cross_tensor_attribution=True),
+            feature_importance.attribute(inp),
             torch.tensor([[0.0, 0.0]]),
             delta=0.0,
         )
         assertTensorAlmostEqual(
             self,
-            feature_importance.attribute(
-                torch.tensor([]), enable_cross_tensor_attribution=True
-            ),
+            feature_importance.attribute(torch.tensor([])),
             torch.tensor([0.0]),
             delta=0.0,
         )
 
         feature_importance._min_examples_per_batch_grouped = 1
         with self.assertRaises(AssertionError):
-            feature_importance.attribute(inp, enable_cross_tensor_attribution=True)
+            feature_importance.attribute(inp)
 
     def test_simple_input_custom_mask_with_min_examples_in_group(self) -> None:
         def forward_func(x1: Tensor, x2: Tensor) -> Tensor:
@@ -169,18 +148,14 @@ class Test(BaseTest):
         )
         assertTensorAlmostEqual(
             self,
-            feature_importance.attribute(
-                inp, feature_mask=mask, enable_cross_tensor_attribution=True
-            )[0],
+            feature_importance.attribute(inp, feature_mask=mask)[0],
             torch.tensor([[0.0, 0.0]]),
             delta=0.0,
         )
 
         feature_importance._min_examples_per_batch_grouped = 1
         with self.assertRaises(AssertionError):
-            feature_importance.attribute(
-                inp, feature_mask=mask, enable_cross_tensor_attribution=True
-            )
+            feature_importance.attribute(inp, feature_mask=mask)
 
     def test_single_input_with_future(
         self,
@@ -200,18 +175,16 @@ class Test(BaseTest):
 
         inp[:, 0] = constant_value
         zeros = torch.zeros_like(inp[:, 0])
-        for enable_cross_tensor_attribution in [True, False]:
-            attribs = feature_importance.attribute_future(
-                inp,
-                enable_cross_tensor_attribution=enable_cross_tensor_attribution,
-            )
+        attribs = feature_importance.attribute_future(
+            inp,
+        )
 
-            self.assertTrue(type(attribs) is torch.Future)
-            attribs = attribs.wait()
+        self.assertTrue(type(attribs) is torch.Future)
+        attribs = attribs.wait()
 
-            self.assertTrue(attribs.squeeze(0).size() == (batch_size,) + input_size)
-            assertTensorAlmostEqual(self, attribs[:, 0], zeros, delta=0.05, mode="max")
-            self.assertTrue((attribs[:, 1 : input_size[0]].abs() > 0).all())
+        self.assertTrue(attribs.squeeze(0).size() == (batch_size,) + input_size)
+        assertTensorAlmostEqual(self, attribs[:, 0], zeros, delta=0.05, mode="max")
+        self.assertTrue((attribs[:, 1 : input_size[0]].abs() > 0).all())
 
     def test_multi_input(
         self,
@@ -247,24 +220,22 @@ class Test(BaseTest):
         )
 
         inp[1][:, :, 1] = 4
-        for enable_cross_tensor_attribution in (True, False):
-            attribs = feature_importance.attribute(
-                inp,
-                feature_mask=feature_mask,
-                enable_cross_tensor_attribution=enable_cross_tensor_attribution,
-            )
+        attribs = feature_importance.attribute(
+            inp,
+            feature_mask=feature_mask,
+        )
 
-            self.assertTrue(isinstance(attribs, tuple))
-            self.assertTrue(len(attribs) == 2)
+        self.assertTrue(isinstance(attribs, tuple))
+        self.assertTrue(len(attribs) == 2)
 
-            self.assertTrue(attribs[0].squeeze(0).size() == inp1_size)
-            self.assertTrue(attribs[1].squeeze(0).size() == inp2_size)
+        self.assertTrue(attribs[0].squeeze(0).size() == inp1_size)
+        self.assertTrue(attribs[1].squeeze(0).size() == inp2_size)
 
-            self.assertTrue((attribs[1][:, :, 1] == 0).all())
-            self.assertTrue((attribs[1][:, :, 2] == 0).all())
+        self.assertTrue((attribs[1][:, :, 1] == 0).all())
+        self.assertTrue((attribs[1][:, :, 2] == 0).all())
 
-            self.assertTrue((attribs[0] != 0).all())
-            self.assertTrue((attribs[1][:, :, 0] != 0).all())
+        self.assertTrue((attribs[0] != 0).all())
+        self.assertTrue((attribs[1][:, :, 0] != 0).all())
 
     def test_multi_input_group_across_input_tensors(
         self,
@@ -295,9 +266,7 @@ class Test(BaseTest):
         feature_mask = tuple(
             torch.zeros_like(inp_tensor[0]).unsqueeze(0) for inp_tensor in inp
         )
-        attribs = feature_importance.attribute(
-            inp, feature_mask=feature_mask, enable_cross_tensor_attribution=True
-        )
+        attribs = feature_importance.attribute(inp, feature_mask=feature_mask)
 
         self.assertTrue(isinstance(attribs, tuple))
         self.assertTrue(len(attribs) == 2)
@@ -348,26 +317,24 @@ class Test(BaseTest):
 
         inp[1][:, :, 1] = 4
 
-        for enable_cross_tensor_attribution in [True, False]:
-            attribs = feature_importance.attribute_future(
-                inp,
-                feature_mask=feature_mask,
-                enable_cross_tensor_attribution=enable_cross_tensor_attribution,
-            )
-            self.assertTrue(type(attribs) is torch.Future)
-            attribs = attribs.wait()
+        attribs = feature_importance.attribute_future(
+            inp,
+            feature_mask=feature_mask,
+        )
+        self.assertTrue(type(attribs) is torch.Future)
+        attribs = attribs.wait()
 
-            self.assertTrue(isinstance(attribs, tuple))
-            self.assertTrue(len(attribs) == 2)
+        self.assertTrue(isinstance(attribs, tuple))
+        self.assertTrue(len(attribs) == 2)
 
-            self.assertTrue(attribs[0].squeeze(0).size() == inp1_size)
-            self.assertTrue(attribs[1].squeeze(0).size() == inp2_size)
+        self.assertTrue(attribs[0].squeeze(0).size() == inp1_size)
+        self.assertTrue(attribs[1].squeeze(0).size() == inp2_size)
 
-            self.assertTrue((attribs[1][:, :, 1] == 0).all())
-            self.assertTrue((attribs[1][:, :, 2] == 0).all())
+        self.assertTrue((attribs[1][:, :, 1] == 0).all())
+        self.assertTrue((attribs[1][:, :, 2] == 0).all())
 
-            self.assertTrue((attribs[0] != 0).all())
-            self.assertTrue((attribs[1][:, :, 0] != 0).all())
+        self.assertTrue((attribs[0] != 0).all())
+        self.assertTrue((attribs[1][:, :, 0] != 0).all())
 
     def test_multiple_perturbations_per_eval(
         self,
@@ -420,28 +387,26 @@ class Test(BaseTest):
             forward_func=self.construct_future_forward(forward_func)
         )
 
-        for enable_cross_tensor_attribution in [True, False]:
-            attribs = feature_importance.attribute_future(
-                inp,
-                perturbations_per_eval=perturbations_per_eval,
-                target=target,
-                enable_cross_tensor_attribution=enable_cross_tensor_attribution,
+        attribs = feature_importance.attribute_future(
+            inp,
+            perturbations_per_eval=perturbations_per_eval,
+            target=target,
+        )
+        self.assertTrue(type(attribs) is torch.Future)
+        attribs = attribs.wait()
+
+        self.assertTrue(attribs.size() == (batch_size,) + input_size)
+
+        for i in range(inp.size(1)):
+            if i == target:
+                continue
+            assertTensorAlmostEqual(
+                self, attribs[:, i], torch.zeros_like(attribs[:, i])
             )
-            self.assertTrue(type(attribs) is torch.Future)
-            attribs = attribs.wait()
 
-            self.assertTrue(attribs.size() == (batch_size,) + input_size)
-
-            for i in range(inp.size(1)):
-                if i == target:
-                    continue
-                assertTensorAlmostEqual(
-                    self, attribs[:, i], torch.zeros_like(attribs[:, i])
-                )
-
-            y = forward_func(inp)
-            actual_diff = torch.stack([(y[0] - y[1])[target], (y[1] - y[0])[target]])
-            assertTensorAlmostEqual(self, attribs[:, target], actual_diff)
+        y = forward_func(inp)
+        actual_diff = torch.stack([(y[0] - y[1])[target], (y[1] - y[0])[target]])
+        assertTensorAlmostEqual(self, attribs[:, target], actual_diff)
 
     def test_broadcastable_masks(
         self,
@@ -461,30 +426,28 @@ class Test(BaseTest):
             torch.tensor([[0, 1, 2, 3]]),
             torch.tensor([[[0, 1, 2, 3], [3, 3, 4, 5], [6, 6, 4, 6], [7, 8, 9, 10]]]),
         ]
-        for enable_cross_tensor_attribution in (True, False):
-            for mask in masks:
+        for mask in masks:
 
-                attribs = feature_importance.attribute(
-                    inp,
-                    feature_mask=mask,
-                    enable_cross_tensor_attribution=enable_cross_tensor_attribution,
+            attribs = feature_importance.attribute(
+                inp,
+                feature_mask=mask,
+            )
+            self.assertTrue(attribs is not None)
+            self.assertTrue(attribs.shape == inp.shape)
+
+            fm = mask.expand_as(inp[0])
+
+            features = set(mask.flatten())
+            for feature in features:
+                m = (fm == feature).bool()
+                attribs_for_feature = attribs[:, m]
+                assertTensorAlmostEqual(
+                    self,
+                    attribs_for_feature[0],
+                    -attribs_for_feature[1],
+                    delta=0.05,
+                    mode="max",
                 )
-                self.assertTrue(attribs is not None)
-                self.assertTrue(attribs.shape == inp.shape)
-
-                fm = mask.expand_as(inp[0])
-
-                features = set(mask.flatten())
-                for feature in features:
-                    m = (fm == feature).bool()
-                    attribs_for_feature = attribs[:, m]
-                    assertTensorAlmostEqual(
-                        self,
-                        attribs_for_feature[0],
-                        -attribs_for_feature[1],
-                        delta=0.05,
-                        mode="max",
-                    )
 
     def test_broadcastable_masks_with_future(
         self,
@@ -507,35 +470,33 @@ class Test(BaseTest):
             torch.tensor([[[0, 1, 2, 3], [3, 3, 4, 5], [6, 6, 4, 6], [7, 8, 9, 10]]]),
         ]
 
-        for enable_cross_tensor_attribution in [True, False]:
-            results = []
-            for mask in masks:
-                attribs_future = feature_importance.attribute_future(
-                    inp,
-                    feature_mask=mask,
-                    enable_cross_tensor_attribution=enable_cross_tensor_attribution,
+        results = []
+        for mask in masks:
+            attribs_future = feature_importance.attribute_future(
+                inp,
+                feature_mask=mask,
+            )
+            results.append(attribs_future)
+            self.assertTrue(attribs_future is not None)
+
+        for idx in range(len(results)):
+            attribs = results[idx].wait()
+            self.assertTrue(attribs is not None)
+            self.assertTrue(attribs.shape == inp.shape)
+
+            fm = masks[idx].expand_as(inp[0])
+
+            features = set(masks[idx].flatten())
+            for feature in features:
+                m = (fm == feature).bool()
+                attribs_for_feature = attribs[:, m]
+                assertTensorAlmostEqual(
+                    self,
+                    attribs_for_feature[0],
+                    -attribs_for_feature[1],
+                    delta=0.05,
+                    mode="max",
                 )
-                results.append(attribs_future)
-                self.assertTrue(attribs_future is not None)
-
-            for idx in range(len(results)):
-                attribs = results[idx].wait()
-                self.assertTrue(attribs is not None)
-                self.assertTrue(attribs.shape == inp.shape)
-
-                fm = masks[idx].expand_as(inp[0])
-
-                features = set(masks[idx].flatten())
-                for feature in features:
-                    m = (fm == feature).bool()
-                    attribs_for_feature = attribs[:, m]
-                    assertTensorAlmostEqual(
-                        self,
-                        attribs_for_feature[0],
-                        -attribs_for_feature[1],
-                        delta=0.05,
-                        mode="max",
-                    )
 
     def test_empty_sparse_features(self) -> None:
         model = BasicModelWithSparseInputs()
@@ -544,13 +505,11 @@ class Test(BaseTest):
 
         # test empty sparse tensor
         feature_importance = FeaturePermutation(model)
-        for enable_cross_tensor_attribution in (True, False):
-            attr1, attr2 = feature_importance.attribute(
-                (inp1, inp2),
-                enable_cross_tensor_attribution=enable_cross_tensor_attribution,
-            )
-            self.assertEqual(attr1.shape, (1, 3))
-            self.assertEqual(attr2.shape, (1,))
+        attr1, attr2 = feature_importance.attribute(
+            (inp1, inp2),
+        )
+        self.assertEqual(attr1.shape, (1, 3))
+        self.assertEqual(attr2.shape, (1,))
 
     def test_sparse_features(self) -> None:
         model = BasicModelWithSparseInputs()
@@ -560,21 +519,18 @@ class Test(BaseTest):
 
         feature_importance = FeaturePermutation(model)
 
-        for enable_cross_tensor_attribution in [True, False]:
-            set_all_random_seeds(1234)
-            total_attr1, total_attr2 = feature_importance.attribute(
+        set_all_random_seeds(1234)
+        total_attr1, total_attr2 = feature_importance.attribute(
+            (inp1, inp2),
+        )
+        for _ in range(50):
+            attr1, attr2 = feature_importance.attribute(
                 (inp1, inp2),
-                enable_cross_tensor_attribution=enable_cross_tensor_attribution,
             )
-            for _ in range(50):
-                attr1, attr2 = feature_importance.attribute(
-                    (inp1, inp2),
-                    enable_cross_tensor_attribution=enable_cross_tensor_attribution,
-                )
-                total_attr1 += attr1
-                total_attr2 += attr2
-            total_attr1 /= 50
-            total_attr2 /= 50
-            self.assertEqual(total_attr2.shape, (1,))
-            assertTensorAlmostEqual(self, total_attr1, torch.zeros_like(total_attr1))
-            assertTensorAlmostEqual(self, total_attr2, [-6.0], delta=0.2)
+            total_attr1 += attr1
+            total_attr2 += attr2
+        total_attr1 /= 50
+        total_attr2 /= 50
+        self.assertEqual(total_attr2.shape, (1,))
+        assertTensorAlmostEqual(self, total_attr1, torch.zeros_like(total_attr1))
+        assertTensorAlmostEqual(self, total_attr2, [-6.0], delta=0.2)


### PR DESCRIPTION
Summary: Defaulted to true everywhere in D81948483 stack

Differential Revision: D83107514


