### PR TITLE
captum: substitute None grads with zero tensors before _reduce_list (#1823)

### DIFF
--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -748,6 +748,19 @@ def compute_layer_gradients_and_eval(
             **grad_kwargs or {},
         )
 
+        # When grad_kwargs sets ``allow_unused=True`` (e.g. layer attribution
+        # for multi-task models where some target layers are not connected to
+        # the selected output), ``torch.autograd.grad`` returns ``None`` for
+        # any input that did not contribute to the output. The mathematically
+        # correct gradient in that case is a zero tensor with the same shape
+        # as the layer output. Substitute zeros here so downstream consumers
+        # (e.g. ``_reduce_list``) keep their Tensor-only invariant intact.
+        if any(g is None for g in saved_grads):
+            saved_grads = tuple(
+                torch.zeros_like(layer_tensor) if grad is None else grad
+                for grad, layer_tensor in zip(saved_grads, grad_inputs)
+            )
+
         offset = 0
         all_grads: List[Tuple[Tensor, ...]] = []
         for single_layer in all_layers:


### PR DESCRIPTION
Summary:

This is a remediation diff produced by the TFR Guardian sample run for failing job aps-v0-ni-f1072658139-1072660020.

Root cause: `compute_layer_gradients_and_eval` calls `torch.autograd.grad(..., **grad_kwargs)`. When the caller (e.g. layer attribution for multi-task NI jobs in `captum/attr/fb/layer_attr.py`) passes `allow_unused=True`, autograd returns `None` for any layer-output tensor that is not connected to the selected output. Those `None` values then flow into the downstream pipeline — `output_fn`, slicing into `curr_saved_grads`, and finally `_reduce_list` — which assumes every element is a `Tensor`. The result is an `AssertionError` / `TypeError` deep in `_reduce_list` instead of the documented "unreachable layer => zero gradient" semantics.

Fix: After `torch.autograd.grad(...)` returns `saved_grads`, walk the tuple and substitute every `None` slot with `torch.zeros_like(grad_inputs[i])`. `grad_inputs` is constructed in the same order as `saved_grads`, so position-wise zip recovers the correct layer-output tensor for each missing-grad slot. The zeros tensor inherits device, dtype, and shape from the captured layer output — which is the mathematically correct gradient when a layer is not connected to the output.

The substitution is gated by `any(g is None for g in saved_grads)` so the common path (no `allow_unused` or all layers connected) is unchanged. The downstream slicing, `output_fn` application, and `_reduce_list` call are also unchanged — they now always see Tensors, preserving `_reduce_list`'s Tensor-only invariant.

Reviewed By: styusuf

Differential Revision: D102939482


