### PR TITLE
Add helpful ImportError stub for retired captum.insights module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: "monthly"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    commit-message:
+      prefix: "[dependabot]"
+    groups:
+      website-all:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 1

--- a/captum/insights/__init__.py
+++ b/captum/insights/__init__.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+"""
+Captum Insights was retired after v0.8.0 and is no longer supported.
+
+This stub module exists to provide a clear error message to users who
+attempt to import the old ``captum.insights`` API (e.g.,
+``AttributionVisualizer``) instead of an opaque ``ModuleNotFoundError``.
+
+For visualization, use the supported matplotlib-based API::
+
+    from captum.attr import visualization as viz
+
+    # Image attributions
+    fig, ax = viz.visualize_image_attr(attr, original_image)
+
+    # Text attributions (renders HTML in Jupyter notebooks)
+    viz.visualize_text(datarecords)
+
+    # Timeseries attributions
+    fig, ax = viz.visualize_timeseries_attr(attr, data)
+
+See https://captum.ai/api/utilities for full documentation.
+"""
+
+_RETIRED_MESSAGE = (
+    "Captum Insights was retired after v0.8.0 and is no longer available. "
+    "The AttributionVisualizer class and its render()/serve() methods have "
+    "been removed.\n\n"
+    "For visualization, use the matplotlib-based API instead:\n\n"
+    "    from captum.attr import visualization as viz\n\n"
+    "    # Image attributions\n"
+    "    fig, ax = viz.visualize_image_attr(attr, original_image)\n\n"
+    "    # Text attributions (HTML in Jupyter notebooks)\n"
+    "    viz.visualize_text(datarecords)\n\n"
+    "    # Timeseries attributions\n"
+    "    fig, ax = viz.visualize_timeseries_attr(attr, data)\n\n"
+    "To view the old Captum Insights code, check out the v0.8.0 tag:\n"
+    "    git checkout v0.8.0\n\n"
+    "See https://captum.ai/api/utilities for documentation."
+)
+
+
+class _RetiredClass:
+    """Placeholder that raises an informative error on instantiation."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        raise ImportError(_RETIRED_MESSAGE)
+
+
+AttributionVisualizer = _RetiredClass
+Batch = _RetiredClass
+
+
+def __getattr__(name: str) -> None:
+    raise ImportError(
+        f"cannot import name '{name}' from 'captum.insights'. " + _RETIRED_MESSAGE
+    )

--- a/tests/test_insights_retired.py
+++ b/tests/test_insights_retired.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import unittest
+
+
+class TestInsightsRetiredStub(unittest.TestCase):
+    def test_import_insights_module(self) -> None:
+        """Importing captum.insights should succeed (stub module exists)."""
+        # Import is the subject under test
+        import captum.insights
+
+        self.assertTrue(hasattr(captum.insights, "_RETIRED_MESSAGE"))
+
+    def test_attribution_visualizer_raises(self) -> None:
+        """Instantiating AttributionVisualizer should raise ImportError."""
+        # Import is the subject under test
+        from captum.insights import AttributionVisualizer
+
+        with self.assertRaises(ImportError) as ctx:
+            AttributionVisualizer()
+        self.assertIn("retired", str(ctx.exception).lower())
+        self.assertIn("v0.8.0", str(ctx.exception))
+
+    def test_batch_raises(self) -> None:
+        """Instantiating Batch should raise ImportError."""
+        # Import is the subject under test
+        from captum.insights import Batch
+
+        with self.assertRaises(ImportError) as ctx:
+            Batch()
+        self.assertIn("retired", str(ctx.exception).lower())
+
+    def test_unknown_attr_raises(self) -> None:
+        """Accessing an unknown attribute should raise ImportError."""
+        # Import is the subject under test
+        import captum.insights
+
+        with self.assertRaises(ImportError) as ctx:
+            captum.insights.SomeNonexistentClass  # noqa: B018
+        self.assertIn("SomeNonexistentClass", str(ctx.exception))
+        self.assertIn("retired", str(ctx.exception).lower())
+
+    def test_error_message_includes_migration_guidance(self) -> None:
+        """Error message should include migration guidance to new API."""
+        # Import is the subject under test
+        from captum.insights import AttributionVisualizer
+
+        with self.assertRaises(ImportError) as ctx:
+            AttributionVisualizer()
+        msg = str(ctx.exception)
+        self.assertIn("visualize_image_attr", msg)
+        self.assertIn("visualize_text", msg)
+        self.assertIn("captum.ai", msg)


### PR DESCRIPTION
Summary:
Add a stub \`captum.insights\` module that raises a clear \`ImportError\` with migration guidance when users attempt to use the retired Captum Insights API (\`AttributionVisualizer\`, \`Batch\`, etc.).

## Motivation

Captum Insights was retired after v0.8.0 (see README.md). The \`captum.insights\` module, including \`AttributionVisualizer\` and its \`render()\`/\`serve()\` methods, was completely removed in v0.9.0.

Users upgrading from v0.8.0 or following older tutorials/examples (including the fastai integration at \`third-party/pypi/fastai/2.7.12/fastai/callback/captum.py\`) currently get an opaque \`ModuleNotFoundError: No module named 'captum.insights'\` with no guidance on what happened or how to migrate.

## What this adds

1. **Stub module** (\`captum/insights/__init__.py\`):
   - The module imports successfully (no \`ModuleNotFoundError\`)
   - \`AttributionVisualizer\` and \`Batch\` are placeholder classes that raise \`ImportError\` with a detailed message on instantiation
   - Any other attribute access (e.g., \`captum.insights.Widget\`) raises \`ImportError\` via \`__getattr__\`
   - The error message includes:
     - Explanation that Insights was retired after v0.8.0
     - Migration examples using the current matplotlib-based API (\`visualize_image_attr\`, \`visualize_text\`, \`visualize_timeseries_attr\`)
     - Link to documentation at https://captum.ai/api/utilities
     - Instructions to check out v0.8.0 tag to view old code

2. **Tests** (\`tests/test_insights_retired.py\`):
   - Verifies the module can be imported
   - Verifies \`AttributionVisualizer()\` raises \`ImportError\` mentioning "retired" and "v0.8.0"
   - Verifies \`Batch()\` raises \`ImportError\`
   - Verifies unknown attribute access raises \`ImportError\`
   - Verifies error message contains migration guidance (function names, URL)

3. **BUCK targets** for both the stub library and test

## Example behavior

Before (confusing):
\`\`\`
>>> from captum.insights import AttributionVisualizer
ModuleNotFoundError: No module named 'captum.insights'
\`\`\`

After (actionable):
\`\`\`
>>> from captum.insights import AttributionVisualizer
>>> visualizer = AttributionVisualizer(...)
ImportError: Captum Insights was retired after v0.8.0 and is no longer available.
The AttributionVisualizer class and its render()/serve() methods have been removed.

For visualization, use the matplotlib-based API instead:

    from captum.attr import visualization as viz

    fig, ax = viz.visualize_image_attr(attr, original_image)
    viz.visualize_text(datarecords)

See https://captum.ai/api/utilities for documentation.
\`\`\`

Differential Revision: D102250460


