### PR TITLE
Handle zero signed attribution visualizations (#959) (#1853)

### DIFF
--- a/captum/attr/_utils/visualization.py
+++ b/captum/attr/_utils/visualization.py
@@ -171,7 +171,13 @@ def _prepare_image(attr_visual: npt.NDArray) -> npt.NDArray:
 
 
 def _normalize_scale(attr: npt.NDArray, scale_factor: float) -> npt.NDArray:
-    assert scale_factor != 0, "Cannot normalize by scale factor = 0"
+    if scale_factor == 0:
+        warnings.warn(
+            "No non-zero attribution values found for the selected sign; "
+            "returning an all-zero attribution visualization.",
+            stacklevel=2,
+        )
+        return np.zeros_like(attr)
     if abs(scale_factor) < 1e-5:
         warnings.warn(
             "Attempting to normalize by value approximately 0, visualized results"

--- a/tests/attr/test_visualization_zero_scale.py
+++ b/tests/attr/test_visualization_zero_scale.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+# pyre-strict
+
+import numpy as np
+import numpy.typing as npt
+import pytest
+from captum.attr._utils.visualization import (
+    visualize_image_attr,
+    visualize_image_attr_multiple,
+)
+from matplotlib import pyplot as plt
+
+ZERO_ATTRIBUTION_WARNING = "No non-zero attribution values found"
+
+
+@pytest.mark.parametrize(
+    "attr, sign",
+    [
+        (np.zeros((4, 4, 3)), "positive"),
+        (-np.ones((4, 4, 3)), "positive"),
+        (np.ones((4, 4, 3)), "negative"),
+    ],
+)
+def test_visualize_image_attr_handles_zero_signed_attributions(
+    attr: npt.NDArray,
+    sign: str,
+) -> None:
+    original_image = np.zeros((4, 4, 3))
+
+    with pytest.warns(UserWarning, match=ZERO_ATTRIBUTION_WARNING):
+        fig, _ = visualize_image_attr(
+            attr,
+            original_image,
+            method="heat_map",
+            sign=sign,
+            show_colorbar=True,
+            use_pyplot=False,
+        )
+
+    plt.close(fig)
+
+
+def test_visualize_image_attr_multiple_handles_zero_signed_attributions() -> None:
+    attr = -np.ones((4, 4, 3))
+    original_image = np.zeros((4, 4, 3))
+
+    with pytest.warns(UserWarning, match=ZERO_ATTRIBUTION_WARNING):
+        fig, _ = visualize_image_attr_multiple(
+            attr,
+            original_image,
+            methods=["original_image", "masked_image", "heat_map"],
+            signs=["all", "positive", "positive"],
+            show_colorbar=True,
+            use_pyplot=False,
+        )
+
+    plt.close(fig)


### PR DESCRIPTION
Summary:
Fixes https://github.com/meta-pytorch/captum/issues/959.

Issue: https://github.com/meta-pytorch/captum/issues/959
Issue summary: Image visualization asserted when the selected attribution sign left no non-zero values to normalize, e.g. all-negative attributions with sign="positive".
- Return an all-zero attribution visualization with a user-facing warning when no non-zero values remain for the selected sign.
- Keep the warning focused on the visualization condition rather than the internal normalization scale.
- Add regression coverage for zero attributions, all-negative attributions with sign="positive", all-positive attributions with sign="negative", and visualize_image_attr_multiple.


Test Plan:
- venv/uv/bin/python -m pytest -q tests/attr/test_visualization_zero_scale.py
- Pyre: not rerun for this amendment; previous local attempt was blocked by broad pre-existing type-resolution failures resolving stdlib / torch imports.

Reviewed By: yeyingxiao

Differential Revision: D106053835

Pulled By: craymichael


