### PR TITLE
Document LIME for tabular Titanic features (#810)

### DIFF
--- a/tutorials/Titanic_Basic_Interpret.ipynb
+++ b/tutorials/Titanic_Basic_Interpret.ipynb
@@ -40,6 +40,7 @@
     "\n",
     "from captum.attr import IntegratedGradients\n",
     "from captum.attr import LayerConductance\n",
+    "from captum.attr import Lime\n",
     "from captum.attr import NeuronConductance\n",
     "\n",
     "import matplotlib\n",
@@ -813,6 +814,50 @@
    "metadata": {},
    "source": [
     "From the visualization above, it is evident that neuron 10 primarily relies on the gender and class features, substantially different from the focus of neuron 0."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Applying LIME to tabular features"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "LIME can also be used for tabular models by treating each column, or a group of related columns, as an interpretable feature. Here each Titanic feature receives its own feature id and missing features are replaced with the mean value from the training set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lime = Lime(net)\n",
+    "\n",
+    "test_input = torch.from_numpy(test_features[:1]).type(torch.FloatTensor)\n",
+    "tabular_baseline = torch.from_numpy(train_features.mean(axis=0, keepdims=True)).type(torch.FloatTensor)\n",
+    "feature_mask = torch.arange(test_input.shape[1]).unsqueeze(0)\n",
+    "\n",
+    "lime_attr = lime.attribute(\n",
+    "    test_input,\n",
+    "    baselines=tabular_baseline,\n",
+    "    target=1,\n",
+    "    feature_mask=feature_mask,\n",
+    "    n_samples=300,\n",
+    "    perturbations_per_eval=64,\n",
+    "    return_input_shape=True,\n",
+    ")\n",
+    "\n",
+    "print(\"Predicted logits:\", net(test_input).detach())\n",
+    "visualize_importances(\n",
+    "    feature_names,\n",
+    "    lime_attr.squeeze(0).detach().numpy(),\n",
+    "    title=\"LIME Feature Importances for a Titanic Passenger\",\n",
+    ")"
    ]
   },
   {


### PR DESCRIPTION
Fixes #810.

Issue: https://github.com/meta-pytorch/captum/issues/810
Issue summary: users asked for a tabular LIME example.

Summary:
- Add a short Titanic tutorial section using Lime with one interpretable feature per tabular column.
- Use a train-set mean baseline and visualize the resulting tabular feature importances.

Test Plan:
- venv/uv/bin/python -m json.tool tutorials/Titanic_Basic_Interpret.ipynb
- Pyre: not applicable; tutorial-only change.

