### PR TITLE
Use pip instead of conda for PyTorch installation in conda CI

### DIFF
--- a/.github/workflows/test-conda-cpu.yml
+++ b/.github/workflows/test-conda-cpu.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         python_version: ["3.10", "3.11", "3.12"]
       fail-fast: false
-    uses: pytorch/test-infra/.github/workflows/linux_job.yml@main
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       runner: linux.12xlarge
       repository: pytorch/captum

--- a/scripts/install_via_conda.sh
+++ b/scripts/install_via_conda.sh
@@ -22,7 +22,7 @@ conda install -q -y pytorch cpuonly -c pytorch
 # install other deps
 conda install -q -y pytest ipywidgets ipython scikit-learn parameterized werkzeug
 conda install -q -y -c conda-forge matplotlib pytest-cov flask flask-compress conda-build openai
-conda install -q -y transformers
+conda install -q -y "transformers>=4.43.0"
 
 # install captum
 python setup.py develop


### PR DESCRIPTION
Summary: The conda installation of PyTorch (`conda install pytorch cpuonly -c pytorch`) has been experiencing reliability issues in CI with timeouts occuring after 120 mins for most conda runs. This change switches to pip installation from the official PyTorch wheel URL for the CPU version.

Differential Revision: D89846702


