### PR TITLE
Remove values from InterpretableInputs

### DIFF
--- a/captum/attr/_utils/interpretable_input.py
+++ b/captum/attr/_utils/interpretable_input.py
@@ -109,7 +109,6 @@ class InterpretableInput(ABC):
     """
 
     n_itp_features: int
-    values: List[str]
 
     @abstractmethod
     def to_tensor(self) -> Tensor:


### PR DESCRIPTION
Summary: `values` won't be mandatory for the upcoming MM input, esp not as `str`

Differential Revision: D87817548


