### PR TITLE
Escape text visualization tokens (#1226) (#1846)

### DIFF
--- a/captum/attr/_utils/visualization.py
+++ b/captum/attr/_utils/visualization.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 # pyre-strict
+import html
 import warnings
 from enum import Enum
 from typing import (
@@ -1121,7 +1122,7 @@ def format_word_importances(
     assert len(words) <= len(importances)
     tags = ["<td>"]
     for word, importance in zip(words, importances[: len(words)]):
-        word = format_special_tokens(word)
+        word = html.escape(format_special_tokens(word))
         color = _get_color(importance)
         unwrapped_tag = '<mark style="background-color: {color}; opacity:1.0; \
                     line-height:1.75"><font color="black"> {word}\

--- a/tests/attr/test_visualization_text.py
+++ b/tests/attr/test_visualization_text.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+# pyre-strict
+
+from captum.attr._utils.visualization import format_word_importances
+from captum.testing.helpers import BaseTest
+
+
+class Test(BaseTest):
+    def test_format_word_importances_escapes_html_tokens(self) -> None:
+        html = format_word_importances(
+            ["hello", "entrar<!--#exec", "cmd", '"ls', "-->"],
+            [0.0, 0.0, 0.0, 0.0, 0.0],
+        )
+
+        self.assertNotIn("<!--#exec", html)
+        self.assertNotIn("-->", html)
+        self.assertIn("&lt;!--#exec", html)
+        self.assertIn("&quot;ls", html)
+        self.assertIn("--&gt;", html)


### PR DESCRIPTION
Summary:
Fixes https://github.com/meta-pytorch/captum/issues/1226.

Issue: https://github.com/meta-pytorch/captum/issues/1226
Issue summary: text visualization rendered unescaped token text into HTML.
- Escape formatted text tokens before inserting them into visualization HTML.
- Add a regression test for HTML comment and quoted-token input.


Test Plan:
- venv/uv/bin/python -m pytest -q tests/attr/test_visualization_text.py
- Pyre: attempted `venv/uv/bin/pyre --noninteractive --dot-pyre-directory /tmp/captum-pyre-logs-config check`; blocked locally by broad pre-existing Pyre type-resolution failures resolving stdlib / torch imports.

Reviewed By: sarahtranfb

Differential Revision: D106053869

Pulled By: craymichael


