### PR TITLE
Add Dependabot configuration for website npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: "monthly"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    commit-message:
+      prefix: "[dependabot]"
+    groups:
+      website-all:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 1


### PR DESCRIPTION
Summary:
Add a `dependabot.yml` configuration to automatically scan and update npm dependencies in the `/website` directory. This eliminates the need for manual yarn resolution overrides to fix security vulnerabilities.

## Motivation

GitHub has detected multiple vulnerabilities in the Captum website's transitive npm dependencies (e.g., `fast-xml-parser`, `immer`, `loader-utils`). These have been addressed manually via yarn resolution overrides in a series of diffs:

| Diff | Package | Date |
|------|---------|------|
| D97403439 | url-parse, tar, send | 2026-03-19 |
| D97525651 | fast-xml-parser, immer, loader-utils | 2026-03-20 |
| D98163605 | form-data | 2026-03-25 |
| D98408476 | got | 2026-03-26 |
| D98912174 | qs | 2026-03-31 |
| D101188899 | lodash | 2026-04-16 |

Without automated scanning, each new vulnerability requires manual discovery and intervention. Adding Dependabot will automate this process.

## What this adds

A `.github/dependabot.yml` with the following configuration:
- **Ecosystem**: `npm` — monitors JavaScript dependencies in `/website`
- **Schedule**: Monthly (1st of each month at 9am PT)
- **Grouping**: All dependency updates (major/minor/patch) batched into a single PR to avoid PR spam
- **PR limit**: 1 open Dependabot PR at a time
- **Commit prefix**: `[dependabot]` for easy filtering in commit history

## Precedent

Other PyTorch GitHub projects already use Dependabot with similar configurations:
- **pytorch/tritonparse**: npm ecosystem, monthly schedule, grouped PRs (identical pattern to this diff)
- **pytorch/torchtitan**: github-actions ecosystem, weekly schedule
- **pytorch/benchmark**: pip ecosystem, daily schedule with selective allow-list

## Impact

Once this is synced to the GitHub mirror, Dependabot will automatically:
1. Scan `/website/package.json` and `/website/yarn.lock` for known vulnerabilities
2. Open grouped PRs with dependency version bumps
3. Reduce manual effort for future security vulnerability remediation

Reviewed By: cyrjano

Differential Revision: D102246292


