### PR TITLE
Remove Titanic tutorial softmax before CrossEntropyLoss (#1010)

### DIFF
--- a/tests/test_tutorial_regressions.py
+++ b/tests/test_tutorial_regressions.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+# pyre-strict
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+TUTORIALS_PATH = Path(__file__).resolve().parents[1] / "tutorials"
+
+
+def _notebook_source(name: str) -> str:
+    with open(TUTORIALS_PATH / name, encoding="utf-8") as notebook_file:
+        notebook: dict[str, Any] = json.load(notebook_file)
+    return "\n".join(
+        "".join(cell.get("source", [])) for cell in notebook["cells"]
+    )
+
+
+def test_titanic_tutorial_models_return_logits_for_cross_entropy_loss() -> None:
+    training_source = _notebook_source("Titanic_Basic_Interpret.ipynb")
+    assert "nn.CrossEntropyLoss()" in training_source
+
+    for notebook_name in (
+        "Titanic_Basic_Interpret.ipynb",
+        "Distributed_Attribution.ipynb",
+    ):
+        source = _notebook_source(notebook_name)
+
+        assert "nn.Softmax" not in source
+        assert "self.softmax" not in source

--- a/tutorials/Distributed_Attribution.ipynb
+++ b/tutorials/Distributed_Attribution.ipynb
@@ -364,13 +364,12 @@
     "        self.linear2 = nn.Linear(12, 8)\n",
     "        self.sigmoid2 = nn.Sigmoid()\n",
     "        self.linear3 = nn.Linear(8, 2)\n",
-    "        self.softmax = nn.Softmax(dim=1)\n",
     "\n",
     "    def forward(self, x):\n",
     "        lin1_out = self.linear1(x)\n",
     "        sigmoid_out1 = self.sigmoid1(lin1_out)\n",
     "        sigmoid_out2 = self.sigmoid2(self.linear2(sigmoid_out1))\n",
-    "        return self.softmax(self.linear3(sigmoid_out2))"
+    "        return self.linear3(sigmoid_out2)"
    ]
   },
   {

--- a/tutorials/Titanic_Basic_Interpret.ipynb
+++ b/tutorials/Titanic_Basic_Interpret.ipynb
@@ -175,7 +175,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We are now ready to define the neural network architecture we will use for the task. We have defined a simple architecture using 2 hidden layers, the first with 12 hidden units and the second with 8 hidden units, each with Sigmoid non-linearity. The final layer performs a softmax operation and has 2 units, corresponding to the outputs of either survived (1) or not survived (0)."
+    "We are now ready to define the neural network architecture we will use for the task. We have defined a simple architecture using 2 hidden layers, the first with 12 hidden units and the second with 8 hidden units, each with Sigmoid non-linearity. The final layer has 2 output units, corresponding to the logits for either survived (1) or not survived (0)."
    ]
   },
   {
@@ -195,13 +195,12 @@
     "        self.linear2 = nn.Linear(12, 8)\n",
     "        self.sigmoid2 = nn.Sigmoid()\n",
     "        self.linear3 = nn.Linear(8, 2)\n",
-    "        self.softmax = nn.Softmax(dim=1)\n",
     "\n",
     "    def forward(self, x):\n",
     "        lin1_out = self.linear1(x)\n",
     "        sigmoid_out1 = self.sigmoid1(lin1_out)\n",
     "        sigmoid_out2 = self.sigmoid2(self.linear2(sigmoid_out1))\n",
-    "        return self.softmax(self.linear3(sigmoid_out2))"
+    "        return self.linear3(sigmoid_out2)"
    ]
   },
   {
@@ -273,8 +272,8 @@
     }
    ],
    "source": [
-    "out_probs = net(input_tensor).detach().numpy()\n",
-    "out_classes = np.argmax(out_probs, axis=1)\n",
+    "out_logits = net(input_tensor).detach().numpy()\n",
+    "out_classes = np.argmax(out_logits, axis=1)\n",
     "print(\"Train Accuracy:\", sum(out_classes == train_labels) / len(train_labels))"
    ]
   },
@@ -293,8 +292,8 @@
    ],
    "source": [
     "test_input_tensor = torch.from_numpy(test_features).type(torch.FloatTensor)\n",
-    "out_probs = net(test_input_tensor).detach().numpy()\n",
-    "out_classes = np.argmax(out_probs, axis=1)\n",
+    "out_logits = net(test_input_tensor).detach().numpy()\n",
+    "out_classes = np.argmax(out_logits, axis=1)\n",
     "print(\"Test Accuracy:\", sum(out_classes == test_labels) / len(test_labels))"
    ]
   },


### PR DESCRIPTION
Fixes #1010.

Issue: https://github.com/meta-pytorch/captum/issues/1010
Issue summary: the Titanic tutorial trained a model with final Softmax using nn.CrossEntropyLoss.

Summary:
- Remove the redundant final Softmax from Titanic tutorial models.
- Rename prediction variables to logits where the notebook feeds CrossEntropyLoss.
- Add a notebook regression check for Titanic and distributed attribution copies.

Test Plan:
- venv/uv/bin/python -m pytest -q tests/test_tutorial_regressions.py
- Pyre: not applicable; notebook-only behavior change covered by regression test.

