### PR TITLE
Add Random Baseline Kernel SHAP (#1789) (#1860)

### DIFF
--- a/captum/attr/__init__.py
+++ b/captum/attr/__init__.py
@@ -10,7 +10,11 @@ from captum.attr._core.guided_backprop_deconvnet import Deconvolution, GuidedBac
 from captum.attr._core.guided_grad_cam import GuidedGradCam
 from captum.attr._core.input_x_gradient import InputXGradient
 from captum.attr._core.integrated_gradients import IntegratedGradients
-from captum.attr._core.kernel_shap import KernelShap
+from captum.attr._core.kernel_shap import (
+    BaselineKernelShap,
+    KernelShap,
+    RandomBaselineKernelShap,
+)
 from captum.attr._core.layer.grad_cam import LayerGradCam
 from captum.attr._core.layer.internal_influence import InternalInfluence
 from captum.attr._core.layer.layer_activation import LayerActivation
@@ -107,7 +111,9 @@ __all__ = [
     "LimeBase",
     "Lime",
     "LRP",
+    "BaselineKernelShap",
     "KernelShap",
+    "RandomBaselineKernelShap",
     "LayerConductance",
     "LayerGradientXActivation",
     "LayerActivation",

--- a/captum/attr/_core/kernel_shap.py
+++ b/captum/attr/_core/kernel_shap.py
@@ -2,12 +2,14 @@
 
 # pyre-strict
 
-from typing import Callable, cast, Generator, Optional, Tuple, Union
+from typing import Any, Callable, cast, Generator, List, Optional, Tuple, Union
 
 import torch
+from captum._utils.common import _reduce_list, _run_forward
 from captum._utils.models.linear_model import SkLearnLinearRegression
 from captum._utils.typing import BaselineType, TargetType, TensorOrTupleOfTensorsGeneric
-from captum.attr._core.lime import construct_feature_mask, Lime
+from captum.attr._core.lime import construct_feature_mask, Lime, LimeBase
+from captum.attr._utils.batching import _batch_example_iterator
 from captum.attr._utils.common import _format_input_baseline
 from captum.log import log_usage
 from torch import Tensor
@@ -29,7 +31,8 @@ class KernelShap(Lime):
     In Captum, missing features are represented by the values provided in
     `baselines`. This means Captum's KernelShap explains the model output
     relative to the chosen baseline values, rather than sampling missing
-    features from a background distribution.
+    features from a background distribution. `BaselineKernelShap` is an alias
+    for this class that makes these baseline-substitution semantics explicit.
     """
 
     def __init__(self, forward_func: Callable[..., Union[int, float, Tensor]]) -> None:
@@ -373,3 +376,465 @@ class KernelShap(Lime):
                 rand_vals, num_features - num_selected_features
             ).values.item()
             yield (rand_vals > threshold).to(device=device).long()
+
+
+BaselineKernelShap = KernelShap
+
+
+class RandomBaselineKernelShap(KernelShap):
+    r"""
+    Random Baseline Kernel SHAP is a perturbation-based method that computes
+    Random Baseline Shapley (RBShap) values using the Kernel SHAP weighted
+    linear surrogate. RBShap averages Baseline Shapley values over a
+    distribution of baselines. For a coalition of selected features `S`,
+    the value function is:
+
+    .. math::
+        v(S) = E_{b \sim D}[f(x_S; b_{\bar{S}})]
+
+    Captum's `KernelShap` / `BaselineKernelShap` uses one fixed baseline value
+    to represent missing features. `RandomBaselineKernelShap` instead uses a
+    baseline distribution and averages model evaluations over baseline samples
+    for each sampled coalition before fitting the same Kernel SHAP surrogate
+    model. This corresponds to the Random Baseline Shapley definition described
+    in "The Many Shapley Values for Model Explanation":
+    https://arxiv.org/abs/1908.08474
+    """
+
+    def __init__(self, forward_func: Callable[..., Union[int, float, Tensor]]) -> None:
+        r"""
+        Args:
+
+            forward_func (Callable): The forward function of the model or
+                        any modification of it.
+        """
+        LimeBase.__init__(
+            self,
+            forward_func,
+            interpretable_model=SkLearnLinearRegression(),
+            similarity_func=self.kernel_shap_similarity_kernel,
+            perturb_func=self.kernel_shap_perturb_generator,
+            perturb_interpretable_space=True,
+            from_interp_rep_transform=self.random_baseline_from_interp_rep_transform,
+            to_interp_rep_transform=None,
+        )
+        self.inf_weight = 1000000.0
+
+    @log_usage(part_of_slo=True)
+    def attribute(  # type: ignore
+        self,
+        inputs: TensorOrTupleOfTensorsGeneric,
+        baselines: BaselineType,
+        target: TargetType = None,
+        additional_forward_args: Optional[object] = None,
+        feature_mask: Union[None, Tensor, Tuple[Tensor, ...]] = None,
+        n_samples: int = 25,
+        perturbations_per_eval: int = 1,
+        return_input_shape: bool = True,
+        show_progress: bool = False,
+        n_baseline_samples: Optional[int] = None,
+    ) -> TensorOrTupleOfTensorsGeneric:
+        r"""
+        This method attributes the output of the model with given target index
+        (in case it is provided, otherwise it assumes that output is a
+        scalar) to the inputs of the model using Random Baseline Kernel SHAP.
+        It trains an interpretable weighted linear model using the Kernel SHAP
+        sampling distribution and returns the learned coefficients.
+
+        It is recommended to only provide a single example as input (tensors
+        with first dimension or batch size = 1). This is because LIME / KernelShap
+        is generally used for sample-based interpretability, training a separate
+        interpretable model to explain a model's prediction on each individual
+        example.
+
+        A batch of inputs can also be provided as inputs, similar to
+        other perturbation-based attribution methods. In this case, if forward_fn
+        returns a scalar per example, attributions will be computed for each
+        example independently, with a separate interpretable model trained for each
+        example. The same baseline distribution is used for each example.
+
+        The number of interpretable features is determined from the provided
+        feature mask, or if none is provided, from the default feature mask,
+        which considers each scalar input as a separate feature. It is
+        generally recommended to provide a feature mask which groups features
+        into a small number of interpretable features / components (e.g.
+        superpixels in images).
+
+        Args:
+
+            inputs (Tensor or tuple[Tensor, ...]): Input for which Random
+                        Baseline Kernel SHAP is computed. If forward_func takes
+                        a single tensor as input, a single input tensor should be
+                        provided. If forward_func takes multiple tensors as input,
+                        a tuple of input tensors should be provided. It is assumed
+                        that for all given input tensors, dimension 0 corresponds
+                        to the number of examples, and if multiple input tensors
+                        are provided, the examples must be aligned appropriately.
+            baselines (scalar, Tensor, tuple of scalar, or Tensor):
+                        Baselines define the reference distribution used to
+                        represent missing features. Tensor baselines should have
+                        first dimension equal to the number of baseline samples,
+                        and all remaining dimensions must match the corresponding
+                        input tensor's dimensions starting from dimension 1.
+                        If multiple input tensors are provided, tensor baselines
+                        may either share the same first dimension or have first
+                        dimension 1, in which case that baseline is broadcast
+                        across baseline samples. Scalar baselines are treated as
+                        a degenerate one-sample baseline distribution.
+            target (int, tuple, Tensor, or list, optional): Output indices for
+                        which surrogate model is trained
+                        (for classification cases,
+                        this is usually the target class).
+                        If the network returns a scalar value per example,
+                        no target index is necessary.
+                        For general 2D outputs, targets can be either:
+
+                        - a single integer or a tensor containing a single
+                          integer, which is applied to all input examples
+
+                        - a list of integers or a 1D tensor, with length matching
+                          the number of examples in inputs (dim 0). Each integer
+                          is applied as the target for the corresponding example.
+
+                        For outputs with > 2 dimensions, targets can be either:
+
+                        - A single tuple, which contains #output_dims - 1
+                          elements. This target index is applied to all examples.
+
+                        - A list of tuples with length equal to the number of
+                          examples in inputs (dim 0), and each tuple containing
+                          #output_dims - 1 elements. Each tuple is applied as the
+                          target for the corresponding example.
+
+                        Default: None
+            additional_forward_args (Any, optional): If the forward function
+                        requires additional arguments other than the inputs for
+                        which attributions should not be computed, this argument
+                        can be provided. It must be either a single additional
+                        argument of a Tensor or arbitrary (non-tuple) type or a
+                        tuple containing multiple additional arguments including
+                        tensors or any arbitrary python types. These arguments
+                        are provided to forward_func in order following the
+                        arguments in inputs. For a tensor, the first dimension
+                        of the tensor must correspond to the number of examples.
+                        For all other types, the given argument is used for all
+                        forward evaluations. Note that attributions are not
+                        computed with respect to these arguments.
+                        Default: None
+            feature_mask (Tensor or tuple[Tensor, ...], optional):
+                        feature_mask defines a mask for the input, grouping
+                        features which correspond to the same interpretable
+                        feature. feature_mask should contain the same number of
+                        tensors as inputs. Each tensor should be the same size as
+                        the corresponding input or broadcastable to match the
+                        input tensor. Values across all tensors should be
+                        integers in the range 0 to num_interp_features - 1, and
+                        indices corresponding to the same feature should have the
+                        same value. Note that features are grouped across
+                        tensors, so if the same index is used in different
+                        tensors, those features are still grouped and added
+                        simultaneously. If None, then a feature mask is
+                        constructed which assigns each scalar within a tensor as
+                        a separate feature.
+                        Default: None
+            n_samples (int, optional): The number of sampled coalitions of the
+                        original model used to train the surrogate interpretable
+                        model.
+                        Default: 25
+            perturbations_per_eval (int, optional): Allows multiple sampled
+                        coalitions to be processed simultaneously in one call to
+                        forward_fn. Each forward pass will contain a maximum of
+                        perturbations_per_eval * #examples * #baseline_samples
+                        samples.
+                        Default: 1
+            return_input_shape (bool, optional): Determines whether the returned
+                        tensor(s) only contain the coefficients for each
+                        interpretable feature from the trained surrogate model,
+                        or whether the returned attributions match the input
+                        shape. When return_input_shape is True, the return type
+                        of attribute matches the input shape, with each element
+                        containing the coefficient of the corresponding
+                        interpretable feature. All elements with the same value
+                        in the feature mask will contain the same coefficient in
+                        the returned attributions. If return_input_shape is
+                        False, a 1D tensor is returned, containing only the
+                        coefficients of the trained interpretable model, with
+                        length num_interp_features.
+                        Default: True
+            show_progress (bool, optional): Displays the progress of computation.
+                        It will try to use tqdm if available for advanced
+                        features (e.g. time estimation). Otherwise, it will
+                        fallback to a simple output of progress.
+                        Default: False
+            n_baseline_samples (int, optional): The number of baseline samples
+                        to draw with replacement from the baseline distribution
+                        for each sampled coalition. If None, all provided
+                        baselines are used for each coalition, giving the exact
+                        average over the finite baseline distribution.
+                        Default: None
+
+        Returns:
+            *Tensor* or *tuple[Tensor, ...]* of **attributions**:
+            - **attributions** (*Tensor* or *tuple[Tensor, ...]*):
+                        The attributions with respect to each input feature.
+                        If return_input_shape = True, attributions will be the
+                        same size as the provided inputs, with each value
+                        providing the coefficient of the corresponding
+                        interpretable feature. If return_input_shape is False,
+                        a 1D tensor is returned, containing only the coefficients
+                        of the trained interpretable model, with length
+                        num_interp_features.
+        Examples::
+            >>> # SimpleClassifier takes a single input tensor of size Nx4x4,
+            >>> # and returns an Nx3 tensor of class probabilities.
+            >>> net = SimpleClassifier()
+
+            >>> # Generating random input with size 1 x 4 x 4 and a
+            >>> # distribution of 10 baseline examples.
+            >>> input = torch.randn(1, 4, 4)
+            >>> baselines = torch.randn(10, 4, 4)
+
+            >>> # Defining Random Baseline Kernel SHAP interpreter
+            >>> rbks = RandomBaselineKernelShap(net)
+            >>> attr = rbks.attribute(input, baselines, target=1, n_samples=200)
+        """
+        formatted_inputs, formatted_baselines = _format_input_baseline(
+            inputs, baselines
+        )
+        num_baselines = self._validate_baseline_distribution(
+            formatted_inputs, formatted_baselines
+        )
+        assert (
+            n_baseline_samples is None
+            or isinstance(n_baseline_samples, int)
+            and n_baseline_samples > 0
+        ), (
+            "n_baseline_samples must be None or a positive integer, "
+            f"received {n_baseline_samples}."
+        )
+        feature_mask, num_interp_features = construct_feature_mask(
+            feature_mask, formatted_inputs
+        )
+
+        if formatted_inputs[0].shape[0] > 1:
+            return self._attribute_batch(
+                inputs,
+                formatted_inputs,
+                formatted_baselines,
+                target,
+                additional_forward_args,
+                feature_mask,
+                n_samples,
+                perturbations_per_eval,
+                return_input_shape,
+                show_progress,
+                n_baseline_samples,
+            )
+
+        num_features_list = torch.arange(num_interp_features, dtype=torch.float)
+        denom = num_features_list * (num_interp_features - num_features_list)
+        probs = torch.tensor((num_interp_features - 1)) / denom
+        probs[0] = 0.0
+        return self._attribute_kwargs(
+            inputs=inputs,
+            baselines=formatted_baselines,
+            target=target,
+            additional_forward_args=additional_forward_args,
+            feature_mask=feature_mask,
+            n_samples=n_samples,
+            perturbations_per_eval=perturbations_per_eval,
+            return_input_shape=return_input_shape,
+            num_select_distribution=Categorical(probs),
+            num_baselines=num_baselines,
+            n_baseline_samples=n_baseline_samples,
+            show_progress=show_progress,
+        )
+
+    def _attribute_batch(
+        self,
+        inputs: TensorOrTupleOfTensorsGeneric,
+        formatted_inputs: Tuple[Tensor, ...],
+        baselines: Tuple[Union[Tensor, int, float], ...],
+        target: TargetType,
+        additional_forward_args: Optional[object],
+        feature_mask: Tuple[Tensor, ...],
+        n_samples: int,
+        perturbations_per_eval: int,
+        return_input_shape: bool,
+        show_progress: bool,
+        n_baseline_samples: Optional[int],
+    ) -> TensorOrTupleOfTensorsGeneric:
+        bsz = formatted_inputs[0].shape[0]
+        test_output = _run_forward(
+            self.forward_func, inputs, target, additional_forward_args
+        )
+        assert isinstance(test_output, Tensor) and torch.numel(test_output) == bsz, (
+            "RandomBaselineKernelShap supports batched inputs only when "
+            "forward_func returns one scalar per example. For a single scalar "
+            "per input batch, compute attributions for one input batch at a time."
+        )
+
+        is_inputs_tuple = isinstance(inputs, tuple)
+        output_list: List[TensorOrTupleOfTensorsGeneric] = []
+        for (
+            curr_inps,
+            curr_target,
+            curr_additional_args,
+            curr_feature_mask,
+        ) in _batch_example_iterator(
+            bsz,
+            formatted_inputs,
+            target,
+            additional_forward_args,
+            feature_mask,
+        ):
+            output_list.append(
+                self.attribute(
+                    curr_inps if is_inputs_tuple else curr_inps[0],
+                    baselines=baselines,
+                    target=curr_target,
+                    additional_forward_args=curr_additional_args,
+                    feature_mask=(
+                        curr_feature_mask if is_inputs_tuple else curr_feature_mask[0]
+                    ),
+                    n_samples=n_samples,
+                    perturbations_per_eval=perturbations_per_eval,
+                    return_input_shape=return_input_shape,
+                    show_progress=show_progress,
+                    n_baseline_samples=n_baseline_samples,
+                )
+            )
+
+        return _reduce_list(output_list)
+
+    def _validate_baseline_distribution(
+        self,
+        inputs: Tuple[Tensor, ...],
+        baselines: Tuple[Union[Tensor, int, float], ...],
+    ) -> int:
+        assert len(inputs) == len(
+            baselines
+        ), "Must provide the same number of baseline entries as input tensors."
+        baseline_counts: List[int] = []
+        for input, baseline in zip(inputs, baselines):
+            if isinstance(baseline, Tensor):
+                assert input.dim() == baseline.dim(), (
+                    "Baseline tensors must have the same number of dimensions "
+                    "as their corresponding input tensor. Found baseline: "
+                    f"{baseline.shape} and input: {input.shape}."
+                )
+                assert input.shape[1:] == baseline.shape[1:], (
+                    "Baseline tensor dimensions after the first dimension must "
+                    "match the corresponding input tensor. Found baseline: "
+                    f"{baseline.shape} and input: {input.shape}."
+                )
+                baseline_counts.append(baseline.shape[0])
+
+        num_baselines = max(baseline_counts) if baseline_counts else 1
+        for count in baseline_counts:
+            assert count in (1, num_baselines), (
+                "All baseline tensors must have the same first dimension, or "
+                "first dimension 1 so they can be broadcast across baseline "
+                f"samples. Found counts: {baseline_counts}."
+            )
+        return num_baselines
+
+    def _get_model_input_multiplier(self, **kwargs: Any) -> int:
+        n_baseline_samples = cast(Optional[int], kwargs["n_baseline_samples"])
+        if n_baseline_samples is not None:
+            return n_baseline_samples
+        return cast(int, kwargs["num_baselines"])
+
+    def _aggregate_model_outputs(
+        self,
+        model_out: Tensor,
+        num_interp_inputs: int,
+        model_input_multiplier: int,
+        **kwargs: Any,
+    ) -> Tensor:
+        return model_out.view(num_interp_inputs, model_input_multiplier).mean(dim=1)
+
+    def random_baseline_from_interp_rep_transform(
+        self,
+        curr_sample: Tensor,
+        original_inputs: TensorOrTupleOfTensorsGeneric,
+        **kwargs: Any,
+    ) -> TensorOrTupleOfTensorsGeneric:
+        assert (
+            "feature_mask" in kwargs
+        ), "Must provide feature_mask to use Random Baseline Kernel SHAP"
+        assert (
+            "baselines" in kwargs
+        ), "Must provide baselines to use Random Baseline Kernel SHAP"
+        if isinstance(original_inputs, Tensor):
+            baseline_indices = self._sample_baseline_indices(original_inputs, **kwargs)
+            return self._replace_missing_with_random_baselines(
+                curr_sample,
+                original_inputs,
+                cast(Tensor, kwargs["feature_mask"]),
+                cast(Union[Tensor, int, float], kwargs["baselines"]),
+                baseline_indices,
+            )
+
+        baseline_indices = self._sample_baseline_indices(original_inputs[0], **kwargs)
+        baselines = cast(Tuple[Union[Tensor, int, float], ...], kwargs["baselines"])
+        feature_mask = cast(Tuple[Tensor, ...], kwargs["feature_mask"])
+        return cast(
+            TensorOrTupleOfTensorsGeneric,
+            tuple(
+                self._replace_missing_with_random_baselines(
+                    curr_sample,
+                    original_inputs[i],
+                    feature_mask[i],
+                    baselines[i],
+                    baseline_indices,
+                )
+                for i in range(len(feature_mask))
+            ),
+        )
+
+    def _sample_baseline_indices(
+        self,
+        input: Tensor,
+        **kwargs: Any,
+    ) -> Tensor:
+        num_baselines = cast(int, kwargs["num_baselines"])
+        n_baseline_samples = cast(Optional[int], kwargs["n_baseline_samples"])
+        if n_baseline_samples is None:
+            return torch.arange(num_baselines, device=input.device)
+        return torch.randint(num_baselines, (n_baseline_samples,), device=input.device)
+
+    def _replace_missing_with_random_baselines(
+        self,
+        curr_sample: Tensor,
+        original_input: Tensor,
+        feature_mask: Tensor,
+        baseline: Union[Tensor, int, float],
+        baseline_indices: Tensor,
+    ) -> Tensor:
+        assert (
+            original_input.shape[0] == 1
+        ), "RandomBaselineKernelShap expects one input example at a time."
+        sample_count = baseline_indices.numel()
+        binary_mask = curr_sample[0][feature_mask].bool()
+        expanded_input = original_input.expand(
+            (sample_count,) + tuple(original_input.shape[1:])
+        )
+        if isinstance(baseline, Tensor):
+            baseline = baseline.to(
+                device=original_input.device, dtype=original_input.dtype
+            )
+            if baseline.shape[0] == 1:
+                selected_baselines = baseline.expand(
+                    (sample_count,) + tuple(baseline.shape[1:])
+                )
+            else:
+                selected_baselines = baseline.index_select(0, baseline_indices)
+        else:
+            selected_baselines = torch.full(
+                (sample_count,) + tuple(original_input.shape[1:]),
+                baseline,
+                device=original_input.device,
+                dtype=original_input.dtype,
+            )
+        return torch.where(binary_mask, expanded_input, selected_baselines)

--- a/captum/attr/_core/lime.py
+++ b/captum/attr/_core/lime.py
@@ -428,6 +428,11 @@ class LimeBase(PerturbationAttribution):
         expanded_additional_args = None
         expanded_target = None
         gen_perturb_func = self._get_perturb_generator_func(inputs, **kwargs)
+        model_input_multiplier = self._get_model_input_multiplier(**kwargs)
+        assert model_input_multiplier >= 1, (
+            "Model input multiplier must be a positive integer, "
+            f"received {model_input_multiplier}."
+        )
 
         if show_progress:
             attr_progress = progress(
@@ -460,18 +465,22 @@ class LimeBase(PerturbationAttribution):
             )
 
             if len(curr_model_inputs) == perturbations_per_eval:
+                num_model_inputs = len(curr_model_inputs) * model_input_multiplier
                 if expanded_additional_args is None:
                     expanded_additional_args = _expand_additional_forward_args(
-                        additional_forward_args, len(curr_model_inputs)
+                        additional_forward_args, num_model_inputs
                     )
                 if expanded_target is None:
-                    expanded_target = _expand_target(target, len(curr_model_inputs))
+                    expanded_target = _expand_target(target, num_model_inputs)
 
                 model_out = self._evaluate_batch(
                     curr_model_inputs,
                     expanded_target,
                     expanded_additional_args,
                     device,
+                    len(curr_model_inputs),
+                    model_input_multiplier,
+                    **kwargs,
                 )
 
                 if show_progress:
@@ -482,15 +491,19 @@ class LimeBase(PerturbationAttribution):
                 curr_model_inputs = []
 
         if len(curr_model_inputs) > 0:
+            num_model_inputs = len(curr_model_inputs) * model_input_multiplier
             expanded_additional_args = _expand_additional_forward_args(
-                additional_forward_args, len(curr_model_inputs)
+                additional_forward_args, num_model_inputs
             )
-            expanded_target = _expand_target(target, len(curr_model_inputs))
+            expanded_target = _expand_target(target, num_model_inputs)
             model_out = self._evaluate_batch(
                 curr_model_inputs,
                 expanded_target,
                 expanded_additional_args,
                 device,
+                len(curr_model_inputs),
+                model_input_multiplier,
+                **kwargs,
             )
             if show_progress:
                 attr_progress.update()
@@ -562,6 +575,9 @@ class LimeBase(PerturbationAttribution):
         expanded_target: TargetType,
         expanded_additional_args: object,
         device: torch.device,
+        num_interp_inputs: int,
+        model_input_multiplier: int,
+        **kwargs: Any,
     ) -> Tensor:
         model_out = _run_forward(
             self.forward_func,
@@ -569,14 +585,36 @@ class LimeBase(PerturbationAttribution):
             expanded_target,
             expanded_additional_args,
         )
+        expected_num_outputs = num_interp_inputs * model_input_multiplier
         if isinstance(model_out, Tensor):
-            assert model_out.numel() == len(curr_model_inputs), (
+            assert model_out.numel() == expected_num_outputs, (
                 "Number of outputs is not appropriate, must return "
                 "one output per perturbed input"
             )
         if isinstance(model_out, Tensor):
-            return model_out.flatten()
+            return self._aggregate_model_outputs(
+                model_out.flatten(),
+                num_interp_inputs,
+                model_input_multiplier,
+                **kwargs,
+            )
+        assert expected_num_outputs == 1, (
+            "Forward function must return a Tensor when each interpretable "
+            "sample expands to multiple model inputs."
+        )
         return torch.tensor([model_out], device=device)
+
+    def _get_model_input_multiplier(self, **kwargs: Any) -> int:
+        return 1
+
+    def _aggregate_model_outputs(
+        self,
+        model_out: Tensor,
+        num_interp_inputs: int,
+        model_input_multiplier: int,
+        **kwargs: Any,
+    ) -> Tensor:
+        return model_out
 
     def has_convergence_delta(self) -> bool:
         return False
@@ -1258,7 +1296,7 @@ class Lime(LimeBase):
                 leading_dim_one=(bsz > 1),
             )
         else:
-            return coefs
+            return cast(TensorOrTupleOfTensorsGeneric, coefs)
 
     @typing.overload
     def _convert_output_shape(

--- a/docs/algorithms_comparison_matrix.md
+++ b/docs/algorithms_comparison_matrix.md
@@ -198,6 +198,26 @@ Please, scroll to the right for more details.
     <td>Similar to Shapely value, but instead of considering all feature permutations it considers only #samples random permutations.</td>
   </tr>
   <tr>
+    <td><strong>KernelSHAP / BaselineKernelShap</strong></td>
+    <td>Perturbation </td>
+    <td>Any traditional or neural network model.</td>
+    <td>O(#examples * #features * #samples)</td>
+    <td>Forward</td>
+     <td>#examples * #samples</td>
+    <td>Yes (Single Baseline Per Input Example)</td>
+    <td>Uses the LIME framework with the Shapley kernel to estimate Baseline Shapley values. Missing features are replaced by the provided baseline values.</td>
+  </tr>
+  <tr>
+    <td><strong>RandomBaselineKernelShap</strong></td>
+    <td>Perturbation </td>
+    <td>Any traditional or neural network model.</td>
+    <td>O(#examples * #features * #samples * #baseline_samples)</td>
+    <td>Forward</td>
+     <td>#examples * #samples * #baseline_samples</td>
+    <td>Yes (Multiple Baselines Per Input Example)</td>
+    <td>Uses the same KernelSHAP surrogate as BaselineKernelShap, but averages each sampled coalition output over a baseline distribution before fitting the surrogate model.</td>
+  </tr>
+  <tr>
     <td><strong>NoiseTunnel</strong></td>
     <td> -  </td>
     <td>This can be used in combination with any above mentioned attribution algorithms</td>

--- a/docs/attribution_algorithms.md
+++ b/docs/attribution_algorithms.md
@@ -128,13 +128,31 @@ We offer two implementation variants of this method, LimeBase and Lime.
 To learn more about Lime, visit the following resources:
 - [Original paper](https://arxiv.org/abs/1602.04938)
 
-### KernelSHAP
+### KernelSHAP / Baseline KernelSHAP
 Kernel SHAP is a method that uses the LIME framework to compute Shapley Values. Setting the loss function, weighting kernel and regularization terms appropriately in the LIME framework allows theoretically obtaining Shapley Values more efficiently than directly computing Shapley Values.
 
 Captum's implementation represents missing features with the values provided in `baselines`. As a result, the attributions explain the model output relative to the chosen baseline values rather than by sampling missing features from a background data distribution.
 
+`BaselineKernelShap` is an alias for `KernelShap` that makes these baseline-substitution semantics explicit.
+
 To learn more about KernelSHAP, visit the following resources:
 - [Original paper](https://arxiv.org/abs/1705.07874)
+
+### Random Baseline KernelSHAP
+Random Baseline KernelSHAP computes Random Baseline Shapley (RBShap) values with the same Kernel SHAP weighted linear surrogate used by KernelSHAP. Instead of using one fixed baseline to represent missing features, it evaluates each sampled coalition against a distribution of baselines and averages those model outputs before fitting the surrogate model.
+
+For a coalition of selected features `S`, KernelSHAP / Baseline KernelSHAP uses:
+
+`v(S) = f(x_S; b_not_S)`
+
+Random Baseline KernelSHAP uses:
+
+`v(S) = E_b[f(x_S; b_not_S)]`
+
+where `b` is drawn from the provided baseline distribution. This makes the returned attributions the expected Baseline Shapley attribution over the baseline distribution. If `n_baseline_samples` is not provided, Captum averages over all provided baseline examples for each sampled coalition. If `n_baseline_samples` is provided, Captum samples that many baselines with replacement for each coalition.
+
+To learn more about Random Baseline Shapley, visit the following resources:
+- [The Many Shapley Values for Model Explanation](https://arxiv.org/abs/1908.08474)
 
 ## Layer Attribution
 ### Layer Conductance

--- a/sphinx/source/kernel_shap.rst
+++ b/sphinx/source/kernel_shap.rst
@@ -1,6 +1,18 @@
 KernelShap
-====================
+==========
 
 .. autoclass:: captum.attr.KernelShap
+    :members:
+    :exclude-members: compute_convergence_delta
+
+BaselineKernelShap
+==================
+
+``BaselineKernelShap`` is an alias for :class:`captum.attr.KernelShap`.
+
+RandomBaselineKernelShap
+========================
+
+.. autoclass:: captum.attr.RandomBaselineKernelShap
     :members:
     :exclude-members: compute_convergence_delta

--- a/tests/attr/test_kernel_shap.py
+++ b/tests/attr/test_kernel_shap.py
@@ -9,7 +9,11 @@ from typing import Any, Callable, List, Tuple, Union
 
 import torch
 from captum._utils.typing import BaselineType, TensorOrTupleOfTensorsGeneric
-from captum.attr._core.kernel_shap import KernelShap
+from captum.attr._core.kernel_shap import (
+    BaselineKernelShap,
+    KernelShap,
+    RandomBaselineKernelShap,
+)
 from captum.testing.helpers.basic import (
     assertTensorAlmostEqual,
     assertTensorTuplesAlmostEqual,
@@ -18,6 +22,7 @@ from captum.testing.helpers.basic import (
 )
 from captum.testing.helpers.basic_models import (
     BasicLinearModel,
+    BasicLinearModel2,
     BasicModel_MultiLayer,
     BasicModel_MultiLayer_MultiInput,
 )
@@ -48,6 +53,152 @@ class Test(BaseTest):
             n_samples=500,
             baselines=baseline,
             expected_coefs=[[40.0, 120.0, 80.0]],
+        )
+
+    def test_baseline_kernel_shap_alias(self) -> None:
+        self.assertIs(BaselineKernelShap, KernelShap)
+
+    def test_random_baseline_kernel_shap_linear(self) -> None:
+        weight = torch.tensor([[1.0, 2.0, 3.0], [3.0, 2.0, 1.0]])
+        net = BasicLinearModel2(3, 2)
+        net.linear.weight = torch.nn.Parameter(weight)
+        inp = torch.tensor([[10.0, 20.0, 30.0]])
+        baselines = torch.tensor([[0.0, 0.0, 0.0], [2.0, 4.0, 6.0]])
+
+        rbks = RandomBaselineKernelShap(net)
+        attributions = rbks.attribute(
+            inp,
+            baselines,
+            target=0,
+            n_samples=500,
+            perturbations_per_eval=2,
+        )
+
+        assertTensorAlmostEqual(
+            self,
+            attributions,
+            [[9.0, 36.0, 81.0]],
+            delta=0.1,
+            mode="max",
+        )
+
+        attributions = rbks.attribute(
+            inp,
+            baselines,
+            target=0,
+            n_samples=500,
+            perturbations_per_eval=2,
+            return_input_shape=False,
+        )
+
+        assertTensorAlmostEqual(
+            self,
+            attributions,
+            [[9.0, 36.0, 81.0]],
+            delta=0.1,
+            mode="max",
+        )
+
+    def test_random_baseline_kernel_shap_matches_single_baseline(self) -> None:
+        net = BasicModel_MultiLayer()
+        inp = torch.tensor([[20.0, 50.0, 30.0]])
+        baseline = torch.tensor([[10.0, 20.0, 10.0]])
+
+        set_all_random_seeds(1234)
+        kernel_shap_attr = KernelShap(net).attribute(
+            inp,
+            baseline,
+            target=0,
+            n_samples=200,
+            perturbations_per_eval=2,
+        )
+
+        set_all_random_seeds(1234)
+        random_baseline_attr = RandomBaselineKernelShap(net).attribute(
+            inp,
+            baseline,
+            target=0,
+            n_samples=200,
+            perturbations_per_eval=2,
+        )
+
+        assertTensorAlmostEqual(
+            self,
+            random_baseline_attr,
+            kernel_shap_attr,
+            delta=0.01,
+            mode="max",
+        )
+
+        set_all_random_seeds(1234)
+        sampled_baseline_attr = RandomBaselineKernelShap(net).attribute(
+            inp,
+            torch.cat((baseline, baseline), dim=0),
+            target=0,
+            n_samples=200,
+            perturbations_per_eval=2,
+            n_baseline_samples=1,
+        )
+
+        assertTensorAlmostEqual(
+            self,
+            sampled_baseline_attr,
+            kernel_shap_attr,
+            delta=0.01,
+            mode="max",
+        )
+
+    def test_random_baseline_kernel_shap_batch_uses_distribution(
+        self,
+    ) -> None:
+        weight = torch.tensor([[1.0, 2.0, 3.0], [3.0, 2.0, 1.0]])
+        net = BasicLinearModel2(3, 2)
+        net.linear.weight = torch.nn.Parameter(weight)
+        inp = torch.tensor([[10.0, 20.0, 30.0], [4.0, 6.0, 8.0]])
+        baselines = torch.tensor([[0.0, 0.0, 0.0], [2.0, 4.0, 6.0]])
+
+        rbks = RandomBaselineKernelShap(net)
+        attributions = rbks.attribute(
+            inp,
+            baselines,
+            target=0,
+            n_samples=500,
+            perturbations_per_eval=2,
+        )
+
+        assertTensorAlmostEqual(
+            self,
+            attributions,
+            [[9.0, 36.0, 81.0], [3.0, 8.0, 15.0]],
+            delta=0.1,
+            mode="max",
+        )
+
+    def test_random_baseline_kernel_shap_multi_input(self) -> None:
+        def model(input1: Tensor, input2: Tensor) -> Tensor:
+            return input1[:, 0] + 2.0 * input1[:, 1] + 3.0 * input2[:, 0]
+
+        inp1 = torch.tensor([[10.0, 20.0]])
+        inp2 = torch.tensor([[30.0]])
+        baselines = (
+            torch.tensor([[0.0, 0.0], [2.0, 4.0]]),
+            torch.tensor([[0.0], [6.0]]),
+        )
+
+        rbks = RandomBaselineKernelShap(model)
+        attributions = rbks.attribute(
+            (inp1, inp2),
+            baselines,
+            n_samples=500,
+            perturbations_per_eval=2,
+        )
+
+        assertTensorTuplesAlmostEqual(
+            self,
+            attributions,
+            ([[9.0, 36.0]], [[81.0]]),
+            delta=0.1,
+            mode="max",
         )
 
     def test_simple_kernel_shap(self) -> None:


### PR DESCRIPTION
Summary:
Follow-up to https://github.com/meta-pytorch/captum/issues/1789. Thanks to conorosully for identifying that Captum `KernelShap` has fixed-baseline Baseline Shapley semantics rather than marginal KernelSHAP semantics.

This PR:
- adds `BaselineKernelShap` as an alias for `KernelShap` so the current fixed-baseline behavior has an explicit name
- adds `RandomBaselineKernelShap` for Random Baseline Shapley values
- extends the LimeBase evaluation path so one sampled interpretable coalition can expand to several model inputs and aggregate the outputs before fitting the surrogate
- documents the distinction in the algorithm overview, comparison matrix, API reference, and class docstrings
- adds coverage for the alias, single-baseline equivalence, finite baseline distributions, sampled baseline draws, batched inputs, and multiple inputs

## Intuition
`KernelShap` / `BaselineKernelShap` uses a fixed baseline: keep selected features from the input and fill missing features from `b`, so each coalition has one model evaluation.

`RandomBaselineKernelShap` treats `baselines` as a distribution: for each coalition it fills missing features from multiple baseline samples, averages those model outputs, and fits the same Shapley-kernel linear surrogate to those averaged values. If `n_baseline_samples` is omitted, Captum averages over all provided baseline examples for each coalition; otherwise it samples that many baselines with replacement for each coalition.

This follows the Random Baseline Shapley framing from Sundararajan et al., "The Many Shapley Values for Model Explanation": https://arxiv.org/abs/1908.08474


Test Plan:
- `venv/uv/bin/python -m pytest tests/attr/test_kernel_shap.py -q`
- `venv/uv/bin/python -m black --check captum/attr/_core/kernel_shap.py captum/attr/_core/lime.py captum/attr/__init__.py tests/attr/test_kernel_shap.py`
- `venv/uv/bin/python -m flake8 captum/attr/_core/kernel_shap.py captum/attr/_core/lime.py captum/attr/__init__.py tests/attr/test_kernel_shap.py`
- `venv/uv/bin/python -m mypy --ignore-missing-imports --follow-imports=silent captum/attr/_core/kernel_shap.py captum/attr/_core/lime.py captum/attr/__init__.py tests/attr/test_kernel_shap.py`
- `git diff --check`
- `pyre check` in a clean worktree: completed, with the local environment still reporting existing dependency/stub issues unrelated to the touched files; after the cleanup there are no RBShap-related Pyre errors reported

Differential Revision: D106246734

Pulled By: craymichael


