### PR TITLE
Revise install_via_pip script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,7 @@ first_party_detection = false
 
 [tool.black]
 target-version = ['py310']
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+norecursedirs = ["tests/insights"]

--- a/scripts/install_via_pip.sh
+++ b/scripts/install_via_pip.sh
@@ -43,9 +43,13 @@ pip cache purge
 pip install --upgrade pip --progress-bar off
 
 # install captum with dev deps
+echo "[install_via_pip] pip install captum dev"
 pip install -e .[dev] --progress-bar off
-BUILD_INSIGHTS=1 python setup.py develop
 
+# echo "[install_via_pip] captum setup"
+# BUILD_INSIGHTS=1 python setup.py develop
+
+echo "[install_via_pip] pip install torch"
 # install pytorch nightly if asked for
 if [[ $PYTORCH_NIGHTLY == true ]]; then
   pip install --upgrade --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html --progress-bar off
@@ -58,15 +62,17 @@ else
   fi
 fi
 
-# install deployment bits if asked for
-if [[ $DEPLOY == true ]]; then
-  pip install beautifulsoup4 ipython nbconvert==5.6.1 --progress-bar off
-fi
-
+echo "[install_via_pip] pip install transformers"
 # install appropriate transformers version
 # If no version is specified, upgrade to the latest release.
 if [[ $CHOSEN_TRANSFORMERS_VERSION == -1 ]]; then
   pip install --upgrade transformers --progress-bar off
 else
   pip install transformers=="$CHOSEN_TRANSFORMERS_VERSION" --progress-bar off
+fi
+
+echo "[install_via_pip] pip install deploy deps"
+# install deployment bits if asked for
+if [[ $DEPLOY == true ]]; then
+  pip install beautifulsoup4 ipython nbconvert==5.6.1 --progress-bar off
 fi

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,6 @@ TEST_REQUIRES = [
 # captum may have some functionality that requires these packages, but they are
 # not required for the core functionality of captum.
 # These packages should be lazily imported.
-# Tests depending on these packages should be skippable
 OPTIONAL_REQUIRES = [
     "openai",  # remote
     "scikit-learn",
@@ -85,8 +84,7 @@ OPTIONAL_REQUIRES = [
 ]
 
 DEV_REQUIRES = (
-    TUTORIALS_REQUIRES
-    + TEST_REQUIRES
+    TEST_REQUIRES
     + OPTIONAL_REQUIRES
     + [
         "sphinx<8.2.0",


### PR DESCRIPTION
Summary:
Objectives:
- clean deps for (CI) tests
- clean deps for OSS dev
- remove captum insight related from deps

continue on D89756995

Revise `install_via_pip` by
- add `echo` log for each section
- skip `python setup develop` which duplicates with `pip install -e .`
- skip `BUILD_INSIGHTS`
  - tests (CI) don't need `insights`
  - remove `insight` from local install

Differential Revision: D89757273


