### PR TITLE
Add return_numpy to visualize_image_attr (#1865)

### DIFF
--- a/captum/attr/_utils/visualization.py
+++ b/captum/attr/_utils/visualization.py
@@ -11,7 +11,9 @@ from typing import (
     Dict,
     Iterable,
     List,
+    Literal,
     Optional,
+    overload,
     Sequence,
     Tuple,
     Union,
@@ -366,6 +368,18 @@ def _visualize_alpha_scaling(
     )
 
 
+def _get_image_attr_visualization_array(image: AxesImage) -> npt.NDArray:
+    image_array = np.asarray(image.get_array())
+
+    if image_array.ndim == 2:
+        return np.asarray(
+            image.to_rgba(image_array, alpha=image.get_alpha(), bytes=True)
+        )
+
+    return image_array.copy()
+
+
+@overload
 def visualize_image_attr(
     attr: npt.NDArray,
     original_image: Optional[npt.NDArray] = None,
@@ -379,7 +393,43 @@ def visualize_image_attr(
     title: Optional[str] = None,
     fig_size: Tuple[int, int] = (6, 6),
     use_pyplot: bool = True,
-) -> Tuple[Figure, Axes]:
+    return_numpy: Literal[False] = False,
+) -> Tuple[Figure, Axes]: ...
+
+
+@overload
+def visualize_image_attr(
+    attr: npt.NDArray,
+    original_image: Optional[npt.NDArray] = None,
+    method: str = "heat_map",
+    sign: str = "absolute_value",
+    plt_fig_axis: Optional[Tuple[Figure, Axes]] = None,
+    outlier_perc: Union[int, float] = 2,
+    cmap: Optional[Union[str, Colormap]] = None,
+    alpha_overlay: float = 0.5,
+    show_colorbar: bool = False,
+    title: Optional[str] = None,
+    fig_size: Tuple[int, int] = (6, 6),
+    use_pyplot: bool = True,
+    return_numpy: Literal[True] = True,
+) -> npt.NDArray: ...
+
+
+def visualize_image_attr(
+    attr: npt.NDArray,
+    original_image: Optional[npt.NDArray] = None,
+    method: str = "heat_map",
+    sign: str = "absolute_value",
+    plt_fig_axis: Optional[Tuple[Figure, Axes]] = None,
+    outlier_perc: Union[int, float] = 2,
+    cmap: Optional[Union[str, Colormap]] = None,
+    alpha_overlay: float = 0.5,
+    show_colorbar: bool = False,
+    title: Optional[str] = None,
+    fig_size: Tuple[int, int] = (6, 6),
+    use_pyplot: bool = True,
+    return_numpy: bool = False,
+) -> Union[Tuple[Figure, Axes], npt.NDArray]:
     r"""
     Visualizes attribution for a given image by normalizing attribution values
     of the desired sign (positive, negative, absolute value, or all) and displaying
@@ -468,9 +518,17 @@ def visualize_image_attr(
                     uses Matplotlib object oriented API and simply returns a
                     figure object without showing.
                     Default: True.
+        return_numpy (bool, optional): If true, returns the visualized image as
+                    a numpy array instead of the matplotlib figure and axis.
+                    Heatmap-based methods return an RGBA array after applying
+                    the colormap. Image-based methods return the image array
+                    passed to matplotlib. In all cases, the returned array has
+                    the attribution image height and width rather than the
+                    rendered figure canvas size.
+                    Default: False.
 
     Returns:
-        2-element tuple of **figure**, **axis**:
+        If return_numpy is False, a 2-element tuple of **figure**, **axis**:
         - **figure** (*matplotlib.pyplot.figure*):
                     Figure object on which visualization
                     is created. If plt_fig_axis argument is given, this is the
@@ -479,6 +537,9 @@ def visualize_image_attr(
                     Axis object on which visualization
                     is created. If plt_fig_axis argument is given, this is the
                     same axis provided.
+
+        If return_numpy is True, returns a numpy array containing the visualized
+                    image data.
 
     Examples::
 
@@ -565,8 +626,16 @@ def visualize_image_attr(
     if title:
         plt_axis.set_title(title)
 
+    visualization_array: Optional[npt.NDArray] = None
+    if return_numpy:
+        image = heat_map if heat_map is not None else plt_axis.images[-1]
+        visualization_array = _get_image_attr_visualization_array(image)
+
     if use_pyplot:
         plt.show()
+
+    if return_numpy:
+        return cast(npt.NDArray, visualization_array)
 
     return plt_fig, plt_axis
 

--- a/tests/attr/test_visualization_image.py
+++ b/tests/attr/test_visualization_image.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+# pyre-strict
+
+import numpy as np
+import numpy.typing as npt
+from captum.attr import visualization
+from captum.testing.helpers import BaseTest
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+
+
+class Test(BaseTest):
+    def _attr(self) -> npt.NDArray:
+        return np.array([[0.2, 0.4, 0.6], [0.8, 1.0, 1.2]])
+
+    def _image(self) -> npt.NDArray:
+        return np.arange(18, dtype=np.uint8).reshape(2, 3, 3)
+
+    def test_visualize_image_attr_default_return_value(self) -> None:
+        fig, ax = visualization.visualize_image_attr(
+            self._attr(), method="heat_map", use_pyplot=False
+        )
+
+        self.assertIsInstance(fig, Figure)
+        self.assertIsInstance(ax, Axes)
+
+    def test_visualize_image_attr_return_numpy_heatmap(self) -> None:
+        image_array = visualization.visualize_image_attr(
+            self._attr(),
+            method="heat_map",
+            sign="all",
+            use_pyplot=False,
+            return_numpy=True,
+        )
+
+        self.assertEqual(image_array.shape, (2, 3, 4))
+        self.assertEqual(image_array.dtype, np.uint8)
+
+    def test_visualize_image_attr_return_numpy_image_methods(self) -> None:
+        masked_image = visualization.visualize_image_attr(
+            self._attr(),
+            self._image(),
+            method="masked_image",
+            sign="absolute_value",
+            use_pyplot=False,
+            return_numpy=True,
+        )
+        alpha_scaled_image = visualization.visualize_image_attr(
+            self._attr(),
+            self._image(),
+            method="alpha_scaling",
+            sign="absolute_value",
+            use_pyplot=False,
+            return_numpy=True,
+        )
+
+        self.assertEqual(masked_image.shape, (2, 3, 3))
+        self.assertEqual(alpha_scaled_image.shape, (2, 3, 4))
+
+    def test_visualize_image_attr_return_numpy_blended_heatmap(self) -> None:
+        image_array = visualization.visualize_image_attr(
+            self._attr(),
+            self._image(),
+            method="blended_heat_map",
+            sign="absolute_value",
+            alpha_overlay=0.25,
+            use_pyplot=False,
+            return_numpy=True,
+        )
+
+        self.assertEqual(image_array.shape, (2, 3, 4))
+        self.assertEqual(image_array.dtype, np.uint8)
+        self.assertAlmostEqual(image_array[0, 0, 3] / 255.0, 0.25, delta=1 / 255)


### PR DESCRIPTION
Summary:
- Adds a `return_numpy` option to `visualize_image_attr` for image-sized numpy output instead of the matplotlib figure and axis.
- Keeps the existing default behavior unchanged and adds overloads for the two return modes.
- Adds coverage for default returns, heat maps, blended heat maps, masked images, and alpha scaling.

Fixes https://github.com/meta-pytorch/captum/issues/1053.


Test Plan:
- `uv run black --check captum/attr/_utils/visualization.py tests/attr/test_visualization_image.py`
- `uv run pytest tests/attr/test_visualization_image.py tests/attr/test_visualization_text.py`
- `UV_PROJECT_ENVIRONMENT=/tmp/captum-mypy-env-1053 uv run --with mypy mypy --follow-imports=skip --ignore-missing-imports captum/attr/_utils/visualization.py tests/attr/test_visualization_image.py`
- `pyre check` attempted locally; this local uv environment reports existing dependency/stub issues unrelated to this change, including numpy attribute errors and missing optional packages such as openai, annoy, and IPython.

Reviewed By: jjuncho

Differential Revision: D106434390

Pulled By: craymichael
