### PR TITLE
Fix UnpicklingError in DLRM tutorial for PyTorch 2.6+

### DIFF
--- a/tutorials/DLRM_Tutorial.ipynb
+++ b/tutorials/DLRM_Tutorial.ipynb
@@ -186,7 +186,7 @@
    "outputs": [],
    "source": [
     "model_path = 'models/kg.pt'\n",
-    "ld_model = torch.load(model_path)\n",
+    "ld_model = torch.load(model_path, weights_only=False)\n",
     "\n",
     "dlrm.load_state_dict(ld_model[\"state_dict\"])\n",
     "dlrm = dlrm.to(device)\n"


### PR DESCRIPTION
Summary:
In PyTorch 2.6, the default value of `weights_only` in `torch.load` changed from `False` to `True`. The DLRM tutorial model file (`kg.pt`) contains numpy scalars which are not in the default allowlist, causing an `UnpicklingError` when loading.

This fix adds `weights_only=False` to the `torch.load` call to restore the previous behavior and allow the model to load successfully.

Differential Revision: D90393326
