### PR TITLE
Clarify sample-wise gradient influence docs (#987)

### DIFF
--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -942,7 +942,9 @@ def _compute_jacobian_wrt_params_with_sample_wise_trick(
     batch trick to fully vectorize the Jacobian calculation. Currently, only
     linear and conv2d layers are supported.
 
-    User must `add_hooks(model)` before calling this function.
+    Hooks required for sample-wise gradients are registered and removed internally.
+    Users do not need to call `SampleGradientWrapper.add_hooks()` before calling
+    this function.
 
     Args:
         model (torch.nn.Module): The trainable model providing the forward pass

--- a/captum/influence/_core/arnoldi_influence_function.py
+++ b/captum/influence/_core/arnoldi_influence_function.py
@@ -394,7 +394,7 @@ class ArnoldiInfluenceFunction(IntermediateQuantitiesInfluenceFunction):
                     inefficient. We offer an implementation of batch-wise gradient
                     computations w.r.t. to model parameters which is computationally
                     more efficient. This implementation can be enabled by setting the
-                    `sample_wise_grad_per_batch` argument to `True`, and should be
+                    `sample_wise_grads_per_batch` argument to `True`, and should be
                     enabled if and only if the `loss_fn` argument is a "reduction" loss
                     function. For example, `nn.BCELoss(reduction="sum")` would be a
                     valid `loss_fn` if this implementation is enabled (see

--- a/captum/influence/_core/influence_function.py
+++ b/captum/influence/_core/influence_function.py
@@ -178,7 +178,7 @@ class InfluenceFunctionBase(DataInfluence):
                     inefficient. We offer an implementation of batch-wise gradient
                     computations w.r.t. to model parameters which is computationally
                     more efficient. This implementation can be enabled by setting the
-                    `sample_wise_grad_per_batch` argument to `True`, and should be
+                    `sample_wise_grads_per_batch` argument to `True`, and should be
                     enabled if and only if the `loss_fn` argument is a "reduction" loss
                     function. For example, `nn.BCELoss(reduction="sum")` would be a
                     valid `loss_fn` if this implementation is enabled (see
@@ -800,7 +800,7 @@ class NaiveInfluenceFunction(IntermediateQuantitiesInfluenceFunction):
                     inefficient. We offer an implementation of batch-wise gradient
                     computations w.r.t. to model parameters which is computationally
                     more efficient. This implementation can be enabled by setting the
-                    `sample_wise_grad_per_batch` argument to `True`, and should be
+                    `sample_wise_grads_per_batch` argument to `True`, and should be
                     enabled if and only if the `loss_fn` argument is a "reduction" loss
                     function. For example, `nn.BCELoss(reduction="sum")` would be a
                     valid `loss_fn` if this implementation is enabled (see

--- a/captum/influence/_core/tracincp.py
+++ b/captum/influence/_core/tracincp.py
@@ -566,7 +566,7 @@ class TracInCP(TracInCPBase):
                     inefficient. We offer an implementation of batch-wise gradient
                     computations w.r.t. to model parameters which is computationally
                     more efficient. This implementation can be enabled by setting the
-                    `sample_wise_grad_per_batch` argument to `True`, and should be
+                    `sample_wise_grads_per_batch` argument to `True`, and should be
                     enabled if and only if the `loss_fn` argument is a "reduction" loss
                     function. For example, `nn.BCELoss(reduction="sum")` would be a
                     valid `loss_fn` if this implementation is enabled (see


### PR DESCRIPTION
Fixes #987.

Issue: https://github.com/meta-pytorch/captum/issues/987
Issue summary: TracIn sample-wise gradient documentation incorrectly implied users must register hooks manually and used an outdated argument spelling.

Summary:
- Clarify that sample-wise gradient hooks are registered and removed internally.
- Correct documentation references to sample_wise_grads_per_batch across influence APIs.

Test Plan:
- Pyre: not applicable; documentation-only docstring change.

