### PR TITLE
Fix binary TCAV classifier predictions (#1122)

### DIFF
--- a/captum/concept/_utils/classifier.py
+++ b/captum/concept/_utils/classifier.py
@@ -192,8 +192,10 @@ class DefaultClassifier(Classifier):
         self.lm.fit(DataLoader(TensorDataset(x_train, y_train)))
 
         predict = self.lm(x_test)
+        classes = self.lm.classes()
+        assert classes is not None
 
-        predict = self.lm.classes()[torch.argmax(predict, dim=1).cpu()]  # type: ignore
+        predict = _predict_classes(predict, classes)
         score = predict.long() == y_test.long().cpu()
 
         accs = score.float().mean()
@@ -233,6 +235,12 @@ class DefaultClassifier(Classifier):
             the model in the `train_and_eval` method.
         """
         return self.lm.classes().detach().numpy()  # type: ignore
+
+
+def _predict_classes(predict: Tensor, classes: Tensor) -> Tensor:
+    if len(classes) == 2 and predict.shape[1] == 1:
+        predict = torch.cat([-predict, predict], dim=1)
+    return classes[torch.argmax(predict, dim=1).cpu()]
 
 
 def _train_test_split(

--- a/tests/concept/test_classifier.py
+++ b/tests/concept/test_classifier.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+# pyre-strict
+
+import torch
+from captum.concept._utils.classifier import _predict_classes
+from captum.testing.helpers import BaseTest
+
+
+class Test(BaseTest):
+    def test_predict_classes_binary_scores(self) -> None:
+        scores = torch.tensor([[-2.0], [3.0], [-0.1]])
+        classes = torch.tensor([4, 9])
+
+        predictions = _predict_classes(scores, classes)
+
+        self.assertTrue(torch.equal(predictions, torch.tensor([4, 9, 4])))
+
+    def test_predict_classes_multiclass_scores(self) -> None:
+        scores = torch.tensor([[0.1, 0.7, 0.2], [5.0, 3.0, 4.0]])
+        classes = torch.tensor([2, 4, 6])
+
+        predictions = _predict_classes(scores, classes)
+
+        self.assertTrue(torch.equal(predictions, torch.tensor([4, 2])))


### PR DESCRIPTION
Fixes #1122.

Issue: https://github.com/meta-pytorch/captum/issues/1122
Issue summary: binary TCAV classifier accuracy treated one-column scores as always class zero.

Summary:
- Convert one-column binary classifier scores to two class logits before selecting predictions.
- Add focused tests for binary and multiclass prediction mapping.

Test Plan:
- venv/uv/bin/python -m pytest -q tests/concept/test_classifier.py
- Pyre: attempted `venv/uv/bin/pyre --noninteractive --dot-pyre-directory /tmp/captum-pyre-logs-config check`; blocked locally by broad pre-existing Pyre type-resolution failures resolving stdlib / torch imports.

