### PR TITLE
Rename baseline in MMImageMaskInput

### DIFF
--- a/captum/attr/_utils/interpretable_input.py
+++ b/captum/attr/_utils/interpretable_input.py
@@ -515,7 +515,7 @@ class MMImageMaskInput(InterpretableInput):
                 and end with same attributions. When mask is None, the entire image is
                 considered as one interpretable feature.
                 Default: None
-        baselines (Tuple[int, int, int], optional): the baseline RGB value for
+        baseline (Tuple[int, int, int], optional): the baseline RGB value for
                 the “absent” image pixels.
                 Default: (255, 255, 255)
 
@@ -568,7 +568,7 @@ class MMImageMaskInput(InterpretableInput):
     processor_fn: Callable[[PIL.Image.Image], Any]
     image: PIL.Image.Image
     mask: Tensor
-    baselines: Tuple[int, int, int]
+    baseline: Tuple[int, int, int]
     n_itp_features: int
     original_model_inputs: Any
     mask_id_to_idx: Dict[int, int]
@@ -579,13 +579,13 @@ class MMImageMaskInput(InterpretableInput):
         processor_fn: Callable[[PIL.Image.Image], Any],
         image: PIL.Image.Image,
         mask: Optional[Tensor] = None,
-        baselines: Tuple[int, int, int] = (255, 255, 255),
+        baseline: Tuple[int, int, int] = (255, 255, 255),
     ) -> None:
         super().__init__()
 
         self.processor_fn = processor_fn
         self.image = image
-        self.baselines = baselines
+        self.baseline = baseline
 
         # Create a dummy mask if None is provided
         if mask is None:
@@ -622,7 +622,7 @@ class MMImageMaskInput(InterpretableInput):
         for mask_id, itp_idx in self.mask_id_to_idx.items():
             if perturbed_tensor[0][itp_idx] == 0:
                 mask_positions = self.mask == mask_id
-                img_array[mask_positions] = self.baselines
+                img_array[mask_positions] = self.baseline
 
         perturbed_image = PIL.Image.fromarray(img_array.astype("uint8"))
 

--- a/tests/attr/test_interpretable_input.py
+++ b/tests/attr/test_interpretable_input.py
@@ -367,7 +367,7 @@ class TestMMImageMaskInput(BaseTest):
         mm_input = MMImageMaskInput(
             processor_fn=self._simple_processor,
             image=image,
-            baselines=(255, 255, 255),  # white baseline
+            baseline=(255, 255, 255),  # white baseline
         )
 
         # Execute: perturb with feature present (value 1)
@@ -386,7 +386,7 @@ class TestMMImageMaskInput(BaseTest):
         mm_input = MMImageMaskInput(
             processor_fn=self._simple_processor,
             image=image,
-            baselines=(255, 255, 255),  # white baseline
+            baseline=(255, 255, 255),  # white baseline
         )
 
         # Execute: perturb with feature absent (value 0)
@@ -411,7 +411,7 @@ class TestMMImageMaskInput(BaseTest):
             processor_fn=self._simple_processor,
             image=image,
             mask=mask,
-            baselines=(255, 255, 255),  # white baseline
+            baseline=(255, 255, 255),  # white baseline
         )
 
         # Execute: perturb to keep left segment (0) but remove right segment (1)
@@ -432,7 +432,7 @@ class TestMMImageMaskInput(BaseTest):
         mm_input = MMImageMaskInput(
             processor_fn=self._simple_processor,
             image=image,
-            baselines=(0, 128, 255),  # Custom blue-ish baseline
+            baseline=(0, 128, 255),  # Custom blue-ish baseline
         )
 
         # Execute: perturb to remove feature


### PR DESCRIPTION
Summary: as title, as there is only one color used to mask out

Reviewed By: Ayush-Warikoo

Differential Revision: D87944294


