### PR TITLE
Document saving visualize_text HTML output (#1130)

### DIFF
--- a/captum/attr/_utils/visualization.py
+++ b/captum/attr/_utils/visualization.py
@@ -1136,6 +1136,14 @@ def format_word_importances(
 def visualize_text(
     datarecords: Iterable[VisualizationDataRecord], legend: bool = True
 ) -> "HTML":  # In quotes because this type doesn't exist in standalone mode
+    r"""
+    Visualizes text attribution records and returns an IPython ``HTML`` object.
+
+    In notebooks this object is displayed inline. To persist the same rendering as
+    HTML, write ``html_obj.data`` from the returned object to an ``.html`` file.
+    Captum does not directly export this visualization as a raster image; use an
+    external HTML renderer or screenshot tool when an image file is required.
+    """
     assert HAS_IPYTHON, (
         "IPython must be available to visualize text. "
         "Please run 'pip install ipython'."


### PR DESCRIPTION
Fixes #1130.

Issue: https://github.com/meta-pytorch/captum/issues/1130
Issue summary: users asked how to save text visualizations as files or images.

Summary:
- Document that visualize_text returns an IPython HTML object whose data can be written to an HTML file.
- Clarify that raster image export requires an external renderer or screenshot tool.

Test Plan:
- Pyre: not applicable; documentation-only docstring change.

