### PR TITLE
Fix GitHub vulnerability in uuid dependency

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -23,6 +23,7 @@
     "qs": ">=6.14.1",
     "lodash": ">=4.18.0",
     "minimatch": ">=3.1.3 <4.0.0",
-    "lodash.template": ">=4.18.0"
+    "lodash.template": ">=4.18.0",
+    "uuid": ">=9.0.0"
   }
 }

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -7426,10 +7426,10 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@^3.0.1, uuid@^3.3.2:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
-  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+uuid@>=9.0.0, uuid@^3.0.1, uuid@^3.3.2:
+  version "14.0.0"
+  resolved "https://registry.facebook.net/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
+  integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"


### PR DESCRIPTION
Summary:
GitHub detected a vulnerability in the uuid dependency used by
meta-pytorch/captum. The uuid v3.4.0 package uses Math.random() for UUID
generation, which is cryptographically insecure (GHSA-vqfx-gj96-3w95).

The vulnerable uuid v3.4.0 was pulled in as a transitive dependency through
webpack-log (used by webpack-dev-server and webpack-dev-middleware) in 
the captum documentation website.

This diff adds yarn resolutions to force uuid to >=9.0.0 (resolved to v14.0.0),
which uses crypto.getRandomValues() for secure random number generation. 
yarn.lock files are regenerated to reflect the resolution.

Addresses: T267662017

Differential Revision: D103610583


