### PR TITLE
Clarify LayerDeepLift additional args docs (#1115)

### DIFF
--- a/captum/attr/_core/layer/layer_deep_lift.py
+++ b/captum/attr/_core/layer/layer_deep_lift.py
@@ -207,7 +207,7 @@ class LayerDeepLift(LayerAttribution, DeepLift):
                           target for the corresponding example.
 
                         Default: None
-            additional_forward_args (Any, optional): If the forward function
+            additional_forward_args (Any, optional): If the model
                         requires additional arguments other than the inputs for
                         which attributions should not be computed, this argument
                         can be provided. It must be either a single additional
@@ -542,7 +542,7 @@ class LayerDeepLiftShap(LayerDeepLift, DeepLiftShap):
                           target for the corresponding example.
 
                         Default: None
-            additional_forward_args (Any, optional): If the forward function
+            additional_forward_args (Any, optional): If the model
                         requires additional arguments other than the inputs for
                         which attributions should not be computed, this argument
                         can be provided. It must be either a single additional


### PR DESCRIPTION
Fixes #1115.

Issue: https://github.com/meta-pytorch/captum/issues/1115
Issue summary: LayerDeepLift documentation described additional_forward_args as belonging to a generic forward function rather than the model being attributed.

Summary:
- Update LayerDeepLift and LayerDeepLiftShap additional_forward_args wording to refer to the model.

Test Plan:
- Pyre: not applicable; documentation-only docstring change.

