### PR TITLE
Add n_samples to FeaturePermutation

### DIFF
--- a/captum/attr/_core/feature_permutation.py
+++ b/captum/attr/_core/feature_permutation.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
 # pyre-strict
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, cast, Dict, List, Optional, Tuple, Union
 
 import torch
+from captum._utils.common import _format_output, _format_tensor_into_tuples
 from captum._utils.typing import BaselineType, TargetType, TensorOrTupleOfTensorsGeneric
 from captum.attr._core.feature_ablation import FeatureAblation
 from captum.log import log_usage
@@ -108,6 +109,7 @@ class FeaturePermutation(FeatureAblation):
         additional_forward_args: Optional[object] = None,
         feature_mask: Union[None, TensorOrTupleOfTensorsGeneric] = None,
         perturbations_per_eval: int = 1,
+        n_samples: int = 1,
         show_progress: bool = False,
         **kwargs: Any,
     ) -> TensorOrTupleOfTensorsGeneric:
@@ -199,6 +201,12 @@ class FeaturePermutation(FeatureAblation):
                             If the forward function returns a single scalar per batch,
                             perturbations_per_eval must be set to 1.
                             Default: 1
+                n_samples (int, optional): The number of independent
+                            permutation-attribution estimates to average. Each sample
+                            runs FeaturePermutation once, drawing a fresh random
+                            permutation for every feature group when using the default
+                            permutation function.
+                            Default: 1
                 show_progress (bool, optional): Displays the progress of computation.
                             It will try to use tqdm if available for advanced features
                             (e.g. time estimation). Otherwise, it will fallback to
@@ -262,6 +270,63 @@ class FeaturePermutation(FeatureAblation):
             >>> attr = feature_perm.attribute(input, target=1,
             >>>                               feature_mask=feature_mask)
         """
+        assert (
+            isinstance(n_samples, int) and n_samples >= 1
+        ), "n_samples must be an integer and at least 1."
+
+        attributions = self._attribute_single_sample(
+            inputs=inputs,
+            target=target,
+            additional_forward_args=additional_forward_args,
+            feature_mask=feature_mask,
+            perturbations_per_eval=perturbations_per_eval,
+            show_progress=show_progress,
+            **kwargs,
+        )
+
+        if n_samples == 1:
+            return attributions
+
+        is_attrib_tuple = isinstance(attributions, tuple)
+        formatted_attributions = _format_tensor_into_tuples(attributions)
+        for _ in range(n_samples - 1):
+            current_attributions = self._attribute_single_sample(
+                inputs=inputs,
+                target=target,
+                additional_forward_args=additional_forward_args,
+                feature_mask=feature_mask,
+                perturbations_per_eval=perturbations_per_eval,
+                show_progress=show_progress,
+                **kwargs,
+            )
+            formatted_current_attributions = _format_tensor_into_tuples(
+                current_attributions
+            )
+            formatted_attributions = tuple(
+                total + current
+                for total, current in zip(
+                    formatted_attributions, formatted_current_attributions
+                )
+            )
+
+        averaged_attributions = tuple(
+            attribution / n_samples for attribution in formatted_attributions
+        )
+        return cast(
+            TensorOrTupleOfTensorsGeneric,
+            _format_output(is_attrib_tuple, averaged_attributions),
+        )
+
+    def _attribute_single_sample(
+        self,
+        inputs: TensorOrTupleOfTensorsGeneric,
+        target: TargetType = None,
+        additional_forward_args: Optional[object] = None,
+        feature_mask: Union[None, TensorOrTupleOfTensorsGeneric] = None,
+        perturbations_per_eval: int = 1,
+        show_progress: bool = False,
+        **kwargs: Any,
+    ) -> TensorOrTupleOfTensorsGeneric:
         # Remove baselines from kwargs if provided so we don't specify this field
         # twice in the FeatureAblation.attribute call below.
         if isinstance(kwargs, dict) and "baselines" in kwargs:

--- a/tests/attr/test_feature_permutation.py
+++ b/tests/attr/test_feature_permutation.py
@@ -110,6 +110,35 @@ class Test(BaseTest):
         assertTensorAlmostEqual(self, attribs[:, 0], zeros, delta=0.05, mode="max")
         self.assertTrue((attribs[:, 1 : input_size[0]].abs() > 0).all())
 
+    def test_single_input_with_n_samples(self) -> None:
+        n_samples = 4
+
+        def forward_func(x: Tensor) -> Tensor:
+            return x.sum(dim=-1)
+
+        feature_importance = FeaturePermutation(forward_func=forward_func)
+        inp = torch.arange(20, dtype=torch.float).view(5, 4)
+
+        set_all_random_seeds(123)
+        attribs = feature_importance.attribute(inp, n_samples=n_samples)
+
+        set_all_random_seeds(123)
+        expected = torch.stack(
+            [feature_importance.attribute(inp) for _ in range(n_samples)]
+        ).mean(dim=0)
+
+        assertTensorAlmostEqual(self, attribs, expected, delta=1e-6, mode="max")
+
+    def test_n_samples_validation(self) -> None:
+        def forward_func(x: Tensor) -> Tensor:
+            return x.sum(dim=-1)
+
+        feature_importance = FeaturePermutation(forward_func=forward_func)
+        inp = torch.randn(2, 3)
+
+        with self.assertRaisesRegex(AssertionError, "n_samples"):
+            feature_importance.attribute(inp, n_samples=0)
+
     def test_simple_input_with_min_examples_in_group(self) -> None:
         def forward_func(x: Tensor) -> Tensor:
             return x.sum(dim=-1)


### PR DESCRIPTION
Summary:
- Adds `n_samples` to `FeaturePermutation.attribute` so users can average independent random permutation attribution estimates directly.
- Keeps the current behavior unchanged for the default `n_samples=1`.
- Validates `n_samples` and documents the new argument.
- Adds focused tests that compare `n_samples` against manually averaging repeated single-sample calls.

Fixes #505.

Test Plan:
- `venv/uv/bin/python -m pytest tests/attr/test_feature_permutation.py -q`
- `venv/uv/bin/python -m black --check captum/attr/_core/feature_permutation.py tests/attr/test_feature_permutation.py`
- `venv/uv/bin/pyre --version none check` attempted locally; this workspace config scans `venv/uv` because `source_directories` is `["."]`, so it fails on unrelated third-party package errors under site-packages rather than producing a useful project-only result.