### PR TITLE
Simplify the handling of use_cached_outputs

### DIFF
--- a/tests/attr/test_llm_attr.py
+++ b/tests/attr/test_llm_attr.py
@@ -5,13 +5,14 @@
 import copy
 
 from collections import UserDict
+from dataclasses import dataclass
+
 from typing import (
     Any,
     cast,
     Dict,
     List,
     Literal,
-    NamedTuple,
     Optional,
     overload,
     Tuple,
@@ -144,7 +145,10 @@ class DummyTokenizer:
         return result
 
 
-class Result(NamedTuple):
+# use dataclass for simplicity, the actual hf model output is an OrderedDict
+# https://github.com/huggingface/transformers/blob/main/src/transformers/utils/generic.py#L283
+@dataclass
+class Result:
     logits: Tensor
     past_key_values: Tensor
 


### PR DESCRIPTION
Summary:
- to use `use_cached_outputs`, we assume the model is a `GenerationMixin`.
  - Let's give up the false illusion that we can be genetic here. Using cache is heavily coupled with model `forward`'s implementation. So officially limit to later versions of hg to simplify our job
  - add docstring to make this clear
- Remove `support_caching` function
  - no need to check as users must ensure the model to be transformers of right versions (we can add an assertion helper later for better exceptions)

Differential Revision: D89715406


