### PR TITLE
Pass attention masks for LLM generation (#1449)

### DIFF
--- a/captum/attr/_core/llm_attr.py
+++ b/captum/attr/_core/llm_attr.py
@@ -621,10 +621,10 @@ class BaseLLMAttribution(Attribution, ABC):
             )
             generate_func = cast(Callable[..., Tensor], self.model.generate)
 
-            if not gen_args:
-                gen_args = DEFAULT_GEN_ARGS
+            gen_args = DEFAULT_GEN_ARGS.copy() if not gen_args else gen_args.copy()
 
             model_inp = self._format_model_input(inp.to_model_input())
+            self._update_model_input_for_generation(model_inp, gen_args)
             input_token_len = model_inp["input_ids"].size(1)
             output_tokens = generate_func(**model_inp, **gen_args)
             target_tokens = output_tokens[0][input_token_len:]
@@ -648,6 +648,20 @@ class BaseLLMAttribution(Attribution, ABC):
                     "{}".format(type(target))
                 )
         return target_tokens
+
+    def _update_model_input_for_generation(
+        self, model_inp: Dict[str, Any], gen_args: Dict[str, Any]
+    ) -> None:
+        input_ids = model_inp.get("input_ids")
+        if isinstance(input_ids, Tensor) and "attention_mask" not in model_inp:
+            model_inp["attention_mask"] = torch.ones_like(input_ids, dtype=torch.long)
+
+        if "pad_token_id" not in gen_args:
+            pad_token_id = getattr(self.tokenizer, "pad_token_id", None)
+            if pad_token_id is None:
+                pad_token_id = getattr(self.tokenizer, "eos_token_id", None)
+            if pad_token_id is not None:
+                gen_args["pad_token_id"] = pad_token_id
 
     def _format_model_input(
         self, model_input: Union[str, Tensor, Mapping]

--- a/tests/attr/test_llm_attr.py
+++ b/tests/attr/test_llm_attr.py
@@ -46,6 +46,8 @@ from torch import nn, Tensor
 class DummyTokenizer:
     vocab_size: int = 256
     sos: int = 0
+    pad_token_id: int = sos
+    eos_token_id: int = sos
     unk: int = 1
     sos_str: str = "<sos>"
     special_tokens: Dict[int, str] = {sos: sos_str, unk: "<unk>"}
@@ -381,6 +383,44 @@ class TestLLMAttr(BaseTest):
         self.assertEqual(res.output_tokens, ["x", "y", "z"])
         self.assertEqual(res.seq_attr.device.type, self.device)
         self.assertEqual(cast(Tensor, res.token_attr).device.type, self.device)
+
+    def test_llm_attr_generation_uses_attention_mask(self) -> None:
+        class RecordingLLM(DummyLLM):
+            generate_kwargs: Dict[str, Any]
+
+            def generate(
+                self,
+                input_ids: Tensor,
+                *args: Any,
+                mock_response: Optional[str] = None,
+                **kwargs: Any,
+            ) -> Tensor:
+                self.generate_kwargs = kwargs
+                return super().generate(
+                    input_ids,
+                    *args,
+                    mock_response=mock_response,
+                    **kwargs,
+                )
+
+        llm = RecordingLLM()
+        llm.to(self.device)
+        tokenizer = DummyTokenizer()
+        fa = FeatureAblation(llm)
+        llm_fa = LLMAttribution(fa, tokenizer)
+
+        inp = TextTemplateInput("{} b {} {} e {}", ["a", "c", "d", "f"])
+        llm_fa.attribute(
+            inp,
+            gen_args={"mock_response": "x y z"},
+            use_cached_outputs=self.use_cached_outputs,
+            forward_in_tokens=self.forward_in_tokens,
+        )
+
+        self.assertIn("attention_mask", llm.generate_kwargs)
+        attention_mask = llm.generate_kwargs["attention_mask"]
+        self.assertTrue(torch.equal(attention_mask, torch.ones_like(attention_mask)))
+        self.assertEqual(llm.generate_kwargs["pad_token_id"], tokenizer.pad_token_id)
 
     def test_llm_attr_fa_log_prob(self) -> None:
         llm = DummyLLM()


### PR DESCRIPTION
Fixes #1449.

Issue: https://github.com/meta-pytorch/captum/issues/1449
Issue summary: LLM attribution generated target tokens without an attention mask.

Summary:
- Add an all-ones attention mask when generating target tokens from prompt inputs.
- Pass the tokenizer pad token id to generation when available.
- Add a regression test covering generation kwargs from LLM attribution.

Test Plan:
- venv/uv/bin/python -m pytest -q tests/attr/test_llm_attr.py
- Pyre: attempted `venv/uv/bin/pyre --noninteractive --dot-pyre-directory /tmp/captum-pyre-logs-config check`; blocked locally by broad pre-existing Pyre type-resolution failures resolving stdlib / torch imports.

