### PR TITLE
Preserve TCAV score order (#1285) (#1848)

### DIFF
--- a/captum/concept/_core/tcav.py
+++ b/captum/concept/_core/tcav.py
@@ -701,7 +701,7 @@ class TCAV(ConceptInterpreter):
         exp_set_lens = np.array(
             [len(exp_set) for exp_set in experimental_sets], dtype=object
         )
-        exp_set_lens_arg_sort = np.argsort(exp_set_lens)
+        exp_set_lens_arg_sort = np.argsort(exp_set_lens, kind="stable")
 
         # compute offsets using sorted lengths using their indices
         exp_set_lens_sort = exp_set_lens[exp_set_lens_arg_sort]
@@ -783,7 +783,13 @@ class TCAV(ConceptInterpreter):
                 )
                 i += 1
 
-        return scores
+        # Preserve the caller-provided experimental set order in the returned
+        # mapping, even though computation batches sets by concept count.
+        ordered_scores: Dict[str, Dict[str, Dict[str, Tensor]]] = {
+            concepts_to_str(concepts): scores[concepts_to_str(concepts)]
+            for concepts in experimental_sets
+        }
+        return ordered_scores
 
     def _tcav_sub_computation(
         self,

--- a/tests/concept/test_tcav.py
+++ b/tests/concept/test_tcav.py
@@ -994,6 +994,37 @@ class Test(BaseTest):
                     self.assertEqual(tcav_i["sign_count"].shape[0], 2)
                     self.assertEqual(tcav_i["magnitude"].shape[0], 2)
 
+    def test_TCAV_interpret_preserves_experimental_set_order(self) -> None:
+        class MultiConceptClassifier(CustomClassifier):
+            def weights(self) -> Tensor:
+                # pyre-fixme[16]: `MultiConceptClassifier` has no attribute
+                #  `num_features`.
+                return torch.ones(len(self.classes()), self.num_features)
+
+        concepts = [
+            ["striped", "random", "ceo"],
+            ["ceo", "random"],
+            ["striped", "dotted"],
+            ["random", "striped", "dotted"],
+        ]
+        classifier = MultiConceptClassifier()
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            tcav, concept_dict = init_TCAV(tmpdirname, classifier, "conv2")
+            experimental_sets = self._create_experimental_sets(concepts, concept_dict)
+
+            scores = tcav.interpret(
+                inputs=100 * get_inputs_tensor(),
+                experimental_sets=experimental_sets,
+                target=0,
+                processes=1,
+            )
+
+            self.assertEqual(
+                list(scores.keys()),
+                [concepts_to_str(concepts) for concepts in experimental_sets],
+            )
+
     # Force Train
     def test_TCAV_1_1_a(self) -> None:
         self.compute_cavs_interpret(


### PR DESCRIPTION
Summary:
Fixes https://github.com/meta-pytorch/captum/issues/1285.

Issue: https://github.com/meta-pytorch/captum/issues/1285
Issue summary: TCAV scores were returned in computation order rather than caller-provided experimental-set order.
- Keep TCAV batching stable while reordering the returned score mapping to match the original experimental_sets order.
- Add a regression test for mixed-length experimental sets.


Test Plan:
- venv/uv/bin/python -m pytest -q tests/concept/test_tcav.py
- Pyre: attempted `venv/uv/bin/pyre --noninteractive --dot-pyre-directory /tmp/captum-pyre-logs-config check`; blocked locally by broad pre-existing Pyre type-resolution failures resolving stdlib / torch imports.

Differential Revision: D106053865

Pulled By: craymichael


