### PR TITLE
Normalize out-of-range visualization images (#1098) (#1842)

### DIFF
--- a/captum/attr/_utils/visualization.py
+++ b/captum/attr/_utils/visualization.py
@@ -170,6 +170,19 @@ def _prepare_image(attr_visual: npt.NDArray) -> npt.NDArray:
     return np.clip(attr_visual.astype(int), 0, 255)
 
 
+def _prepare_image_for_display(original_image: npt.NDArray) -> npt.NDArray:
+    if np.issubdtype(original_image.dtype, np.floating):
+        min_value = np.min(original_image)
+        max_value = np.max(original_image)
+        if min_value < 0 or max_value > 1:
+            if min_value != max_value:
+                original_image = (original_image - min_value) / (max_value - min_value)
+            else:
+                original_image = np.zeros_like(original_image)
+        original_image = original_image * 255
+    return _prepare_image(original_image)
+
+
 def _normalize_scale(attr: npt.NDArray, scale_factor: float) -> npt.NDArray:
     assert scale_factor != 0, "Cannot normalize by scale factor = 0"
     if abs(scale_factor) < 1e-5:
@@ -478,8 +491,7 @@ def visualize_image_attr(
         plt_axis = plt_axis[0]
 
     if original_image is not None:
-        if np.max(original_image) <= 1.0:
-            original_image = _prepare_image(original_image * 255)
+        original_image = _prepare_image_for_display(original_image)
     elif (
         ImageVisualizationMethod[method].value
         != ImageVisualizationMethod.heat_map.value

--- a/tests/attr/test_visualization_image_display.py
+++ b/tests/attr/test_visualization_image_display.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+# pyre-strict
+
+import numpy as np
+from captum.attr._utils.visualization import visualize_image_attr
+from matplotlib import pyplot as plt
+
+
+def test_visualize_image_attr_normalizes_out_of_range_float_images() -> None:
+    attr = np.ones((2, 2, 3))
+    original_image = np.array(
+        [
+            [[-1.0, 0.0, 1.0], [2.0, -0.5, 0.5]],
+            [[1.5, -1.5, 0.25], [0.75, 1.25, -0.25]],
+        ]
+    )
+
+    fig, ax = visualize_image_attr(
+        attr,
+        original_image,
+        method="original_image",
+        sign="positive",
+        use_pyplot=False,
+    )
+    rendered_image = np.asarray(ax.images[0].get_array())
+
+    assert rendered_image.min() == 0
+    assert rendered_image.max() == 255
+    plt.close(fig)


### PR DESCRIPTION
Summary:
Fixes https://github.com/meta-pytorch/captum/issues/1098.

Issue: https://github.com/meta-pytorch/captum/issues/1098
Issue summary: original_image inputs outside the expected display range were clipped or passed through inconsistently.
- Normalize floating-point original images outside [0, 1] before display.
- Preserve existing uint-style image preparation through a shared display helper.
- Add a regression test for negative and greater-than-one float images.


Test Plan:
- venv/uv/bin/python -m pytest -q tests/attr/test_visualization_image_display.py
- Pyre: attempted `venv/uv/bin/pyre --noninteractive --dot-pyre-directory /tmp/captum-pyre-logs-config check`; blocked locally by broad pre-existing Pyre type-resolution failures resolving stdlib / torch imports.

Reviewed By: yeyingxiao

Differential Revision: D106053882

Pulled By: craymichael


