### PR TITLE
fix long tensor issue in interpretable input

### DIFF
--- a/captum/attr/_utils/interpretable_input.py
+++ b/captum/attr/_utils/interpretable_input.py
@@ -55,6 +55,11 @@ def _scatter_itp_attr_by_mask(
     else:
         expanded_itp_attr = itp_attr
 
+    # gather index must be long
+    # may support int32 soon https://github.com/pytorch/pytorch/pull/151822
+    if expanded_feature_indices.dtype != torch.long:
+        expanded_feature_indices = expanded_feature_indices.long()
+
     # gather from (*output_dims, *inp.shape[1:-1], n_itp_features)
     attr = torch.gather(expanded_itp_attr, -1, expanded_feature_indices)
 


### PR DESCRIPTION
Summary:
`torch.gather` requires `index` as `long` in the released versions of pytorch

`int32` is already supported in source code (why the internal tests pass)

this diff gonna fix [the CI fails](https://github.com/meta-pytorch/captum/actions/runs/19831857827/job/56826961913), which is caused by test cases using int32 `mask`

Differential Revision: D88101395


