### PR TITLE
Revise setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,27 +61,37 @@ INSIGHTS_FILE_SUBDIRS = [
 
 TUTORIALS_REQUIRES = INSIGHTS_REQUIRES + ["torchtext", "torchvision"]
 
-TEST_REQUIRES = ["pytest", "pytest-cov", "parameterized", "flask", "flask-compress"]
+# TODO: review if all of them are still needed
+TEST_REQUIRES = [
+    "pytest",
+    "pytest-cov",
+    "parameterized",
+    "black",
+    "flake8",
+    "mypy>=0.760",
+    "pyre-check-nightly==0.0.101750936314",
+    "usort==1.0.2",
+    "ufmt",
+]
 
-REMOTE_REQUIRES = ["openai"]
+# captum may have some functionality that requires these packages, but they are
+# not required for the core functionality of captum.
+# These packages should be lazily imported.
+# Tests depending on these packages should be skippable
+OPTIONAL_REQUIRES = [
+    "openai",  # remote
+    "scikit-learn",
+    "annoy",  # influence
+]
 
 DEV_REQUIRES = (
     TUTORIALS_REQUIRES
     + TEST_REQUIRES
-    + REMOTE_REQUIRES
+    + OPTIONAL_REQUIRES
     + [
-        "black",
-        "flake8",
         "sphinx<8.2.0",
         "sphinx-autodoc-typehints",
         "sphinxcontrib-katex",
-        "mypy>=0.760",
-        "pyre-check-nightly==0.0.101750936314",
-        "usort==1.0.2",
-        "ufmt",
-        "scikit-learn",
-        "annoy",
-        "click<8.2.0",
     ]
 )
 
@@ -174,7 +184,6 @@ if __name__ == "__main__":
             "insights": INSIGHTS_REQUIRES,
             "test": TEST_REQUIRES,
             "tutorials": TUTORIALS_REQUIRES,
-            "remote": REMOTE_REQUIRES,
         },
         package_data={"captum": package_files},
         data_files=[


### PR DESCRIPTION
Summary:
Objectives:
- clean deps for (CI) tests
- clean deps for OSS dev
- remove captum insight related from deps

As the 1st step, revise the `setup.py` by
- add `OPTIONAL_REQUIRES` for packages that captum src may use for some optional functionalities. We do not want to them put to `install_requires`, but expect users to install themselves if they want
- update `TEST_REQUIRES` so it should cover everything CI needs

Differential Revision: D89756995


