### PR TITLE
Select valid BERT QA answer spans (#684)

### DIFF
--- a/tests/test_tutorial_regressions.py
+++ b/tests/test_tutorial_regressions.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+# pyre-strict
+
+import json
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+
+TUTORIALS_PATH = Path(__file__).resolve().parents[1] / "tutorials"
+
+
+def _notebook_cells(name: str) -> list[str]:
+    with open(TUTORIALS_PATH / name, encoding="utf-8") as notebook_file:
+        notebook: dict[str, Any] = json.load(notebook_file)
+    return ["".join(cell.get("source", [])) for cell in notebook["cells"]]
+
+
+def _exec_bert_answer_span_cell(
+    notebook_name: str,
+    predict: Callable[..., Any],
+) -> dict[str, Any]:
+    answer_cells = [
+        cell for cell in _notebook_cells(notebook_name) if "valid_span_mask" in cell
+    ]
+    assert len(answer_cells) == 1
+    namespace: dict[str, Any] = {
+        "torch": torch,
+        "predict": predict,
+        "input_ids": torch.tensor([[0, 1, 2]]),
+        "token_type_ids": None,
+        "position_ids": None,
+        "attention_mask": None,
+        "question": "question?",
+        "all_tokens": ["zero", "one", "two"],
+    }
+
+    exec(answer_cells[0], namespace)
+    return namespace
+
+
+def test_bert_squad_tutorials_select_valid_answer_spans() -> None:
+    # The highest start score is after the highest end score. The old notebook
+    # logic selected those positions independently and produced an empty span.
+    start_scores = torch.tensor([[0.0, 0.0, 10.0]])
+    end_scores = torch.tensor([[9.0, 0.0, 0.0]])
+
+    part1_namespace = _exec_bert_answer_span_cell(
+        "Bert_SQUAD_Interpret.ipynb",
+        lambda *args, **kwargs: (start_scores, end_scores),
+    )
+    part2_namespace = _exec_bert_answer_span_cell(
+        "Bert_SQUAD_Interpret2.ipynb",
+        lambda *args, **kwargs: (start_scores, end_scores, None),
+    )
+
+    for namespace in (part1_namespace, part2_namespace):
+        assert namespace["start_idx"] <= namespace["end_idx"]
+        assert namespace["end_idx"] == 2

--- a/tutorials/Bert_SQUAD_Interpret.ipynb
+++ b/tutorials/Bert_SQUAD_Interpret.ipynb
@@ -284,9 +284,17 @@
     "                                   position_ids=position_ids, \\\n",
     "                                   attention_mask=attention_mask)\n",
     "\n",
+    "start_scores = start_scores.squeeze(0)\n",
+    "end_scores = end_scores.squeeze(0)\n",
+    "span_scores = start_scores.unsqueeze(1) + end_scores.unsqueeze(0)\n",
+    "valid_span_mask = torch.triu(torch.ones_like(span_scores, dtype=torch.bool))\n",
+    "span_scores = span_scores.masked_fill(~valid_span_mask, float('-inf'))\n",
+    "best_span = torch.argmax(span_scores)\n",
+    "start_idx = (best_span // span_scores.size(1)).item()\n",
+    "end_idx = (best_span % span_scores.size(1)).item()\n",
     "\n",
     "print('Question: ', question)\n",
-    "print('Predicted Answer: ', ' '.join(all_tokens[torch.argmax(start_scores) : torch.argmax(end_scores)+1]))"
+    "print('Predicted Answer: ', ' '.join(all_tokens[start_idx : end_idx + 1]))"
    ]
   },
   {

--- a/tutorials/Bert_SQUAD_Interpret2.ipynb
+++ b/tutorials/Bert_SQUAD_Interpret2.ipynb
@@ -293,9 +293,17 @@
     "                                   position_ids=position_ids, \\\n",
     "                                   attention_mask=attention_mask)\n",
     "\n",
+    "start_scores = start_scores.squeeze(0)\n",
+    "end_scores = end_scores.squeeze(0)\n",
+    "span_scores = start_scores.unsqueeze(1) + end_scores.unsqueeze(0)\n",
+    "valid_span_mask = torch.triu(torch.ones_like(span_scores, dtype=torch.bool))\n",
+    "span_scores = span_scores.masked_fill(~valid_span_mask, float('-inf'))\n",
+    "best_span = torch.argmax(span_scores)\n",
+    "start_idx = (best_span // span_scores.size(1)).item()\n",
+    "end_idx = (best_span % span_scores.size(1)).item()\n",
     "\n",
     "print('Question: ', question)\n",
-    "print('Predicted Answer: ', ' '.join(all_tokens[torch.argmax(start_scores) : torch.argmax(end_scores)+1]))"
+    "print('Predicted Answer: ', ' '.join(all_tokens[start_idx : end_idx + 1]))"
    ]
   },
   {


### PR DESCRIPTION
Fixes #684.

Issue: https://github.com/meta-pytorch/captum/issues/684
Issue summary: The BERT SQuAD tutorials selected the start and end tokens independently. If the highest-scoring end token came before the highest-scoring start token, the printed answer span was empty.

Context:
In extractive question answering, a span is the contiguous slice of input tokens used as the answer. The start token is the first token in that slice, and the end token is the last token. A valid answer must satisfy end_idx >= start_idx.

Summary:
- Select the best valid answer span by scoring every start/end token pair and masking pairs where the end token precedes the start token.
- Apply the same span selection to both BERT SQuAD tutorial notebooks.
- Add a notebook regression test for invalid independent argmax spans.

Test Plan:
- venv/uv/bin/python -m pytest -q tests/test_tutorial_regressions.py
- Pyre: not applicable; notebook-only behavior change covered by regression test.

