### PR TITLE
Bump `undici` from 7.24.5 to 7.29.0 in captum/website

### DIFF
--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -7388,9 +7388,9 @@ undici-types@~7.18.0:
   integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
 
 undici@^7.19.0:
-  version "7.24.5"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.24.5.tgz#7debcf5623df2d1cb469b6face01645d9c852ae2"
-  integrity sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.29.0.tgz#ae0f6f62e06e057a9cbb7b2b5fde2bb74f791b8f"
+  integrity sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
Summary:
`undici` 7.24.5 (used transitively by the Captum website) is affected by
several security advisories fixed in the 7.28.0/7.29.0 line, including
GHSA-4cwx-7wf7-3272 (cache-directive parsing / cross-user disclosure),
GHSA-m8rv-5g2x-5cg5 (CRLF injection via blob content-type), and the
retry/cookie hardening fixes. This bumps the resolved `undici` version in
`yarn.lock` from 7.24.5 to 7.29.0, which satisfies the existing `^7.19.0`
constraint, and adds the 7.29.0 tarball to the yarn offline mirror.

This corresponds to the dependabot PR meta-pytorch/captum#1890 (T282864785).
As with the earlier `tar` bump, the change is applied internally with the
public `registry.yarnpkg.com` resolved URL (not the internal
`registry.facebook.net` mirror) so the open-source `Test deployment` GitHub CI
can fetch the package. Only the `undici` entry is touched.

Differential Revision: D114297315


