### PR TITLE
Fix pyre type errors in Captum attr visualization helpers (#1874)

### DIFF
--- a/captum/attr/_core/llm_attr.py
+++ b/captum/attr/_core/llm_attr.py
@@ -248,7 +248,8 @@ class LLMAttributionResult:
         for i in range(data.shape[0]):
             for j in range(data.shape[1]):
                 val = data[i, j]
-                color = "black" if 0.2 < im.norm(val) < 0.8 else "white"
+                norm_val = cast(float, im.norm(val))
+                color = "black" if 0.2 < norm_val < 0.8 else "white"
                 im.axes.text(
                     j,
                     i,

--- a/captum/attr/_utils/visualization.py
+++ b/captum/attr/_utils/visualization.py
@@ -1094,7 +1094,7 @@ def visualize_timeseries_attr(
     else:
         raise AssertionError("Invalid visualization method: {}".format(method))
 
-    plt.xlim([x_values[0], x_values[-1]])
+    plt.xlim((float(x_values[0]), float(x_values[-1])))
 
     if show_colorbar:
         axis_separator = make_axes_locatable(plt_axis_list[-1])


### PR DESCRIPTION
Summary:

Captum's GitHub Actions `Type checks / tests` job (pyre) fails on two pre-existing type errors that are unrelated to any particular PR but block every PR's CI. This fixes both.

`captum/attr/_core/llm_attr.py:251` — pyre `Unsupported operand [58]`: `im.norm(val)` (a matplotlib `Normalize` call) returns a numpy value, so the chained comparison `0.2 < im.norm(val) < 0.8` is not statically supported. Wrap the single scalar in `float()` before comparing. Behavior is unchanged.

`captum/attr/_utils/visualization.py:1097` — pyre `Incompatible parameter type [6]`: `plt.xlim` expects `Tuple[float, float]`, but was passed a list of numpy scalars. Pass a `(float(...), float(...))` tuple instead. matplotlib accepts this identically.

Differential Revision: D110250340


