### PR TITLE
Add `group_size` parameter to `TextSegmentInput` (#1857)

### DIFF
--- a/captum/attr/_utils/interpretable_input.py
+++ b/captum/attr/_utils/interpretable_input.py
@@ -406,6 +406,11 @@ class TextSegmentInput(TextTemplateInput):
                 when it is "absent". If None, the segment is removed (empty string).
                 If a string, it is used as the baseline for all segments.
                 Default: None
+        group_size (int, optional): group every ``group_size`` consecutive
+                segments into one interpretable feature. Segments in the same
+                group are perturbed together and share the same attribution.
+                The last group may contain fewer segments.
+                Default: 1 (each segment is its own feature)
 
     Examples::
 
@@ -424,16 +429,16 @@ class TextSegmentInput(TextTemplateInput):
         >>> # "Hello, . Welcome!"
 
         >>> seg_inp = TextSegmentInput(
-        >>>     "Hello world. How are you?",
-        >>>     level="sentence",
-        >>>     baselines="[MASK]",
+        >>>     "one two three four five six",
+        >>>     level="word",
+        >>>     group_size=2,
         >>> )
         >>>
-        >>> seg_inp.values
-        >>> # ["Hello world.", "How are you?"]
+        >>> seg_inp.n_itp_features
+        >>> # 3
         >>>
-        >>> seg_inp.to_model_input(torch.tensor([[0, 1]]))
-        >>> # "[MASK] How are you?"
+        >>> seg_inp.to_model_input(torch.tensor([[1, 0, 1]]))
+        >>> # "one two   five six"
 
     """
 
@@ -449,23 +454,31 @@ class TextSegmentInput(TextTemplateInput):
         text: str,
         level: str = "word",
         baselines: Optional[str] = None,
+        group_size: int = 1,
     ) -> None:
         segments, template = self._segment_text(text, level)
 
         assert len(segments) > 0, "text must contain at least one segment"
+        assert group_size > 0, "group_size must be a positive integer"
 
         baseline_list: Optional[List[str]] = None
         if baselines is not None:
             baseline_list = [baselines] * len(segments)
 
+        mask: Optional[List[int]] = None
+        if group_size > 1:
+            mask = [i // group_size for i in range(len(segments))]
+
         super().__init__(
             template=template,
             values=segments,
             baselines=baseline_list,
+            mask=mask,
         )
 
         self.text = text
         self.level = level
+        self.group_size = group_size
 
     @staticmethod
     def _segment_text(text: str, level: str) -> Tuple[List[str], str]:

--- a/tests/attr/test_interpretable_input.py
+++ b/tests/attr/test_interpretable_input.py
@@ -337,6 +337,54 @@ class TestTextSegmentInput(BaseTest):
         seg_inp = TextSegmentInput("hello world")
         self.assertIsInstance(seg_inp, TextTemplateInput)
 
+    def test_group_size_even(self) -> None:
+        text = "one two three four five six"
+        seg_inp = TextSegmentInput(text, level="word", group_size=2)
+
+        self.assertEqual(seg_inp.values, ["one", "two", "three", "four", "five", "six"])
+        self.assertEqual(seg_inp.n_itp_features, 3)
+
+        expected_tensor = torch.tensor([[1.0] * 3])
+        assertTensorAlmostEqual(self, seg_inp.to_tensor(), expected_tensor)
+
+        self.assertEqual(seg_inp.to_model_input(), text)
+
+        # remove middle group (three, four)
+        perturbed = torch.tensor([[1.0, 0.0, 1.0]])
+        self.assertEqual(seg_inp.to_model_input(perturbed), "one two   five six")
+
+    def test_group_size_uneven(self) -> None:
+        text = "a b c d e f g"
+        seg_inp = TextSegmentInput(text, level="word", group_size=3)
+
+        self.assertEqual(seg_inp.n_itp_features, 3)
+        self.assertEqual(seg_inp.to_model_input(), text)
+
+        # remove last group (only 1 segment: "g")
+        perturbed = torch.tensor([[1.0, 1.0, 0.0]])
+        self.assertEqual(seg_inp.to_model_input(perturbed), "a b c d e f ")
+
+    def test_group_size_default(self) -> None:
+        seg_inp = TextSegmentInput("a b c")
+        self.assertEqual(seg_inp.n_itp_features, 3)
+        self.assertEqual(seg_inp.group_size, 1)
+
+    def test_group_size_format_attr(self) -> None:
+        text = "a b c d"
+        seg_inp = TextSegmentInput(text, level="word", group_size=2)
+
+        # 2 interpretable features → scatter back to 4 raw features
+        attr = torch.tensor([[0.5, 0.8]])
+        formatted = seg_inp.format_attr(attr)
+        assertTensorAlmostEqual(self, formatted, torch.tensor([[0.5, 0.5, 0.8, 0.8]]))
+
+    def test_group_size_with_baselines(self) -> None:
+        text = "a b c d"
+        seg_inp = TextSegmentInput(text, level="word", baselines="X", group_size=2)
+
+        perturbed = torch.tensor([[0.0, 1.0]])
+        self.assertEqual(seg_inp.to_model_input(perturbed), "X X c d")
+
 
 class TestTextTokenInput(BaseTest):
     def test_input(self) -> None:


### PR DESCRIPTION
Summary:

Adds a `group_size` parameter to `TextSegmentInput` that groups every N consecutive segments into one interpretable feature. This reduces the feature count for long texts while keeping the segmentation level. For example, 7 word segments with `group_size=3` produces 3 interpretable features (the last group may be smaller). Internally, this auto-generates a mask and passes it to `TextTemplateInput`, which already handles mask-based grouping in `to_tensor()`, `to_model_input()`, and `format_attr()`.

Reviewed By: Ayush-Warikoo

Differential Revision: D105348674


