### PR TITLE
Fix feature_mask expansion in sensitivity_max metric

### DIFF
--- a/captum/metrics/_core/sensitivity.py
+++ b/captum/metrics/_core/sensitivity.py
@@ -10,6 +10,7 @@ import torch
 from captum._utils.common import (
     _expand_and_update_additional_forward_args,
     _expand_and_update_baselines,
+    _expand_and_update_feature_mask,
     _expand_and_update_target,
     _format_baseline,
     _format_tensor_into_tuples,
@@ -178,7 +179,8 @@ def sensitivity_max(
                 Any additional arguments that need be passed to the explanation
                 function should be included here.
                 For instance, such arguments include:
-                `additional_forward_args`, `baselines` and `target`.
+                `additional_forward_args`, `baselines`, `target`,
+                and `feature_mask`.
 
     Returns:
 
@@ -245,6 +247,7 @@ def sensitivity_max(
                 current_n_perturb_samples, kwargs_copy
             )
             _expand_and_update_target(current_n_perturb_samples, kwargs_copy)
+            _expand_and_update_feature_mask(current_n_perturb_samples, kwargs_copy)
             if "baselines" in kwargs:
                 baselines = kwargs["baselines"]
                 baselines = _format_baseline(

--- a/tests/metrics/test_sensitivity.py
+++ b/tests/metrics/test_sensitivity.py
@@ -9,6 +9,7 @@ import torch
 from captum._utils.typing import BaselineType, TargetType, TensorOrTupleOfTensorsGeneric
 from captum.attr import (
     DeepLift,
+    FeatureAblation,
     GradientShap,
     GuidedBackprop,
     IntegratedGradients,
@@ -276,6 +277,40 @@ class Test(BaseTest):
             max_examples_per_batch=30,
         )
         assertTensorAlmostEqual(self, sens1, sens2)
+
+    def test_sensitivity_max_with_feature_mask(self) -> None:
+        r"""
+        Test that sensitivity_max correctly expands feature_mask
+        when batching perturbed inputs.
+        """
+        model = BasicModel_MultiLayer()
+        input = torch.arange(1.0, 7.0).view(2, 3)
+        feature_mask = torch.tensor([[0, 0, 1], [0, 1, 1]])
+        target: List[int] = [0, 0]
+
+        fa = FeatureAblation(model)
+
+        sens1 = sensitivity_max(
+            fa.attribute,
+            input,
+            perturb_func=_perturb_func,
+            target=target,
+            feature_mask=feature_mask,
+            n_perturb_samples=5,
+        )
+        self.assertEqual(sens1.shape, torch.Size([2]))
+
+        # Verify batched computation gives the same result
+        sens2 = sensitivity_max(
+            fa.attribute,
+            input,
+            perturb_func=_perturb_func,
+            target=target,
+            feature_mask=feature_mask,
+            n_perturb_samples=5,
+            max_examples_per_batch=2,
+        )
+        assertTensorAlmostEqual(self, sens1, sens2, 0.0)
 
     def sensitivity_max_assert(
         self,


### PR DESCRIPTION
Summary:
Fix a bug where `sensitivity_max` does not expand `feature_mask` when batching perturbed inputs, causing incorrect behavior with perturbation-based attribution methods like LIME and KernelSHAP.

## Problem

When `sensitivity_max` evaluates explanation sensitivity, it repeats inputs `n_perturb_samples` times via `repeat_interleave` and correctly expands three kwargs for the batched call:
- `additional_forward_args` (via `_expand_and_update_additional_forward_args`)
- `target` (via `_expand_and_update_target`)
- `baselines` (via `_expand_and_update_baselines`)

However, it **does not expand `feature_mask`**, even though the utility function `_expand_and_update_feature_mask` already exists in `captum._utils.common` and is used by `NoiseTunnel` for exactly this purpose. This causes shape mismatches or incorrect per-example slicing when attribution methods like LIME try to use `feature_mask` with the expanded batch.

## Fix

Add `_expand_and_update_feature_mask(current_n_perturb_samples, kwargs_copy)` alongside the existing expansion calls in `_next_sensitivity_max`, matching the pattern used by `NoiseTunnel`.

Also updated the docstring to list `feature_mask` among the supported kwargs.

Differential Revision: D102364918


