### PR TITLE
pin click version <8.2 for OSS CI

### DIFF
--- a/.github/workflows/type-checks.yml
+++ b/.github/workflows/type-checks.yml
@@ -24,4 +24,6 @@ jobs:
         ./scripts/install_via_pip.sh ${{ matrix.pytorch_args }} -d
         # Fix the version of numpy to install to avoid pyre issues
         pip install --upgrade numpy==2.1.3
+        # See https://github.com/facebook/pyre-check/issues/988
+        pip install 'click<8.2.0'
         pyre check


### PR DESCRIPTION
Summary:
Example failure: https://github.com/meta-pytorch/captum/actions/runs/22370953193/job/64749427532?pr=1793
```
+ pyre check

25lUsage: pyre [OPTIONS] COMMAND [ARGS]...
Try 'pyre -h' for help.

Error: Invalid value for '--version': <VersionKind.NONE: 'none'> is not one of 'none', 'client', 'client_and_binary'.
```

See https://github.com/facebook/pyre-check/issues/988

Differential Revision: D94275432


