### PR TITLE
Type logistic regression fit kwargs (#1882)

### DIFF
--- a/captum/_utils/models/linear_model/model.py
+++ b/captum/_utils/models/linear_model/model.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
-from typing import Callable, cast, List, Optional
+from typing import Any, Callable, cast, List, Optional
 
 import torch.nn as nn
 from captum._utils.models.model import Model
@@ -360,8 +360,7 @@ class SkLearnLogisticRegression(SkLearnLinearModel):
         super().__init__(sklearn_module="linear_model.LogisticRegression", **kwargs)
 
     # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def fit(self, train_data: DataLoader, **kwargs):
+    def fit(self, train_data: DataLoader, **kwargs: Any):
         return super().fit(train_data=train_data, **kwargs)
 
 

--- a/tests/influence/_core/test_tracin_self_influence.py
+++ b/tests/influence/_core/test_tracin_self_influence.py
@@ -216,10 +216,14 @@ class TestTracInSelfInfluence(BaseTest):
             # this test is only relevant for implementations of `TracInCPBase`, as
             # implementations of `InfluenceFunctionBase` do not use checkpoints.
             if isinstance(tracin, TracInCPBase):
-                self_tracin_scores_by_checkpoints = tracin.self_influence(  # type: ignore
-                    DataLoader(train_dataset, batch_size=batch_size),
-                    # pyrefly: ignore [unexpected-keyword]
-                    outer_loop_by_checkpoints=True,
+                self_tracin_scores_by_checkpoints = (  # type: ignore
+                    tracin.self_influence(
+                        DataLoader(  # noqa: TOR401
+                            train_dataset, batch_size=batch_size
+                        ),
+                        # pyrefly: ignore [unexpected-keyword]
+                        outer_loop_by_checkpoints=True,
+                    )
                 )
                 assertTensorAlmostEqual(
                     self,


### PR DESCRIPTION
Summary:

Annotate forwarded `SkLearnLogisticRegression.fit` keyword arguments as `Any`, removing the targeted Pyre missing-annotation suppression without changing behavior.

Differential Revision: D114161496


