### PR TITLE
Type neuron gradient forward callable

### DIFF
--- a/captum/_utils/gradient.py
+++ b/captum/_utils/gradient.py
@@ -497,8 +497,7 @@ def _forward_layer_eval_with_neuron_grads(
 
 
 def _forward_layer_eval_with_neuron_grads(
-    # pyre-fixme[24]: Generic type `Callable` expects 2 type parameters.
-    forward_fn: Callable,
+    forward_fn: Callable[..., object],
     inputs: Union[Tensor, Tuple[Tensor, ...]],
     layer: ModuleOrModuleList,
     additional_forward_args: Optional[object] = None,


### PR DESCRIPTION
Summary: Annotate `_forward_layer_eval_with_neuron_grads.forward_fn` as accepting arbitrary arguments and returning `object`, removing the bare-`Callable` Pyre suppression without changing runtime behavior.

Differential Revision: D114162475


