### PR TITLE
Type logistic regression fit kwargs

### DIFF
--- a/captum/_utils/models/linear_model/model.py
+++ b/captum/_utils/models/linear_model/model.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 # pyre-strict
-from typing import Callable, cast, List, Optional
+from typing import Any, Callable, cast, List, Optional
 
 import torch.nn as nn
 from captum._utils.models.model import Model
@@ -360,8 +360,7 @@ class SkLearnLogisticRegression(SkLearnLinearModel):
         super().__init__(sklearn_module="linear_model.LogisticRegression", **kwargs)
 
     # pyre-fixme[3]: Return type must be annotated.
-    # pyre-fixme[2]: Parameter must be annotated.
-    def fit(self, train_data: DataLoader, **kwargs):
+    def fit(self, train_data: DataLoader, **kwargs: Any):
         return super().fit(train_data=train_data, **kwargs)
 
 


### PR DESCRIPTION
Summary:
Annotate the forwarded `SkLearnLogisticRegression.fit` keyword arguments as
`Any`, removing the targeted Pyre missing-annotation suppression
(`pyre-fixme[2]`) without changing runtime behavior.

Clean replacement for D114161496 / PR #1882, which additionally carried an
out-of-scope reformat of `tests/influence/_core/test_tracin_self_influence.py`.
That test edit was a redundant fix for a flake8 E501 line already resolved on
`main`, and its stale patch context broke the `export-diff-to-pull-request`
ShipIt step. This diff contains only the intended `model.py` change.

Differential Revision: D114178253


