### PR TITLE
Clean up type annotations for attr.stats modules

### DIFF
--- a/captum/attr/__init__.py
+++ b/captum/attr/__init__.py
@@ -76,6 +76,7 @@ from captum.attr._utils.stat import (
     Mean,
     Min,
     MSE,
+    StatValue,
     StdDev,
     Sum,
     Var,
@@ -156,5 +157,6 @@ __all__ = [
     "Max",
     "Sum",
     "Count",
+    "StatValue",
     "SummarizerSingleTensor",
 ]

--- a/captum/attr/_utils/class_summarizer.py
+++ b/captum/attr/_utils/class_summarizer.py
@@ -6,7 +6,7 @@ from typing import Any, cast, Dict, Generic, List, Optional, TypeVar, Union
 
 from captum._utils.common import _format_tensor_into_tuples
 from captum._utils.typing import TargetType, TensorOrTupleOfTensorsGeneric
-from captum.attr._utils.stat import Stat
+from captum.attr._utils.stat import Stat, StatValue
 from captum.attr._utils.summarizer import Summarizer
 from captum.log import log_usage
 from torch import Tensor
@@ -92,7 +92,9 @@ class ClassSummarizer(Summarizer, Generic[KeyType]):
         self,
     ) -> Dict[
         KeyType,
-        Union[None, Dict[str, Optional[Tensor]], List[Dict[str, Optional[Tensor]]]],
+        Union[
+            None, Dict[str, Optional[StatValue]], List[Dict[str, Optional[StatValue]]]
+        ],
     ]:
         r"""
         Returns:

--- a/captum/attr/_utils/summarizer.py
+++ b/captum/attr/_utils/summarizer.py
@@ -5,7 +5,18 @@
 from typing import Dict, List, Optional, Tuple, Type, Union
 
 import torch
-from captum.attr._utils.stat import Count, Max, Mean, Min, MSE, Stat, StdDev, Sum, Var
+from captum.attr._utils.stat import (
+    Count,
+    Max,
+    Mean,
+    Min,
+    MSE,
+    Stat,
+    StatValue,
+    StdDev,
+    Sum,
+    Var,
+)
 from captum.log import log_usage
 from torch import Tensor
 
@@ -89,7 +100,7 @@ class Summarizer:
     def summary(
         self,
     ) -> Optional[
-        Union[Dict[str, Optional[Tensor]], List[Dict[str, Optional[Tensor]]]]
+        Union[Dict[str, Optional[StatValue]], List[Dict[str, Optional[StatValue]]]]
     ]:
         r"""
         Effectively calls `get` on each `Stat` object within this object for each input
@@ -233,7 +244,7 @@ class SummarizerSingleTensor:
         return self._stat_to_stat[stat]
 
     @property
-    def summary(self) -> Dict[str, Optional[Tensor]]:
+    def summary(self) -> Dict[str, Optional[StatValue]]:
         """
         Returns:
             Optional[Dict[str, Optional[Tensor]]]


### PR DESCRIPTION
Summary:
Add proper Pyre type annotations and introduce `StatValue` type alias across captum.attr modules to ensure type safety and remove all `pyre-fixme` comments.

**stat.py changes:**
- Add `Dict[str, Any]` annotation to `self.params` attribute
- Add `-> None` return type to `Stat.update()` method
- Change `Stat.get()` return type to `Optional[Union[Tensor, int]]` to support `Count.get()` returning `int`
- Add `StatValue = Union[Tensor, int, float]` type alias for stat return values
- Add proper type annotations to `MSE`, `Var`, and `StdDev` class attributes
- Fix `Callable` type parameters to use `Callable[[Tensor, Tensor], Tensor]`
- Make `_get_stat` method generic using `TypeVar` bound to `Stat`, eliminating need for `cast()` calls
- Remove all `# type: ignore` and `pyre-fixme` comments

**summarizer.py changes:**
- Import and use `StatValue` type alias in summary return types

**class_summarizer.py changes:**
- Import and use `StatValue` type alias in `class_summaries` return type

**__init__.py changes:**
- Export `StatValue` in public API

**parsing.py changes:**
- Import `StatValue` from stat module
- Update type annotations in `extract_attr` and `_iter_summary` functions
- Add assert statements to narrow `StatValue` types to `Tensor` before calling tensor-specific methods (`.view()`, `.size()`)

Differential Revision: D90599873


