### PR TITLE
Fix visualization module import (#990) (#1854)

### DIFF
--- a/captum/attr/visualization.py
+++ b/captum/attr/visualization.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+# pyre-strict
+
+from captum.attr._utils.visualization import (
+    draw_mask_border,
+    draw_mask_legend,
+    format_classname,
+    format_special_tokens,
+    format_tooltip,
+    format_word_importances,
+    ImageVisualizationMethod,
+    TimeseriesVisualizationMethod,
+    VisualizationDataRecord,
+    visualize_image_attr,
+    visualize_image_attr_multiple,
+    visualize_text,
+    visualize_timeseries_attr,
+    VisualizeSign,
+)
+
+__all__ = [
+    "draw_mask_border",
+    "draw_mask_legend",
+    "format_classname",
+    "format_special_tokens",
+    "format_tooltip",
+    "format_word_importances",
+    "ImageVisualizationMethod",
+    "TimeseriesVisualizationMethod",
+    "VisualizationDataRecord",
+    "VisualizeSign",
+    "visualize_image_attr",
+    "visualize_image_attr_multiple",
+    "visualize_text",
+    "visualize_timeseries_attr",
+]


### PR DESCRIPTION
Summary:
Fixes https://github.com/meta-pytorch/captum/issues/990.

Issue: https://github.com/meta-pytorch/captum/issues/990
Issue summary: importing captum.attr.visualization failed.
- Add a public captum.attr.visualization compatibility module re-exporting the visualization helpers.
- Cover the import path with a focused regression test.


Test Plan:
- venv/uv/bin/python -m pytest -q tests/attr/test_visualization_import.py
- Pyre: attempted `venv/uv/bin/pyre --noninteractive --dot-pyre-directory /tmp/captum-pyre-logs-config check`; blocked locally by broad pre-existing Pyre type-resolution failures resolving stdlib / torch imports.

Reviewed By: sarahtranfb

Differential Revision: D106053826

Pulled By: craymichael


