### PR TITLE
Add `TextSegmentInput` to Captum's interpretable input classes (#1830)

### DIFF
--- a/captum/attr/__init__.py
+++ b/captum/attr/__init__.py
@@ -66,6 +66,7 @@ from captum.attr._utils.class_summarizer import ClassSummarizer
 from captum.attr._utils.interpretable_input import (
     ImageMaskInput,
     InterpretableInput,
+    TextSegmentInput,
     TextTemplateInput,
     TextTokenInput,
 )
@@ -140,6 +141,7 @@ __all__ = [
     "GradientShap",
     "ImageMaskInput",
     "InterpretableEmbeddingBase",
+    "TextSegmentInput",
     "TextTemplateInput",
     "TextTokenInput",
     "TokenReferenceBase",

--- a/captum/attr/_utils/interpretable_input.py
+++ b/captum/attr/_utils/interpretable_input.py
@@ -1,4 +1,5 @@
 # pyre-strict
+import re
 from abc import ABC, abstractmethod
 from typing import (
     Any,
@@ -378,6 +379,131 @@ class TextTemplateInput(InterpretableInput):
             torch.tensor([self.formatted_mask], device=device),
         )
         return formatted_attr
+
+
+class TextSegmentInput(TextTemplateInput):
+    """
+    TextSegmentInput is an implementation of InterpretableInput that automatically
+    segments a text string into interpretable features based on a segmentation level.
+    It builds on TextTemplateInput by auto-generating the template and values from
+    the raw text, so users don't need to manually define them.
+
+    Supported segmentation levels:
+
+    - ``"word"``: split on whitespace and common punctuation
+      (``. , ! ? ; : ' " - ( ) [ ] { }``). Punctuation stays in the template.
+    - ``"sentence"``: split after sentence-ending punctuation (``.``, ``!``, ``?``)
+      or on newlines
+    - ``"line"``: split on newlines
+    - ``"paragraph"``: split on blank lines (one or more empty lines)
+
+    Args:
+
+        text (str): the raw text to segment
+        level (str, optional): the segmentation level.
+                Default: "word"
+        baselines (str or None, optional): the baseline value for each segment
+                when it is "absent". If None, the segment is removed (empty string).
+                If a string, it is used as the baseline for all segments.
+                Default: None
+
+    Examples::
+
+        >>> seg_inp = TextSegmentInput(
+        >>>     "Hello, world. Welcome!",
+        >>>     level="word",
+        >>> )
+        >>>
+        >>> seg_inp.values
+        >>> # ["Hello", "world", "Welcome"]
+        >>>
+        >>> seg_inp.to_model_input()
+        >>> # "Hello, world. Welcome!"
+        >>>
+        >>> seg_inp.to_model_input(torch.tensor([[1, 0, 1]]))
+        >>> # "Hello, . Welcome!"
+
+        >>> seg_inp = TextSegmentInput(
+        >>>     "Hello world. How are you?",
+        >>>     level="sentence",
+        >>>     baselines="[MASK]",
+        >>> )
+        >>>
+        >>> seg_inp.values
+        >>> # ["Hello world.", "How are you?"]
+        >>>
+        >>> seg_inp.to_model_input(torch.tensor([[0, 1]]))
+        >>> # "[MASK] How are you?"
+
+    """
+
+    SPLIT_PATTERNS: Dict[str, str] = {
+        "word": r"([\s.,!?;:'\"\-()\[\]{}]+)",
+        "sentence": r"((?<=[.!?])\s+|\n+)",
+        "line": r"(\n)",
+        "paragraph": r"(\n\s*\n)",
+    }
+
+    def __init__(
+        self,
+        text: str,
+        level: str = "word",
+        baselines: Optional[str] = None,
+    ) -> None:
+        segments, template = self._segment_text(text, level)
+
+        assert len(segments) > 0, "text must contain at least one segment"
+
+        baseline_list: Optional[List[str]] = None
+        if baselines is not None:
+            baseline_list = [baselines] * len(segments)
+
+        super().__init__(
+            template=template,
+            values=segments,
+            baselines=baseline_list,
+        )
+
+        self.text = text
+        self.level = level
+
+    @staticmethod
+    def _segment_text(text: str, level: str) -> Tuple[List[str], str]:
+        """
+        Segment text by the given level and return (segments, template).
+
+        Uses ``re.split`` with a capture group so delimiters are preserved.
+        Segments become values and delimiters become literal parts of the
+        template string with ``{}`` placeholders where segments were.
+        """
+        assert level in TextSegmentInput.SPLIT_PATTERNS, (
+            f"unsupported segmentation level: {level}, "
+            f"must be one of {list(TextSegmentInput.SPLIT_PATTERNS.keys())}"
+        )
+
+        pattern = TextSegmentInput.SPLIT_PATTERNS[level]
+        parts = re.split(pattern, text)
+
+        segments: List[str] = []
+        template_parts: List[str] = []
+        escape_braces = TextSegmentInput._escape_braces
+
+        for i, part in enumerate(parts):
+            if i % 2 == 0:
+                # segment position
+                if part:
+                    segments.append(part)
+                    template_parts.append("{}")
+                # empty segment: skip (no placeholder)
+            else:
+                # delimiter position: always goes into the template
+                template_parts.append(escape_braces(part))
+
+        return segments, "".join(template_parts)
+
+    @staticmethod
+    def _escape_braces(s: str) -> str:
+        return s.replace("{", "{{").replace("}", "}}")
 
 
 class TextTokenInput(InterpretableInput):

--- a/tests/attr/test_interpretable_input.py
+++ b/tests/attr/test_interpretable_input.py
@@ -10,6 +10,7 @@ import torch
 from captum._utils.typing import BatchEncodingType
 from captum.attr._utils.interpretable_input import (
     ImageMaskInput,
+    TextSegmentInput,
     TextTemplateInput,
     TextTokenInput,
 )
@@ -193,6 +194,148 @@ class TestTextTemplateInput(BaseTest):
         assertTensorAlmostEqual(
             self, tt_input.format_attr(attr), torch.tensor([[0.1, 0.2, 0.1, 0.2]])
         )
+
+
+class TestTextSegmentInput(BaseTest):
+    def test_word_segmentation(self) -> None:
+        text = "The quick brown fox"
+        seg_inp = TextSegmentInput(text, level="word")
+
+        self.assertEqual(seg_inp.values, ["The", "quick", "brown", "fox"])
+        self.assertEqual(seg_inp.n_itp_features, 4)
+
+        expected_tensor = torch.tensor([[1.0] * 4])
+        assertTensorAlmostEqual(self, seg_inp.to_tensor(), expected_tensor)
+
+        self.assertEqual(seg_inp.to_model_input(), text)
+
+        perturbed = torch.tensor([[1.0, 0.0, 1.0, 0.0]])
+        self.assertEqual(seg_inp.to_model_input(perturbed), "The  brown ")
+
+    def test_word_segmentation_with_punctuation(self) -> None:
+        text = "Hello, world."
+        seg_inp = TextSegmentInput(text, level="word")
+
+        self.assertEqual(seg_inp.values, ["Hello", "world"])
+        self.assertEqual(seg_inp.n_itp_features, 2)
+        self.assertEqual(seg_inp.to_model_input(), text)
+
+        perturbed = torch.tensor([[1.0, 0.0]])
+        self.assertEqual(seg_inp.to_model_input(perturbed), "Hello, .")
+
+    def test_word_segmentation_with_hyphens(self) -> None:
+        text = "a good-example here"
+        seg_inp = TextSegmentInput(text, level="word")
+
+        self.assertEqual(seg_inp.values, ["a", "good", "example", "here"])
+        self.assertEqual(seg_inp.to_model_input(), text)
+
+    def test_sentence_segmentation(self) -> None:
+        text = "Hello world. How are you? Fine!"
+        seg_inp = TextSegmentInput(text, level="sentence")
+
+        self.assertEqual(seg_inp.values, ["Hello world.", "How are you?", "Fine!"])
+        self.assertEqual(seg_inp.n_itp_features, 3)
+        self.assertEqual(seg_inp.to_model_input(), text)
+
+        perturbed = torch.tensor([[1.0, 0.0, 1.0]])
+        self.assertEqual(seg_inp.to_model_input(perturbed), "Hello world.  Fine!")
+
+    def test_sentence_segmentation_with_newlines(self) -> None:
+        text = "First sentence.\nSecond line\nThird line."
+        seg_inp = TextSegmentInput(text, level="sentence")
+
+        self.assertEqual(
+            seg_inp.values,
+            ["First sentence.", "Second line", "Third line."],
+        )
+        self.assertEqual(seg_inp.to_model_input(), text)
+
+    def test_line_segmentation(self) -> None:
+        text = "line one\nline two\nline three"
+        seg_inp = TextSegmentInput(text, level="line")
+
+        self.assertEqual(seg_inp.values, ["line one", "line two", "line three"])
+        self.assertEqual(seg_inp.n_itp_features, 3)
+        self.assertEqual(seg_inp.to_model_input(), text)
+
+        perturbed = torch.tensor([[0.0, 1.0, 0.0]])
+        self.assertEqual(seg_inp.to_model_input(perturbed), "\nline two\n")
+
+    def test_paragraph_segmentation(self) -> None:
+        text = "First paragraph.\n\nSecond paragraph.\n\nThird paragraph."
+        seg_inp = TextSegmentInput(text, level="paragraph")
+
+        self.assertEqual(
+            seg_inp.values,
+            ["First paragraph.", "Second paragraph.", "Third paragraph."],
+        )
+        self.assertEqual(seg_inp.n_itp_features, 3)
+        self.assertEqual(seg_inp.to_model_input(), text)
+
+        perturbed = torch.tensor([[1.0, 0.0, 1.0]])
+        self.assertEqual(
+            seg_inp.to_model_input(perturbed),
+            "First paragraph.\n\n\n\nThird paragraph.",
+        )
+
+    def test_baselines_none(self) -> None:
+        text = "hello world"
+        seg_inp = TextSegmentInput(text, level="word", baselines=None)
+
+        perturbed = torch.tensor([[0.0, 1.0]])
+        self.assertEqual(seg_inp.to_model_input(perturbed), " world")
+
+    def test_baselines_string(self) -> None:
+        text = "hello world"
+        seg_inp = TextSegmentInput(text, level="word", baselines="[MASK]")
+
+        perturbed = torch.tensor([[0.0, 1.0]])
+        self.assertEqual(seg_inp.to_model_input(perturbed), "[MASK] world")
+
+        perturbed = torch.tensor([[0.0, 0.0]])
+        self.assertEqual(seg_inp.to_model_input(perturbed), "[MASK] [MASK]")
+
+    def test_single_segment(self) -> None:
+        text = "oneword"
+        seg_inp = TextSegmentInput(text, level="word")
+
+        self.assertEqual(seg_inp.values, ["oneword"])
+        self.assertEqual(seg_inp.n_itp_features, 1)
+        self.assertEqual(seg_inp.to_model_input(), text)
+
+    def test_multiple_whitespace(self) -> None:
+        text = "hello   world"
+        seg_inp = TextSegmentInput(text, level="word")
+
+        self.assertEqual(seg_inp.values, ["hello", "world"])
+        self.assertEqual(seg_inp.to_model_input(), text)
+
+    def test_leading_delimiter(self) -> None:
+        text = ". Hello world"
+        seg_inp = TextSegmentInput(text, level="word")
+
+        self.assertEqual(seg_inp.values, ["Hello", "world"])
+        self.assertEqual(seg_inp.to_model_input(), text)
+
+    def test_trailing_delimiter(self) -> None:
+        text = "Hello world! "
+        seg_inp = TextSegmentInput(text, level="word")
+
+        self.assertEqual(seg_inp.values, ["Hello", "world"])
+        self.assertEqual(seg_inp.to_model_input(), text)
+
+    def test_default_level_is_word(self) -> None:
+        seg_inp = TextSegmentInput("a b c")
+        self.assertEqual(seg_inp.values, ["a", "b", "c"])
+
+    def test_invalid_level(self) -> None:
+        with self.assertRaises(AssertionError):
+            TextSegmentInput("hello", level="invalid")
+
+    def test_is_instance_of_text_template_input(self) -> None:
+        seg_inp = TextSegmentInput("hello world")
+        self.assertIsInstance(seg_inp, TextTemplateInput)
 
 
 class TestTextTokenInput(BaseTest):


### PR DESCRIPTION
Summary:

`TextSegmentInput` extends `TextTemplateInput` to automatically segment raw text into interpretable features based on a segmentation level, so users don't need to manually define a template and values. It supports four levels: `"word"` (split on whitespace and common punctuation), `"sentence"` (split after `.!?` or on newlines), `"line"` (split on newlines), and `"paragraph"` (split on blank lines). Punctuation and whitespace stay in the template as literals rather than becoming part of segments.

Since it inherits from `TextTemplateInput`, it automatically works with `LLMAttribution` without any changes to the attribution classes.

Reviewed By: pchlenski

Differential Revision: D105100060


