### PR TITLE
Add missing argument documentation for 4 methods

### DIFF
--- a/captum/attr/_core/neuron/neuron_conductance.py
+++ b/captum/attr/_core/neuron/neuron_conductance.py
@@ -254,6 +254,9 @@ class NeuronConductance(NeuronAttribution, GradientAttribution):
                         attribute to the input or output, is a single tensor.
                         Support for multiple tensors will be added later.
                         Default: False
+            grad_kwargs (dict[str, Any], optional): Additional keyword
+                        arguments for torch.autograd.grad.
+                        Default: None
 
         Returns:
             *Tensor* or *tuple[Tensor, ...]* of **attributions**:

--- a/captum/concept/_core/tcav.py
+++ b/captum/concept/_core/tcav.py
@@ -289,6 +289,13 @@ class TCAV(ConceptInterpreter):
                     If `layer_attr_method` is None, we default it to gradients
                     for the layers using `LayerGradientXActivation` layer
                     attribution algorithm.
+            attribute_to_layer_input (bool, optional): Indicates whether to
+                    compute the attributions with respect to the layer input
+                    or output. If `attribute_to_layer_input` is set to True
+                    then the attributions will be computed with respect to
+                    layer inputs, otherwise it will be computed with respect
+                    to layer outputs.
+                    Default: False
             save_path (str, optional): The path for storing CAVs and
                     Activation Vectors (AVs).
             classifier_kwargs (Any, optional): Additional arguments such as

--- a/captum/influence/_core/similarity_influence.py
+++ b/captum/influence/_core/similarity_influence.py
@@ -123,6 +123,12 @@ class SimilarityInfluence(DataInfluence):
                     For example, `similarity_metric(av_test, av_src)` should return a
                     tensor of shape (3, 16).
 
+            similarity_direction (str): Specifies the direction for selecting
+                    top-k similar examples. If set to "max", the examples with
+                    highest similarity scores are selected (most similar). If
+                    set to "min", the examples with lowest similarity scores
+                    are selected (least similar / most distant).
+                    Default: "max"
             batch_size (int): Batch size for iterating through `influence_src_dataset`.
             **kwargs: Additional key-value arguments that are necessary for specific
                     implementation of `DataInfluence` abstract class.

--- a/captum/influence/_core/tracincp.py
+++ b/captum/influence/_core/tracincp.py
@@ -401,6 +401,11 @@ class TracInCPBase(DataInfluence):
                     or opponents (`proponents=False`), if running in k-most influential
                     mode.
                     Default: True
+            unpack_inputs (bool, optional): If True and `inputs` is a tuple or list,
+                    the elements are unpacked as separate positional arguments to the
+                    model. If False, `inputs` is wrapped in a tuple and passed as a
+                    single argument.
+                    Default: True
             show_progress (bool, optional): For all modes, computation of results
                     requires "training dataset computations": computations for each
                     batch in the training dataset `train_dataset`, which may


### PR DESCRIPTION
Summary:
Added documentation for missing arguments in 4 methods where other arguments
were already documented:

- TCAV.__init__: Added `attribute_to_layer_input` documentation
- SimilarityInfluence.__init__: Added `similarity_direction` documentation
- NeuronConductance.attribute: Added `grad_kwargs` documentation
- TracInCPBase.influence: Added `unpack_inputs` documentation

These were identified by analyzing the RST documentation files and comparing
them with the actual method signatures in the source code.

Differential Revision: D92080047


