### PR TITLE
Defer non-differentiable checks to attribution. (#1826)

### DIFF
--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -783,9 +783,12 @@ def _reduce_list(
     assert len(val_list) > 0, "Cannot reduce empty list!"
     if isinstance(val_list[0], torch.Tensor):
         first_device = cast(Tensor, val_list[0]).device
-        return red_func(
-            [elem.to(first_device) for elem in cast(List[Tensor], val_list)]
-        )
+        elems = [elem.to(first_device) for elem in cast(List[Tensor], val_list)]
+        # torch.cat cannot concatenate 0-dim tensors; unsqueeze so cat
+        # adds a leading dimension, matching torch.stack semantics.
+        if red_func is torch.cat and elems[0].dim() == 0:
+            elems = [e.unsqueeze(0) for e in elems]
+        return red_func(elems)
     elif isinstance(val_list[0], bool):
         # pyre-fixme[7]: Expected `TupleOrTensorOrBoolGeneric` but got `bool`.
         return any(val_list)

--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -54,7 +54,7 @@ def apply_gradient_requirements(
         grad_required.append(input.requires_grad)
         inputs_dtype = input.dtype
         # Note: torch 1.2 doesn't support is_complex for dtype that's why we check
-        # on the existance of is_complex method.
+        # on the existence of is_complex method.
         if not inputs_dtype.is_floating_point and not (
             hasattr(inputs_dtype, "is_complex") and inputs_dtype.is_complex
         ):
@@ -317,9 +317,12 @@ def _forward_layer_distributed_eval(
                             eval_tsr.clone() for eval_tsr in eval_tsrs
                         ]
                     else:
-                        eval_tsrs_to_return = tuple(
-                            eval_tsr.clone() for eval_tsr in eval_tsrs
-                        )
+                        cloned = tuple(eval_tsr.clone() for eval_tsr in eval_tsrs)
+                        # Preserve namedtuple types (which are tuple subclasses)
+                        if type(eval_tsrs) is not tuple:
+                            eval_tsrs_to_return = type(eval_tsrs)(*cloned)
+                        else:
+                            eval_tsrs_to_return = cloned
                     return eval_tsrs_to_return
                 else:
                     saved_layer[original_module][eval_tsrs[0].device] = tuple(
@@ -748,21 +751,10 @@ def compute_layer_gradients_and_eval(
             **grad_kwargs or {},
         )
 
-        # When grad_kwargs sets ``allow_unused=True`` (e.g. layer attribution
-        # for multi-task models where some target layers are not connected to
-        # the selected output), ``torch.autograd.grad`` returns ``None`` for
-        # any input that did not contribute to the output. The mathematically
-        # correct gradient in that case is a zero tensor with the same shape
-        # as the layer output. Substitute zeros here so downstream consumers
-        # (e.g. ``_reduce_list``) keep their Tensor-only invariant intact.
-        if any(g is None for g in saved_grads):
-            saved_grads = tuple(
-                torch.zeros_like(layer_tensor) if grad is None else grad
-                for grad, layer_tensor in zip(saved_grads, grad_inputs)
-            )
+        has_allow_unused = (grad_kwargs or {}).get("allow_unused", False)
 
         offset = 0
-        all_grads: List[Tuple[Tensor, ...]] = []
+        all_grads: List[Optional[Tuple[Tensor, ...]]] = []
         for single_layer in all_layers:
             num_tensors = len(next(iter(saved_layer[single_layer].values())))
             curr_saved_grads = [
@@ -772,6 +764,27 @@ def compute_layer_gradients_and_eval(
                 )
             ]
             offset += len(key_list) * num_tensors
+
+            flat_grads = [g for grp in curr_saved_grads for g in grp]
+            if has_allow_unused and all(g is None for g in flat_grads):
+                all_grads.append(None)
+                continue
+
+            if any(g is None for g in flat_grads):
+                curr_saved_grads = [
+                    tuple(
+                        (
+                            torch.zeros_like(
+                                saved_layer[single_layer][key_list[dev_idx]][tensor_idx]
+                            )
+                            if g is None
+                            else g
+                        )
+                        for tensor_idx, g in enumerate(grp)
+                    )
+                    for dev_idx, grp in enumerate(curr_saved_grads)
+                ]
+
             if output_fn is not None:
                 curr_saved_grads = [
                     output_fn(curr_saved_grad) for curr_saved_grad in curr_saved_grads
@@ -782,10 +795,13 @@ def compute_layer_gradients_and_eval(
             # (torch.cat) since reducing on GPU first is slightly more
             # memory-efficient than moving individual tensors before reduction.
             if offload_to_cpu:
-                reduced = tuple(t.cpu() for t in reduced)
+                reduced = tuple(t.cpu() if t is not None else None for t in reduced)
             all_grads.append(reduced)
 
-        layer_grads: Union[Tuple[Tensor, ...], List[Tuple[Tensor, ...]]]
+        layer_grads: Union[
+            Optional[Tuple[Tensor, ...]],
+            List[Optional[Tuple[Tensor, ...]]],
+        ]
         layer_grads = all_grads
         if isinstance(layer, Module):
             layer_grads = all_grads[0]

--- a/captum/attr/_core/layer/layer_gradient_x_activation.py
+++ b/captum/attr/_core/layer/layer_gradient_x_activation.py
@@ -85,7 +85,9 @@ class LayerGradientXActivation(LayerAttribution, GradientAttribution):
         additional_forward_args: Optional[object] = None,
         attribute_to_layer_input: bool = False,
         grad_kwargs: Optional[Dict[str, Any]] = None,
-    ) -> Union[Tensor, Tuple[Tensor, ...], List[Union[Tensor, Tuple[Tensor, ...]]]]:
+    ) -> Union[
+        Tensor, Tuple[Tensor, ...], List[Union[Tensor, Tuple[Tensor, ...], None]], None
+    ]:
         r"""
         Args:
 
@@ -145,8 +147,8 @@ class LayerGradientXActivation(LayerAttribution, GradientAttribution):
                         arguments for torch.autograd.grad.
                         Default: None
         Returns:
-            *Tensor* or *tuple[Tensor, ...]* or list of **attributions**:
-            - **attributions** (*Tensor*, *tuple[Tensor, ...]*, or *list*):
+            *Tensor* or *tuple[Tensor, ...]* or *None* or list of **attributions**:
+            - **attributions** (*Tensor*, *tuple[Tensor, ...]*, *None*, or *list*):
                         Product of gradient and activation for each
                         neuron in given layer output.
                         Attributions will always be the same size as the
@@ -154,9 +156,13 @@ class LayerGradientXActivation(LayerAttribution, GradientAttribution):
                         Attributions are returned in a tuple if
                         the layer inputs / outputs contain multiple tensors,
                         otherwise a single tensor is returned.
+                        If the layer is not differentiable with respect to
+                        the output, None is returned.
                         If multiple layers are provided, attributions
                         are returned as a list, each element corresponding to the
-                        activations of the corresponding layer.
+                        attributions of the corresponding layer. Individual
+                        elements may be None for layers that are not
+                        differentiable with respect to the output.
 
 
         Examples::
@@ -190,6 +196,8 @@ class LayerGradientXActivation(LayerAttribution, GradientAttribution):
             offload_to_cpu=self._memory_efficient,
         )
         if isinstance(self.layer, Module):
+            if layer_gradients is None:
+                return None
             return _format_output(
                 len(layer_evals) > 1,
                 self.multiply_gradient_acts(
@@ -202,22 +210,22 @@ class LayerGradientXActivation(LayerAttribution, GradientAttribution):
             for i in range(len(self.layer)):
                 grads_i = layer_gradients[i]
                 evals_i = layer_evals[i]
-                results.append(
-                    _format_output(
-                        len(evals_i) > 1,
-                        self.multiply_gradient_acts(grads_i, evals_i),
+                if grads_i is None or (
+                    isinstance(grads_i, tuple) and all(g is None for g in grads_i)
+                ):
+                    results.append(None)
+                else:
+                    results.append(
+                        _format_output(
+                            len(evals_i) > 1,
+                            self.multiply_gradient_acts(grads_i, evals_i),
+                        )
                     )
-                )
             return results
 
     def multiply_gradient_acts(
         self, gradients: Tuple[Tensor, ...], evals: Tuple[Tensor, ...]
     ) -> Tuple[Tensor, ...]:
-        return tuple(
-            (
-                single_gradient * single_eval
-                if self.multiplies_by_inputs
-                else single_gradient
-            )
-            for single_gradient, single_eval in zip(gradients, evals)
-        )
+        if not self.multiplies_by_inputs:
+            return gradients
+        return tuple(g * e for g, e in zip(gradients, evals))


### PR DESCRIPTION
Summary:

Previously, LayerGradientAttributor._find_differentiable_layers ran an upfront torch.autograd.grad call against the first task to identify which layers are differentiable, filtering them out before attribution. This had two problems:

  1. A layer differentiable for the first task but non-differentiable for other tasks would pass the check, then crash during attribution with a None gradient error in _reduce_list. There was a patch fix for this here: D102939482
  2. A layer non-differentiable for the first task but differentiable for other tasks would be discarded entirely, losing valid attributions for those tasks.

 This diff removes the upfront differentiability check and instead defers detection to the attribution computation itself. The key insight is that differentiability is a per-task property, not a per-layer property — a layer may be connected to the computation graph for some tasks and not others.

 Non-differentiable vs. zero attribution

 These are semantically different:

  - Non-differentiable: The layer has no path in the computation graph to the task's output. torch.autograd.grad returns None. The gradient literally does not exist — the layer plays no role in producing that task's prediction.
  - Zero attribution: The layer IS connected to the task's output and autograd.grad returns a real tensor, but the gradient values happen to be zero (or near-zero). The layer participates in the computation but its contribution cancels out or is negligible for the given input.

 Both produce zero-valued tensors in the final output. The distinction is preserved through None propagation in the gradient pipeline and surfaced via logging in _consolidate_task_attributions, which logs layers that are non-differentiable for ALL tasks. For layers non-differentiable for only some tasks, the None entries are replaced with zero tensors to allow stacking — these are indistinguishable from genuine zero attributions in the output tensor.

  Changes

  gradient.py — compute_layer_gradients_and_eval:
  - Replaces D102939482's bulk None→zeros substitution with per-layer handling
  - When allow_unused=True and ALL grads for a layer are None, returns None for that layer (preserves non-differentiable signal for downstream consumers)
  - When only SOME grads are None (partial differentiability edge case), substitutes zeros to protect _reduce_list's Tensor-only invariant
  - None return is gated behind allow_unused=True so existing callers that don't pass allow_unused are unaffected

  layer_gradient_x_activation.py — LayerGradientXActivation.attribute:
  - Multi-layer path: propagates None grads through to the caller instead of crashing
  - multiply_gradient_acts: guards against individual None gradient elements

  layer_attr.py — LayerGradientAttributor:
  - Renames _find_differentiable_layers → _approve_supported_layers: approves all layers with valid output format (tensor, tuple of tensors, floating-point, requires_grad) without checking differentiability
  - _get_attributions: passes allow_unused=True to autograd.grad, allowing None returns for non-differentiable layers
  - _consolidate_task_attributions: handles per-task None attributions — all-None layers are logged as non-differentiable and return None; partial-None layers are zero-filled from a reference attribution shape
  - Fixes _log_layers_not_differentiable type signature to match 3-tuple call site

  common.py — _reduce_list: handles None values that may appear when allow_unused=True is used

Differential Revision: D103563408


