### PR TITLE
Fix DeepLift adjacent nonlinear hooks (#1104) (#1843)

### DIFF
--- a/captum/_utils/common.py
+++ b/captum/_utils/common.py
@@ -866,6 +866,18 @@ def _register_backward_hook(
 ) -> List[torch.utils.hooks.RemovableHandle]:
     grad_out: Dict[device, Tensor] = {}
 
+    def backward_pre_hook(
+        module: Module,
+        grad_output: Union[Tensor, Tuple[Tensor, ...]],
+    ) -> None:
+        if isinstance(grad_output, tuple):
+            assert (
+                len(grad_output) == 1
+            ), "Backward hooks not supported for module with >1 output"
+            grad_out[grad_output[0].device] = grad_output[0]
+        else:
+            grad_out[grad_output.device] = grad_output
+
     def forward_hook(
         module: Module,
         inp: Union[Tensor, Tuple[Tensor, ...]],
@@ -905,10 +917,13 @@ def _register_backward_hook(
             inp.register_hook(input_tensor_hook)
             return inp.clone()
 
-    return [
+    hooks = [
         module.register_forward_pre_hook(pre_hook),
         module.register_forward_hook(forward_hook),
     ]
+    if not getattr(module, "inplace", False):
+        hooks.append(module.register_full_backward_pre_hook(backward_pre_hook))
+    return hooks
 
 
 def _get_max_feature_index(feature_mask: Tuple[Tensor, ...]) -> int:

--- a/tests/attr/test_deeplift_basic.py
+++ b/tests/attr/test_deeplift_basic.py
@@ -14,6 +14,7 @@ from captum.testing.helpers.basic import (
     BaseTest,
 )
 from captum.testing.helpers.basic_models import (
+    BasicModel_MaxPool_ReLU,
     BasicModelWithReusedModules,
     Conv1dSeqModel,
     LinearMaxPoolLinearModel,
@@ -289,6 +290,39 @@ class Test(BaseTest):
             target=(0, 0),
         )
         self.assertEqual(attr.shape, rand_seq_data.shape)
+
+    def test_deepliftshap_maxpool_relu_nonzero_baselines(self) -> None:
+        model = BasicModel_MaxPool_ReLU().double().eval()
+        input = torch.tensor(
+            [
+                [
+                    [15.4100, -2.9343, -21.7879],
+                    [5.6843, -10.8452, -13.9860],
+                ]
+            ],
+            dtype=torch.float64,
+        )
+        baselines = torch.tensor(
+            [
+                [
+                    [-1.4347, -1.1161, -6.1358],
+                    [0.3159, -4.9268, 2.4841],
+                ],
+                [
+                    [-11.2560, -3.1700, -10.9247],
+                    [-0.8519, 3.2761, -7.6071],
+                ],
+            ],
+            dtype=torch.float64,
+        )
+
+        _, delta = DeepLiftShap(model).attribute(  # type: ignore[has-type]
+            input,
+            baselines,
+            return_convergence_delta=True,
+        )
+
+        assertTensorAlmostEqual(self, delta, torch.zeros_like(delta), 1e-10, "max")
 
     def test_reusable_modules(self) -> None:
         model = BasicModelWithReusedModules()


### PR DESCRIPTION
Summary:
Fixes https://github.com/meta-pytorch/captum/issues/1104.

Issue: https://github.com/meta-pytorch/captum/issues/1104
Issue summary: adjacent supported nonlinear modules could use stale output gradients in DeepLift.
- Capture non-inplace module output gradients with a full backward pre-hook.
- Keep the tensor-output fallback for inplace modules.
- Add a regression test for adjacent MaxPool and ReLU modules with nonzero baselines.


Test Plan:
- venv/uv/bin/python -m pytest -q tests/attr/test_deeplift_basic.py
- Pyre: attempted `venv/uv/bin/pyre --noninteractive --dot-pyre-directory /tmp/captum-pyre-logs-config check`; blocked locally by broad pre-existing Pyre type-resolution failures resolving stdlib / torch imports.

Differential Revision: D106053881

Pulled By: craymichael


