### PR TITLE
Bump minimum Python version to 3.10

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -13,7 +13,7 @@ build:
 
 requirements:
   host:
-    - python>=3.9
+    - python>=3.10
     - setuptools
   run:
     - numpy

--- a/.github/workflows/test-conda-cpu.yml
+++ b/.github/workflows/test-conda-cpu.yml
@@ -15,7 +15,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        python_version: ["3.9", "3.10", "3.11", "3.12"]
+        python_version: ["3.10", "3.11", "3.12"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
     with:

--- a/.github/workflows/test-pip-cpu.yml
+++ b/.github/workflows/test-pip-cpu.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         pytorch_args: ["-v 2.3.0", "-v 2.4.0", "-v 2.5.0", "-v 2.6.0", "-v 2.7.0"]
         transformers_args: ["-t 4.38.0", "-t 4.39.0", "-t 4.41.0", "-t 4.43.0", "-t 4.45.2"]
-        docker_img: ["cimg/python:3.9", "cimg/python:3.10", "cimg/python:3.11", "cimg/python:3.12"]
+        docker_img: ["cimg/python:3.10", "cimg/python:3.11", "cimg/python:3.12"]
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Github Actions will fail on your PR if it does not adhere to the ufmt or flake8 
 
 #### Type Hints
 
-Captum is fully typed using Python 3.9+
+Captum is fully typed using Python 3.10+
 [type hints](https://www.python.org/dev/peps/pep-0484/).
 We expect any contributions to also use proper type annotations, and we enforce
 consistency of these in our continuous integration tests.
@@ -63,7 +63,7 @@ Then run this script from the repository root:
 ```
 Note that we expect mypy to have version 0.760 or higher, and when type checking, use PyTorch 1.10 or
 higher due to fixes to the PyTorch type hints available. We also use the Literal feature which is
-available only in Python 3.9 or above.
+available only in Python 3.10 or above.
 
 We also use [pyre](https://pyre-check.org/) for type checking. For contributors, the nightly version of
 pyre is used which can be installed with pip `pip install pyre-check-nightly`. To run pyre, you can

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Captum can also be used by application engineers who are using trained models in
 ## Installation
 
 **Installation Requirements**
-- Python >= 3.9
+- Python >= 3.10
 - PyTorch >= 2.3
 
 

--- a/captum/_utils/typing.py
+++ b/captum/_utils/typing.py
@@ -3,17 +3,7 @@
 # pyre-strict
 
 from collections import UserDict
-from typing import (
-    List,
-    Literal,
-    Optional,
-    overload,
-    Protocol,
-    Tuple,
-    TYPE_CHECKING,
-    TypeVar,
-    Union,
-)
+from typing import List, Literal, Optional, overload, Protocol, Tuple, TypeVar, Union
 
 from torch import Tensor
 from torch.nn import Module
@@ -51,11 +41,7 @@ except TypeError:
     # pyre-ignore[24]: Generic type `slice` expects 3 type parameters.
     SliceIntType = slice  # type: ignore
 
-# Necessary for Python >=3.7 and <3.9!
-if TYPE_CHECKING:
-    BatchEncodingType = UserDict[Union[int, str], object]
-else:
-    BatchEncodingType = UserDict
+BatchEncodingType = UserDict[Union[int, str], object]
 
 
 class TokenizerLike(Protocol):

--- a/captum/concept/_core/cav.py
+++ b/captum/concept/_core/cav.py
@@ -4,7 +4,7 @@
 
 import os
 from contextlib import AbstractContextManager, nullcontext
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 import torch
@@ -168,11 +168,7 @@ class CAV:
         cavs_path = CAV.assemble_save_path(cavs_path, model_id, concepts, layer)
 
         if os.path.exists(cavs_path):
-            # Necessary for Python >=3.7 and <3.9!
-            if TYPE_CHECKING:
-                ctx: AbstractContextManager[None, None]
-            else:
-                ctx: AbstractContextManager
+            ctx: AbstractContextManager[None, None]
             if hasattr(torch.serialization, "safe_globals"):
                 safe_globals = [
                     # pyre-ignore[16]: Module `numpy.core.multiarray` has no attribute

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,4 +2,4 @@
 first_party_detection = false
 
 [tool.black]
-target-version = ['py39']
+target-version = ['py310']

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import sys
 from setuptools import find_packages, setup
 
 REQUIRED_MAJOR = 3
-REQUIRED_MINOR = 9
+REQUIRED_MINOR = 10
 
 # Check for python version
 if sys.version_info < (REQUIRED_MAJOR, REQUIRED_MINOR):


### PR DESCRIPTION
Summary: Python 3.9 is EOL. Bump minimum version of Python to 3.10.

Differential Revision: D85569426


