### PR TITLE
Clarify TCAV classifier learned weights (#1308)

### DIFF
--- a/captum/_utils/models/linear_model/train.py
+++ b/captum/_utils/models/linear_model/train.py
@@ -403,7 +403,9 @@ def sklearn_train_linear_model(
 
     t2 = time.time()
 
-    # Convert weights to pytorch
+    # `w` above is an optional per-example sample weight passed to sklearn.fit.
+    # The learned linear model weights are populated by sklearn during fit and
+    # exposed separately through `coef_` and `intercept_`.
     classes = (
         torch.IntTensor(sklearn_model.classes_)
         if hasattr(sklearn_model, "classes_")


### PR DESCRIPTION
Fixes #1308.

Issue: https://github.com/meta-pytorch/captum/issues/1308
Issue summary: users were confused about whether the sklearn sample-weight argument represented learned TCAV classifier weights.

Summary:
- Clarify in the sklearn linear-model training helper that w is an optional per-example sample weight.
- Note that learned linear weights come from sklearn coef_ and intercept_ after fitting.

Test Plan:
- Pyre: not applicable; documentation-only source comment change.

