### PR TITLE
disable github action flow for pyre type checking

### DIFF
--- a/.github/workflows/test-pip-cpu-with-type-checks.yml
+++ b/.github/workflows/test-pip-cpu-with-type-checks.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   tests:
+    if: false  # Workflow disabled
     strategy:
       matrix:
         pytorch_args: ["", "-n"]


### PR DESCRIPTION
Summary:
the OSS pyre check has been failing since it could not handle `numpy`

https://github.com/facebook/pyre-check/issues/1001

our CI faliure e.g.,

https://github.com/meta-pytorch/captum/actions/runs/20378451716/job/58565331811

So temporarily disable it untill someone finds a fix.

In the meantime, internal pyre does pass. As all PRs are either exported from internal or imported to internal, it will still be checked

Differential Revision: D89562562


