### PR TITLE
Update copyright statement on Captum homepage to Meta Platforms, Inc. (#1868)

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -107,7 +107,7 @@ class Footer extends React.Component {
           {this.props.config.copyright && (
             <span>{this.props.config.copyright}</span>
           )}{" "}
-          Copyright &copy; {currentYear} Facebook Inc.
+          Copyright &copy; {currentYear} Meta Platforms, Inc.
         </section>
         {process.env.NODE_ENV !== 'development' &&
           <script dangerouslySetInnerHTML={{


### PR DESCRIPTION
Summary:

The OSS Automated Checkup flagged `HOMEPAGE_COPYRIGHT_STATEMENT_EXISTS` because the footer copyright said `Facebook Inc.` instead of `Meta Platforms, Inc.`. The checkup regex requires `Meta Platforms, Inc` to be present. Updated `website/core/Footer.js` accordingly.

Reviewed By: pchlenski

Differential Revision: D106843827


