### PR TITLE
Preserve custom LRP rules across attributions (#1059)

### DIFF
--- a/captum/attr/_core/lrp.py
+++ b/captum/attr/_core/lrp.py
@@ -61,6 +61,7 @@ class LRP(GradientAttribution):
         """
         GradientAttribution.__init__(self, model)
         self.model = model
+        self._layers_with_added_rules: List[Module] = []
         self._check_rules()
 
     @property
@@ -198,6 +199,7 @@ class LRP(GradientAttribution):
         self._original_state_dict = self.model.state_dict()
         self.layers = []
         self._get_layers(self.model)
+        self._layers_with_added_rules = []
         self._check_and_attach_rules()
         self.backward_handles: List[RemovableHandle] = []
         self.forward_handles: List[RemovableHandle] = []
@@ -305,10 +307,12 @@ class LRP(GradientAttribution):
             elif type(layer) in SUPPORTED_LAYERS_WITH_RULES.keys():
                 layer.activations = {}  # type: ignore
                 layer.rule = SUPPORTED_LAYERS_WITH_RULES[type(layer)]()  # type: ignore
+                self._layers_with_added_rules.append(layer)
                 layer.rule.relevance_input = defaultdict(list)  # type: ignore
                 layer.rule.relevance_output = {}  # type: ignore
             elif type(layer) in SUPPORTED_NON_LINEAR_LAYERS:
                 layer.rule = None  # type: ignore
+                self._layers_with_added_rules.append(layer)
             else:
                 raise TypeError(
                     (
@@ -400,7 +404,7 @@ class LRP(GradientAttribution):
                 layer.rule._handle_output_hook.remove()  # type: ignore
 
     def _remove_rules(self) -> None:
-        for layer in self.layers:
+        for layer in self._layers_with_added_rules:
             if hasattr(layer, "rule"):
                 del layer.rule
 

--- a/tests/attr/test_lrp.py
+++ b/tests/attr/test_lrp.py
@@ -128,6 +128,34 @@ class Test(BaseTest):
         output_after = model(inputs)
         assertTensorAlmostEqual(self, output, output_after)
 
+    def test_lrp_preserves_custom_rules_for_repeated_attributions(self) -> None:
+        class UnsupportedLinear(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.weight = nn.Parameter(torch.ones(1, 2))
+
+            def forward(self, input: Tensor) -> Tensor:
+                return input.matmul(self.weight.t())
+
+        class Model(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.layer = UnsupportedLinear()
+                self.layer.rule = EpsilonRule()  # type: ignore
+
+            def forward(self, input: Tensor) -> Tensor:
+                return self.layer(input)
+
+        model = Model().eval()
+        inputs = torch.tensor([[1.0, 2.0]])
+        lrp = LRP(model)
+
+        relevance = lrp.attribute(inputs)  # type: ignore[has-type]
+        self.assertTrue(hasattr(model.layer, "rule"))
+        repeated_relevance = lrp.attribute(inputs)  # type: ignore[has-type]
+
+        assertTensorAlmostEqual(self, relevance, repeated_relevance)
+
     def test_lrp_simple_inplaceReLU(self) -> None:
         model_default, inputs = _get_simple_model()
         model_inplace, _ = _get_simple_model(inplace=True)


### PR DESCRIPTION
Fixes #1059.

Issue: https://github.com/meta-pytorch/captum/issues/1059
Issue summary: custom LRP rules were removed after an attribution call.

Summary:
- Track rules inserted internally by LRP separately from user-provided module rules.
- Remove only Captum-inserted rules during cleanup.
- Add a regression test covering repeated attribution with a custom rule on an unsupported leaf module.

Test Plan:
- venv/uv/bin/python -m pytest -q tests/attr/test_lrp.py
- Pyre: attempted `venv/uv/bin/pyre --noninteractive --dot-pyre-directory /tmp/captum-pyre-logs-config check`; blocked locally by broad pre-existing Pyre type-resolution failures resolving stdlib / torch imports.

