### PR TITLE
Add recurrent model attribution tutorial (#1205) (#1834)

### DIFF
--- a/tutorials/Recurrent_Model_Interpret.ipynb
+++ b/tutorials/Recurrent_Model_Interpret.ipynb
@@ -1,0 +1,238 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Interpreting Recurrent Models"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates Captum attribution on an LSTM classifier whose input shape is `(batch, sequence_length, features)`. It shows how to compute input attributions, how to aggregate them by time step or by feature, and how to use layer attribution on the recurrent layer.\n",
+    "\n",
+    "**Note:** Before running this tutorial, please install matplotlib."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import torch.nn.functional as F\n",
+    "from torch.utils.data import DataLoader, TensorDataset\n",
+    "\n",
+    "from captum.attr import IntegratedGradients, LayerIntegratedGradients"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create a sequence classification task"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The synthetic label depends on feature 0 near the end of the sequence, feature 1 near the beginning, and feature 2 in the middle. This gives us a known pattern to compare against the attribution summaries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "torch.manual_seed(7)\n",
+    "\n",
+    "def make_sequences(num_examples, seq_len=24, num_features=4):\n",
+    "    x = torch.randn(num_examples, seq_len, num_features)\n",
+    "    time_feature = torch.linspace(-1, 1, seq_len).view(1, seq_len)\n",
+    "    x[:, :, 3] = time_feature\n",
+    "\n",
+    "    evidence = (\n",
+    "        x[:, -8:, 0].sum(dim=1)\n",
+    "        - x[:, :8, 1].sum(dim=1)\n",
+    "        + 0.5 * x[:, 8:16, 2].sum(dim=1)\n",
+    "    )\n",
+    "    y = (evidence > 0).long()\n",
+    "    return x, y\n",
+    "\n",
+    "train_x, train_y = make_sequences(2048)\n",
+    "test_x, test_y = make_sequences(256)\n",
+    "\n",
+    "train_loader = DataLoader(\n",
+    "    TensorDataset(train_x, train_y),\n",
+    "    batch_size=64,\n",
+    "    shuffle=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train a small LSTM classifier"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class LSTMClassifier(nn.Module):\n",
+    "    def __init__(self, input_size, hidden_size, output_size):\n",
+    "        super().__init__()\n",
+    "        self.lstm = nn.LSTM(input_size, hidden_size, batch_first=True)\n",
+    "        self.fc = nn.Linear(hidden_size, output_size)\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        output, _ = self.lstm(x)\n",
+    "        return self.fc(output[:, -1, :])\n",
+    "\n",
+    "model = LSTMClassifier(input_size=4, hidden_size=16, output_size=2)\n",
+    "optimizer = torch.optim.Adam(model.parameters(), lr=0.01)\n",
+    "\n",
+    "for epoch in range(8):\n",
+    "    model.train()\n",
+    "    for batch_x, batch_y in train_loader:\n",
+    "        logits = model(batch_x)\n",
+    "        loss = F.cross_entropy(logits, batch_y)\n",
+    "        optimizer.zero_grad()\n",
+    "        loss.backward()\n",
+    "        optimizer.step()\n",
+    "\n",
+    "model.eval()\n",
+    "with torch.no_grad():\n",
+    "    accuracy = (model(test_x).argmax(dim=1) == test_y).float().mean()\n",
+    "\n",
+    "print(\"Test accuracy:\", accuracy.item())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Attribute a prediction to sequence inputs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`IntegratedGradients` returns attributions with the same shape as the input. For this model, that means one attribution score per `(time step, feature)` pair."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "example = test_x[:1]\n",
+    "baseline = torch.zeros_like(example)\n",
+    "target = model(example).argmax(dim=1).item()\n",
+    "\n",
+    "ig = IntegratedGradients(model)\n",
+    "\n",
+    "# CuDNN RNN backward does not support eval mode on some GPU setups.\n",
+    "with torch.backends.cudnn.flags(enabled=False):\n",
+    "    attributions, delta = ig.attribute(\n",
+    "        example,\n",
+    "        baselines=baseline,\n",
+    "        target=target,\n",
+    "        return_convergence_delta=True,\n",
+    "    )\n",
+    "\n",
+    "print(\"Attribution shape:\", tuple(attributions.shape))\n",
+    "print(\"Convergence delta:\", delta.item())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Aggregate over the feature dimension to rank time steps, or aggregate over the time dimension to rank input features."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_importance = attributions.abs().sum(dim=2).squeeze(0).detach()\n",
+    "feature_importance = attributions.abs().sum(dim=1).squeeze(0).detach()\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 4))\n",
+    "\n",
+    "axes[0].bar(range(example.shape[1]), time_importance)\n",
+    "axes[0].set_xlabel(\"Time step\")\n",
+    "axes[0].set_ylabel(\"Absolute attribution\")\n",
+    "axes[0].set_title(\"Importance by time step\")\n",
+    "\n",
+    "axes[1].bar(range(example.shape[2]), feature_importance)\n",
+    "axes[1].set_xlabel(\"Feature\")\n",
+    "axes[1].set_title(\"Importance by feature\")\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Attribute through the recurrent layer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`LayerIntegratedGradients` can attribute to the recurrent layer inputs or outputs. Attributing to layer inputs keeps the result aligned with the original `(sequence_length, features)` axes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lig = LayerIntegratedGradients(model, model.lstm)\n",
+    "\n",
+    "with torch.backends.cudnn.flags(enabled=False):\n",
+    "    layer_input_attr = lig.attribute(\n",
+    "        example,\n",
+    "        baselines=baseline,\n",
+    "        target=target,\n",
+    "        attribute_to_layer_input=True,\n",
+    "    )\n",
+    "\n",
+    "print(\"Layer input attribution shape:\", tuple(layer_input_attr.shape))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "python3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/website/tutorials.json
+++ b/website/tutorials.json
@@ -31,6 +31,10 @@
       "title": "Interpreting a regression model of California house prices"
     },
     {
+      "id": "Recurrent_Model_Interpret",
+      "title": "Interpreting recurrent models"
+    },
+    {
       "id": "Segmentation_Interpret",
       "title": "Interpreting semantic segmentation models"
     },


### PR DESCRIPTION
Summary:
Fixes https://github.com/meta-pytorch/captum/issues/1205.

Issue: https://github.com/meta-pytorch/captum/issues/1205
Issue summary: Captum lacked a recurrent-model tutorial showing sequence and recurrent-layer attribution.
- Add an LSTM sequence-classification tutorial with input attribution and time/feature aggregation.
- Include LayerIntegratedGradients on the recurrent layer with attribute_to_layer_input=True.


Test Plan:
- venv/uv/bin/python -m json.tool tutorials/Recurrent_Model_Interpret.ipynb
- Pyre: not applicable; tutorial-only change.

Reviewed By: Ayush-Warikoo

Differential Revision: D106053939

Pulled By: craymichael


