### PR TITLE
Handle non-tensor layer outputs in layer gradients (#1220) (#1845)

### DIFF
--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -62,8 +62,7 @@ def apply_gradient_requirements(
                 warnings.warn(
                     """Input Tensor %d has a dtype of %s.
                     Gradients cannot be activated
-                    for these data types."""
-                    % (index, str(inputs_dtype)),
+                    for these data types.""" % (index, str(inputs_dtype)),
                     stacklevel=2,
                 )
         elif not input.requires_grad:
@@ -298,10 +297,21 @@ def _forward_layer_distributed_eval(
         # pyre-fixme[2]: Parameter must be annotated.
         def forward_hook(module, inp, out=None):
             eval_tsrs = inp if attribute_to_layer_input else out
-            is_eval_tuple_or_list = isinstance(eval_tsrs, (tuple, list))
+            raw_eval_tsrs = eval_tsrs
+            is_eval_tuple_or_list = isinstance(raw_eval_tsrs, (tuple, list))
 
             if not is_eval_tuple_or_list:
                 eval_tsrs = (eval_tsrs,)
+            else:
+                eval_tsrs = tuple(
+                    eval_tsr
+                    for eval_tsr in raw_eval_tsrs
+                    if isinstance(eval_tsr, Tensor)
+                )
+            assert len(eval_tsrs) > 0, (
+                "Forward hook did not obtain any tensor inputs or outputs for "
+                "given layer."
+            )
             if require_layer_grads:
                 apply_gradient_requirements(eval_tsrs, warn=False)
             with lock:
@@ -312,13 +322,25 @@ def _forward_layer_distributed_eval(
                     saved_layer[original_module][eval_tsrs[0].device] = eval_tsrs
                     if not is_eval_tuple_or_list:
                         eval_tsrs_to_return = eval_tsrs[0].clone()
-                    elif isinstance(eval_tsrs, list):
+                    elif isinstance(raw_eval_tsrs, list):
+                        eval_tsr_iter = iter(eval_tsr.clone() for eval_tsr in eval_tsrs)
                         eval_tsrs_to_return = [
-                            eval_tsr.clone() for eval_tsr in eval_tsrs
+                            (
+                                next(eval_tsr_iter)
+                                if isinstance(eval_tsr, Tensor)
+                                else eval_tsr
+                            )
+                            for eval_tsr in raw_eval_tsrs
                         ]
                     else:
+                        eval_tsr_iter = iter(eval_tsr.clone() for eval_tsr in eval_tsrs)
                         eval_tsrs_to_return = tuple(
-                            eval_tsr.clone() for eval_tsr in eval_tsrs
+                            (
+                                next(eval_tsr_iter)
+                                if isinstance(eval_tsr, Tensor)
+                                else eval_tsr
+                            )
+                            for eval_tsr in raw_eval_tsrs
                         )
                     return eval_tsrs_to_return
                 else:

--- a/captum/attr/_core/layer/layer_integrated_gradients.py
+++ b/captum/attr/_core/layer/layer_integrated_gradients.py
@@ -138,7 +138,7 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
             else:
                 # scatter method does not have a precise enough return type in its
                 # stub, so suppress the type warning.
-                scattered_inputs = scatter(  # type:ignore
+                scattered_inputs = scatter(  # type: ignore
                     # pyre-fixme[6]: For 1st argument expected `Tensor` but got
                     #  `Union[Tensor, typing.Tuple[Tensor, ...]]`.
                     inputs,
@@ -169,13 +169,34 @@ class LayerIntegratedGradients(LayerAttribution, GradientAttribution):
                     )
 
                     if is_layer_tuple:
+                        replacement_outputs = scattered_inputs_dict[device][
+                            num_outputs_cumsum[layer_idx] : num_outputs_cumsum[
+                                layer_idx + 1
+                            ]
+                        ]
+                        if hook_outputs is not None and isinstance(
+                            hook_outputs, (tuple, list)
+                        ):
+                            replacement_output_iter = iter(replacement_outputs)
+                            replaced_outputs = [
+                                (
+                                    next(replacement_output_iter)
+                                    if isinstance(hook_output, Tensor)
+                                    else hook_output
+                                )
+                                for hook_output in hook_outputs
+                            ]
+                            return cast(
+                                Union[Tensor, Tuple[Tensor, ...]],
+                                (
+                                    tuple(replaced_outputs)
+                                    if isinstance(hook_outputs, tuple)
+                                    else replaced_outputs
+                                ),
+                            )
                         return cast(
                             Union[Tensor, Tuple[Tensor, ...]],
-                            scattered_inputs_dict[device][
-                                num_outputs_cumsum[layer_idx] : num_outputs_cumsum[
-                                    layer_idx + 1
-                                ]
-                            ],
+                            replacement_outputs,
                         )
 
                     return scattered_inputs_dict[device][num_outputs_cumsum[layer_idx]]

--- a/tests/attr/layer/test_layer_integrated_gradients.py
+++ b/tests/attr/layer/test_layer_integrated_gradients.py
@@ -92,6 +92,62 @@ class Test(BaseTest):
             ([[90.0, 100.0, 100.0, 100.0]], [[90.0, 100.0, 100.0, 100.0]]),
         )
 
+    def test_lstm_layer_output_with_state_tuple(self) -> None:
+        class LSTMModel(Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.lstm = torch.nn.LSTM(7, 3, 1, batch_first=True)
+                self.linear = torch.nn.Linear(3, 2)
+
+            def forward(self, input: Tensor) -> Tensor:
+                output, _ = self.lstm(input)
+                return self.linear(output[:, -1, :])
+
+        model = LSTMModel().eval()
+        inputs = torch.randn(4, 5, 7)
+        layer_ig = LayerIntegratedGradients(model, model.lstm)
+
+        attributions, delta = layer_ig.attribute(  # type: ignore[has-type]
+            inputs, target=0, return_convergence_delta=True
+        )
+
+        self.assertEqual(attributions.shape, (4, 5, 3))
+        self.assertEqual(delta.shape, (4,))
+
+    def test_tensor_layer_output_with_non_tensor_metadata(self) -> None:
+        class TensorAndMetadataLayer(Module):
+            def forward(self, input: Tensor) -> Tuple[Tensor, None]:
+                return 2 * input, None
+
+        class TensorAndMetadataModel(Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.layer = TensorAndMetadataLayer()
+
+            def forward(self, input: Tensor) -> Tensor:
+                layer_output, _ = self.layer(input)
+                return 3 * layer_output[:, 0] - 2 * layer_output[:, 1]
+
+        model = TensorAndMetadataModel()
+        inputs = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        baselines = torch.zeros_like(inputs)
+        layer_ig = LayerIntegratedGradients(model, model.layer)
+
+        attributions, delta = layer_ig.attribute(  # type: ignore[has-type]
+            inputs,
+            baselines,
+            return_convergence_delta=True,
+        )
+
+        assertTensorAlmostEqual(
+            self,
+            attributions,
+            [[6.0, -8.0], [18.0, -16.0]],
+            delta=1e-5,
+            mode="max",
+        )
+        assertTensorAlmostEqual(self, delta, [0.0, 0.0], delta=1e-5, mode="max")
+
     def test_multiple_layers_single_inputs(self) -> None:
         input1 = torch.tensor([[2, 5, 0, 1], [3, 1, 1, 0]])
         input2 = torch.tensor([[0, 2, 4, 1], [2, 3, 5, 7]])

--- a/tests/utils/test_gradient.py
+++ b/tests/utils/test_gradient.py
@@ -248,6 +248,54 @@ class Test(BaseTest):
         assertTensorAlmostEqual(self, grads[0], [[0.0, 1.0]], delta=0.01, mode="max")
         assertTensorAlmostEqual(self, eval[0], [[26.0, 28.0]], delta=0.01, mode="max")
 
+    def test_layer_gradient_ignores_non_tensor_layer_outputs(self) -> None:
+        class TensorAndMetadataLayer(torch.nn.Module):
+            def forward(self, input: torch.Tensor) -> Tuple[torch.Tensor, None]:
+                return 2 * input, None
+
+        class TensorAndMetadataModel(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.layer = TensorAndMetadataLayer()
+
+            def forward(self, input: torch.Tensor) -> torch.Tensor:
+                layer_output, _ = self.layer(input)
+                return 3 * layer_output[:, 0] - 2 * layer_output[:, 1]
+
+        model = TensorAndMetadataModel()
+        input = torch.tensor([[1.0, 2.0], [3.0, 4.0]], requires_grad=True)
+
+        grads, eval = compute_layer_gradients_and_eval(model, model.layer, input)
+
+        assertTensorAlmostEqual(
+            self, grads[0], [[3.0, -2.0], [3.0, -2.0]], delta=0.0, mode="max"
+        )
+        assertTensorAlmostEqual(
+            self, eval[0], [[2.0, 4.0], [6.0, 8.0]], delta=0.0, mode="max"
+        )
+
+    def test_layer_gradient_lstm_output_with_state_tuple(self) -> None:
+        class LSTMModel(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.lstm = torch.nn.LSTM(3, 2, 1, batch_first=True)
+                self.linear = torch.nn.Linear(2, 1, bias=False)
+                self.linear.weight = torch.nn.Parameter(torch.tensor([[3.0, -2.0]]))
+
+            def forward(self, input: torch.Tensor) -> torch.Tensor:
+                output, _ = self.lstm(input)
+                return self.linear(output[:, -1, :]).squeeze(1)
+
+        model = LSTMModel().eval()
+        input = torch.randn(4, 5, 3, requires_grad=True)
+
+        grads, eval = compute_layer_gradients_and_eval(model, model.lstm, input)
+
+        expected_grads = torch.zeros_like(eval[0])
+        expected_grads[:, -1, :] = model.linear.weight
+        assertTensorAlmostEqual(self, grads[0], expected_grads, delta=0.0, mode="max")
+        self.assertEqual(eval[0].shape, (4, 5, 2))
+
     def test_layer_gradient_unused_layer(self) -> None:
         if version.parse(torch.__version__) < version.parse("2.1.0"):
             raise unittest.SkipTest(


### PR DESCRIPTION
Summary:
Fixes https://github.com/meta-pytorch/captum/issues/1220.
Fixes https://github.com/meta-pytorch/captum/issues/745.
Fixes https://github.com/meta-pytorch/captum/issues/1528.

Issue: https://github.com/meta-pytorch/captum/issues/1220
Issue summary: LayerIntegratedGradients failed on nn.LSTM because the selected layer returned `(output, (hidden, cell))` and the layer hook tried to clone the nested state tuple as though every top-level output was a Tensor.

Context:
The failure surfaced through LayerIntegratedGradients on LSTM layers, but the underlying code path is the shared layer-gradient hook utility used to collect layer evaluations and gradients.

Scope:
This is intentionally limited to top-level tensor layer outputs with non-tensor metadata entries preserved in the returned hook structure. It does not add recursive nested tensor-leaf attribution support. In particular, it should not be treated as support for models that consume nested LSTM state tensors such as `hidden` while ignoring the top-level `output`; that broader behavior should be handled consistently across layer-gradient methods in a separate design / implementation.

Changes:
- Save only top-level Tensor entries from layer hook inputs / outputs for layer evaluations and gradient computation.
- Preserve the original top-level list / tuple structure, including non-tensor entries such as LSTM state tuples, when returning cloned Tensor outputs to the forward pass.
- Keep the LSTM LayerIntegratedGradients regression test.
- Add exact gradient and attribution coverage for tuple / list layer outputs that include non-tensor metadata, plus exact LSTM layer-output gradient coverage.

Test Plan:
- `venv/uv/bin/python -m pytest -q tests/utils/test_gradient.py tests/attr/layer/test_layer_integrated_gradients.py`
- `venv/uv/bin/python -m black --check captum/_utils/gradient.py captum/attr/_core/layer/layer_integrated_gradients.py tests/utils/test_gradient.py tests/attr/layer/test_layer_integrated_gradients.py`
- `git diff --check`
- Pyre: not rerun for this amendment; previous local attempt was blocked by broad pre-existing type-resolution failures resolving stdlib / torch imports.
