### PR TITLE
Clarify KernelShap baseline semantics (#1789)

### DIFF
--- a/captum/attr/_core/kernel_shap.py
+++ b/captum/attr/_core/kernel_shap.py
@@ -25,6 +25,11 @@ class KernelShap(Lime):
     More information regarding this method and proof of equivalence
     can be found in the original paper here:
     https://arxiv.org/abs/1705.07874
+
+    In Captum, missing features are represented by the values provided in
+    `baselines`. This means Captum's KernelShap explains the model output
+    relative to the chosen baseline values, rather than sampling missing
+    features from a background distribution.
     """
 
     def __init__(self, forward_func: Callable[..., Union[int, float, Tensor]]) -> None:
@@ -99,7 +104,10 @@ class KernelShap(Lime):
             baselines (scalar, Tensor, tuple of scalar, or Tensor, optional):
                         Baselines define the reference value which replaces each
                         feature when the corresponding interpretable feature
-                        is set to 0.
+                        is set to 0. Since missing features are replaced by
+                        these values, the returned attributions explain the
+                        model relative to the provided baselines rather than a
+                        background data distribution.
                         Baselines can be provided as:
 
                         - a single tensor, if inputs is a single tensor, with

--- a/docs/attribution_algorithms.md
+++ b/docs/attribution_algorithms.md
@@ -131,6 +131,8 @@ To learn more about Lime, visit the following resources:
 ### KernelSHAP
 Kernel SHAP is a method that uses the LIME framework to compute Shapley Values. Setting the loss function, weighting kernel and regularization terms appropriately in the LIME framework allows theoretically obtaining Shapley Values more efficiently than directly computing Shapley Values.
 
+Captum's implementation represents missing features with the values provided in `baselines`. As a result, the attributions explain the model output relative to the chosen baseline values rather than by sampling missing features from a background data distribution.
+
 To learn more about KernelSHAP, visit the following resources:
 - [Original paper](https://arxiv.org/abs/1705.07874)
 


### PR DESCRIPTION
Fixes #1789.

Issue: https://github.com/meta-pytorch/captum/issues/1789
Issue summary: KernelShap documentation did not make clear that Captum replaces missing features with the provided baselines rather than sampling them from a background distribution.

Summary:
- Clarify in the KernelShap API docs that missing features are represented by `baselines`.
- Clarify the same point in the attribution algorithm overview.

Test Plan:
- venv/uv/bin/python -m py_compile captum/attr/_core/kernel_shap.py
- Pyre: not applicable; documentation-only clarification.
