### PR TITLE
Increase GPU test workflow timeout from 30 to 60 minutes

### DIFF
--- a/.github/workflows/test-pip-gpu.yml
+++ b/.github/workflows/test-pip-gpu.yml
@@ -16,6 +16,7 @@ jobs:
       fail-fast: false
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
+      timeout: 60
       runner: linux.4xlarge.nvidia.gpu
       repository: pytorch/captum
       gpu-arch-type: cuda


### PR DESCRIPTION
Summary:
The GPU test workflow was using the default 30 minute timeout from the linux_job_v2.yml reusable workflow, which may not be sufficient for GPU tests.

Recent run was killed after 36 mins with test still in progress: https://github.com/meta-pytorch/captum/actions/runs/20527356963/job/58973025740?pr=1694

This change explicitly sets the timeout to 60 minutes to provide adequate time for the GPU CI tests to complete.

Differential Revision: D89819762


