### PR TITLE
Use include list for package discovery to exclude non-package directories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dev = [
 ]
 
 [tool.setuptools.packages.find]
-exclude = ["tests", "tests.*"]
+include = ["captum", "captum.*"]
 
 [tool.setuptools.dynamic]
 version = { attr = "captum.__version__" }


### PR DESCRIPTION
Previous `exclude` won't exclude `scripts` `sphinx`.
Use `include` instead