### PR TITLE
Enable Pyrefly in fbcode/pytorch directories (#1878)

### DIFF
--- a/captum/_utils/av.py
+++ b/captum/_utils/av.py
@@ -83,6 +83,7 @@ class AV:
             # pyre-fixme[4]: Attribute must be annotated.
             self.files = AV.sort_files(files)
 
+        # pyrefly: ignore [bad-override-param-name]
         def __getitem__(self, idx: int) -> Union[Tensor, Tuple[Tensor, ...]]:
             assert idx < len(self.files), "Layer index is out of bounds!"
             fl = self.files[idx]

--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -212,6 +212,7 @@ def _forward_layer_eval(
     attribute_to_layer_input: bool = False,
     grad_enabled: bool = False,
 ) -> Union[Tuple[Tensor, ...], List[Tuple[Tensor, ...]]]:
+    # pyrefly: ignore [no-matching-overload]
     return _forward_layer_eval_with_neuron_grads(
         forward_fn,
         inputs,

--- a/captum/_utils/progress.py
+++ b/captum/_utils/progress.py
@@ -36,6 +36,7 @@ class BaseProgress(Protocol):
     Note: This protocol is based on the tqdm type stubs.
     """
 
+    # pyrefly: ignore [not-a-type]
     def __enter__(self) -> Self: ...
 
     def __exit__(
@@ -126,6 +127,7 @@ class NullProgress(IterableProgress[IterableType], Progress):
         for it in iterable:
             yield it
 
+    # pyrefly: ignore [not-a-type]
     def __enter__(self) -> Self:
         return self
 
@@ -174,6 +176,7 @@ def progress(
     mininterval: float = 0.5,
     **kwargs: object,
 ) -> Union[Progress, IterableProgress[IterableType]]:
+    # pyrefly: ignore [bad-return, no-matching-overload]
     return tqdm(
         iterable,
         desc=desc,

--- a/captum/attr/_core/dataloader_attr.py
+++ b/captum/attr/_core/dataloader_attr.py
@@ -368,6 +368,7 @@ class DataLoaderAttribution(Attribution):
             inputs_tuple = _format_tensor_into_tuples(inputs)
 
         if input_roles:
+            # pyrefly: ignore [unbound-name]
             assert len(input_roles) == len(inputs_tuple), (
                 "input_roles must have the same size as the return of the dataloader,",
                 f"length of input_roles is {len(input_roles)} ",
@@ -380,6 +381,7 @@ class DataLoaderAttribution(Attribution):
             )
         else:
             # by default, assume every element in the dataloader needs attribution
+            # pyrefly: ignore [unbound-name]
             input_roles = tuple(InputRole.need_attr for _ in inputs_tuple)
 
         attr_inputs = tuple(

--- a/captum/attr/_core/feature_ablation.py
+++ b/captum/attr/_core/feature_ablation.py
@@ -1008,6 +1008,7 @@ class FeatureAblation(PerturbationAttribution):
 
             ablated_out_fut: Future[Tuple[List[Tensor], List[Tensor]]] = eval_futs.then(
                 lambda eval_futs, current_inputs=current_inputs, current_mask=current_masks, i=i: self._eval_fut_to_ablated_out_fut_cross_tensor(  # type: ignore # noqa: E501 line too long
+                    # pyrefly: ignore [bad-argument-type]
                     eval_futs=eval_futs,
                     current_inputs=current_inputs,
                     current_mask=current_mask,

--- a/captum/attr/_core/guided_backprop_deconvnet.py
+++ b/captum/attr/_core/guided_backprop_deconvnet.py
@@ -108,6 +108,7 @@ class ModifiedReluGradientAttribution(GradientAttribution):
     ) -> Union[Tuple[Tensor], Tensor]:
         to_override_grads = grad_output if self.use_relu_grad_output else grad_input
         if isinstance(to_override_grads, tuple):
+            # pyrefly: ignore [bad-return]
             return tuple(
                 F.relu(to_override_grad) for to_override_grad in to_override_grads  # type: ignore # noqa: E501 line too long
             )

--- a/captum/attr/_core/integrated_gradients.py
+++ b/captum/attr/_core/integrated_gradients.py
@@ -309,12 +309,16 @@ class IntegratedGradients(GradientAttribution):
             return (
                 cast(
                     TensorOrTupleOfTensorsGeneric,
+                    # pyrefly: ignore [no-matching-overload]
                     _format_output(is_inputs_tuple, attributions),
                 ),
                 delta,
             )
         return cast(
-            TensorOrTupleOfTensorsGeneric, _format_output(is_inputs_tuple, attributions)
+            # pyrefly: ignore [no-matching-overload]
+            TensorOrTupleOfTensorsGeneric,
+            # pyrefly: ignore [no-matching-overload]
+            _format_output(is_inputs_tuple, attributions),
         )
 
     def attribute_future(self) -> None:

--- a/captum/attr/_core/kernel_shap.py
+++ b/captum/attr/_core/kernel_shap.py
@@ -773,6 +773,7 @@ class RandomBaselineKernelShap(KernelShap):
         ), "Must provide baselines to use Random Baseline Kernel SHAP"
         if isinstance(original_inputs, Tensor):
             baseline_indices = self._sample_baseline_indices(original_inputs, **kwargs)
+            # pyrefly: ignore [bad-return]
             return self._replace_missing_with_random_baselines(
                 curr_sample,
                 original_inputs,

--- a/captum/attr/_core/layer/internal_influence.py
+++ b/captum/attr/_core/layer/internal_influence.py
@@ -250,6 +250,7 @@ class InternalInfluence(LayerAttribution, GradientAttribution):
                 grad_kwargs=grad_kwargs,
             )
 
+        # pyrefly: ignore [bad-return]
         return attrs
 
     def _attribute(

--- a/captum/attr/_core/layer/layer_conductance.py
+++ b/captum/attr/_core/layer/layer_conductance.py
@@ -324,7 +324,9 @@ class LayerConductance(LayerAttribution, GradientAttribution):
                 target=target,
                 additional_forward_args=additional_forward_args,
             )
+            # pyrefly: ignore [no-matching-overload]
             return _format_output(is_layer_tuple, attributions), delta
+        # pyrefly: ignore [no-matching-overload]
         return _format_output(is_layer_tuple, attributions)
 
     def _attribute(

--- a/captum/attr/_core/layer/layer_deep_lift.py
+++ b/captum/attr/_core/layer/layer_deep_lift.py
@@ -687,6 +687,7 @@ class LayerDeepLiftShap(LayerDeepLift, DeepLiftShap):
                 self, inp_bsz, base_bsz, attributions
             )
         if return_convergence_delta:
+            # pyrefly: ignore [unbound-name]
             return attributions, delta
         else:
             return cast(

--- a/captum/attr/_core/layer/layer_lrp.py
+++ b/captum/attr/_core/layer/layer_lrp.py
@@ -49,6 +49,7 @@ class LayerLRP(LRP, LayerAttribution):
     Ancona et al. [https://openreview.net/forum?id=Sy21R9JAW].
     """
 
+    # pyrefly: ignore [bad-override-mutable-attribute]
     device_ids: List[int]
     verbose: bool
     layers: List[Module]
@@ -79,6 +80,7 @@ class LayerLRP(LRP, LayerAttribution):
             self.device_ids = cast(List[int], self.model.device_ids)
 
     @typing.overload  # type: ignore
+    # pyrefly: ignore [inconsistent-overload]
     def attribute(
         self,
         inputs: TensorOrTupleOfTensorsGeneric,
@@ -94,6 +96,7 @@ class LayerLRP(LRP, LayerAttribution):
     ]: ...
 
     @typing.overload
+    # pyrefly: ignore [inconsistent-overload]
     def attribute(
         self,
         inputs: TensorOrTupleOfTensorsGeneric,

--- a/captum/attr/_core/lime.py
+++ b/captum/attr/_core/lime.py
@@ -489,6 +489,7 @@ class LimeBase(PerturbationAttribution):
                 )
 
                 if show_progress:
+                    # pyrefly: ignore [unbound-name]
                     attr_progress.update()
 
                 outputs.append(model_out)
@@ -511,6 +512,7 @@ class LimeBase(PerturbationAttribution):
                 **kwargs,
             )
             if show_progress:
+                # pyrefly: ignore [unbound-name]
                 attr_progress.update()
             outputs.append(model_out)
 
@@ -649,8 +651,12 @@ def default_from_interp_rep_transform(
     if isinstance(feature_mask, Tensor):
         binary_mask = curr_sample[0][feature_mask].bool()
         return (
+            # pyrefly: ignore [missing-attribute]
             binary_mask.to(original_inputs.dtype) * original_inputs
-            + (~binary_mask).to(original_inputs.dtype) * kwargs["baselines"]
+            + (~binary_mask).to(
+                original_inputs.dtype  # pyrefly: ignore [missing-attribute]
+            )  # pyrefly: ignore [missing-attribute]
+            * kwargs["baselines"]  # pyrefly: ignore [missing-attribute]
         )
     else:
         binary_mask = tuple(
@@ -1264,6 +1270,7 @@ class Lime(LimeBase):
                         else:
                             output_list.append(coefs.reshape(1, -1))  # type: ignore
 
+                    # pyrefly: ignore [bad-return, bad-specialization]
                     return _reduce_list(output_list)
                 else:
                     raise AssertionError(

--- a/captum/attr/_core/llm_attr.py
+++ b/captum/attr/_core/llm_attr.py
@@ -603,6 +603,7 @@ class BaseLLMAttribution(Attribution, ABC):
         self.model: nn.Module = cast(nn.Module, self.forward_func)
 
         self.tokenizer: TokenizerLike = tokenizer
+        # pyrefly: ignore [read-only]
         self.device: torch.device = (
             cast(torch.device, self.model.device)
             if hasattr(self.model, "device")
@@ -907,6 +908,7 @@ class LLMAttribution(BaseLLMAttribution):
             log_prob_list.append(log_probs[0][target_token].detach())
 
             model_inp["input_ids"] = torch.cat(
+                # pyrefly: ignore [bad-argument-type]
                 (
                     model_inp["input_ids"],
                     torch.tensor([[target_token]]).to(self.device),

--- a/captum/attr/_core/lrp.py
+++ b/captum/attr/_core/lrp.py
@@ -293,6 +293,7 @@ class LRP(GradientAttribution):
                 )
         else:
             summed_attr = _sum_rows(attributions)
+        # pyrefly: ignore [unbound-name]
         return output.flatten() - summed_attr.flatten()
 
     def _get_layers(self, model: Module) -> None:

--- a/captum/attr/_core/neuron/neuron_conductance.py
+++ b/captum/attr/_core/neuron/neuron_conductance.py
@@ -337,7 +337,10 @@ class NeuronConductance(NeuronAttribution, GradientAttribution):
                 grad_kwargs=grad_kwargs,
             )
         return cast(
-            TensorOrTupleOfTensorsGeneric, _format_output(is_inputs_tuple, attrs)
+            # pyrefly: ignore [no-matching-overload]
+            TensorOrTupleOfTensorsGeneric,
+            # pyrefly: ignore [no-matching-overload]
+            _format_output(is_inputs_tuple, attrs),
         )
 
     def _attribute(

--- a/captum/attr/_core/shapley_value.py
+++ b/captum/attr/_core/shapley_value.py
@@ -352,6 +352,7 @@ class ShapleyValueSampling(PerturbationAttribution):
             )
 
             if show_progress:
+                # pyrefly: ignore [unbound-name]
                 attr_progress.update()
 
             agg_output_mode = _find_output_mode_and_verify(
@@ -518,6 +519,7 @@ class ShapleyValueSampling(PerturbationAttribution):
             )
 
             if show_progress:
+                # pyrefly: ignore [unbound-name]
                 attr_progress.update()
 
             prev_result_tuple: Future[
@@ -593,7 +595,11 @@ class ShapleyValueSampling(PerturbationAttribution):
 
                     prev_result_tuple = eval_futs.then(
                         lambda evals=eval_futs, masks=current_masks: self._eval_fut_to_prev_results_tuple(  # type: ignore # noqa: E501 line too long
-                            evals, num_examples, inputs_tuple, masks
+                            # pyrefly: ignore [bad-argument-type]
+                            evals,
+                            num_examples,
+                            inputs_tuple,
+                            masks,
                         )
                     )
 
@@ -605,7 +611,10 @@ class ShapleyValueSampling(PerturbationAttribution):
             formatted_attr: Future[Union[Tensor, tuple[Tensor, ...]]] = (
                 prev_result_tuple.then(
                     lambda inp=prev_result_tuple: self._prev_result_tuple_to_formatted_attr(  # type: ignore # noqa: E501 line too long
-                        inp, iter_count, is_inputs_tuple
+                        # pyrefly: ignore [bad-argument-type]
+                        inp,
+                        iter_count,
+                        is_inputs_tuple,
                     )
                 )
             )
@@ -1042,6 +1051,7 @@ class ShapleyValues(ShapleyValueSampling):
                         feature importance across all examples in the batch.
         """
         ShapleyValueSampling.__init__(self, forward_func)
+        # pyrefly: ignore [bad-assignment, bad-override-param-name]
         self.permutation_generator = _all_perm_generator
 
     @log_usage(part_of_slo=True)

--- a/captum/attr/_utils/batching.py
+++ b/captum/attr/_utils/batching.py
@@ -175,6 +175,7 @@ def _batched_generator(
     else:
         for current_total in range(0, num_examples, internal_batch_size):
             with torch.autograd.set_grad_enabled(True):
+                # pyrefly: ignore [no-matching-overload]
                 inputs_splice = _tuple_splice_range(
                     # pyre-fixme[6]: For 1st argument expected `None` but got
                     #  `TensorOrTupleOfTensorsGeneric`.

--- a/captum/attr/_utils/visualization.py
+++ b/captum/attr/_utils/visualization.py
@@ -49,6 +49,7 @@ def draw_mask_border(
     ax: Axes,
     mask: npt.NDArray[np.bool_],
     border_width: int = 1,
+    # pyrefly: ignore [bad-specialization]
     border_color: Union[str, npt.NDArray[np.floating[Any]]] = "black",
 ) -> None:
     """
@@ -302,6 +303,7 @@ def _visualize_original_image(
     ), "Original image expected for original_image method."
     if len(original_image.shape) > 2 and original_image.shape[2] == 1:
         original_image = np.squeeze(original_image, axis=2)
+    # pyrefly: ignore [bad-argument-type]
     plt_axis.imshow(original_image)
 
 
@@ -313,6 +315,7 @@ def _visualize_heat_map(
     vmax: float,
     **kwargs: Any,
 ) -> AxesImage:
+    # pyrefly: ignore [bad-argument-type]
     heat_map = plt_axis.imshow(norm_attr, cmap=cmap, vmin=vmin, vmax=vmax)
     return heat_map
 
@@ -332,7 +335,12 @@ def _visualize_blended_heat_map(
     ), "Original Image expected for blended_heat_map method."
     plt_axis.imshow(np.mean(original_image, axis=2), cmap="gray")
     heat_map = plt_axis.imshow(
-        norm_attr, cmap=cmap, vmin=vmin, vmax=vmax, alpha=alpha_overlay
+        # pyrefly: ignore [bad-argument-type]
+        norm_attr,
+        cmap=cmap,
+        vmin=vmin,
+        vmax=vmax,
+        alpha=alpha_overlay,
     )
     return heat_map
 
@@ -348,6 +356,7 @@ def _visualize_masked_image(
         "Cannot display masked image with both positive and negative "
         "attributions, choose a different sign option."
     )
+    # pyrefly: ignore [bad-argument-type]
     plt_axis.imshow(_prepare_image(original_image * np.expand_dims(norm_attr, 2)))
 
 

--- a/captum/concept/_core/tcav.py
+++ b/captum/concept/_core/tcav.py
@@ -79,6 +79,7 @@ class LabelledDataset(Dataset):
                 right = mid
         return -1
 
+    # pyrefly: ignore [bad-override-param-name]
     def __getitem__(self, i: int) -> Tuple[Union[Tensor, Tuple[Tensor, ...]], Tensor]:
         """
         Returns a batch of activation vectors, as well as a batch of labels

--- a/captum/influence/_core/arnoldi_influence_function.py
+++ b/captum/influence/_core/arnoldi_influence_function.py
@@ -661,6 +661,7 @@ class ArnoldiInfluenceFunction(IntermediateQuantitiesInfluenceFunction):
         # by the scalar.
         return [_parameter_multiply(v, l) for (v, l) in zip(vs, ls)]
 
+    # pyrefly: ignore [bad-override]
     def compute_intermediate_quantities(
         self,
         inputs_dataset: Union[Tuple[Tensor, ...], DataLoader],
@@ -737,6 +738,7 @@ class ArnoldiInfluenceFunction(IntermediateQuantitiesInfluenceFunction):
         inputs_dataset = _format_inputs_dataset(inputs_dataset)
 
         if show_progress:
+            # pyrefly: ignore [bad-assignment]
             inputs_dataset = _progress_bar_constructor(
                 self, inputs_dataset, "inputs_dataset", "intermediate quantities"
             )
@@ -811,6 +813,7 @@ class ArnoldiInfluenceFunction(IntermediateQuantitiesInfluenceFunction):
         # sum, depending on `aggregate`
         return _get_dataset_embeddings_intermediate_quantities_influence_function(
             get_batch_embeddings,
+            # pyrefly: ignore [bad-argument-type]
             inputs_dataset,
             aggregate,
         )

--- a/captum/influence/_core/influence_function.py
+++ b/captum/influence/_core/influence_function.py
@@ -588,6 +588,7 @@ def _compute_dataset_func(
     # names of each param in `params`.
     # Both are needed for calling `_flatten_forward_factory`
     _unflatten_params = _unflatten_params_factory(
+        # pyrefly: ignore [bad-argument-type]
         tuple([param.shape for param in params])
     )
     param_names = _params_to_names(params, model)
@@ -956,6 +957,7 @@ class NaiveInfluenceFunction(IntermediateQuantitiesInfluenceFunction):
             device=torch.device("cpu") if projection_on_cpu else self.model_device
         )
 
+    # pyrefly: ignore [bad-override]
     def compute_intermediate_quantities(
         self,
         inputs_dataset: Union[Tuple[Any, ...], DataLoader],
@@ -1026,6 +1028,7 @@ class NaiveInfluenceFunction(IntermediateQuantitiesInfluenceFunction):
         inputs_dataset = _format_inputs_dataset(inputs_dataset)
 
         if show_progress:
+            # pyrefly: ignore [bad-assignment]
             inputs_dataset = _progress_bar_constructor(
                 self, inputs_dataset, "inputs_dataset", "intermediate quantities"
             )
@@ -1075,6 +1078,7 @@ class NaiveInfluenceFunction(IntermediateQuantitiesInfluenceFunction):
         # sum, depending on `aggregate`
         return _get_dataset_embeddings_intermediate_quantities_influence_function(
             get_batch_embeddings,
+            # pyrefly: ignore [bad-argument-type]
             inputs_dataset,
             aggregate,
         )

--- a/captum/influence/_utils/common.py
+++ b/captum/influence/_utils/common.py
@@ -331,6 +331,7 @@ class _DatasetFromList(Dataset):
     def __init__(self, _l: List[Any]) -> None:
         self._l = _l
 
+    # pyrefly: ignore [bad-override-param-name]
     def __getitem__(self, i: int) -> Any:
         return self._l[i]
 
@@ -636,7 +637,9 @@ def _influence_batch_intermediate_quantities_influence_function(
     `IntermediateQuantitiesInfluenceFunction`
     """
     return torch.matmul(
+        # pyrefly: ignore [bad-argument-type]
         influence_inst.compute_intermediate_quantities(test_batch),
+        # pyrefly: ignore [missing-attribute]
         influence_inst.compute_intermediate_quantities(train_batch).T,
     )
 
@@ -670,7 +673,9 @@ def _influence_helper_intermediate_quantities_influence_function(
     return torch.cat(
         [
             torch.matmul(
+                # pyrefly: ignore [bad-argument-type]
                 inputs_intermediate_quantities,
+                # pyrefly: ignore [missing-attribute]
                 influence_inst.compute_intermediate_quantities(batch).T,
             )
             for batch in train_dataloader
@@ -701,6 +706,7 @@ def _self_influence_helper_intermediate_quantities_influence_function(
     inputs_dataset = _format_inputs_dataset(inputs_dataset)
 
     if show_progress:
+        # pyrefly: ignore [bad-assignment]
         inputs_dataset = _progress_bar_constructor(
             influence_inst, inputs_dataset, "inputs_dataset", "self influence scores"
         )
@@ -708,6 +714,7 @@ def _self_influence_helper_intermediate_quantities_influence_function(
     return torch.cat(
         [
             torch.sum(
+                # pyrefly: ignore [unsupported-operation]
                 influence_inst.compute_intermediate_quantities(
                     batch,
                     show_progress=False,
@@ -715,6 +722,7 @@ def _self_influence_helper_intermediate_quantities_influence_function(
                 ** 2,
                 dim=1,
             )
+            # pyrefly: ignore [not-iterable]
             for batch in inputs_dataset
         ]
     )

--- a/captum/testing/helpers/basic_models.py
+++ b/captum/testing/helpers/basic_models.py
@@ -413,6 +413,7 @@ class BasicModel_GradientLayerAttribution(nn.Module):
 
         self.dict_output = dict_output
         # Linear 0 is simply identity transform
+        # pyrefly: ignore [invalid-type-var]
         self.unsupported_layer_output = unsupported_layer_output
         self.linear0 = nn.Linear(3, 3)
         self.linear0.weight = nn.Parameter(torch.eye(3))

--- a/captum/testing/helpers/influence/common.py
+++ b/captum/testing/helpers/influence/common.py
@@ -63,6 +63,7 @@ class ExplicitDataset(Dataset):
     def __len__(self) -> int:
         return len(self.samples)
 
+    # pyrefly: ignore [bad-override-param-name]
     def __getitem__(self, idx: int) -> Tuple[Tensor, Tensor]:
         return (self.samples[idx], self.labels[idx])
 
@@ -634,7 +635,9 @@ class DataInfluenceConstructor:
         else:
             return self.data_influence_class(
                 net,
+                # pyrefly: ignore [bad-argument-type]
                 dataset,
+                # pyrefly: ignore [bad-argument-type]
                 tmpdir,
                 batch_size=batch_size,
                 loss_fn=loss_fn,

--- a/tests/attr/layer/test_grad_cam.py
+++ b/tests/attr/layer/test_grad_cam.py
@@ -24,6 +24,7 @@ from torch import Tensor
 from torch.nn import Module
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_simple_input_non_conv(self) -> None:
         net = BasicModel_MultiLayer()

--- a/tests/attr/layer/test_layer_feature_permutation.py
+++ b/tests/attr/layer/test_layer_feature_permutation.py
@@ -13,6 +13,7 @@ from captum.testing.helpers.basic_models import BasicModel_MultiLayer
 from torch import Tensor
 
 
+# pyrefly: ignore [invalid-inheritance]
 class TestLayerFeaturePermutation(BaseTest):
     def test_single_input(self) -> None:
         net = BasicModel_MultiLayer()

--- a/tests/attr/layer/test_layer_lrp.py
+++ b/tests/attr/layer/test_layer_lrp.py
@@ -51,6 +51,7 @@ def _get_simple_model2(inplace: bool = False) -> Tuple[Any, Tensor]:
     return model, input
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_lrp_creator(self) -> None:
         model, _ = _get_basic_config()

--- a/tests/attr/neuron/test_neuron_ablation.py
+++ b/tests/attr/neuron/test_neuron_ablation.py
@@ -28,6 +28,7 @@ from torch import Tensor
 from torch.nn import Module
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_simple_ablation_with_mask(self) -> None:
         net = BasicModel_MultiLayer()

--- a/tests/attr/neuron/test_neuron_conductance.py
+++ b/tests/attr/neuron/test_neuron_conductance.py
@@ -26,6 +26,7 @@ from torch import Tensor
 from torch.nn import Module
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_simple_conductance_input_linear2(self) -> None:
         net = BasicModel_MultiLayer()

--- a/tests/attr/neuron/test_neuron_deeplift.py
+++ b/tests/attr/neuron/test_neuron_deeplift.py
@@ -29,6 +29,7 @@ from captum.testing.helpers.basic_models import (
 from torch import Tensor
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_relu_neuron_deeplift(self) -> None:
         model = ReLULinearModel(inplace=True)

--- a/tests/attr/neuron/test_neuron_gradient_shap.py
+++ b/tests/attr/neuron/test_neuron_gradient_shap.py
@@ -21,6 +21,7 @@ from torch import Tensor
 from torch.nn import Module
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_basic_multilayer(self) -> None:
         model = BasicModel_MultiLayer(inplace=True)

--- a/tests/attr/test_baselines.py
+++ b/tests/attr/test_baselines.py
@@ -12,6 +12,7 @@ from captum.attr._utils.baselines import ProductBaselines
 from captum.testing.helpers import BaseTest
 
 
+# pyrefly: ignore [invalid-inheritance]
 class TestProductBaselines(BaseTest):
     def test_list(self) -> None:
         baseline_values = [

--- a/tests/attr/test_class_summarizer.py
+++ b/tests/attr/test_class_summarizer.py
@@ -14,6 +14,7 @@ from captum.testing.helpers import BaseTest
 from torch import Tensor
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def class_test(
         self,
@@ -23,6 +24,7 @@ class Test(BaseTest):
     ) -> None:
         summarizer = ClassSummarizer(stats=CommonStats())
         for x, y in data:
+            # pyrefly: ignore [bad-argument-type]
             summarizer.update(x, y)
 
         summ = summarizer.summary
@@ -31,6 +33,7 @@ class Test(BaseTest):
         for s, size in zip(summ, x_sizes):
             self.assertIsInstance(s, dict)
             for key in s:
+                # pyrefly: ignore [missing-attribute]
                 self.assertEqual(s[key].size(), size)
 
         self.assertIsNotNone(summarizer.class_summaries)
@@ -49,6 +52,7 @@ class Test(BaseTest):
             for s, size in zip(summ, x_sizes):
                 self.assertIsInstance(s, dict)
                 for key in s:
+                    # pyrefly: ignore [missing-attribute]
                     self.assertEqual(s[key].size(), size)
 
         self.assertEqual(len(all_keys), 0)
@@ -108,6 +112,7 @@ class Test(BaseTest):
         self.assertIsNotNone(summ)
         self.assertIsInstance(summ, dict)
         for key in summ:
+            # pyrefly: ignore [missing-attribute]
             self.assertTrue(summ[key].size() == size)
 
         self.assertIsNotNone(summarizer.class_summaries)
@@ -122,6 +127,7 @@ class Test(BaseTest):
 
         for label in single_labels:
             summarizer = ClassSummarizer(stats=CommonStats())
+            # pyrefly: ignore [bad-argument-type]
             summarizer.update(data, label)
             summ1 = summarizer.summary
             summ2 = summarizer.class_summaries
@@ -133,6 +139,8 @@ class Test(BaseTest):
 
             self.assertIsInstance(summ2, dict)
             self.assertTrue(label in summ2)
+            # pyrefly: ignore [bad-argument-type]
             self.assertTrue(len(summ1) == len(summ2[label]))
             for key in summ1[0].keys():
+                # pyrefly: ignore [bad-index, missing-attribute, unsupported-operation]
                 self.assertTrue((summ1[0][key] == summ2[label][0][key]).all())

--- a/tests/attr/test_common.py
+++ b/tests/attr/test_common.py
@@ -13,6 +13,7 @@ from captum.attr._utils.common import _validate_input, _validate_noise_tunnel_ty
 from captum.testing.helpers import BaseTest
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_validate_input(self) -> None:
         with self.assertRaises(AssertionError) as err:

--- a/tests/attr/test_deconvolution.py
+++ b/tests/attr/test_deconvolution.py
@@ -24,6 +24,7 @@ from captum.testing.helpers.basic_models import BasicModel_ConvNet_One_Conv
 from torch.nn import Module
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_simple_input_conv_deconv(self) -> None:
         net = BasicModel_ConvNet_One_Conv()

--- a/tests/attr/test_feature_ablation.py
+++ b/tests/attr/test_feature_ablation.py
@@ -39,6 +39,7 @@ from captum.testing.helpers.basic_models import (
 from torch import Tensor
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     r"""
     The following conversion tests are underlying assumptions
@@ -910,6 +911,7 @@ class Test(BaseTest):
                 assertTensorAlmostEqual(self, attributions, expected_ablation)
 
 
+# pyrefly: ignore [invalid-inheritance]
 class TestParseForwardOutput(BaseTest):
 
     def test_parse_forward_out_tensor_passthrough(self) -> None:
@@ -940,6 +942,7 @@ class TestParseForwardOutput(BaseTest):
             _parse_forward_out(None)
 
 
+# pyrefly: ignore [invalid-inheritance]
 class TestFormatResult(BaseTest):
 
     def test_format_result_single_tensor_no_weights(self) -> None:
@@ -1028,6 +1031,7 @@ class TestFormatResult(BaseTest):
         )
 
 
+# pyrefly: ignore [invalid-inheritance]
 class TestCheckOutputShapeValid(BaseTest):
     def test_valid_output_shape_scaling(self) -> None:
         inputs = (torch.randn(4, 3),)
@@ -1092,6 +1096,7 @@ class TestCheckOutputShapeValid(BaseTest):
             )
 
 
+# pyrefly: ignore [invalid-inheritance]
 class TestShouldSkipInputsAndWarn(BaseTest):
     def test_skip_when_batch_size_less_than_min_examples(self) -> None:
         current_feature_idxs = [0, 1]

--- a/tests/attr/test_feature_permutation.py
+++ b/tests/attr/test_feature_permutation.py
@@ -17,6 +17,7 @@ from captum.testing.helpers.basic_models import BasicModelWithSparseInputs
 from torch import Tensor
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def construct_future_forward(
         self, original_forward: Callable[..., Tensor]

--- a/tests/attr/test_gradient_shap.py
+++ b/tests/attr/test_gradient_shap.py
@@ -25,6 +25,7 @@ from captum.testing.helpers.basic_models import BasicLinearModel, BasicModel2
 from captum.testing.helpers.classification_models import SoftmaxModel
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
 
     # This test reproduces some of the test cases from the original implementation

--- a/tests/attr/test_guided_backprop.py
+++ b/tests/attr/test_guided_backprop.py
@@ -26,6 +26,7 @@ from captum.testing.helpers.basic_models import BasicModel_ConvNet_One_Conv
 from torch.nn import Module
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_simple_input_conv_gb(self) -> None:
         net = BasicModel_ConvNet_One_Conv()

--- a/tests/attr/test_guided_grad_cam.py
+++ b/tests/attr/test_guided_grad_cam.py
@@ -20,6 +20,7 @@ from torch import Tensor
 from torch.nn import Module
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_simple_input_conv(self) -> None:
         net = BasicModel_ConvNet_One_Conv()

--- a/tests/attr/test_hook_removal.py
+++ b/tests/attr/test_hook_removal.py
@@ -179,5 +179,6 @@ class HookRemovalMeta(type):
         return hook_removal_test_assert
 
 
+# pyrefly: ignore [invalid-inheritance]
 class TestHookRemoval(BaseTest, metaclass=HookRemovalMeta):
     pass

--- a/tests/attr/test_input_x_gradient.py
+++ b/tests/attr/test_input_x_gradient.py
@@ -23,6 +23,7 @@ from torch import Tensor
 from torch.nn import Module
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_input_x_gradient_test_basic_vanilla(self) -> None:
         self._input_x_gradient_base_assert(*get_basic_config())

--- a/tests/attr/test_integrated_gradients_basic.py
+++ b/tests/attr/test_integrated_gradients_basic.py
@@ -30,6 +30,7 @@ from captum.testing.helpers.basic_models import (
 from torch.nn import Module
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_multivariable_vanilla(self) -> None:
         self._assert_multi_variable("vanilla", "riemann_right")

--- a/tests/attr/test_integrated_gradients_classification.py
+++ b/tests/attr/test_integrated_gradients_classification.py
@@ -19,6 +19,7 @@ from captum.testing.helpers.classification_models import SigmoidModel, SoftmaxMo
 from torch.nn import Module
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_sigmoid_classification_vanilla(self) -> None:
         self._assert_sigmoid_classification("vanilla", "riemann_right")

--- a/tests/attr/test_interpretable_input.py
+++ b/tests/attr/test_interpretable_input.py
@@ -36,6 +36,7 @@ class DummyTokenizer:
         self.unk_idx = len(vocab_list) + 1
 
     @overload
+    # pyrefly: ignore [inconsistent-overload-default]
     def encode(
         self, text: str, add_special_tokens: bool = ..., return_tensors: None = ...
     ) -> List[int]: ...
@@ -105,6 +106,7 @@ class DummyTokenizer:
         raise NotImplementedError
 
 
+# pyrefly: ignore [invalid-inheritance]
 class TestTextTemplateInput(BaseTest):
     @parameterized.expand(
         [
@@ -201,6 +203,7 @@ class TestTextTemplateInput(BaseTest):
         )
 
 
+# pyrefly: ignore [invalid-inheritance]
 class TestTextSegmentInput(BaseTest):
     def test_word_segmentation(self) -> None:
         text = "The quick brown fox"
@@ -391,6 +394,7 @@ class TestTextSegmentInput(BaseTest):
         self.assertEqual(seg_inp.to_model_input(perturbed), "X X c d")
 
 
+# pyrefly: ignore [invalid-inheritance]
 class TestTextTokenInput(BaseTest):
     def test_input(self) -> None:
         tokenizer = DummyTokenizer(["a", "b", "c"])
@@ -453,6 +457,7 @@ class TestTextTokenInput(BaseTest):
         )
 
 
+# pyrefly: ignore [invalid-inheritance]
 class TestImageMaskInput(BaseTest):
     def _create_test_image(
         self,

--- a/tests/attr/test_jit.py
+++ b/tests/attr/test_jit.py
@@ -182,6 +182,7 @@ class JITMeta(type):
             ):
                 formatted_inputs = _format_tensor_into_tuples(args["inputs"])
                 additional_args: Tuple[Any, ...] = (
+                    # pyrefly: ignore [bad-assignment]
                     _format_additional_forward_args(args["additional_forward_args"])
                     if "additional_forward_args" in args
                     and args["additional_forward_args"] is not None

--- a/tests/attr/test_llm_attr.py
+++ b/tests/attr/test_llm_attr.py
@@ -256,6 +256,7 @@ class DummyLLM(nn.Module):
         for forward_in_tokens in [True, False]
     ],
 )
+# pyrefly: ignore [invalid-inheritance]
 class TestLLMAttr(BaseTest):
     device: str = "cpu"
     use_cached_outputs: bool = False
@@ -576,6 +577,7 @@ class TestLLMAttr(BaseTest):
 @parameterized_class(
     ("device",), [("cpu",), ("cuda",)] if torch.cuda.is_available() else [("cpu",)]
 )
+# pyrefly: ignore [invalid-inheritance]
 class TestLLMGradAttr(BaseTest):
     device: str = "cpu"
 
@@ -737,6 +739,7 @@ class TestLLMGradAttr(BaseTest):
         self.assertEqual(res.output_tokens, ["m", "n", "o", "p", "q"])
 
 
+# pyrefly: ignore [invalid-inheritance]
 class TestVLLMProvider(BaseTest):
     """Test suite for VLLMProvider class."""
 
@@ -1138,6 +1141,7 @@ class DummyRemoteLLMProvider(RemoteLLMProvider):
 @parameterized_class(
     ("device",), [("cpu",), ("cuda",)] if torch.cuda.is_available() else [("cpu",)]
 )
+# pyrefly: ignore [invalid-inheritance]
 class TestRemoteLLMAttr(BaseTest):
     device: str = "cpu"
 

--- a/tests/attr/test_lrp.py
+++ b/tests/attr/test_lrp.py
@@ -67,6 +67,7 @@ def _get_simple_model2(inplace: bool = False) -> Tuple[Module, Tensor]:
     return model, input
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def _assert_lrp_supports_module(self, module: Module, inputs: Tensor) -> None:
         class SingleModuleModel(nn.Module):

--- a/tests/attr/test_occlusion.py
+++ b/tests/attr/test_occlusion.py
@@ -30,6 +30,7 @@ from captum.testing.helpers.basic_models import (
 from torch import Tensor
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_improper_window_shape(self) -> None:
         net = BasicModel_ConvNet_One_Conv()

--- a/tests/attr/test_stat.py
+++ b/tests/attr/test_stat.py
@@ -28,6 +28,7 @@ def get_values(
             yield random.random() * (float(hi) - float(lo)) + float(lo)
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_div0(self) -> None:
         summarizer = Summarizer([Var(), Mean()])
@@ -36,12 +37,16 @@ class Test(BaseTest):
 
         summarizer.update(torch.tensor(10))
         summ = summarizer.summary
+        # pyrefly: ignore [bad-index, unsupported-operation]
         assertTensorAlmostEqual(self, summ["mean"], 10)
+        # pyrefly: ignore [bad-index, unsupported-operation]
         assertTensorAlmostEqual(self, summ["variance"], 0)
 
         summarizer.update(torch.tensor(10))
         summ = summarizer.summary
+        # pyrefly: ignore [bad-index, unsupported-operation]
         assertTensorAlmostEqual(self, summ["mean"], 10)
+        # pyrefly: ignore [bad-index, unsupported-operation]
         assertTensorAlmostEqual(self, summ["variance"], 0)
 
     def test_var_defin(self) -> None:
@@ -72,9 +77,11 @@ class Test(BaseTest):
 
             actual_var = torch.var(torch.tensor(values).double(), unbiased=False)
 
+            # pyrefly: ignore [bad-index, unsupported-operation]
             var = summ.summary["variance"]
 
             assertTensorAlmostEqual(self, var, actual_var)
+            # pyrefly: ignore [missing-attribute, unsupported-operation]
             self.assertTrue((var > 0).all())
 
     def test_multi_dim(self) -> None:
@@ -85,10 +92,17 @@ class Test(BaseTest):
         summarizer = Summarizer([Mean(), Var()])
         summarizer.update(x1)
         assertTensorAlmostEqual(
-            self, summarizer.summary["mean"], x1, delta=0.05, mode="max"
+            # pyrefly: ignore [bad-index, unsupported-operation]
+            self,
+            # pyrefly: ignore [bad-index, unsupported-operation]
+            summarizer.summary["mean"],
+            x1,
+            delta=0.05,
+            mode="max",
         )
         assertTensorAlmostEqual(
             self,
+            # pyrefly: ignore [bad-index, unsupported-operation]
             summarizer.summary["variance"],
             torch.zeros_like(x1),
             delta=0.05,
@@ -98,6 +112,7 @@ class Test(BaseTest):
         summarizer.update(x2)
         assertTensorAlmostEqual(
             self,
+            # pyrefly: ignore [bad-index, unsupported-operation]
             summarizer.summary["mean"],
             torch.tensor([1.5, 1.5, 2.5, 4]),
             delta=0.05,
@@ -105,6 +120,7 @@ class Test(BaseTest):
         )
         assertTensorAlmostEqual(
             self,
+            # pyrefly: ignore [bad-index, unsupported-operation]
             summarizer.summary["variance"],
             torch.tensor([0.25, 0.25, 0.25, 0]),
             delta=0.05,
@@ -114,6 +130,7 @@ class Test(BaseTest):
         summarizer.update(x3)
         assertTensorAlmostEqual(
             self,
+            # pyrefly: ignore [bad-index, unsupported-operation]
             summarizer.summary["mean"],
             torch.tensor([2, 2, 2, 4]),
             delta=0.05,
@@ -121,6 +138,7 @@ class Test(BaseTest):
         )
         assertTensorAlmostEqual(
             self,
+            # pyrefly: ignore [bad-index, unsupported-operation]
             summarizer.summary["variance"],
             torch.tensor([2.0 / 3.0, 2.0 / 3.0, 2.0 / 3.0, 0]),
             delta=0.05,
@@ -171,6 +189,7 @@ class Test(BaseTest):
             actual = gt(values)
             for x in values:
                 summ.update(x)
+            # pyrefly: ignore [bad-index, unsupported-operation]
             stat_val = summ.summary[name]
             # rounding errors is a serious issue (moreso for MSE)
             assertTensorAlmostEqual(self, stat_val, actual, delta=0.005)

--- a/tests/attr/test_summarizer.py
+++ b/tests/attr/test_summarizer.py
@@ -11,6 +11,7 @@ from captum.attr import CommonStats, Summarizer
 from captum.testing.helpers import BaseTest
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_single_input(self) -> None:
         size = (2, 3)
@@ -24,6 +25,7 @@ class Test(BaseTest):
         self.assertTrue(isinstance(summ, dict))
 
         for k in summ:
+            # pyrefly: ignore [missing-attribute]
             self.assertTrue(summ[k].size() == size)
 
     def test_multi_input(self) -> None:
@@ -39,9 +41,13 @@ class Test(BaseTest):
         summ = summarizer.summary
         self.assertIsNotNone(summ)
         self.assertTrue(len(summ) == 2)
+        # pyrefly: ignore [bad-index]
         self.assertTrue(isinstance(summ[0], dict))
+        # pyrefly: ignore [bad-index]
         self.assertTrue(isinstance(summ[1], dict))
 
         for k in summ[0]:
+            # pyrefly: ignore [missing-attribute]
             self.assertTrue(summ[0][k].size() == size1)
+            # pyrefly: ignore [missing-attribute]
             self.assertTrue(summ[1][k].size() == size2)

--- a/tests/attr/test_utils_batching.py
+++ b/tests/attr/test_utils_batching.py
@@ -20,6 +20,7 @@ from captum.testing.helpers.basic import assertTensorAlmostEqual
 from torch import Tensor
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_tuple_splice_range(self) -> None:
         test_tuple = (

--- a/tests/concept/test_concept.py
+++ b/tests/concept/test_concept.py
@@ -43,6 +43,7 @@ class CustomIterableDataset(IterableDataset):
         return mapped_itr
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_create_concepts_from_images(self) -> None:
         def get_tensor_from_filename(filename):

--- a/tests/concept/test_tcav.py
+++ b/tests/concept/test_tcav.py
@@ -701,6 +701,7 @@ def remove_pkls(path: str) -> None:
         os.remove(pkl_file)
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     r"""
     Class for testing the TCAV class through a sequence of operations:
@@ -915,6 +916,7 @@ class Test(BaseTest):
         def forward_hook_wrapper(expected_act: Tensor) -> int:
             # pyre-fixme[2]: Parameter `module` must have a type other than `Any`.
             def forward_hook(module: Any, inp: Tensor, out=None) -> None:
+                # pyrefly: ignore [bad-argument-type, missing-attribute]
                 out = torch.reshape(out, (out.shape[0], -1))
                 self.assertEqual(out.detach().shape[1:], expected_act.shape[1:])
 

--- a/tests/influence/_core/test_arnoldi_influence.py
+++ b/tests/influence/_core/test_arnoldi_influence.py
@@ -39,6 +39,7 @@ from torch import Tensor
 from torch.utils.data import DataLoader
 
 
+# pyrefly: ignore [invalid-inheritance]
 class TestArnoldiInfluence(BaseTest):
     @parameterized.expand(
         [
@@ -450,6 +451,7 @@ class TestArnoldiInfluence(BaseTest):
         checkpoints can be different, and is specified using the `model_type` argument.
         """
         with tempfile.TemporaryDirectory() as tmpdir:
+            # pyrefly: ignore [bad-unpacking]
             (
                 net,
                 train_dataset,

--- a/tests/influence/_core/test_dataloader.py
+++ b/tests/influence/_core/test_dataloader.py
@@ -26,6 +26,7 @@ from parameterized import parameterized
 from torch.utils.data import DataLoader
 
 
+# pyrefly: ignore [invalid-inheritance]
 class TestTracInDataLoader(BaseTest):
     """
     This tests that the influence score computed when a Dataset is fed to the
@@ -84,6 +85,7 @@ class TestTracInDataLoader(BaseTest):
 
             batch_size = 5
 
+            # pyrefly: ignore [bad-unpacking]
             (
                 net,
                 train_dataset,

--- a/tests/influence/_core/test_naive_influence.py
+++ b/tests/influence/_core/test_naive_influence.py
@@ -46,6 +46,7 @@ gpu_settings_list = (
 )
 
 
+# pyrefly: ignore [invalid-inheritance]
 class TestNaiveInfluence(BaseTest):
     def setUp(self) -> None:
         super().setUp()
@@ -139,6 +140,7 @@ class TestNaiveInfluence(BaseTest):
         error loss.
         """
         with tempfile.TemporaryDirectory() as tmpdir:
+            # pyrefly: ignore [bad-unpacking]
             (
                 net,
                 train_dataset,

--- a/tests/influence/_core/test_similarity_influence.py
+++ b/tests/influence/_core/test_similarity_influence.py
@@ -48,10 +48,12 @@ class RangeDataset(Dataset):
     def __len__(self) -> int:
         return len(self.samples)
 
+    # pyrefly: ignore [bad-override-param-name]
     def __getitem__(self, idx: int) -> Tensor:
         return self.samples[idx]
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_cosine_with_zeros(self) -> None:
         a = torch.cat((torch.zeros((1, 3, 16, 16)), torch.rand((1, 3, 16, 16))))

--- a/tests/influence/_core/test_tracin_aggregate_influence.py
+++ b/tests/influence/_core/test_tracin_aggregate_influence.py
@@ -47,6 +47,7 @@ class TestTracInAggregateInfluence(BaseTest):
         summing
         """
         with tempfile.TemporaryDirectory() as tmpdir:
+            # pyrefly: ignore [bad-unpacking]
             (
                 net,
                 train_dataset,
@@ -107,6 +108,7 @@ class TestTracInAggregateInfluence(BaseTest):
         when the batches are collated into a single batch
         """
         with tempfile.TemporaryDirectory() as tmpdir:
+            # pyrefly: ignore [bad-unpacking]
             (
                 net,
                 train_dataset,
@@ -118,6 +120,7 @@ class TestTracInAggregateInfluence(BaseTest):
 
             # create a single batch representing the entire dataset
             single_batch = next(
+                # pyrefly: ignore [bad-argument-type]
                 iter(DataLoader(train_dataset, batch_size=len(train_dataset)))
             )
 

--- a/tests/influence/_core/test_tracin_intermediate_quantities.py
+++ b/tests/influence/_core/test_tracin_intermediate_quantities.py
@@ -28,6 +28,7 @@ from parameterized import parameterized
 from torch.utils.data import DataLoader
 
 
+# pyrefly: ignore [invalid-inheritance]
 class TestTracInIntermediateQuantities(BaseTest):
     @parameterized.expand(
         [
@@ -50,6 +51,7 @@ class TestTracInIntermediateQuantities(BaseTest):
         summing
         """
         with tempfile.TemporaryDirectory() as tmpdir:
+            # pyrefly: ignore [bad-unpacking]
             (
                 net,
                 train_dataset,
@@ -110,6 +112,7 @@ class TestTracInIntermediateQuantities(BaseTest):
         when the batches are collated into a single batch
         """
         with tempfile.TemporaryDirectory() as tmpdir:
+            # pyrefly: ignore [bad-unpacking]
             (
                 net,
                 train_dataset,
@@ -121,6 +124,7 @@ class TestTracInIntermediateQuantities(BaseTest):
 
             # create a single batch representing the entire dataset
             single_batch = next(
+                # pyrefly: ignore [bad-argument-type]
                 iter(DataLoader(train_dataset, batch_size=len(train_dataset)))
             )
 
@@ -217,6 +221,7 @@ class TestTracInIntermediateQuantities(BaseTest):
         same method, both ways should give the same result by definition.
         """
         with tempfile.TemporaryDirectory() as tmpdir:
+            # pyrefly: ignore [bad-unpacking]
             (
                 net,
                 train_dataset,
@@ -309,6 +314,7 @@ class TestTracInIntermediateQuantities(BaseTest):
         See inline comments for "at most" caveat
         """
         with tempfile.TemporaryDirectory() as tmpdir:
+            # pyrefly: ignore [bad-unpacking]
             (
                 net,
                 train_dataset,

--- a/tests/influence/_core/test_tracin_k_most_influential.py
+++ b/tests/influence/_core/test_tracin_k_most_influential.py
@@ -24,6 +24,7 @@ from captum.testing.helpers.influence.common import (
 from parameterized import parameterized
 
 
+# pyrefly: ignore [invalid-inheritance]
 class TestTracInGetKMostInfluential(BaseTest):
     param_list: List[
         Tuple[str, DataInfluenceConstructor, bool, bool, int, int, str, bool]
@@ -105,6 +106,7 @@ class TestTracInGetKMostInfluential(BaseTest):
         the calls to wrapper method `influence`.
         """
         with tempfile.TemporaryDirectory() as tmpdir:
+            # pyrefly: ignore [bad-unpacking]
             (
                 net,
                 train_dataset,

--- a/tests/influence/_core/test_tracin_regression.py
+++ b/tests/influence/_core/test_tracin_regression.py
@@ -33,6 +33,7 @@ from parameterized import parameterized
 from torch import Tensor
 
 
+# pyrefly: ignore [invalid-inheritance]
 class TestTracInRegression(BaseTest):
     def _test_tracin_regression_setup(
         self, tmpdir: str, features: int, use_gpu: bool = False

--- a/tests/influence/_core/test_tracin_self_influence.py
+++ b/tests/influence/_core/test_tracin_self_influence.py
@@ -27,6 +27,7 @@ from parameterized import parameterized
 from torch.utils.data import DataLoader
 
 
+# pyrefly: ignore [invalid-inheritance]
 class TestTracInSelfInfluence(BaseTest):
 
     param_list = []
@@ -166,6 +167,7 @@ class TestTracInSelfInfluence(BaseTest):
         gpu_setting: Optional[str],
     ) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
+            # pyrefly: ignore [bad-unpacking]
             (
                 net,
                 train_dataset,
@@ -189,7 +191,11 @@ class TestTracInSelfInfluence(BaseTest):
             )
             train_scores = tracin.influence(
                 _format_batch_into_tuple(
-                    train_dataset.samples, train_dataset.labels, unpack_inputs
+                    # pyrefly: ignore [missing-attribute]
+                    train_dataset.samples,
+                    # pyrefly: ignore [missing-attribute]
+                    train_dataset.labels,
+                    unpack_inputs,
                 ),
                 k=None,
             )
@@ -210,11 +216,10 @@ class TestTracInSelfInfluence(BaseTest):
             # this test is only relevant for implementations of `TracInCPBase`, as
             # implementations of `InfluenceFunctionBase` do not use checkpoints.
             if isinstance(tracin, TracInCPBase):
-                self_tracin_scores_by_checkpoints = (
-                    tracin.self_influence(  # type: ignore
-                        DataLoader(train_dataset, batch_size=batch_size),
-                        outer_loop_by_checkpoints=True,
-                    )
+                self_tracin_scores_by_checkpoints = tracin.self_influence(  # type: ignore
+                    DataLoader(train_dataset, batch_size=batch_size),
+                    # pyrefly: ignore [unexpected-keyword]
+                    outer_loop_by_checkpoints=True,
                 )
                 assertTensorAlmostEqual(
                     self,
@@ -250,6 +255,7 @@ class TestTracInSelfInfluence(BaseTest):
         # DataLoader of batches is the same as when the batches are collated into a
         # single batch
         with tempfile.TemporaryDirectory() as tmpdir:
+            # pyrefly: ignore [bad-unpacking]
             (
                 net,
                 train_dataset,
@@ -257,6 +263,7 @@ class TestTracInSelfInfluence(BaseTest):
 
             # create a single batch representing the entire dataset
             single_batch = next(
+                # pyrefly: ignore [bad-argument-type]
                 iter(DataLoader(train_dataset, batch_size=len(train_dataset)))
             )
 

--- a/tests/influence/_core/test_tracin_show_progress.py
+++ b/tests/influence/_core/test_tracin_show_progress.py
@@ -23,6 +23,7 @@ from parameterized import parameterized
 from torch.utils.data import DataLoader
 
 
+# pyrefly: ignore [invalid-inheritance]
 class TestTracInShowProgress(BaseTest):
     """
     This tests that the progress bar correctly shows a "100%" message at some point in
@@ -121,6 +122,7 @@ class TestTracInShowProgress(BaseTest):
 
                 batch_size = 5
 
+                # pyrefly: ignore [bad-unpacking]
                 (
                     net,
                     train_dataset,

--- a/tests/influence/_core/test_tracin_validation.py
+++ b/tests/influence/_core/test_tracin_validation.py
@@ -19,6 +19,7 @@ from captum.testing.helpers.influence.common import (
 from parameterized import parameterized
 
 
+# pyrefly: ignore [invalid-inheritance]
 class TestTracinValidator(BaseTest):
 
     param_list = [
@@ -49,6 +50,7 @@ class TestTracinValidator(BaseTest):
         influence methods required `inputs_dataset`.
         """
         with tempfile.TemporaryDirectory() as tmpdir:
+            # pyrefly: ignore [bad-unpacking]
             (
                 net,
                 train_dataset,
@@ -74,6 +76,7 @@ class TestTracinValidator(BaseTest):
         with a valid `final_fc_layer`.
         """
         with tempfile.TemporaryDirectory() as tmpdir:
+            # pyrefly: ignore [bad-unpacking]
             (
                 net,
                 train_dataset,
@@ -106,6 +109,7 @@ class TestTracinValidator(BaseTest):
         """
         with tempfile.TemporaryDirectory() as invalid_tmpdir:
             with tempfile.TemporaryDirectory() as tmpdir:
+                # pyrefly: ignore [bad-unpacking]
                 (
                     net,
                     train_dataset,

--- a/tests/influence/_core/test_tracin_xor.py
+++ b/tests/influence/_core/test_tracin_xor.py
@@ -26,6 +26,7 @@ from captum.testing.helpers.influence.common import (
 from parameterized import parameterized
 
 
+# pyrefly: ignore [invalid-inheritance]
 class TestTracInXOR(BaseTest):
 
     # TODO: Move test setup to use setUp and tearDown method overrides.

--- a/tests/influence/_utils/test_common.py
+++ b/tests/influence/_utils/test_common.py
@@ -13,6 +13,7 @@ from captum.testing.helpers import BaseTest
 from captum.testing.helpers.basic import assertTensorAlmostEqual
 
 
+# pyrefly: ignore [invalid-inheritance]
 class TestCommon(BaseTest):
     def setUp(self) -> None:
         super().setUp()

--- a/tests/metrics/test_infidelity.py
+++ b/tests/metrics/test_infidelity.py
@@ -116,6 +116,7 @@ def _global_perturb_func1(
     return (pert1, pert2), (torch.zeros(input1.shape), torch.zeros(input2.shape))
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_basic_infidelity_single(self) -> None:
         input1 = torch.tensor([3.0])
@@ -439,6 +440,7 @@ class Test(BaseTest):
         else:
             attrs = ig.attribute(inputs)  # type: ignore[has-type]
 
+        # pyrefly: ignore [bad-specialization]
         return self.infidelity_assert(
             model,
             attrs,

--- a/tests/metrics/test_sensitivity.py
+++ b/tests/metrics/test_sensitivity.py
@@ -67,6 +67,7 @@ def _perturb_func(
     return perturbed_input1, input2 + perturb_ratio(input2)
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_basic_sensitivity_max_single(self) -> None:
         model = BasicModel2()

--- a/tests/module/test_binary_concrete_stochastic_gates.py
+++ b/tests/module/test_binary_concrete_stochastic_gates.py
@@ -15,6 +15,7 @@ from captum.testing.helpers import BaseTest
 from captum.testing.helpers.basic import assertTensorAlmostEqual
 
 
+# pyrefly: ignore [invalid-inheritance]
 class TestBinaryConcreteStochasticGates(BaseTest):
     testing_device: str = "cpu"
 

--- a/tests/module/test_gaussian_stochastic_gates.py
+++ b/tests/module/test_gaussian_stochastic_gates.py
@@ -15,6 +15,7 @@ from captum.testing.helpers import BaseTest
 from captum.testing.helpers.basic import assertTensorAlmostEqual
 
 
+# pyrefly: ignore [invalid-inheritance]
 class TestGaussianStochasticGates(BaseTest):
     testing_device: str = "cpu"
 

--- a/tests/robust/test_FGSM.py
+++ b/tests/robust/test_FGSM.py
@@ -22,6 +22,7 @@ from torch import Tensor
 from torch.nn import CrossEntropyLoss
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_attack_nontargeted(self) -> None:
         model = BasicModel()

--- a/tests/robust/test_PGD.py
+++ b/tests/robust/test_PGD.py
@@ -18,6 +18,7 @@ from captum.testing.helpers.basic_models import (
 from torch.nn import CrossEntropyLoss
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_attack_nontargeted(self) -> None:
         model = BasicModel()

--- a/tests/robust/test_attack_comparator.py
+++ b/tests/robust/test_attack_comparator.py
@@ -69,6 +69,7 @@ class SamplePerturb:
         return mask * inp
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_attack_comparator_basic(self) -> None:
         model = BasicModel()

--- a/tests/robust/test_min_param_perturbation.py
+++ b/tests/robust/test_min_param_perturbation.py
@@ -46,6 +46,7 @@ def alt_correct_fn(model_out: Tensor, target: int, threshold: float) -> bool:
     return False
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_minimal_pert_basic_linear(self) -> None:
         model = BasicModel()

--- a/tests/utils/test_av.py
+++ b/tests/utils/test_av.py
@@ -30,10 +30,12 @@ class RangeDataset(Dataset):
     def __len__(self) -> int:
         return len(self.samples)
 
+    # pyrefly: ignore [bad-override-param-name]
     def __getitem__(self, idx):
         return self.samples[idx]
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_exists_without_version(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/utils/test_gradient.py
+++ b/tests/utils/test_gradient.py
@@ -30,6 +30,7 @@ from captum.testing.helpers.basic_models import (
 from packaging import version
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_apply_gradient_reqs(self) -> None:
         initial_grads = [False, True, False]

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -12,6 +12,7 @@ from captum.testing.helpers import BaseTest
 from captum.testing.helpers.basic import assertTensorAlmostEqual
 
 
+# pyrefly: ignore [invalid-inheritance]
 class HelpersTest(BaseTest):
     def test_assert_tensor_almost_equal(self) -> None:
         with self.assertRaises(AssertionError) as cm:

--- a/tests/utils/test_jacobian.py
+++ b/tests/utils/test_jacobian.py
@@ -21,6 +21,7 @@ from captum.testing.helpers.basic_models import (
 )
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_jacobian_scores_single_scalar(self) -> None:
         model = BasicLinearModel2(5, 1)

--- a/tests/utils/test_linear_model.py
+++ b/tests/utils/test_linear_model.py
@@ -21,6 +21,7 @@ from captum.testing.helpers.evaluate_linear_model import evaluate
 from torch import Tensor
 
 
+# pyrefly: ignore [invalid-inheritance]
 class TestLinearModel(BaseTest):
     MAX_POINTS: int = 3
 

--- a/tests/utils/test_progress.py
+++ b/tests/utils/test_progress.py
@@ -15,6 +15,7 @@ from captum._utils.progress import NullProgress, progress
 from captum.testing.helpers import BaseTest
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     @unittest.mock.patch("sys.stderr", new_callable=io.StringIO)
     def test_nullprogress(self, mock_stderr) -> None:

--- a/tests/utils/test_sample_gradient.py
+++ b/tests/utils/test_sample_gradient.py
@@ -27,6 +27,7 @@ from torch import Tensor
 from torch.nn import Module
 
 
+# pyrefly: ignore [invalid-inheritance]
 class Test(BaseTest):
     def test_sample_grads_linear_sum(self) -> None:
         model = BasicModel_MultiLayer(multi_input_module=True)
@@ -90,6 +91,7 @@ class Test(BaseTest):
                     )
                     assertTensorAlmostEqual(
                         self,
+                        # pyrefly: ignore [missing-attribute]
                         layer.bias.grad,
                         layer.bias.sample_grad[i],  # type: ignore
                         mode="max",


### PR DESCRIPTION
Summary:

Automated migration to enable Pyrefly type checking for 66 directories:

- `fbcode/pytorch/benchmark`
- `fbcode/pytorch/tritonbench`
- `fbcode/pytorch/ao`
- `fbcode/pytorch/captum`
- `fbcode/pytorch/torchtitan`
- `fbcode/pytorch/audio`
- `fbcode/pytorch/torchtune`
- `fbcode/pytorch/botorch`
- `fbcode/pytorch/apex`
- `fbcode/pytorch/rl`
- `fbcode/pytorch/gpytorch`
- `fbcode/pytorch/vision`
- `fbcode/pytorch/data`
- `fbcode/pytorch/text`
- `fbcode/pytorch/PFNs`
- `fbcode/pytorch/botorch_fb`
- `fbcode/pytorch/tritonparse`
- `fbcode/pytorch/kernelagent`
- `fbcode/pytorch/pippy`
- `fbcode/pytorch/opacus`
- `fbcode/pytorch/baselines`
- `fbcode/pytorch/torchforge`
- `fbcode/pytorch/torcharrow`
- `fbcode/pytorch/linear_operator`
- `fbcode/pytorch/autoparallel`
- `fbcode/pytorch/tensordict`
- `fbcode/pytorch/torchcodec`
- `fbcode/pytorch/facto`
- `fbcode/pytorch/tensorboardX`
- `fbcode/pytorch/lightning`
- `fbcode/pytorch/skorch`
- `fbcode/pytorch/torchstore`
- `fbcode/pytorch/inplace_abn`
- `fbcode/pytorch/pt2_sparse`
- `fbcode/pytorch/kraken`
- `fbcode/pytorch/examples`
- `fbcode/pytorch/gh`
- `fbcode/pytorch/elastic`
- `fbcode/pytorch/mamba`
- `fbcode/pytorch/maskedtensor`
- `fbcode/pytorch/a11`
- `fbcode/pytorch/torch-scatter`
- `fbcode/pytorch/tokenizers`
- `fbcode/pytorch/torchdata`
- `fbcode/pytorch/torchdistx`
- `fbcode/pytorch/pLBFGS`
- `fbcode/pytorch/hyper_attn`
- `fbcode/pytorch/recipes`
- `fbcode/pytorch/pytorch-lbfgs`
- `fbcode/pytorch/madgrad`
- `fbcode/pytorch/tritonaten`
- `fbcode/pytorch/torchvision_extra_decoders`
- `fbcode/pytorch/csprng`
- `fbcode/pytorch/cprint`
- `fbcode/pytorch/warpctc`
- `fbcode/pytorch/tensorlist`
- `fbcode/pytorch/rpc`
- `fbcode/pytorch/manifold`
- `fbcode/pytorch/causal_conv1d`
- `fbcode/pytorch/tlc`
- `fbcode/pytorch/hiveio`
- `fbcode/pytorch/diff_train_tests`
- `fbcode/pytorch/accimage`
- `fbcode/pytorch/feature_rollout`
- `fbcode/pytorch/feature_notification`
- `fbcode/pytorch/aoti-edge`

- Added `python.set_pyrefly(True)` to PACKAGE files
- Suppressed pre-existing type errors

Pyrefly is Meta's next-generation Python type checker, replacing Pyre.

If you encounter issues, you can revert the PACKAGE change by removing
the `python.set_pyrefly(True)` line in the relevant PACKAGE file.
#pyreupgrade

Differential Revision: D112858335
