### PR TITLE
Update TCAV Broden dataset URL (#1045)

### DIFF
--- a/tutorials/TCAV_Image.ipynb
+++ b/tutorials/TCAV_Image.ipynb
@@ -158,7 +158,7 @@
     "\n",
     "Note that concepts should be created and stored under `data/tcav/image/concepts/` folder in advance. \n",
     "\n",
-    "`striped`, `zigzagged` and `dotted` concepts can be found in broden dataset:  https://netdissect.csail.mit.edu/broden1_224, under `images/dtd` folder as also described here: https://github.com/tensorflow/tcav/tree/master/tcav/tcav_examples/image_models/imagenet. There are in total 120 images for each of the `striped`, `zigzagged` and `dotted` concepts.\n",
+    "`striped`, `zigzagged` and `dotted` concepts can be found in broden dataset:  https://netdissect.csail.mit.edu/data/broden1_224.zip, under `images/dtd` folder as also described here: https://github.com/tensorflow/tcav/tree/master/tcav/tcav_examples/image_models/imagenet. There are in total 120 images for each of the `striped`, `zigzagged` and `dotted` concepts.\n",
     "\n",
     "Please, download those concept images and place under `striped`, `zigzagged` and `dotted` folders under `data/tcav/image/concepts/` folder accordingly.\n",
     "\n",


### PR DESCRIPTION
Fixes #1045.

Issue: https://github.com/meta-pytorch/captum/issues/1045
Issue summary: the TCAV tutorial used the Broden HTML page URL instead of the downloadable archive.

Summary:
- Point the TCAV image tutorial at the HTTPS Broden zip endpoint.
- Add a notebook regression check for the dataset URL.

Test Plan:
- venv/uv/bin/python -m pytest -q tests/test_tutorial_regressions.py
- Pyre: not applicable; notebook URL change only.

