### PR TITLE
Fix flake8 E501 line-too-long in test_tracin_self_influence.py

### DIFF
--- a/tests/influence/_core/test_tracin_self_influence.py
+++ b/tests/influence/_core/test_tracin_self_influence.py
@@ -216,14 +216,14 @@ class TestTracInSelfInfluence(BaseTest):
             # this test is only relevant for implementations of `TracInCPBase`, as
             # implementations of `InfluenceFunctionBase` do not use checkpoints.
             if isinstance(tracin, TracInCPBase):
-                self_tracin_scores_by_checkpoints = tracin.self_influence(  # type: ignore
+                self_scores_by_checkpoints = tracin.self_influence(  # type: ignore
                     DataLoader(train_dataset, batch_size=batch_size),
                     # pyrefly: ignore [unexpected-keyword]
                     outer_loop_by_checkpoints=True,
                 )
                 assertTensorAlmostEqual(
                     self,
-                    self_tracin_scores_by_checkpoints,
+                    self_scores_by_checkpoints,
                     self_tracin_scores,
                     delta=0.01,
                     mode="max",


### PR DESCRIPTION
Summary:
The `Captum Lint` CI job runs `flake8` across the entire repo and was failing
on every captum PR with:

  tests/influence/_core/test_tracin_self_influence.py:219:89: E501 line too long (90 > 88 characters)

The over-length line was introduced by the automated `[pyrefly][automated]
Enable Pyrefly in fbcode/pytorch directories` change, which appended a trailing
`# type: ignore` to the `tracin.self_influence(` call, pushing it to 90
characters.

This shortens the line to 83 characters by renaming the local variable
`self_tracin_scores_by_checkpoints` to `self_scores_by_checkpoints` (both the
assignment and its single use). The `# type: ignore` and
`# pyrefly: ignore [unexpected-keyword]` suppressions are left untouched, so
all type-checking behavior is preserved.

Differential Revision: D114164695


